### PR TITLE
Updates to centaur/bitops/fast-rotate and build/make_cert_help.pl

### DIFF
--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -275,6 +275,29 @@ sub parse_max_mem_arg
     return $ret;
 }
 
+sub extract_pbs_from_acl2file
+{
+    # PBS directives placed in .acl2 files are extracted and used. An
+    # example of a PBS directive is:
+    #   
+    #    ;PBS -l host=<my-host-name>
+
+    my $filename = shift;
+    my @pbs = ();
+    open(my $fd, "<", $filename) or die("Can't open $filename: $!\n");
+    while(<$fd>) {
+	my $line = $_;
+	chomp($line);
+	if ($line =~ m/^;PBS (.*)$/)
+	{
+	    push(@pbs, $1);
+	}
+    }
+    close($fd);
+
+    return \@pbs;
+}
+
 sub scan_source_file
 {
     my $filename = shift;
@@ -522,6 +545,7 @@ my $acl2file = (-f "$file.acl2") ? "$file.acl2"
     : "";
 
 my $usercmds = $acl2file ? read_file_except_certify($acl2file) : "";
+my $extra_pbs = $acl2file ? extract_pbs_from_acl2file($acl2file) : [];
 
 # Don't hideously underapproximate timings in event summaries
 $instrs .= "(acl2::assign acl2::get-internal-time-as-realtime acl2::t)\n";
@@ -587,6 +611,10 @@ write_whole_file($lisptmp, $instrs);
 
     $shinsts .= "#PBS -l pmem=${max_mem}gb\n";
     $shinsts .= "#PBS -l walltime=${max_time}:00\n\n";
+
+    foreach my $directive (@$extra_pbs) {
+	$shinsts .= "#PBS $directive\n";
+    }
 
 # $shinsts .= "echo List directories of prereqs >> $outfile\n";
 # $shinsts .= "time ( ls @$prereq_dirs > /dev/null ) 2> $outfile\n";

--- a/books/centaur/bitops/fast-rotate.lisp
+++ b/books/centaur/bitops/fast-rotate.lisp
@@ -33,6 +33,10 @@
 (include-book "rotate")
 (include-book "std/strings/cat" :dir :system)
 
+(local (include-book "ihs/quotient-remainder-lemmas" :dir :system))
+(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
+(local (include-book "arithmetic/top-with-meta" :dir :system))
+
 ;; ======================================================================
 
 (defsection bitops/fast-rotate
@@ -60,181 +64,30 @@ expand into a call of a specialized, inlined function.</p>
 
   )
 
+(defmacro fast-rotate-left (x width places)
+  (cond ((eql width 8)   `(rotate-left-8  ,x ,places))
+        ((eql width 9)   `(rotate-left-9  ,x ,places))
+        ((eql width 16)  `(rotate-left-16 ,x ,places))
+        ((eql width 17)  `(rotate-left-17 ,x ,places))
+        ((eql width 32)  `(rotate-left-32 ,x ,places))
+        ((eql width 33)  `(rotate-left-33 ,x ,places))
+        ((eql width 64)  `(rotate-left-64 ,x ,places))
+        ((eql width 65)  `(rotate-left-65 ,x ,places))
+        (t
+         `(rotate-left ,x ,width ,places))))
 
-(defmacro fast-rotate-left (n x places)
-  (cond ((eql n 8)   `(rotate-left-8  ,x    ,places))
-        ((eql n 9)   `(rotate-left-9  ,x    ,places))
-        ((eql n 16)  `(rotate-left-16 ,x    ,places))
-        ((eql n 17)  `(rotate-left-17 ,x    ,places))
-        ((eql n 32)  `(rotate-left-32 ,x    ,places))
-        ((eql n 33)  `(rotate-left-33 ,x    ,places))
-        ((eql n 64)  `(rotate-left-64 ,x    ,places))
-        ((eql n 65)  `(rotate-left-65 ,x    ,places))
-        (t           `(rotate-left    ,x ,n ,places))))
+(defmacro fast-rotate-right (x width places)
+  (cond ((eql width 8)   `(rotate-right-8  ,x ,places))
+        ((eql width 9)   `(rotate-right-9  ,x ,places))
+        ((eql width 16)  `(rotate-right-16 ,x ,places))
+        ((eql width 17)  `(rotate-right-17 ,x ,places))
+        ((eql width 32)  `(rotate-right-32 ,x ,places))
+        ((eql width 33)  `(rotate-right-33 ,x ,places))
+        ((eql width 64)  `(rotate-right-64 ,x ,places))
+        ((eql width 65)  `(rotate-right-65 ,x ,places))
+        (t
+         `(rotate-right ,x ,width ,places))))
 
-(defmacro fast-rotate-right (n x places)
-  (cond ((eql n 8)   `(rotate-right-8  ,x    ,places))
-        ((eql n 9)   `(rotate-right-9  ,x    ,places))
-        ((eql n 16)  `(rotate-right-16 ,x    ,places))
-        ((eql n 17)  `(rotate-right-17 ,x    ,places))
-        ((eql n 32)  `(rotate-right-32 ,x    ,places))
-        ((eql n 33)  `(rotate-right-33 ,x    ,places))
-        ((eql n 64)  `(rotate-right-64 ,x    ,places))
-        ((eql n 65)  `(rotate-right-65 ,x    ,places))
-        (t           `(rotate-right    ,x ,n ,places))))
-
-
-;; ======================================================================
-;; Some misc. macros and lemmas:
-
-(defmacro defthm-usb
-  (name &key hyp bound concl
-        gen-type gen-linear
-        hyp-t hyp-l
-        hints
-        hints-t hints-l
-        otf-flg)
-
-  (if (and concl bound)
-      (let ((hyp (or hyp t))
-            (hints-t (or hints-t hints))
-            (hints-l (or hints-l hints))
-            (2^bound (if (natp bound)
-                         (expt 2 bound)
-                       `(expt 2 ,bound))))
-        `(defthm ,name
-           (implies ,hyp
-                    (unsigned-byte-p ,bound ,concl))
-           ,@(and hints `(:hints ,hints))
-           ,@(and otf-flg `(:otf-flg t))
-           :rule-classes
-           ((:rewrite
-             :corollary
-             (implies ,hyp
-                      (unsigned-byte-p ,bound ,concl))
-             ,@(and hints `(:hints ,hints)))
-            ,@(and gen-type
-                   `((:type-prescription
-                      :corollary
-                      (implies ,(or hyp-t hyp)
-                               (natp ,concl))
-                      ,@(and hints-t `(:hints ,hints-t)))))
-            ,@(and gen-linear
-                   `((:linear
-                      :corollary
-                      (implies ,(or hyp-l hyp)
-                               (< ,concl ,2^bound))
-                      ,@(and hints-l `(:hints ,hints-l))))))))
-    nil))
-
-(local
- (encapsulate
-  ()
-
-  (local (include-book "arithmetic-5/top" :dir :system))
-
-  (local
-   (set-default-hints
-    '((acl2::nonlinearp-default-hint++ id stable-under-simplificationp
-                                       hist nil))))
-
-  (defthm mod-strict-positive-bound
-    (implies (and (< 0 y)
-                  (integerp y)
-                  (integerp x))
-             (and (<= 0 (mod x y))
-                  (<= (mod x y) (1- y))))
-    :rule-classes (:rewrite :linear))
-
-
-  (defthm-usb unsigned-byte-p-width-ash-n-mod
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n src))
-    :bound n
-    :concl (+ -1 (ash 1 (- n (mod src n))))
-    :gen-type t
-    :gen-linear t)
-
-  (defthm-usb rotate-left-n-guard-helper-1
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places))
-    :bound n
-    :concl (ash (logand x
-                        (+ -1 (ash 1 (+ n (- (mod places n))))))
-                (mod places n))
-    :gen-type t
-    :gen-linear t)
-
-  (defthm-usb rotate-right-n-guard-helper-1
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places)
-              (< places n))
-    :bound n
-    :concl (ash 1 places))
-
-
-  (defthm-usb rotate-right-n-guard-helper-2
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places)
-              (< places n))
-    :bound n
-    :concl (+ -1 (ash 1 places)))
-
-  (defthm-usb rotate-right-n-guard-helper-3
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places)
-              (unsigned-byte-p n x)
-              (< places n))
-    :bound n
-    :concl (ash (logand x (+ -1 (ash 1 places)))
-                (+ n (- places))))
-
-  (defthm-usb rotate-right-n-guard-helper-4
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places)
-              (<= n places))
-    :bound n
-    :concl (+ -1 (ash 1 (mod places n))))
-
-  (defthm-usb rotate-right-n-guard-helper-5
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places)
-              (<= n places))
-    :bound n
-    :concl (ash 1 (mod places n)))
-
-  (defthm-usb rotate-right-n-guard-helper-6
-    :hyp (and (syntaxp (quotep n))
-              (natp n)
-              (< 0 n)
-              (unsigned-byte-p n places)
-              (unsigned-byte-p n x)
-              (<= n places))
-    :bound n
-    :concl (ash (logand x (+ -1 (ash 1 (mod places n))))
-                (+ n (- (mod places n)))))
-
-  ))
-
-;; ======================================================================
-
-(local (include-book "ihs/quotient-remainder-lemmas" :dir :system))
-(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
-(local (include-book "arithmetic/top-with-meta" :dir :system))
 
 ;; ======================================================================
 ;; Rotate left:
@@ -255,6 +108,87 @@ expand into a call of a specialized, inlined function.</p>
             (equal (rem places width)
                    (mod places width)))
    :hints(("Goal" :in-theory (enable mod rem)))))
+
+(local
+ (defthm ash-monotonic
+   (implies (and (<= m n)
+                 (posp x)
+                 (natp m)
+                 (natp n))
+            (<= (ash x m) (ash x n)))
+   :hints (("Goal" :in-theory (e/d* (ash) ())))))
+
+(local
+ (defthm ash-1-x-non-zero
+   (implies (natp x)
+            (not (equal (ash 1 x) 0)))
+   :hints (("Goal" :in-theory (e/d* (ash) ())))))
+
+(local
+ (defthm rotate-left-guard-helper-1
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (<= (mod places n) (1- n)))
+   :rule-classes :linear))
+
+(local
+ (defthm rotate-left-guard-helper-2
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (<= (+ n (- (mod places n))) n))
+   :rule-classes :linear))
+
+(local
+ (defthm rotate-left-guard-helper-3
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (<= (ash 1 (+ n (- (mod places n))))
+                (ash 1 n)))
+   :rule-classes :linear))
+
+(local
+ (defthm rotate-left-guard-helper-3-1
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (< (+ -1 (ash 1 (+ n (- (mod places n)))))
+               (expt 2 n)))
+   :hints (("Goal" :in-theory (e/d* (expt-2-is-ash)
+                                    (unsigned-byte-p))))))
+
+(local
+ (defthm rotate-left-guard-helper-3-2
+   (implies (and (unsigned-byte-p n places)
+                 (unsigned-byte-p n x))
+            (unsigned-byte-p n (+ -1 (ash 1 (+ n (- (mod places n)))))))))
+
+(local
+ (defthm rotate-left-guard-helper-4
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p (+ n (- (mod places n))) (+ -1 (ash 1 (+ n (- (mod places n)))))))
+   :hints (("Goal" :in-theory (e/d* (expt-2-is-ash)
+                                    (acl2::exponents-add
+                                     acl2::expt-minus))))))
+
+(local
+ (defthm rotate-left-guard-helper-5
+   (implies
+    (and (unsigned-byte-p n places)
+         (unsigned-byte-p n x))
+    (unsigned-byte-p (+ n (- (mod places n)))
+                     (logand x (+ -1 (ash 1 (+ n (- (mod places n))))))))
+   :hints (("Goal" :in-theory (e/d* ()
+                                    ())))))
+
+(local
+ (defthm rotate-left-guard-helper-6
+   (implies
+    (and (unsigned-byte-p n places)
+         (unsigned-byte-p n x)
+         (posp n))
+    (unsigned-byte-p n (ash (logand x (+ -1 (ash 1 (+ n (- (mod places n))))))
+                            (mod places n))))))
+
 
 (define rotate-left-n-function-gen
   ((n natp))
@@ -306,15 +240,10 @@ expand into a call of a specialized, inlined function.</p>
 
        ///
 
-       (defthm-usb ,bound-rule-name
-         :hyp (and (unsigned-byte-p ,n x)
-                   (unsigned-byte-p ,n places))
-         :bound ,n
-         :concl (,fn-name x places)
-         :gen-type t
-         :gen-linear t
-         :hints-l (("Goal" :in-theory (e/d (unsigned-byte-p)
-                                           (,fn-name))))))))
+       (defthm ,bound-rule-name
+         (implies (and (unsigned-byte-p ,n x)
+                       (unsigned-byte-p ,n places))
+                  (unsigned-byte-p ,n (,fn-name x places)))))))
 
 ;; Feel free to create different versions of fast-rotate-left-<n> as
 ;; required.
@@ -329,10 +258,87 @@ expand into a call of a specialized, inlined function.</p>
 (make-event (rotate-left-n-function-gen 33))
 (make-event (rotate-left-n-function-gen 65))
 
-
 ;; ======================================================================
 ;; Rotate right:
 ;; ======================================================================
+
+(local
+ (defthm rotate-right-guard-helper-1
+   (implies (and (unsigned-byte-p n places)
+                 (< places n))
+            (unsigned-byte-p n (ash 1 places)))
+   :hints (("Goal" :in-theory (e/d* (ash) ())))))
+
+(local
+ (defthm rotate-right-guard-helper-2
+   (implies (and (unsigned-byte-p n places)
+                 (< places n))
+            (unsigned-byte-p n (+ -1 (ash 1 places))))
+   :hints (("Goal" :in-theory (e/d* (ash) ())))))
+
+(local
+ (defthm rotate-right-guard-helper-3
+   (implies (unsigned-byte-p n places)
+            (unsigned-byte-p places (+ -1 (ash 1 places))))
+   :hints (("Goal" :in-theory (e/d* (expt-2-is-ash)
+                                    (acl2::exponents-add
+                                     acl2::expt-minus))))))
+
+(local
+ (defthm rotate-right-guard-helper-4
+   (implies (unsigned-byte-p n places)
+            (unsigned-byte-p places (logand x (+ -1 (ash 1 places)))))
+   :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))))
+
+(local
+ (defthm rotate-right-guard-helper-5
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p n
+                             (ash (logand x (+ -1 (ash 1 places)))
+                                  (+ n (- places)))))
+   :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))))
+
+(local
+ (defthm rotate-right-guard-helper-6
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p n (ash 1 (mod places n))))))
+
+(local
+ (defthmd rotate-right-guard-helper-7
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p n (mod places n)))))
+
+(local
+ (defthm rotate-right-guard-helper-8-1
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p (mod places n)
+                             (+ -1 (ash 1 (mod places n)))))
+   :hints (("Goal"
+            :use ((:instance rotate-right-guard-helper-7))
+            :in-theory (e/d* () (unsigned-byte-p))))))
+
+(local
+ (defthm rotate-right-guard-helper-8-2
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p n
+                             (+ -1 (ash 1 (mod places n)))))
+   :hints (("Goal"
+            :use ((:instance rotate-right-guard-helper-7))
+            :in-theory (e/d* () (unsigned-byte-p))))))
+
+(local
+ (defthm rotate-right-guard-helper-9
+   (implies (and (unsigned-byte-p n places)
+                 (posp n))
+            (unsigned-byte-p n
+                             (ash (logand x (+ -1 (ash 1 (mod places n))))
+                                  (+ n (- (mod places n))))))
+   :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))))
 
 (define rotate-right-n-function-gen
   ((n natp))
@@ -382,17 +388,10 @@ expand into a call of a specialized, inlined function.</p>
 
        ///
 
-       (defthm-usb ,bound-rule-name
-         :hyp (and (unsigned-byte-p ,n x)
-                   (unsigned-byte-p ,n places))
-         :bound ,n
-         :concl (,fn-name x places)
-         :gen-type t
-         :gen-linear t
-         :hints (("Goal" :in-theory (e/d (unsigned-byte-p)
-                                         ())))
-         :hints-l (("Goal" :in-theory (e/d (unsigned-byte-p)
-                                           (,fn-name))))))))
+       (defthm ,bound-rule-name
+         (implies (and (unsigned-byte-p ,n x)
+                       (unsigned-byte-p ,n places))
+                  (unsigned-byte-p ,n (,fn-name x places)))))))
 
 ;; Feel free to create different versions of fast-rotate-right-<n> as
 ;; required.

--- a/books/projects/x86isa/machine/instructions-spec/sal-sar-shl-shr-rcl-rcr-rol-ror.lisp
+++ b/books/projects/x86isa/machine/instructions-spec/sal-sar-shl-shr-rcl-rcr-rol-ror.lisp
@@ -76,7 +76,8 @@
                                       (logior (the (unsigned-byte ,size+1)
                                                 (ash old-cf ,size))
                                               dst))))
-            (raw-result  (the (unsigned-byte ,size+1) (fast-rotate-left ,size+1 new-dst src)))
+            (raw-result  (the (unsigned-byte ,size+1)
+                                                   (fast-rotate-left new-dst ,size+1 src)))
             (result      (the (unsigned-byte ,size) (n-size ,size raw-result)))
 
             ((mv (the (unsigned-byte 32) output-rflags)
@@ -240,9 +241,9 @@ the most-significant bit of the result.</p>"
                                :exec input-rflags))
 
             (result  (mbe :logic
-                          (n-size ,size (the (unsigned-byte ,size+1) (fast-rotate-left ,size dst src)))
+                          (n-size ,size (the (unsigned-byte ,size+1) (fast-rotate-left dst ,size src)))
                           :exec
-                          (the (unsigned-byte ,size) (fast-rotate-left ,size dst src))))
+                          (the (unsigned-byte ,size) (fast-rotate-left dst ,size src))))
 
             ((mv (the (unsigned-byte 32) output-rflags)
                  (the (unsigned-byte 32) undefined-flags))
@@ -252,7 +253,7 @@ the most-significant bit of the result.</p>"
                 ;; No flags, except OF, affected. OF is undefined.
                 (b* ((undefined-flags (the (unsigned-byte 32)
                                         (!rflags-slice :of 1 0))))
-                    (mv input-rflags undefined-flags)))
+                  (mv input-rflags undefined-flags)))
                (1
                 ;; CF and OF are the only affected flags.
                 (b* ((cf
@@ -277,7 +278,7 @@ the most-significant bit of the result.</p>"
                                        :cf cf
                                        (!rflags-slice
                                         :of of input-rflags)))))
-                    (mv output-rflags 0)))
+                  (mv output-rflags 0)))
 
                (otherwise
                 ;; CF is affected, OF is undefined.
@@ -297,14 +298,16 @@ the most-significant bit of the result.</p>"
                      (undefined-flags
                       (the (unsigned-byte 32)
                         (!rflags-slice :of 1 0))))
-                    (mv output-rflags undefined-flags)))))
+                  (mv output-rflags undefined-flags)))))
 
             (output-rflags (mbe :logic (n32 output-rflags)
                                 :exec output-rflags)))
 
-           (mv result output-rflags undefined-flags))
+         (mv result output-rflags undefined-flags))
 
        ///
+
+       (local (in-theory (e/d () (unsigned-byte-p))))
 
        (defthm-usb ,(mk-name "N" str-nbits "-MV-NTH-0-" fn-name)
          :bound ,size
@@ -422,7 +425,7 @@ most-significant bit of the result.</p>"
                                       (logior (the (unsigned-byte ,size+1)
                                                 (ash input-cf ,size))
                                               dst))))
-            (raw-result  (the (unsigned-byte ,size+1) (fast-rotate-right ,size+1 new-dst src)))
+            (raw-result  (the (unsigned-byte ,size+1) (fast-rotate-right new-dst ,size+1 src)))
             (result      (the (unsigned-byte ,size) (n-size ,size raw-result)))
 
             ((mv (the (unsigned-byte 32) output-rflags)
@@ -465,7 +468,7 @@ most-significant bit of the result.</p>"
                                        :cf cf
                                        (!rflags-slice
                                         :of of input-rflags)))))
-                    (mv output-rflags 0)))
+                  (mv output-rflags 0)))
 
                (otherwise
                 ;; CF is affected, OF is undefined.
@@ -486,11 +489,13 @@ most-significant bit of the result.</p>"
 
                      (undefined-flags (the (unsigned-byte 32)
                                         (!rflags-slice :of 1 0))))
-                    (mv output-rflags undefined-flags))))))
+                  (mv output-rflags undefined-flags))))))
 
-           (mv result output-rflags undefined-flags))
+         (mv result output-rflags undefined-flags))
 
        ///
+
+       (local (in-theory (e/d () (unsigned-byte-p))))
 
        (defthm-usb ,(mk-name "N" str-nbits "-MV-NTH-0-" fn-name)
          :bound ,size
@@ -581,116 +586,118 @@ the result.</p>"
        (fn-name (mk-name "ROR-SPEC-" size))
        (str-nbits (if (eql size 8) "08" size)))
 
-      `(define ,fn-name
-         ((dst    :type (unsigned-byte ,size))
-          (src    :type (unsigned-byte 6)
-                  "We assume @('src') has been masked appropriately by the decoding part of the rotate instructions.")
-          (input-rflags :type (unsigned-byte 32)))
+    `(define ,fn-name
+       ((dst    :type (unsigned-byte ,size))
+        (src    :type (unsigned-byte 6)
+                "We assume @('src') has been masked appropriately by the decoding part of the rotate instructions.")
+        (input-rflags :type (unsigned-byte 32)))
 
-         :guard-hints (("Goal" :in-theory (e/d () (unsigned-byte-p))))
-         :parents (ror-spec)
+       :guard-hints (("Goal" :in-theory (e/d () (unsigned-byte-p))))
+       :parents (ror-spec)
 
-         (b* ((dst (mbe :logic (n-size ,size dst)
-                        :exec dst))
-              (src (mbe :logic (n-size 6 src)
-                        :exec src))
-              (input-rflags (mbe :logic (n32 input-rflags)
-                                 :exec input-rflags))
+       (b* ((dst (mbe :logic (n-size ,size dst)
+                      :exec dst))
+            (src (mbe :logic (n-size 6 src)
+                      :exec src))
+            (input-rflags (mbe :logic (n32 input-rflags)
+                               :exec input-rflags))
 
-              (result  (mbe :logic
-                            (n-size ,size (the (unsigned-byte ,size) (fast-rotate-right ,size dst src)))
-                            :exec
-                            (the (unsigned-byte ,size) (fast-rotate-right ,size dst src))))
+            (result  (mbe :logic
+                          (n-size ,size (the (unsigned-byte ,size) (fast-rotate-right dst ,size src)))
+                          :exec
+                          (the (unsigned-byte ,size) (fast-rotate-right dst ,size src))))
 
-              ((mv (the (unsigned-byte 32) output-rflags)
-                   (the (unsigned-byte 32) undefined-flags))
+            ((mv (the (unsigned-byte 32) output-rflags)
+                 (the (unsigned-byte 32) undefined-flags))
 
-               (case src
-                 (0
-                  ;; No flags, except OF, affected.
-                  (b* ((undefined-flags (the (unsigned-byte 32)
-                                          (!rflags-slice :of 1 0))))
+             (case src
+               (0
+                ;; No flags, except OF, affected.
+                (b* ((undefined-flags (the (unsigned-byte 32)
+                                        (!rflags-slice :of 1 0))))
 
-                      (mv input-rflags undefined-flags)))
+                  (mv input-rflags undefined-flags)))
 
-                 (1
-                  ;; CF and OF are the only affected flags.
-                  (b* ((cf
-                        ;; CF = MSB of the  result.
-                        (mbe :logic (logbit ,size-1 result)
-                             :exec (logand 1
-                                           (the (unsigned-byte 1)
-                                             (ash (the (unsigned-byte ,size)
-                                                    result)
-                                                  ,neg-size-1)))))
-                       (of
-                        ;; OF = XOR of the two most significant bits of
-                        ;; the result.
-                        (b-xor (mbe :logic (logbit ,size-1 result)
-                                    :exec (logand 1
-                                                  (the (unsigned-byte 1)
-                                                    (ash (the (unsigned-byte ,size)
-                                                           result)
-                                                         ,neg-size-1))))
-                               (mbe :logic ;; (logbit ,size-2 result)
-                                    (part-select result :low ,size-2 :width 1)
-                                    :exec (logand 1
-                                                  (the (unsigned-byte 2)
-                                                    (ash (the (unsigned-byte ,size)
-                                                           result)
-                                                         ,neg-size-2))))))
-                       (output-rflags (the (unsigned-byte 32)
-                                        (!rflags-slice
-                                         :cf cf
-                                         (!rflags-slice
-                                          :of of
-                                          input-rflags)))))
-                      (mv output-rflags 0)))
+               (1
+                ;; CF and OF are the only affected flags.
+                (b* ((cf
+                      ;; CF = MSB of the  result.
+                      (mbe :logic (logbit ,size-1 result)
+                           :exec (logand 1
+                                         (the (unsigned-byte 1)
+                                           (ash (the (unsigned-byte ,size)
+                                                  result)
+                                                ,neg-size-1)))))
+                     (of
+                      ;; OF = XOR of the two most significant bits of
+                      ;; the result.
+                      (b-xor (mbe :logic (logbit ,size-1 result)
+                                  :exec (logand 1
+                                                (the (unsigned-byte 1)
+                                                  (ash (the (unsigned-byte ,size)
+                                                         result)
+                                                       ,neg-size-1))))
+                             (mbe :logic ;; (logbit ,size-2 result)
+                                  (part-select result :low ,size-2 :width 1)
+                                  :exec (logand 1
+                                                (the (unsigned-byte 2)
+                                                  (ash (the (unsigned-byte ,size)
+                                                         result)
+                                                       ,neg-size-2))))))
+                     (output-rflags (the (unsigned-byte 32)
+                                      (!rflags-slice
+                                       :cf cf
+                                       (!rflags-slice
+                                        :of of
+                                        input-rflags)))))
+                  (mv output-rflags 0)))
 
-                 (otherwise
-                  ;; CF is affected, OF is undefined.
-                  ;; All other flags are unaffected.
-                  (b* ((cf ;; CF = MSB of the result.
-                        (mbe :logic
-                             (part-select result :low 0 :width 1)
-                             :exec
-                             (the (unsigned-byte 1)
-                               (logand 1 (the (unsigned-byte ,size)
-                                           result)))))
-                       (output-rflags (the (unsigned-byte 32)
-                                        (!rflags-slice
-                                         :cf cf
-                                         input-rflags)))
+               (otherwise
+                ;; CF is affected, OF is undefined.
+                ;; All other flags are unaffected.
+                (b* ((cf ;; CF = MSB of the result.
+                      (mbe :logic
+                           (part-select result :low 0 :width 1)
+                           :exec
+                           (the (unsigned-byte 1)
+                             (logand 1 (the (unsigned-byte ,size)
+                                         result)))))
+                     (output-rflags (the (unsigned-byte 32)
+                                      (!rflags-slice
+                                       :cf cf
+                                       input-rflags)))
 
-                       (undefined-flags (the (unsigned-byte 32)
-                                          (!rflags-slice :of 1 0))))
-                      (mv output-rflags undefined-flags)))))
+                     (undefined-flags (the (unsigned-byte 32)
+                                        (!rflags-slice :of 1 0))))
+                  (mv output-rflags undefined-flags)))))
 
-              (output-rflags (mbe :logic (n32 output-rflags)
-                                  :exec output-rflags)))
+            (output-rflags (mbe :logic (n32 output-rflags)
+                                :exec output-rflags)))
 
-             (mv result output-rflags undefined-flags))
+         (mv result output-rflags undefined-flags))
 
-         ///
+       ///
 
-         (defthm-usb ,(mk-name "N" str-nbits "-MV-NTH-0-" fn-name)
-           :bound ,size
-           :concl (mv-nth 0 (,fn-name dst src input-rflags))
-           :gen-type t
-           :gen-linear t)
+       (local (in-theory (e/d () (unsigned-byte-p))))
 
-         (defthm-usb ,(mk-name "MV-NTH-1-" fn-name)
-           :bound 32
-           :concl (mv-nth 1 (,fn-name dst src input-rflags))
-           :gen-type t
-           :gen-linear t)
+       (defthm-usb ,(mk-name "N" str-nbits "-MV-NTH-0-" fn-name)
+         :bound ,size
+         :concl (mv-nth 0 (,fn-name dst src input-rflags))
+         :gen-type t
+         :gen-linear t)
 
-         (defthm-usb ,(mk-name "MV-NTH-2-" fn-name)
-           :bound 32
-           :concl (mv-nth 2 (,fn-name dst src input-rflags))
-           :gen-type t
-           :gen-linear t))
-      ))
+       (defthm-usb ,(mk-name "MV-NTH-1-" fn-name)
+         :bound 32
+         :concl (mv-nth 1 (,fn-name dst src input-rflags))
+         :gen-type t
+         :gen-linear t)
+
+       (defthm-usb ,(mk-name "MV-NTH-2-" fn-name)
+         :bound 32
+         :concl (mv-nth 2 (,fn-name dst src input-rflags))
+         :gen-type t
+         :gen-linear t))
+    ))
 
 (make-event (ror-spec-gen  8))
 (make-event (ror-spec-gen 16))


### PR DESCRIPTION
Removed dependency on arithmetic-5 for centaur/bitops/fast-rotate.lisp. Also pushing in Jared's edits to build/make_cert_help.pl to support extracting PBS directives from .acl2 files.