### PR TITLE
Adding hons and hons-acons tests for the spec-mv-let system.

### DIFF
--- a/books/system/hons-check/memoize-tests.lisp
+++ b/books/system/hons-check/memoize-tests.lisp
@@ -248,6 +248,9 @@
 ;;    nil))
 
 (defun test-simultaneously-acons ()
+; We may need to verify guards to execute the raw Lisp (parallelized) version
+; of pand.
+  (declare (xargs :verify-guards t))
   (pand (progn$
          ;; (show-me-default-hons-space 'thread-1-pre)
          ;; (hons-summary)
@@ -265,11 +268,44 @@
 
 (assert! (test-simultaneously-acons))
 
+(defun test-simultaneously-acons-with-spec-mv-let ()
+; We must verify guards to execute the raw Lisp (parallelized) version of
+; spec-mv-let.
+  (declare (xargs :verify-guards t))
+  (spec-mv-let (x)
+    (hons-acons 1 2 nil)
+    (mv-let (y z)
+      (mv (hons-acons 3 4 nil)
+          6)
+      (if t
+          (+ (caar x) (cdar x) (caar y) (cdar y) z)
+        (+ (caar y) (cadr y) z)))))
+
+(assert! (test-simultaneously-acons-with-spec-mv-let))
+
 (defun test-simultaneously-hons ()
+; We may need to verify guards to execute the raw Lisp (parallelized) version
+; of pand.
+  (declare (xargs :verify-guards t))
   (pand (hons 1 2)
         (hons 3 4)))
 
 (assert! (test-simultaneously-hons))
+
+(defun test-simultaneously-hons-with-spec-mv-let ()
+; We must verify guards to execute the raw Lisp (parallelized) version of
+; spec-mv-let.
+  (declare (xargs :verify-guards t))
+  (spec-mv-let (x)
+    (hons 7 8)
+    (mv-let (y z)
+      (mv (hons 9 10) 11)
+      (if t
+          (+ (car x) (cdr x) (car y) (cdr y) z)
+        (+ (car y) (cdr y) z)))))
+
+(assert! (test-simultaneously-hons-with-spec-mv-let))
+
 
 ;; Basic check to try to see if threads will interfere with one another
 


### PR DESCRIPTION
Adding hons and hons-acons tests for the spec-mv-let system.

Also, cleaning up hons and hons-acons tests that used pand, since functions that use pand probably need their guards verified to actually use the parallelism system.

Fixes #279 
