### PR TITLE
Fix bug in STRUCTURAL-DECOMP-HINT-CAREFUL

### DIFF
--- a/books/clause-processors/decomp-hint.lisp
+++ b/books/clause-processors/decomp-hint.lisp
@@ -171,7 +171,7 @@
         (value
          `(:computed-hint-replacement
            ((structural-decomp-hint-careful
-             clause ',arg stable-under-simplificationp world ',def-alist ',exclude))
+             clause ',arg stable-under-simplificationp state ',def-alist ',exclude))
            :expand ,expands)))
        ;; Heuristically decide based on presence in the conclusion
        ;; or in rest of clause whether to prefer expanding


### PR DESCRIPTION
The function needs to accept `state` rather than `world`.  This function
is not actually used anywhere in the books so it seems this bug was
overlooked.

cc @solswords for confirmation