### PR TITLE
Fix header in books/centaur/fty/visitor.lisp

### DIFF
--- a/books/centaur/fty/visitor.lisp
+++ b/books/centaur/fty/visitor.lisp
@@ -1,5 +1,5 @@
-; VL Verilog Toolkit
-; Copyright (C) 2008-2014 Centaur Technology
+; FTY type support library
+; Copyright (C) 2014 Centaur Technology
 ;
 ; Contact:
 ;   Centaur Technology Formal Verification Group


### PR DESCRIPTION
This file had the VL header instead of the FTY header, for some reason. cc/@solswords