### PR TITLE
Certify defsort/remove-dups in ACL2(r)

### DIFF
--- a/books/defsort/remove-dups.lisp
+++ b/books/defsort/remove-dups.lisp
@@ -31,8 +31,6 @@
 (in-package "ACL2")
 (include-book "uniquep")
 
-; cert_param: (non-acl2r)
-
 (defund remove-adjacent-duplicates (x)
   (declare (xargs :guard t))
   (cond ((atom x)

--- a/induct.lisp
+++ b/induct.lisp
@@ -2870,11 +2870,16 @@
                                        wrld))))
 
 #+:non-standard-analysis
-(defun remove-adjacent-duplicates (lst)
-  (cond ((or (null lst) (null (cdr lst))) lst)
-        ((equal (car lst) (car (cdr lst)))
-         (remove-adjacent-duplicates (cdr lst)))
-        (t (cons (car lst) (remove-adjacent-duplicates (cdr lst))))))
+(defun remove-adjacent-duplicates (x)
+  (cond ((atom x)
+         nil)
+        ((atom (cdr x))
+         (list (car x)))
+        ((equal (car x) (cadr x))
+         (remove-adjacent-duplicates (cdr x)))
+        (t
+         (cons (car x)
+               (remove-adjacent-duplicates (cdr x))))))
 
 #+:non-standard-analysis
 (defun non-standard-induction-vars (candidate wrld)


### PR DESCRIPTION
The book `defsort/remove-dups` was marked as `non-acl2r` though its topic is far from reals.
The reason is definition of function `remove-adjacent-duplicates`. It is defined in the system ACL2 book `induct.lisp` in ACL2(r) mode with slightly different signature. This conflict prevents ACL2(r) to certify this book.

Difference is in treating lists that are not true lists. The version in `defstort/remove-dups` ensures that output list is `true-listp` even when input list is not `true-listp`. The version in `induct.lisp` passes endp atom from input list to output list.

I suggest to change definition in `induct.lisp` so that it matched the definition in the community book.
I request to verify that it is safe.