### PR TITLE
Fixing bug in vl-to-svex-main

### DIFF
--- a/books/centaur/sv/vl/top.lisp
+++ b/books/centaur/sv/vl/top.lisp
@@ -253,7 +253,9 @@
         (cw-unformatted (vl-reportcard-to-string (vl-design-reportcard good)))
         (cw "Reportcard for bad mods:~%")
         (cw-unformatted (vl-reportcard-to-string (vl-design-reportcard bad)))
-        (mv (msg "The following modules were not among the good simplified modules.~%" bad-mods)
+        (mv (msg "The following modules were not among the good simplified ~
+                  modules: ~x0~%"
+                 bad-mods)
             nil
             good bad))
        (good.mods (redundant-mergesort good.mods))


### PR DESCRIPTION
@solswords or @jaredcdavis Can you please merge as appropriate?

I haven't built the entire regression yet (just the books that I've modified), because it'll be built as part of the port from `testing` to `master`.  But, with this change my massive example is making it to the next stage (still failing though, because the module can't be converted to svex).  I think this change can be confirmed as correct just by inspection.