### PR TITLE
Update linkes from RTL section of ACL2 manual to online RTL manual

### DIFF
--- a/books/rtl/rel11/lib/doc.lisp
+++ b/books/rtl/rel11/lib/doc.lisp
@@ -40,10 +40,11 @@
       |Floating-Point Decomposition|
       |Exactness|)
      (|Floating-Point Formats| ; reps.lisp
-      |Representations with Explicit Leading One|
-      |Representations with Implicit Leading One|
-      |Denormal Representations|
-      |Rebiasing Exponents|)
+       |Classification of Formats|
+       |Normal Encodings|
+       |Denormals and Zeroes|
+       |Infinities and NaNs|
+       |Rebiasing Exponents|)
      (|Rounding| ; round.lisp
       |Truncation|
       |Rounding Away from Zero|
@@ -51,6 +52,18 @@
       |Odd Rounding|
       |IEEE Rounding|
       |Denormal Rounding|))
+     (|Floating-Point Exceptions and Specification of x86 Elementary Arithmetic Instructions| ; exps.lisp
+      (|SSE Floating-Point Instructions|
+       |The SSE Control and Status Register|
+       |Overview of SSE Floating-Point Exceptions|
+       |SSE Pre-Computation Exceptions|
+       |SSE Post-Computation Exceptions|) 
+      (|x87 Instructions|
+       |x87 Control Word|
+       |x87 Status Word|
+       |Overview of x87 Exceptions|
+       |x87 Pre-Computation Exceptions|
+       |x87 Post-Computation Exceptions|))
     (|Implementation of Elementary Operations|
      (|Addition| ; add.lisp
       |Bit Vector Addition|
@@ -73,6 +86,17 @@
       |Truncation {Square Root}|
       |Odd Rounding {Square Root}|
       |IEEE Rounding {Square Root}|))
+    (|Modeling Algorithms in SystemC and ACL2| ; masc.lisp
+     (|MASC: The Formal Language|
+      |Language Overview|
+      |Arithmetic|
+      |Control Restrictions|
+      |Mapping SystemC to MASC|
+      |Mapping MASC to ACL2|)
+     (|Applications|
+      |Integer Multiplication|
+      |Vector Compression|
+      |Fused Multiply-Accumulate|))
     |Bibliography|))
 
 (defun rtl-node-name-basic (sym)
@@ -211,7 +235,9 @@
 
 (rtl-order-subtopics rtl (|Register-Transfer Logic|
                           |Floating-Point Arithmetic|
+                          |Floating-Point Exceptions and Specification of x86 Elementary Arithmetic Instructions|
                           |Implementation of Elementary Operations|
+                          |Modeling Algorithms in SystemC and ACL2|
                           |Bibliography|))
 
 (defun defsection-rtl-list-for-tree (parent trees)

--- a/books/rtl/rel11/lib/excps.lisp
+++ b/books/rtl/rel11/lib/excps.lisp
@@ -419,6 +419,8 @@
 ;;;                   SSE Operations
 ;;;***************************************************************
 
+(defsection-rtl |The SSE Control and Status Register| |SSE Floating-Point Instructions|
+
 ;; Exception flag bits (indices shared by SSE and x87):
 
 (defun ibit () 0)
@@ -448,8 +450,11 @@
     (1 'rdn)
     (2 'rup)
     (3 'rtz)))
+)
 
 ;;--------------------------------------------------------------------------------
+
+(defsection-rtl |Overview of SSE Floating-Point Exceptions| |SSE Floating-Point Instructions|
 
 ;; The arguments of SSE-BINARY-SPEC are an operation (add, sub, mul, or div), 2 data 
 ;; inputs, the initial MXCSR register, and the significand and exponent widths. It 
@@ -719,11 +724,14 @@
           (mv (and (not (unmasked-excp-p post-flags (mxcsr-masks mxcsr)))
                    result)
               (logior (logior mxcsr pre-flags) post-flags)))))))
+)
 
 
 ;;;***************************************************************
 ;;;                   x87 Operations
 ;;;***************************************************************
+
+(defsection-rtl |x87 Control Word| |x87 Instructions|
 
 ;; Rounding and precision control in FCW
 
@@ -739,6 +747,9 @@
     ((0 1) 24)
     (2 53)
     (3 64)))
+)
+
+(defsection-rtl |x87 Status Word| |x87 Instructions|
 
 ;; Additional FSW status bits that are set by x87 instructions:
 
@@ -755,6 +766,9 @@
 
 (defun clear-c1 (fsw)
   (logand fsw #xfdff))
+)
+
+(defsection-rtl |Overview of x87 Exceptions| |x87 Instructions|
 
 ;; The arguments of X87-BINARY-SPEC are two data inputs, their formats, and the initial 
 ;; FCW and FSW registers. It returns a data result, which is NIL in the event of an  
@@ -913,3 +927,4 @@
                 (if (unmasked-excp-p post-flags fcw)
                     (set-es (logior (logior fsw pre-flags) post-flags))
                   (logior (logior fsw pre-flags) post-flags)))))))))
+)

--- a/books/rtl/rel11/lib/masc.lisp
+++ b/books/rtl/rel11/lib/masc.lisp
@@ -117,6 +117,8 @@
 ;Allows things like (in-theory (disable cat)) to refer to binary-cat.
 (add-macro-alias cat binary-cat)
 
+(defsection-rtl |Language Overview| |MASC: The Formal Language|
+
 (defun setbits (x w i j y)
   (declare (xargs :guard (and (natp x)
                               (integerp y)
@@ -210,6 +212,7 @@
 
 (defmacro in-function (fn term)
   `(if1 ,term () (er hard ',fn "Assertion ~x0 failed" ',term)))
+)
 
 
 ;;;**********************************************************************
@@ -222,6 +225,8 @@
 ;;;**********************************************************************
 ;;;                      Fixed-Point Registers
 ;;;**********************************************************************
+
+(defsection-rtl |Arithmetic| |MASC: The Formal Language|
 
 (defund ui (r) r)
 
@@ -306,3 +311,4 @@
                 (< y (expt 2 (1- n))))
             (equal (sf r n m) 
                    (* (expt 2 (- m n)) y))))
+)

--- a/books/rtl/rel11/lib/reps.lisp
+++ b/books/rtl/rel11/lib/reps.lisp
@@ -153,7 +153,7 @@
 ;;;               Classification of Formats
 ;;;***************************************************************
 
-;(defsection-rtl |Classification of Formats| |Floating-Point Formats|
+(defsection-rtl |Classification of Formats| |Floating-Point Formats|
 
 ;;Format parameters:
 
@@ -215,12 +215,12 @@
 
 (defund bias (f) (declare (xargs :guard (formatp f))) (- (expt 2 (- (expw f) 1)) 1))
 
-;)
+)
 ;;;***************************************************************
 ;;;                    Normal Encodings
 ;;;***************************************************************
 
-;(defsection-rtl |Normal Encodings| |Floating-Point Formats|
+(defsection-rtl |Normal Encodings| |Floating-Point Formats|
 
 (defund normp (x f)
   (declare (xargs :guard (formatp f)))
@@ -359,13 +359,13 @@
            (<= x (lpn f)))
   :rule-classes
   ((:rewrite :match-free :once)))
-;)
+)
 
 ;;;***************************************************************
 ;;;               Denormals and Zeroes
 ;;;***************************************************************
 
-;(defsection-rtl |Denormals and Zeroes| |Floating-Point Formats|
+(defsection-rtl |Denormals and Zeroes| |Floating-Point Formats|
 
 (defund zerp (x f)
   (declare (xargs :guard (formatp f)))
@@ -488,12 +488,12 @@
 		     (<= 1 m)
 		     (< m (expt 2 (1- (prec f))))))))
 
-;)
+)
 ;;;***************************************************************
 ;;;                 Infinities and NaNs
 ;;;***************************************************************
 
-;(defsection-rtl |Infinities and NaNs| |Floating-Point Formats|
+(defsection-rtl |Infinities and NaNs| |Floating-Point Formats|
 
 (defund infp (x f)
   (declare (xargs :guard (formatp f)))
@@ -537,7 +537,7 @@
          0
          (1- (sigw f)))))
 
-;)
+)
 ;;;***************************************************************
 ;;;                Rebiasing Exponents
 ;;;***************************************************************


### PR DESCRIPTION
Synchronize `doc.lisp` with current online manual.
Uncomment `defsection-rtl` in `reps.lisp` .
Insert naive `defsection-rtl` into `excps.lisp` and `masc.lisp` .