### PR TITLE
Configurable ACL2 path and image extension in SV cosims

### DIFF
--- a/books/centaur/sv/cosims/Makefile
+++ b/books/centaur/sv/cosims/Makefile
@@ -36,8 +36,10 @@ all:
 #  Building the cosim image
 
 STARTJOB ?= $(SHELL)
+ACL2 ?= acl2
 
 CORE := ./cosim-core
+IMG_EXT ?= ccl
 
 ACL2_SYSTEM_BOOKS ?= ../../..
 
@@ -55,9 +57,9 @@ $(info Done rebuilding makefiles)
 -include Makefile-books
 
 cosim-core: cosims.cert make-cosim.lsp
-	rm -f $(CORE) $(CORE).ccl cosim-core cosim-core.ccl
-	$(STARTJOB) -c "acl2 < make-cosim.lsp &> make-cosim.out"
-	ls -la $(CORE) $(CORE).ccl
+	rm -f $(CORE) $(CORE).$(IMG_EXT) cosim-core cosim-core.ccl
+	$(STARTJOB) -c "$(ACL2) < make-cosim.lsp &> make-cosim.out"
+	ls -la $(CORE) $(CORE).$(IMG_EXT)
 
 all: cosim-core symlinks
 

--- a/books/centaur/sv/cosims/Makefile
+++ b/books/centaur/sv/cosims/Makefile
@@ -39,7 +39,7 @@ STARTJOB ?= $(SHELL)
 ACL2 ?= acl2
 
 CORE := ./cosim-core
-IMG_EXT ?= ccl
+IMG_EXT ?= lx86cl64
 
 ACL2_SYSTEM_BOOKS ?= ../../..
 

--- a/books/centaur/sv/cosims/Makefile
+++ b/books/centaur/sv/cosims/Makefile
@@ -57,9 +57,8 @@ $(info Done rebuilding makefiles)
 -include Makefile-books
 
 cosim-core: cosims.cert make-cosim.lsp
-	rm -f $(CORE) $(CORE).$(IMG_EXT) cosim-core cosim-core.ccl
+	rm -f $(CORE) 
 	$(STARTJOB) -c "$(ACL2) < make-cosim.lsp &> make-cosim.out"
-	ls -la $(CORE) $(CORE).$(IMG_EXT)
 
 all: cosim-core symlinks
 


### PR DESCRIPTION
Hi @solswords @jaredcdavis  ,
Here's a pull request for making the cosim Makefile more generic and basing it off the default CCL settings.  Could you please merge this when you have a moment to update your scripts that call cosim and have them pass in IMG_EXT=ccl ?

-- Andrew and David

