### PR TITLE
Changing defsvtv's autoins-lookup-casesplit function so that it doesn…

### DIFF
--- a/books/centaur/sv/svtv/process.lisp
+++ b/books/centaur/sv/svtv/process.lisp
@@ -891,7 +891,9 @@ defined with @(see sv::defsvtv).</p>"
                                                     assoc-of-nil
                                                     car-cons cdr-cons
                                                     member-equal))
-                          :cases ,(autoins-lookup-casesplit invars 'k))))
+                          ,@(if (autoins-lookup-casesplit invars 'k)
+                                `(:cases ,(autoins-lookup-casesplit invars 'k))
+                              nil))))
                (defmacro ,name-autoins-body ()
                  ',(svtv-autoins svtv))
 


### PR DESCRIPTION
@solswords @jaredcdavis Could you please have a look at this when you have a chance?  If it looks fine, feel free to just merge it -- the community books built with the change.



Changing defsvtv's autoins-lookup-casesplit function so that it doesn't provide a casesplit hint when there are no cases.

I have some concern that the lack of cases in my very large example might actually mean that something else is amiss, but I'm fairly sure that the problem isn't with the circuit.  If something is amiss, it would more likely be that the autoins-lookup theorem could use some adjustment.  Either way, I think this is a reasonable solution for now, as it allows our massive defsvtv to go through.