### PR TITLE
Added the updated OVERSPILL macro to the end of books/nonstd/nsa/overspill.lisp.

### DIFF
--- a/books/nonstd/nsa/overspill-test.lisp
+++ b/books/nonstd/nsa/overspill-test.lisp
@@ -1,12 +1,14 @@
 ; Copyright (C) 2015, Regents of the University of Texas
-; Written by Matt Kaufmann, May, 2015
+; Written by Cuong Chau and Matt Kaufmann, May, 2015
 ; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
 
 ; cert_param: (uses-acl2r)
 
 (in-package "ACL2")
 
-(include-book "nonstd/nsa/overspill" :dir :system)
+(include-book "overspill")
+
+; Test with a single extra formal after the first (natural number) formal.
 
 (encapsulate
  ((r (k y) t)) ; classical predicate (necessary for overspill)
@@ -17,7 +19,7 @@
                       (standardp j))
                  (r j z)))))
 
-(overspill r)
+(overspill r x)
 
 (defthm r-holds-on-i-large
   (let ((n (r-witness x)))
@@ -27,3 +29,45 @@
                   (r m x))))
   :hints (("Goal" :use r-overspill))
   :rule-classes nil)
+
+; Test as above, but this time use the keyword parameters and also a variable
+; different from x.
+
+(overspill r u
+           :pred* r*-2
+           :witness r-witness-2
+           :pred-overspill r-overspill-2)
+
+(defthm r-holds-on-i-large-2
+  (let ((n (r-witness-2 u)))
+    (and (natp n)
+         (i-large n)
+         (implies (and (natp m) (<= m n))
+                  (r m u))))
+  :hints (("Goal" :use ((:instance r-overspill-2
+                                   (x u)))))
+  :rule-classes nil)
+
+; Test with a list of formals (after the first natural number formal).
+
+(encapsulate
+ ((s (k x y) t)) ; classical predicate (necessary for overspill)
+ (local (defun s (k x y) (declare (ignore k x y)) t))
+ (defthm s-prop
+   (and (s 0 x z)
+        (implies (and (natp j)
+                      (standardp j))
+                 (s j x z)))))
+
+(overspill s (x y))
+
+(defthm s-holds-on-i-large
+  (let ((n (s-witness x y)))
+    (and (natp n)
+         (i-large n)
+         (implies (and (natp m) (<= m n))
+                  (s m x y))))
+  :hints (("Goal" :use (:instance s-overspill
+                                  (x (list x y)))))
+  :rule-classes nil)
+

--- a/books/nonstd/nsa/overspill.lisp
+++ b/books/nonstd/nsa/overspill.lisp
@@ -1,8 +1,8 @@
 ; Copyright (C) 2015, Regents of the University of Texas
-; Written by Matt Kaufmann in consultation with Cuong Chau, April, 2015
+; Written by Cuong Chau and Matt Kaufmann, April/May, 2015
 ; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
 
-; See overspill-test.lisp for a trivial application.
+; See overspill-test.lisp for trivial applications.
 
 ; cert_param: (uses-acl2r)
 
@@ -28,6 +28,8 @@
 ;                   (overspill-p n x)
 ;                   (i-large n)))
 
+; We can avoid an include-book with :dir :system, since overspill-proof is in
+; this same directory.
 (local (include-book "overspill-proof"))
 
 (set-enforce-redundancy t)
@@ -69,60 +71,97 @@
 ; overspill-p-witness, not to be classical, to avoid needlessly restricting the
 ; set of legal functional substitutions.
 
-(defmacro overspill (pred &key pred* witness pred-overspill)
-  (let ((pred*
-         (or pred*
-             (intern-in-package-of-symbol
-              (concatenate 'string (symbol-name pred) "*")
-              pred)))
-        (witness
-         (or witness
-             (intern-in-package-of-symbol
-              (concatenate 'string (symbol-name pred) "-WITNESS")
-              pred)))
-        (pred-overspill
-         (or pred-overspill
-             (intern-in-package-of-symbol
-              (concatenate 'string (symbol-name pred) "-OVERSPILL")
-              pred))))
+(defun make-nth-calls (i var acc)
+
+; Return the user-level term list ((nth 0 var) (nth 1 var) ... (nth i-1 var)).
+
+  (declare (xargs :guard (and (natp i)
+                              (symbolp var))))
+  (cond ((zp i) acc)
+        (t (let ((k (1- i)))
+             (make-nth-calls k
+                             var
+                             (cons `(nth ,k ,var) acc))))))
+
+(defun create-bindings (x y)
+  (declare (xargs :guard (and (true-listp x)
+                              (true-listp y))))
+  (pairlis$ x (pairlis$ y nil)))
+
+(defmacro overspill (pred params &key pred* witness pred-overspill)
+
+; Params is a list of distinct variable names in one-to-one correspondence with
+; the cdr of the formals of pred -- so, (pred n . params) is a well-formed call
+; -- or else is a single variable.
+
+  (let* ((atom-p
+          (atom params))
+         (nth-x ; list of expressions representing the parameters
+          (if atom-p
+              '(x)
+            (make-nth-calls (len params) 'x nil)))
+         (params
+          (if (atom params) (list params) params))
+         (pred*
+          (or pred*
+              (intern-in-package-of-symbol
+               (concatenate 'string (symbol-name pred) "*")
+               pred)))
+         (witness
+          (or witness
+              (intern-in-package-of-symbol
+               (concatenate 'string (symbol-name pred) "-WITNESS")
+               pred)))
+         (pred-overspill
+          (or pred-overspill
+              (intern-in-package-of-symbol
+               (concatenate 'string (symbol-name pred) "-OVERSPILL")
+               pred))))
     `(encapsulate
       ()
 
       (local (include-book ; linebreak defeats bogus cert.pl dependency
               "nonstd/nsa/overspill" :dir :system))
 
-      (defun ,pred* (n x)
+      (defun ,pred* (n ,@params)
         (if (zp n)
-            (,pred 0 x)
-          (and (,pred n x)
-               (,pred* (1- n) x))))
+            (,pred 0 ,@params)
+          (and (,pred n ,@params)
+               (,pred* (1- n) ,@params))))
 
-      (defchoose ,witness (n) (x)
+      (defchoose ,witness (n) (,@params)
         (or (and (natp n)
                  (standardp n)
-                 (not (,pred n x)))
+                 (not (,pred n ,@params)))
             (and (natp n)
                  (i-large n)
-                 (,pred* n x))))
+                 (,pred* n ,@params))))
 
       (defthm ,pred-overspill
-        (let ((n (,witness x)))
+        (let ((n (,witness ,@nth-x)))
           (or (and (natp n)
                    (standardp n)
-                   (not (,pred n x)))
+                   (not (,pred n ,@nth-x)))
               (and (natp n)
                    (i-large n)
                    (implies (and (natp m)
                                  (<= m n))
-                            (,pred m x)))))
+                            (,pred m ,@nth-x)))))
         :hints (("Goal"
                  :by (:functional-instance
                       overspill-p-overspill
-                      (overspill-p ,pred)
-                      (overspill-p* ,pred*)
-                      (overspill-p-witness ,witness))
+                      (overspill-p
+                       (lambda (n x)
+                         (,pred n ,@nth-x)))
+                      (overspill-p*
+                       (lambda (n x)
+                         (,pred* n ,@nth-x)))
+                      (overspill-p-witness
+                       (lambda (x)
+                         (,witness ,@nth-x))))
                  :in-theory (theory 'minimal-theory)
-                 :expand ((,pred* n x)))
-                '(:use ,witness))
+                 :expand ((,pred* n ,@nth-x)))
+                '(:use (:instance ,witness
+                                  ,@(create-bindings params nth-x))))
         :rule-classes nil)
       )))


### PR DESCRIPTION
In agreement with Matt Kaufmann, added the updated OVERSPILL macro to the
end of books/nonstd/nsa/overspill.lisp. The use of this macro is illustrated in
books/nonstd/nsa/overspill-test.lisp.