### PR TITLE
Removing the disabling of waterfall parallelism for 20 books.

### DIFF
--- a/books/centaur/4v-sexpr/sexpr-rewrites.lisp
+++ b/books/centaur/4v-sexpr/sexpr-rewrites.lisp
@@ -38,17 +38,6 @@
 (local (include-book "std/lists/top" :dir :system))
 (local (in-theory (disable set::double-containment)))
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (defxdoc sexpr-rewriting :parents (4v-sexprs))
 (defxdoc sexpr-rewriting-internals :parents (sexpr-rewriting))
 (defsection sexpr-rewrite-ground

--- a/books/centaur/aig/bddify-correct.lisp
+++ b/books/centaur/aig/bddify-correct.lisp
@@ -42,7 +42,6 @@
                     aig-q-compose-correct))
 
 (set-inhibit-warnings "theory")
-(set-waterfall-parallelism nil) ; for defthm aig-bddify-x-weakening-ok-point
 
 
 ;; --------- UBDDP-VAL-ALISTP
@@ -2743,75 +2742,76 @@
                                       abs-memo-okp))))
 
 
-  (defthm aig-bddify-var-weakening-ok
-    (implies (and (abs-bdd-al-okp bdd-al n)
-                  (integerp n)
-                  (<= (bdd-al-max-depth al) n)
-                  (abs-fmemo-okp fmemo al)
-                  (abs-memo-okp memo n al bdd-al)
-                  (<= 1 max-count)
-                  (equal nxtbdd (qv (+ n (len bdd-al)))))
-             (b* (((mv bdd aig & new-fmemo new-memo new-bdd-al new-nxtbdd exact)
-                   (aig-bddify-var-weakening
-                    x al max-count fmemo memo bdd-al nxtbdd))
-                  (exact-bdd (aig-q-compose x al)))
-               (and (suffixp bdd-al new-bdd-al)
-                    (<= (len bdd-al) (len new-bdd-al))
-                    (<= (bdd-max-depth bdd) (+ n (len new-bdd-al)))
-                    (abs-bdd-al-okp new-bdd-al n)
-                    (bdds-compatible-for-al
-                     exact-bdd bdd new-bdd-al n)
-                    (bdd-equiv (aig-q-compose aig al) exact-bdd)
-                    (implies exact
-                             (bdd-equiv bdd exact-bdd))
-                    (abs-memo-okp new-memo n al new-bdd-al)
-                    (abs-fmemo-okp new-fmemo al)
-                    (equal new-nxtbdd (qv (+ n (len new-bdd-al)))))))
-    :hints (("goal" :induct (aig-bddify-var-weakening-induct
-                             x al max-count fmemo memo bdd-al nxtbdd)
-             :expand ((:free (nxtbdd)
-                       (aig-bddify-var-weakening
-                        x al max-count fmemo memo bdd-al nxtbdd)))
-             :do-not-induct t)
-            ;; ("Subgoal *1/4" :in-theory (enable aig-q-compose bdd-max-depth booleanp))
-            ;; ("Subgoal *1/3" :in-theory (enable aig-q-compose-not-decomp-x booleanp))
-            ;; ("Subgoal *1/2" :in-theory (disable qv)) ;;aig-q-compose-and-decomp-x))
-            ;; ("Subgoal *1/1" :in-theory (e/d (aig-q-compose-and-decomp-x)
-            ;;                                 (and-bddify-var-weakening 
-            ;;                                  qv len
-            ;;                                  mv-nth-cons-meta
-            ;;                                  hons-assoc-equal
-            ;;                                  equal-of-booleans-rewrite
-            ;;                                  ;; normalize-terms-such-as-a/a+b-+-b/a+b
-            ;;                                  ;;                                             normalize-addends
-            ;;                                  and-bddify-var-weakening-ok)))
-            ;; (and (equal (car id) '(0 1))
-            ;;      '(:restrict 
-            ;;        ((aig-bddify-var-weakening ((x x)) ((x t)) ((x nil))))
-            ;;        :expand
-            ;;        ((:free (nxtbdd)
-            ;;                (aig-bddify-var-weakening
-            ;;                 x al max-count fmemo memo bdd-al nxtbdd)))))
+  (without-waterfall-parallelism
+   (defthm aig-bddify-var-weakening-ok
+     (implies (and (abs-bdd-al-okp bdd-al n)
+                   (integerp n)
+                   (<= (bdd-al-max-depth al) n)
+                   (abs-fmemo-okp fmemo al)
+                   (abs-memo-okp memo n al bdd-al)
+                   (<= 1 max-count)
+                   (equal nxtbdd (qv (+ n (len bdd-al)))))
+              (b* (((mv bdd aig & new-fmemo new-memo new-bdd-al new-nxtbdd exact)
+                    (aig-bddify-var-weakening
+                     x al max-count fmemo memo bdd-al nxtbdd))
+                   (exact-bdd (aig-q-compose x al)))
+                (and (suffixp bdd-al new-bdd-al)
+                     (<= (len bdd-al) (len new-bdd-al))
+                     (<= (bdd-max-depth bdd) (+ n (len new-bdd-al)))
+                     (abs-bdd-al-okp new-bdd-al n)
+                     (bdds-compatible-for-al
+                      exact-bdd bdd new-bdd-al n)
+                     (bdd-equiv (aig-q-compose aig al) exact-bdd)
+                     (implies exact
+                              (bdd-equiv bdd exact-bdd))
+                     (abs-memo-okp new-memo n al new-bdd-al)
+                     (abs-fmemo-okp new-fmemo al)
+                     (equal new-nxtbdd (qv (+ n (len new-bdd-al)))))))
+     :hints (("goal" :induct (aig-bddify-var-weakening-induct
+                              x al max-count fmemo memo bdd-al nxtbdd)
+              :expand ((:free (nxtbdd)
+                              (aig-bddify-var-weakening
+                               x al max-count fmemo memo bdd-al nxtbdd)))
+              :do-not-induct t)
+             ;; ("Subgoal *1/4" :in-theory (enable aig-q-compose bdd-max-depth booleanp))
+             ;; ("Subgoal *1/3" :in-theory (enable aig-q-compose-not-decomp-x booleanp))
+             ;; ("Subgoal *1/2" :in-theory (disable qv)) ;;aig-q-compose-and-decomp-x))
+             ;; ("Subgoal *1/1" :in-theory (e/d (aig-q-compose-and-decomp-x)
+             ;;                                 (and-bddify-var-weakening 
+             ;;                                  qv len
+             ;;                                  mv-nth-cons-meta
+             ;;                                  hons-assoc-equal
+             ;;                                  equal-of-booleans-rewrite
+             ;;                                  ;; normalize-terms-such-as-a/a+b-+-b/a+b
+             ;;                                  ;;                                             normalize-addends
+             ;;                                  and-bddify-var-weakening-ok)))
+             ;; (and (equal (car id) '(0 1))
+             ;;      '(:restrict 
+             ;;        ((aig-bddify-var-weakening ((x x)) ((x t)) ((x nil))))
+             ;;        :expand
+             ;;        ((:free (nxtbdd)
+             ;;                (aig-bddify-var-weakening
+             ;;                 x al max-count fmemo memo bdd-al nxtbdd)))))
 
 
-            (if (case-match id (((0 1) (1 &) . 0) t))
-                (with-quoted-forms
-                 (b* (((mv bdd1 aig1 count1 fmemo memo bdd-al nxtbdd exact1)
-                       (aig-bddify-var-weakening 
-                        (car x) al max-count fmemo memo bdd-al
-                        (qv (+ n (len bdd-al)))))
-                      ((mv bdd2 aig2 count2 & memo bdd-al nxtbdd exact2)
-                       (aig-bddify-var-weakening
-                        (cdr x) al max-count fmemo memo bdd-al nxtbdd)))
-                   `(:use ((:instance 
-                            and-bddify-var-weakening-ok
-                            . ,(var-fq-bindings
-                                (bdd1 aig1 count1 exact1 bdd2 aig2 count2 exact2
-                                      bdd-al nxtbdd memo))))
-                     :in-theory (disable and-bddify-var-weakening-ok
-                                         and-bddify-var-weakening-suffixp-rw))))
-              (value nil))
-            )))
+             (if (case-match id (((0 1) (1 &) . 0) t))
+                 (with-quoted-forms
+                  (b* (((mv bdd1 aig1 count1 fmemo memo bdd-al nxtbdd exact1)
+                        (aig-bddify-var-weakening 
+                         (car x) al max-count fmemo memo bdd-al
+                         (qv (+ n (len bdd-al)))))
+                       ((mv bdd2 aig2 count2 & memo bdd-al nxtbdd exact2)
+                        (aig-bddify-var-weakening
+                         (cdr x) al max-count fmemo memo bdd-al nxtbdd)))
+                    `(:use ((:instance 
+                             and-bddify-var-weakening-ok
+                             . ,(var-fq-bindings
+                                 (bdd1 aig1 count1 exact1 bdd2 aig2 count2 exact2
+                                       bdd-al nxtbdd memo))))
+                           :in-theory (disable and-bddify-var-weakening-ok
+                                               and-bddify-var-weakening-suffixp-rw))))
+               (value nil))
+             ))))
 
 (in-theory (disable aig-bddify-var-weakening))
 
@@ -2979,49 +2979,50 @@
                             mv-nth-cons-meta
                             bdds-compatible-for-al-self)))
 
- (defthm aig-bddify-list-var-weakening-ok
-   (implies (and (abs-args-okp fmemo memo bdd-al nxtbdd al n)
-                 (<= 1 max-count))
-            (b* ((ans
-                  (aig-bddify-list-var-weakening
-                   x al max-count fmemo memo bdd-al nxtbdd n))
-                 ((mv bdds aigs new-fmemo exact)
-                  ans)
-                 (exact-bdds (aig-q-compose-list x al)))
-              (and
-               (abs-args-okp new-fmemo memo bdd-al nxtbdd al n)
+ (without-waterfall-parallelism
+  (defthm aig-bddify-list-var-weakening-ok
+    (implies (and (abs-args-okp fmemo memo bdd-al nxtbdd al n)
+                  (<= 1 max-count))
+             (b* ((ans
+                   (aig-bddify-list-var-weakening
+                    x al max-count fmemo memo bdd-al nxtbdd n))
+                  ((mv bdds aigs new-fmemo exact)
+                   ans)
+                  (exact-bdds (aig-q-compose-list x al)))
+               (and
+                (abs-args-okp new-fmemo memo bdd-al nxtbdd al n)
 
-               (bdd-equiv-list (aig-q-compose-list aigs al) exact-bdds)
-               
-               (implies exact
-                        (and (bdd-equiv-list bdds exact-bdds)
-;;                              (fv-simplifiedp-list aigs al)
-                             )))))
-   :hints (("Goal" :induct (aig-bddify-list-var-weakening
-                            x al max-count fmemo memo bdd-al nxtbdd n)
-            :in-theory (enable aig-bddify-list-var-weakening))
-           (if (equal id (parse-clause-id "Subgoal *1/2"))
-               (with-quoted-forms
-                (b* (((mv & & & fmemo2 memo2 bdd-al2 nxtbdd2 &)
-                      (aig-bddify-var-weakening
-                       (car x) al max-count fmemo memo bdd-al nxtbdd)))
-                  `(:use
-                    ((:instance
-                      aig-bddify-var-weakening-ok-if-args-ok-2
-                      (x (car x)))
-                     (:instance
-                      abs-recheck-exactness-top-abs-args-okp
-                      (x (car x));;  (fmemo1 fmemo)
-                      (fmemo2 ,(fq fmemo2))
-                      (memo2 ,(fq memo2))
-                      (bdd-al2 ,(fq bdd-al2))
-                      (nxtbdd2 ,(fq nxtbdd2))))
-                    :in-theory (e/d (aig-bddify-list-var-weakening;;  mv-nth
-                                                                   eql)
-                                    (aig-bddify-var-weakening-ok-if-args-ok-2
-                                     aig-bddify-var-weakening-ok-if-args-ok
-                                     abs-recheck-exactness-top-abs-args-okp)))))
-             (value nil)))))
+                (bdd-equiv-list (aig-q-compose-list aigs al) exact-bdds)
+
+                (implies exact
+                         (and (bdd-equiv-list bdds exact-bdds)
+                              ;; (fv-simplifiedp-list aigs al)
+                              )))))
+    :hints (("Goal" :induct (aig-bddify-list-var-weakening
+                             x al max-count fmemo memo bdd-al nxtbdd n)
+             :in-theory (enable aig-bddify-list-var-weakening))
+            (if (equal id (parse-clause-id "Subgoal *1/2"))
+                (with-quoted-forms
+                 (b* (((mv & & & fmemo2 memo2 bdd-al2 nxtbdd2 &)
+                       (aig-bddify-var-weakening
+                        (car x) al max-count fmemo memo bdd-al nxtbdd)))
+                   `(:use
+                     ((:instance
+                       aig-bddify-var-weakening-ok-if-args-ok-2
+                       (x (car x)))
+                      (:instance
+                       abs-recheck-exactness-top-abs-args-okp
+                       (x (car x)) ;;  (fmemo1 fmemo)
+                       (fmemo2 ,(fq fmemo2))
+                       (memo2 ,(fq memo2))
+                       (bdd-al2 ,(fq bdd-al2))
+                       (nxtbdd2 ,(fq nxtbdd2))))
+                     :in-theory (e/d (aig-bddify-list-var-weakening ;;  mv-nth
+                                      eql)
+                                     (aig-bddify-var-weakening-ok-if-args-ok-2
+                                      aig-bddify-var-weakening-ok-if-args-ok
+                                      abs-recheck-exactness-top-abs-args-okp)))))
+              (value nil))))))
 
 
 

--- a/books/centaur/aignet/from-hons-aig.lisp
+++ b/books/centaur/aignet/from-hons-aig.lisp
@@ -50,11 +50,6 @@
                            set::sets-are-true-lists
                            make-list-ac)))
 
-(set-waterfall-parallelism nil) ; currently unknown why we need to disable
-                                ; waterfall-parallelism; something to examine
-
-
-
 (local (in-theory (disable true-listp-update-nth
                            acl2::nth-with-large-index)))
 ;; An xmemo is a fast alist mapping hons AIGs to literals.  It's well-formed if

--- a/books/centaur/aignet/semantics.lisp
+++ b/books/centaur/aignet/semantics.lisp
@@ -54,8 +54,6 @@
 
 (local (include-book "std/lists/nth" :dir :system))
 
-(set-waterfall-parallelism nil) ; currently unknown why we need to disable
-                                ; waterfall-parallelism; something to examine
 
 (local (in-theory (disable true-listp-update-nth
                            acl2::nth-when-zp

--- a/books/centaur/esim/esim-paths.lisp
+++ b/books/centaur/esim/esim-paths.lisp
@@ -38,17 +38,6 @@
 (include-book "std/util/defmvtypes" :dir :system)
 (local (include-book "esim-sexpr-support-thms"))
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state)
-          (f-get-global 'parallel-execution-enabled state))
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (std::deflist cons-listp (x)
               (consp x)
               :guard t

--- a/books/centaur/esim/esim-sexpr-correct.lisp
+++ b/books/centaur/esim/esim-sexpr-correct.lisp
@@ -40,17 +40,6 @@
 (local (in-theory (disable set::double-containment)))
 (local (in-theory (disable occmap)))
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state)
-          (f-get-global 'parallel-execution-enabled state))
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (defthm hons-assoc-equal-4v-sexpr-alist-extract
   (equal (hons-assoc-equal k (4v-sexpr-alist-extract keys al))
          (and (member-equal k keys)

--- a/books/centaur/esim/esim-sexpr-support.lisp
+++ b/books/centaur/esim/esim-sexpr-support.lisp
@@ -40,18 +40,6 @@
 (local (include-book "std/strings/explode-atom" :dir :system))
 (set-well-founded-relation nat-list-<)
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
-
 (defund stringify-atom (x)
   (declare (xargs :guard (atom x)))
   (cond ((symbolp x) (symbol-name x))

--- a/books/centaur/esim/esim-sexpr.lisp
+++ b/books/centaur/esim/esim-sexpr.lisp
@@ -45,17 +45,6 @@
 (local (include-book "esim-sexpr-support-thms"))
 (local (include-book "centaur/4v-sexpr/sexpr-advanced" :dir :system))
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.  
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (local (in-theory (disable* set::double-containment)))
 
 (set-well-founded-relation nat-list-<)

--- a/books/centaur/esim/esim-spec.lisp
+++ b/books/centaur/esim/esim-spec.lisp
@@ -45,17 +45,6 @@
 
 (set-well-founded-relation nat-list-<)
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.  
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (defun 4v-x-res (i alist)
   (declare (xargs :guard t))
   (if (atom i)

--- a/books/centaur/esim/stv/stv-compile.lisp
+++ b/books/centaur/esim/stv/stv-compile.lisp
@@ -47,17 +47,6 @@
 (local (include-book "../esim-sexpr-support-thms"))
 (local (include-book "centaur/vl/util/arithmetic" :dir :system))
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state)
-          (f-get-global 'parallel-execution-enabled state))
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (local (defthm atom-listp-of-pat-flatten1
          (atom-listp (pat-flatten1 x))
          :hints(("Goal" :in-theory (e/d (pat-flatten1)

--- a/books/centaur/misc/defapply.lisp
+++ b/books/centaur/misc/defapply.lisp
@@ -92,8 +92,7 @@
 (include-book "evaluator-metatheorems")
 (include-book "interp-function-lookup")
 (include-book "tools/def-functional-instance" :dir :system)
-
-(set-waterfall-parallelism nil) ; for apply-for-ev-cp
+(include-book "misc/without-waterfall-parallelism" :dir :system)
 
 (defmacro ecc (call)
   (declare (xargs :guard (consp call)))
@@ -547,6 +546,7 @@ The function ~x0 is missing its ~x1 property; perhaps it is not defined.~%"
    (ifl-ev-meta-extract-global-badguy
     evmeta-ev-meta-extract-global-badguy)))
 
+(without-waterfall-parallelism
 (defun apply-for-ev-cp (clause hints state)
   (declare (ignore hints)
            (xargs :stobjs state
@@ -585,7 +585,7 @@ The function ~x0 is missing its ~x1 property; perhaps it is not defined.~%"
                        cases-clauses)))))
     (& (mv (msg "The clause was not of the correct form: ~x0"
                 clause)
-           nil state))))
+           nil state)))))
 
 (in-theory (disable ev-collect-apply-lemmas))
 
@@ -644,14 +644,15 @@ The function ~x0 is missing its ~x1 property; perhaps it is not defined.~%"
           )
      :theoremsp nil)
 
-   (defthm evmeta-ev-apply-agrees-with-evmeta-ev
-     (implies (mv-nth 0 (evmeta-ev-apply fn args))
-              (equal (mv-nth 1 (evmeta-ev-apply fn args))
-                     (evmeta-ev (cons fn (kwote-lst args)) nil)))
-     :hints (("goal" :clause-processor
-              (apply-for-ev-cp clause nil state))
-             (use-by-computed-hint clause)
-             (use-these-hints-hint clause)))))
+   (without-waterfall-parallelism
+    (defthm evmeta-ev-apply-agrees-with-evmeta-ev
+      (implies (mv-nth 0 (evmeta-ev-apply fn args))
+               (equal (mv-nth 1 (evmeta-ev-apply fn args))
+                      (evmeta-ev (cons fn (kwote-lst args)) nil)))
+      :hints (("goal" :clause-processor
+               (apply-for-ev-cp clause nil state))
+              (use-by-computed-hint clause)
+              (use-these-hints-hint clause))))))
 
 
 
@@ -909,14 +910,15 @@ The function ~x0 is missing its ~x1 property; perhaps it is not defined.~%"
  (progn
    ;; (defapply/ev/concrete-ev mything2 (if len mv-list binary-append))
 
-   (make-event
-    `(defapply/ev/concrete-ev
-       everything
+   (without-waterfall-parallelism
+    (make-event
+     `(defapply/ev/concrete-ev
+        everything
 
-       ;; Note: Earlier this was (nthcdr 400 *all-logic-function-syms*), but
-       ;; Allegro CL died with a large rewrite stack.
+        ;; Note: Earlier this was (nthcdr 400 *all-logic-function-syms*), but
+        ;; Allegro CL died with a large rewrite stack.
 
-       ,(take 100 *all-logic-function-syms*)))))
+        ,(take 100 *all-logic-function-syms*))))))
 
 ;;  100:    2.02      97M
 ;;  200:    4.02     204M
@@ -927,6 +929,3 @@ The function ~x0 is missing its ~x1 property; perhaps it is not defined.~%"
 ;; 1200:   66.82    6708M
 ;; 1246:   71.74    7391M
 
-
-
-           

--- a/books/centaur/regression/common.lisp
+++ b/books/centaur/regression/common.lisp
@@ -33,14 +33,14 @@
 (include-book "tools/plev-ccl" :dir :system)
 (include-book "centaur/misc/memory-mgmt" :dir :system)
 (include-book "std/strings/top" :dir :system)
-
-(set-waterfall-parallelism nil) ; for below call of def-gl-clause-processor
+(include-book "misc/without-waterfall-parallelism" :dir :system)
 
 ; I'm unsure why the below is critical, but the "GL Clock" runs out without it.
 ; It introduces a GL clause processor that can natively execute at least the
 ; functions from the above books that get marked with add-clause-proc-exec-fns.
 
-(def-gl-clause-processor my-glcp)
+(without-waterfall-parallelism
+(def-gl-clause-processor my-glcp))
 
 (include-book "centaur/gl/bfr-satlink" :dir :system)
 

--- a/books/centaur/tutorial/alu16-book.lisp
+++ b/books/centaur/tutorial/alu16-book.lisp
@@ -47,17 +47,6 @@
 (value-triple (set-max-mem (* 3 (expt 2 30))))
 ; cert_param: (hons-only)
 
-(make-event
-
-; Disabling waterfall parallelism for unknown reasons other than that
-; certification stalls out with it enabled.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (defmodules *alu16-translation*
   (vl::make-vl-loadconfig
    :start-files (list "alu16.v")))

--- a/books/centaur/tutorial/boothmul.lisp
+++ b/books/centaur/tutorial/boothmul.lisp
@@ -65,17 +65,6 @@
 (value-triple (set-max-mem (* 3 (expt 2 30))))
 (value-triple (tshell-ensure))
 
-(make-event
-
-; Disabling waterfall parallelism for unknown reasons other than that
-; certification stalls out with it enabled.
-
- (if (and (hons-enabledp state)
-          (f-get-global 'parallel-execution-enabled state))
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 
 ; Setup.  This should be familiar if you've looked at, e.g., the alu16
 ; tutorial.

--- a/books/centaur/tutorial/intro.lisp
+++ b/books/centaur/tutorial/intro.lisp
@@ -77,14 +77,14 @@
 (include-book "centaur/4v-sexpr/top" :dir :system)
 (include-book "tools/plev-ccl" :dir :system)
 (include-book "centaur/misc/memory-mgmt" :dir :system)
-
-(set-waterfall-parallelism nil) ; for below call of def-gl-clause-processor
+(include-book "misc/without-waterfall-parallelism" :dir :system)
 
 ; This is critical.  It introduces a GL clause processor that can natively
 ; execute at least the functions from the above books that get marked with
 ; add-clause-proc-exec-fns:
 
-(def-gl-clause-processor my-glcp)
+(without-waterfall-parallelism
+(def-gl-clause-processor my-glcp))
 
 
 (defxdoc esim-tutorial

--- a/books/centaur/ubdds/extra-operations.lisp
+++ b/books/centaur/ubdds/extra-operations.lisp
@@ -23,17 +23,6 @@
 (in-package "ACL2")
 (include-book "core")
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 (local (defun q-binop-induct (x y vals)
          (declare (xargs :verify-guards nil))
          (if (atom x)

--- a/books/centaur/ubdds/param.lisp
+++ b/books/centaur/ubdds/param.lisp
@@ -38,18 +38,6 @@
 (local (in-theory (enable eval-bdd eval-bdd-list ubddp ubdd-listp
                           q-compose q-compose-list)))
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
-
 ;; -------------------------------------------------------------------
 ;; Function Definitions
 ;; -------------------------------------------------------------------

--- a/books/centaur/vcd/esim-snapshot.lisp
+++ b/books/centaur/vcd/esim-snapshot.lisp
@@ -33,17 +33,6 @@
 (include-book "std/strings/top" :dir :system)
 (include-book "../esim/esim-paths")
 
-(make-event
-
-; Disabling waterfall parallelism because this book allegedly uses memoization
-; while performing its proofs.  
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil))))
-
 ; esim-snapshot.lisp -- this is a tool for building nice snapshots from ESIM
 ; runs of VL-generated modules.
 

--- a/books/projects/taspi/code/fringes/fringes-guards.lisp
+++ b/books/projects/taspi/code/fringes/fringes-guards.lisp
@@ -6,17 +6,6 @@
 (include-book "../gen-trees/btrees-bdds-sets")
 (include-book "../gen-trees/app-rev-lists")
 ; cert_param: (non-acl2r)
-(make-event
-
-; David Rager, 3/1/2013: Disabling waterfall parallelism because this book
-; allegedly uses memoization while performing its proofs.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil)))
- :check-expansion nil)
 
 
 ;;;;;;;;;;;;;;;;;;;;;; ofringe ;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/projects/taspi/code/gen-helper/bdd-functions.lisp
+++ b/books/projects/taspi/code/gen-helper/bdd-functions.lisp
@@ -5,18 +5,6 @@
 (in-package "ACL2")
 (include-book "sets")
 
-(make-event
-
-; ; David Rager, 3/1/2013: Disabling waterfall parallelism because this book
-; allegedly uses memoization while performing its proofs.
-
- (if (and (hons-enabledp state) 
-          (f-get-global 'parallel-execution-enabled state)) 
-     (er-progn (set-waterfall-parallelism nil)
-               (value '(value-triple nil)))
-   (value '(value-triple nil)))
- :check-expansion nil)
-
 (defmacro qcons (x y)
   ;; should this be called qhons?
   `(cond ((or (and (eq ,x t)   (eq ,y t))


### PR DESCRIPTION
Some of them now use without-waterfall-parallelism instead, since that's the classier way of doing things.

Updates #281
