### PR TITLE
Fixing a typo

### DIFF
--- a/books/centaur/sv/svtv/process.lisp
+++ b/books/centaur/sv/svtv/process.lisp
@@ -1545,7 +1545,7 @@ an error like:</p>
 
 @({ ERROR: some bits assumed to be Boolean were not. })
 
-<p>If you see such an error, you should set @(':boolmasks nil').</p>
+<p>If you see such an error, you should set @(':boolvars nil').</p>
 
 <h3>Decomposition Proofs</h3>
 


### PR DESCRIPTION
@solswords Can you please confirm that this was indeed a typo and merge?  It looks to me like `:boolvars` is the right argument to `svtv-run`, not `:boolmasks`, and I'm guessing this documentation just got outdated as you cleaned up the interface.