### PR TITLE
sig is now just defdata::sig

### DIFF
--- a/books/defdata/package.lsp
+++ b/books/defdata/package.lsp
@@ -35,7 +35,7 @@
      u::defloop def-ruleset
 
      ;polymorphic sig
-     sig
+     ; sig  ;;Clashing with sig in RTL library
 
      )
    


### PR DESCRIPTION
Minor patch that I hope will fix the manual build failure.
