### PR TITLE
Add a lemma to std/lists/duplicity

### DIFF
--- a/books/std/lists/duplicity.lisp
+++ b/books/std/lists/duplicity.lisp
@@ -88,7 +88,7 @@ no-duplicatesp), e.g., see @(see no-duplicatesp-equal-same-by-duplicity).</p>"
     :hints(("Goal" :in-theory (enable duplicity duplicity-exec))))
 
   (verify-guards duplicity
-    :hints(("Goal" :in-theory (enable duplicity))))
+                 :hints(("Goal" :in-theory (enable duplicity))))
 
   (defthm duplicity-when-not-consp
     (implies (not (consp x))
@@ -140,6 +140,11 @@ no-duplicatesp), e.g., see @(see no-duplicatesp-equal-same-by-duplicity).</p>"
     (implies (not (member-equal a x))
              (equal (duplicity a x)
                     0)))
+
+  (defthm duplicity-when-member-equal
+    (implies (member-equal a x)
+             (> (duplicity a x)
+                0)))
 
   (defthm no-duplicatesp-equal-when-high-duplicity
     (implies (> (duplicity a x) 1)


### PR DESCRIPTION
We already have `duplicity-when-non-member-equal'; this commit adds
a complementary lemma, `duplicity-when-member-equal'.  I found it useful
in a proof I was doing, and since `duplicity' needs to be enabled in
order to prove it, it seemed like putting it in std/lists/duplicity made
sense.