### PR TITLE
Jvm overload

### DIFF
--- a/books/models/jvm/m5/apprentice-state.lisp
+++ b/books/models/jvm/m5/apprentice-state.lisp
@@ -17,25 +17,25 @@ JSM
                      '()
                      '()
                      (list
-                        '("<init>" () nil
+                        '("<init>()V" () nil
                            (aload_0)
-                           (invokespecial "java.lang.Object" "<init>" 0)
+                           (invokespecial "java.lang.Object" "<init>()V" 0)
                            (return))
-                        '("main" (java.lang.String[]) nil
+                        '("main([Ljava/lang/String;)V" (java.lang.String[]) nil
                            (new "Container")
                            (dup)
-                           (invokespecial "Container" "<init>" 0)
+                           (invokespecial "Container" "<init>()V" 0)
                            (astore_1)
                            (goto LABEL::TAG_0)
                            (LABEL::TAG_0 new "Job")
                            (dup)
-                           (invokespecial "Job" "<init>" 0)
+                           (invokespecial "Job" "<init>()V" 0)
                            (astore_2)
                            (aload_2)
                            (aload_1)
-                           (invokevirtual "Job" "setref" 1)
+                           (invokevirtual "Job" "setref(LContainer;)V" 1)
                            (aload_2)
-                           (invokevirtual "java.lang.Thread" "start" 0)
+                           (invokevirtual "java.lang.Thread" "start()V" 0)
                            (goto LABEL::TAG_0)))
                      '(REF -1))
     (make-class-decl "Container"
@@ -44,9 +44,9 @@ JSM
                      '()
                      '()
                      (list
-                        '("<init>" () nil
+                        '("<init>()V" () nil
                            (aload_0)
-                           (invokespecial "java.lang.Object" "<init>" 0)
+                           (invokespecial "java.lang.Object" "<init>()V" 0)
                            (return)))
                      '(REF -1))
     (make-class-decl "Job"
@@ -55,11 +55,11 @@ JSM
                      '()
                      '()
                      (list
-                        '("<init>" () nil
+                        '("<init>()V" () nil
                            (aload_0)
-                           (invokespecial "java.lang.Thread" "<init>" 0)
+                           (invokespecial "java.lang.Thread" "<init>()V" 0)
                            (return))
-                        '("incr" () nil
+                        '("incr()LJob;" () nil
                            (aload_0)
                            (getfield "Job" "objref")
                            (astore_1)
@@ -83,15 +83,15 @@ JSM
                            (athrow)
                            (LABEL::TAG_0 aload_0)
                            (areturn))
-                        '("setref" (Container) nil
+                        '("setref(LContainer;)V" (Container) nil
                            (aload_0)
                            (aload_1)
                            (putfield "Job" "objref")
                            (return))
-                        '("run" () nil
+                        '("run()V" () nil
                            (goto LABEL::TAG_0)
                            (LABEL::TAG_0 aload_0)
-                           (invokevirtual "Job" "incr" 0)
+                           (invokevirtual "Job" "incr()LJob;" 0)
                            (pop)
                            (goto LABEL::TAG_0)))
                      '(REF -1)))))
@@ -99,18 +99,18 @@ JSM
 (defconst *Apprentice-main*
    '((new "Container")
      (dup)
-     (invokespecial "Container" "<init>" 0)
+     (invokespecial "Container" "<init>()V" 0)
      (astore_1)
      (goto LABEL::TAG_0)
      (LABEL::TAG_0 new "Job")
      (dup)
-     (invokespecial "Job" "<init>" 0)
+     (invokespecial "Job" "<init>()V" 0)
      (astore_2)
      (aload_2)
      (aload_1)
-     (invokevirtual "Job" "setref" 1)
+     (invokevirtual "Job" "setref(LContainer;)V" 1)
      (aload_2)
-     (invokevirtual "java.lang.Thread" "start" 0)
+     (invokevirtual "java.lang.Thread" "start()V" 0)
      (goto LABEL::TAG_0)))
 
 (defun Apprentice-ms ()

--- a/books/models/jvm/m5/apprentice.lisp
+++ b/books/models/jvm/m5/apprentice.lisp
@@ -141,14 +141,14 @@ version.
  several useful suggestions for simplifying his original code.  The most
  important was to rearrange the code sequence
     (load job1)
-    (invokevirtual "Job" "start" 0)
+    (invokevirtual "Job" "start()V" 0)
     (load job2)
-    (invokevirtual "Job" "start" 0)
+    (invokevirtual "Job" "start()V" 0)
  to
     (load job2)
     (load job1)
-    (invokevirtual "Job" "start" 0)
-    (invokevirtual "Job" "start" 0)
+    (invokevirtual "Job" "start()V" 0)
+    (invokevirtual "Job" "start()V" 0)
  In retrospect this is not a big deal and could be easily dealt with.
  But at the time I was doing the proof I just couldn't stand the
  idea of carrying more invariants further into the ``pre-*s1*'' state.
@@ -317,34 +317,34 @@ Sun Jul 15 14:17:26 2001
 
 (defconst *java.lang.Thread.<init>*
   '((ALOAD_0)                                     ;;;  0
-    (INVOKESPECIAL "java.lang.Object" "<init>" 0) ;;;  1
+    (INVOKESPECIAL "java.lang.Object" "<init>()V" 0) ;;;  1
     (RETURN)))                                    ;;;  4
 
 (defconst *Apprentice.main*
   '((NEW "Container")                             ;;;  0
     (DUP)                                         ;;;  3
-    (INVOKESPECIAL "Container" "<init>" 0)        ;;;  4
+    (INVOKESPECIAL "Container" "<init>()V" 0)     ;;;  4
     (ASTORE_1)                                    ;;;  7
     (GOTO 3)                                      ;;;  8
     (NEW "Job")                                   ;;; 11
     (DUP)                                         ;;; 14
-    (INVOKESPECIAL "Job" "<init>" 0)              ;;; 15
+    (INVOKESPECIAL "Job" "<init>()V" 0)           ;;; 15
     (ASTORE_2)                                    ;;; 18
     (ALOAD_2)                                     ;;; 19
     (ALOAD_1)                                     ;;; 20
-    (INVOKEVIRTUAL "Job" "setref" 1)              ;;; 21
+    (INVOKEVIRTUAL "Job" "setref(LContainer;)V" 1)       ;;; 21
     (ALOAD_2)                                     ;;; 24
-    (INVOKEVIRTUAL "java.lang.Thread" "start" 0)  ;;; 25
+    (INVOKEVIRTUAL "java.lang.Thread" "start()V" 0) ;;; 25
     (GOTO -17)))                                  ;;; 28
 
 (defconst *Container.<init>*
   '((ALOAD_0)                                     ;;;  0
-    (INVOKESPECIAL "java.lang.Object" "<init>" 0) ;;;  1
+    (INVOKESPECIAL "java.lang.Object" "<init>()V" 0) ;;;  1
     (RETURN)))                                    ;;;  4
 
 (defconst *Job.<init>*
   '((ALOAD_0)                                     ;;;  0
-    (INVOKESPECIAL "java.lang.Thread" "<init>" 0) ;;;  1
+    (INVOKESPECIAL "java.lang.Thread" "<init>()V" 0) ;;;  1
     (RETURN)))                                    ;;;  4
 
 (defconst *Job.incr*
@@ -381,7 +381,7 @@ Sun Jul 15 14:17:26 2001
 (defconst *Job.run*
   '((GOTO 3)                                      ;;;  0
     (ALOAD_0)                                     ;;;  3
-    (INVOKEVIRTUAL "Job" "incr" 0)                ;;;  4
+    (INVOKEVIRTUAL "Job" "incr()LJob;" 0)         ;;;  4
     (POP)                                         ;;;  7
     (GOTO -5)))                                   ;;;  8
 
@@ -401,33 +401,33 @@ Sun Jul 15 14:17:26 2001
   (cond
    ((equal class "java.lang.Object")
     (cond
-     ((equal method "<init>")
+     ((equal method "<init>()V")
       *java.lang.Object.<init>*)
      (t nil)))
    ((equal class "java.lang.Thread")
     (cond
-     ((equal method "<init>")
+     ((equal method "<init>()V")
       *java.lang.Thread.<init>*)
      (t nil)))
    ((equal class "Apprentice")
     (cond
-     ((equal method "main")
+     ((equal method "main([Ljava/lang/String;)V")
       *Apprentice.main*)
      (t nil)))
    ((equal class "Container")
     (cond
-     ((equal method "<init>")
+     ((equal method "<init>()V")
       *Container.<init>*)
      (t nil)))
    ((equal class "Job")
     (cond
-     ((equal method "<init>")
+     ((equal method "<init>()V")
       *Job.<init>*)
-     ((equal method "incr")
+     ((equal method "incr()LJob;")
       *Job.incr*)
-     ((equal method "setref")
+     ((equal method "setref(LContainer;)V")
       *Job.setref*)
-     ((equal method "run")
+     ((equal method "run()V")
       *Job.run*)
      (t nil)))
    (t nil)))
@@ -540,7 +540,7 @@ Sun Jul 15 14:17:26 2001
   (let ((pc      (pc frame))
         (flg     (sync-flg frame)))
     (and
-     (programp frame "java.lang.Object" "<init>")
+     (programp frame "java.lang.Object" "<init>()V")
      (equal flg 'UNLOCKED)
      (equal pc 0))))
 
@@ -548,7 +548,7 @@ Sun Jul 15 14:17:26 2001
   (let ((pc      (pc frame))
         (flg     (sync-flg frame)))
     (and
-     (programp frame "java.lang.Thread" "<init>")
+     (programp frame "java.lang.Thread" "<init>()V")
      (equal flg 'UNLOCKED)
      (or (equal pc 0)
          (equal pc 1)
@@ -558,7 +558,7 @@ Sun Jul 15 14:17:26 2001
   (let ((pc      (pc frame))
         (flg     (sync-flg frame)))
     (and
-     (programp frame "Container" "<init>")
+     (programp frame "Container" "<init>()V")
      (equal flg 'UNLOCKED)
      (or (equal pc 0)
          (equal pc 1)
@@ -568,7 +568,7 @@ Sun Jul 15 14:17:26 2001
   (let ((pc      (pc frame))
         (flg     (sync-flg frame)))
     (and
-     (programp frame "Job" "<init>")
+     (programp frame "Job" "<init>()V")
      (equal flg 'UNLOCKED)
      (or (equal pc 0)
          (equal pc 1)
@@ -580,7 +580,7 @@ Sun Jul 15 14:17:26 2001
         (stack   (stack frame))
         (flg     (sync-flg frame)))
     (and
-     (programp frame "Job" "setref")
+     (programp frame "Job" "setref(LContainer;)V")
      (equal locals `((REF ,i) (REF 8)))
      (equal flg 'UNLOCKED)
      (case pc
@@ -605,7 +605,7 @@ Sun Jul 15 14:17:26 2001
          (container (nth 1 locals))
          (job       (nth 2 locals)))
     (and
-     (programp frame "Apprentice" "main")
+     (programp frame "Apprentice" "main([Ljava/lang/String;)V")
      (equal flg 'UNLOCKED)
      (case pc
        (0 (and (not suspendedp)
@@ -683,9 +683,9 @@ Sun Jul 15 14:17:26 2001
          (equal status 'SCHEDULED)
          (equal rref nil)
          (cond ((endp cs) nil)
-               ((programp (frame0 cs) "java.lang.Object" "<init>")
+               ((programp (frame0 cs) "java.lang.Object" "<init>()V")
                 (cond
-                 ((programp (frame1 cs) "java.lang.Thread" "<init>")
+                 ((programp (frame1 cs) "java.lang.Thread" "<init>()V")
                   (and (good-java.lang.Object.<init>-frame (frame0 cs))
                        (not (endp (cdr cs)))
                        (good-java.lang.Thread.<init>-frame (frame1 cs))
@@ -693,28 +693,28 @@ Sun Jul 15 14:17:26 2001
                        (good-Job.<init>-frame (frame2 cs))
                        (not (endp (cdddr cs)))
                        (good-main-frame i (frame3 cs) 18)))
-                 ((programp (frame1 cs) "Container" "<init>")
+                 ((programp (frame1 cs) "Container" "<init>()V")
                   (and (good-java.lang.Object.<init>-frame (frame0 cs))
                        (not (endp (cdr cs)))
                        (good-container.<init>-frame (frame1 cs))
                        (not (endp (cddr cs)))
                        (good-main-frame i (frame2 cs) 7)))
                  (t nil)))
-               ((programp (frame0 cs) "java.lang.Thread" "<init>")
+               ((programp (frame0 cs) "java.lang.Thread" "<init>()V")
                 (and (good-java.lang.Thread.<init>-frame (frame0 cs))
                      (not (endp (cdr cs)))
                      (good-Job.<init>-frame (frame1 cs))
                      (not (endp (cddr cs)))
                      (good-main-frame i (frame2 cs) 18)))
-               ((programp (frame0 cs) "Container" "<init>")
+               ((programp (frame0 cs) "Container" "<init>()V")
                 (and (good-container.<init>-frame (frame0 cs))
                      (not (endp (cdr cs)))
                      (good-main-frame i (frame1 cs) 7)))
-               ((programp (frame0 cs) "Job" "<init>")
+               ((programp (frame0 cs) "Job" "<init>()V")
                 (and (good-Job.<init>-frame (frame0 cs))
                      (not (endp (cdr cs)))
                      (good-main-frame i (frame1 cs) 18)))
-               ((programp (frame0 cs) "Job" "setref")
+               ((programp (frame0 cs) "Job" "setref(LContainer;)V")
                 (and (good-Job.setref-frame i (frame0 cs))
                      (not (endp (cdr cs)))
                      (good-main-frame i (frame1 cs) 24)))
@@ -815,9 +815,9 @@ Sun Jul 15 14:17:26 2001
 ; the pc in the main frame?  The main frame may be suspended,
 ; of course.
 
-  (cond ((programp (frame0 cs) "java.lang.Object" "<init>")
+  (cond ((programp (frame0 cs) "java.lang.Object" "<init>()V")
          (cond
-          ((programp (frame1 cs) "java.lang.Thread" "<init>")
+          ((programp (frame1 cs) "java.lang.Thread" "<init>()V")
 
 ; The main frame is suspended waiting for the Job.<init>.
 
@@ -827,13 +827,13 @@ Sun Jul 15 14:17:26 2001
 ; frame is suspended waiting for Container.<init>.
 
            7)))
-        ((programp (frame0 cs) "java.lang.Thread" "<init>")
+        ((programp (frame0 cs) "java.lang.Thread" "<init>()V")
          18)
-        ((programp (frame0 cs) "Container" "<init>")
+        ((programp (frame0 cs) "Container" "<init>()V")
          7)
-        ((programp (frame0 cs) "Job" "<init>")
+        ((programp (frame0 cs) "Job" "<init>()V")
          18)
-        ((programp (frame0 cs) "Job" "setref")
+        ((programp (frame0 cs) "Job" "setref(LContainer;)V")
          24)
         (t (pc (frame0 cs)))))
 
@@ -945,7 +945,7 @@ Sun Jul 15 14:17:26 2001
         (stack (stack frame))
         (flg   (sync-flg frame)))
     (and
-     (programp frame "Job" "run")
+     (programp frame "Job" "run()V")
      (equal locals `((REF ,(+ 8 th))))
      (equal flg 'UNLOCKED)
      (if activep
@@ -973,7 +973,7 @@ Sun Jul 15 14:17:26 2001
         (flg   (sync-flg frame))
         (self `(REF ,(+ 8 th))))
     (and
-     (programp frame "Job" "incr")
+     (programp frame "Job" "incr()LJob;")
      (equal flg 'UNLOCKED)
      (case pc
        (0 (and (equal locals `(,self))
@@ -1064,7 +1064,7 @@ Sun Jul 15 14:17:26 2001
                 (and (good-run-frame th (frame0 cs) t monitor mcount)
                      (null (cdr cs))))
                ((endp cs) nil)
-               ((programp (frame0 cs) "Job" "incr")
+               ((programp (frame0 cs) "Job" "incr()LJob;")
                 (and (good-incr-frame th (frame0 cs) counter monitor mcount)
                      (not (endp (frame0 cs)))
                      (good-run-frame th (frame1 cs) nil monitor mcount)))
@@ -1930,8 +1930,8 @@ Sun Jul 15 14:17:26 2001
 (defthm lookup-method-incr
   (implies (and (equal ct (class-table *a0*))
                 (force (equal class "Job")))
-           (equal (lookup-method "incr" class ct)
-                  '("incr" NIL NIL
+           (equal (lookup-method "incr()LJob;" class ct)
+                  '("incr()LJob;" NIL NIL
                     (ALOAD_0)
                     (GETFIELD "Job" "objref")
                     (ASTORE_1)
@@ -1959,11 +1959,11 @@ Sun Jul 15 14:17:26 2001
 (defthm lookup-method-run
   (implies (and (equal ct (class-table *a0*))
                 (force (equal class "Job")))
-           (equal (lookup-method "run" class ct)
-                  '("run" NIL NIL
+           (equal (lookup-method "run()V" class ct)
+                  '("run()V" NIL NIL
                     (GOTO 3)
                     (ALOAD_0)
-                    (INVOKEVIRTUAL "Job" "incr" 0)
+                    (INVOKEVIRTUAL "Job" "incr()LJob;" 0)
                     (POP)
                     (GOTO -5)))))
 
@@ -2588,7 +2588,7 @@ Sun Jul 15 14:17:26 2001
   (11 job3))
  (("java.lang.Object" NIL ("monitor" "mcount" "wait-set")
                       NIL
-                      NIL (("<init>" NIL NIL (RETURN)))
+                      NIL (("<init>()V" NIL NIL (RETURN)))
                       (REF 0))
   ("ARRAY" ("java.lang.Object")
            (("<array>" . *ARRAY*))
@@ -2596,64 +2596,64 @@ Sun Jul 15 14:17:26 2001
   ("java.lang.Thread"
        ("java.lang.Object")
        NIL NIL NIL
-       (("run" NIL NIL (RETURN))
-        ("start" NIL NIL NIL)
-        ("stop" NIL NIL NIL)
-        ("<init>" NIL NIL (ALOAD_0)
-                  (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (("run()V" NIL NIL (RETURN))
+        ("start()V" NIL NIL NIL)
+        ("stop()V" NIL NIL NIL)
+        ("<init>()V" NIL NIL (ALOAD_0)
+                  (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
                   (RETURN)))
        (REF 2))
   ("java.lang.String"
        ("java.lang.Object")
        ("strcontents")
        NIL NIL
-       (("<init>" NIL NIL (ALOAD_0)
-                  (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (("<init>()V" NIL NIL (ALOAD_0)
+                  (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
                   (RETURN)))
        (REF 3))
   ("java.lang.Class"
        ("java.lang.Object")
        NIL NIL NIL
-       (("<init>" NIL NIL (ALOAD_0)
-                  (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (("<init>()V" NIL NIL (ALOAD_0)
+                  (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
                   (RETURN)))
        (REF 4))
   ("Apprentice" ("java.lang.Object")
                 NIL NIL NIL
-                (("<init>" NIL NIL (ALOAD_0)
-                           (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+                (("<init>()V" NIL NIL (ALOAD_0)
+                           (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
                            (RETURN))
-                 ("main" (|JAVA.LANG.STRING[]|)
+                 ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|)
                          NIL (NEW "Container")
                          (DUP)
-                         (INVOKESPECIAL "Container" "<init>" 0)
+                         (INVOKESPECIAL "Container" "<init>()V" 0)
                          (ASTORE_1)
                          (GOTO 3)
                          (NEW "Job")
                          (DUP)
-                         (INVOKESPECIAL "Job" "<init>" 0)
+                         (INVOKESPECIAL "Job" "<init>()V" 0)
                          (ASTORE_2)
                          (ALOAD_2)
                          (ALOAD_1)
-                         (INVOKEVIRTUAL "Job" "setref" 1)
+                         (INVOKEVIRTUAL "Job" "setref(LContainer;)V" 1)
                          (ALOAD_2)
-                         (INVOKEVIRTUAL "java.lang.Thread" "start" 0)
+                         (INVOKEVIRTUAL "java.lang.Thread" "start()V" 0)
                          (GOTO -17)))
                 (REF 5))
   ("Container" ("java.lang.Object")
                ("counter")
                NIL NIL
-               (("<init>" NIL NIL (ALOAD_0)
-                          (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+               (("<init>()V" NIL NIL (ALOAD_0)
+                          (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
                           (RETURN)))
                (REF 6))
   ("Job" ("java.lang.Thread" "java.lang.Object")
          ("objref")
          NIL NIL
-         (("<init>" NIL NIL (ALOAD_0)
-                    (INVOKESPECIAL "java.lang.Thread" "<init>" 0)
+         (("<init>()V" NIL NIL (ALOAD_0)
+                    (INVOKESPECIAL "java.lang.Thread" "<init>()V" 0)
                     (RETURN))
-          ("incr" NIL NIL (ALOAD_0)
+          ("incr()LJob;" NIL NIL (ALOAD_0)
                   (GETFIELD "Job" "objref")
                   (ASTORE_1)
                   (ALOAD_1)
@@ -2676,14 +2676,14 @@ Sun Jul 15 14:17:26 2001
                   (ATHROW)
                   (ALOAD_0)
                   (ARETURN))
-          ("setref" (CONTAINER)
+          ("setref(LContainer;)V" (CONTAINER)
                     NIL (ALOAD_0)
                     (ALOAD_1)
                     (PUTFIELD "Job" "objref")
                     (RETURN))
           ("run" NIL NIL (GOTO 3)
                  (ALOAD_0)
-                 (INVOKEVIRTUAL "Job" "incr" 0)
+                 (INVOKEVIRTUAL "Job" "incr()LJob;" 0)
                  (POP)
                  (GOTO -5)))
          (REF 7)))))

--- a/books/models/jvm/m5/demo.lisp
+++ b/books/models/jvm/m5/demo.lisp
@@ -107,29 +107,29 @@ Below is the output of jvm2acl2 for M5.
      '("ans")
      '()
      (list
-      '("<init>" () nil
+      '("<init>()V" () nil
         (aload_0)
-        (invokespecial "java.lang.Object" "<init>" 0)
+        (invokespecial "java.lang.Object" "<init>()V" 0)
         (return))
-      '("fact" (int) nil
+      '("fact(I)I" (int) nil
         (iload_0)
         (ifle LABEL::TAG_0)
         (iload_0)
         (iload_0)
         (iconst_1)
         (isub)
-        (invokestatic "Demo" "fact" 1)
+        (invokestatic "Demo" "fact(I)I" 1)
         (imul)
         (ireturn)
         (LABEL::TAG_0 iconst_1)
         (ireturn))
-      '("main" (java.lang.String[]) nil
+      '("main([Ljava/lang/String;)V" (java.lang.String[]) nil
         (iconst_4)
         (istore_1)
         (iload_1)
         (iconst_1)
         (iadd)
-        (invokestatic "Demo" "fact" 1)
+        (invokestatic "Demo" "fact(I)I" 1)
         (putstatic "Demo" "ans" nil)
         (return)))
      '(REF -1)))))
@@ -140,7 +140,7 @@ Below is the output of jvm2acl2 for M5.
     (iload_1)
     (iconst_1)
     (iadd)
-    (invokestatic "Demo" "fact" 1)
+    (invokestatic "Demo" "fact(I)I" 1)
     (putstatic "Demo" "ans" nil)
     (return)))
 
@@ -167,7 +167,7 @@ Below is the output of jvm2acl2 for M5.
           (ILOAD_1)
           (ICONST_1)
           (IADD)
-          (INVOKESTATIC "Demo" "fact" 1)
+          (INVOKESTATIC "Demo" "fact(I)I" 1)
           (PUTSTATIC "Demo" "ans" NIL)
           (RETURN))
          UNLOCKED "Demo"))
@@ -198,7 +198,7 @@ Below is the output of jvm2acl2 for M5.
       ("mcount" . 0)
       ("wait-set" . 0))))
  (("java.lang.Object" NIL ("monitor" "mcount" "wait-set")
-   NIL NIL (("<init>" NIL NIL (RETURN)))
+   NIL NIL (("<init>()V" NIL NIL (RETURN)))
    (REF 0))
   ("ARRAY" ("java.lang.Object")
    (("<array>" . *ARRAY*))
@@ -206,52 +206,52 @@ Below is the output of jvm2acl2 for M5.
   ("java.lang.Thread"
    ("java.lang.Object")
    NIL NIL NIL
-   (("run" NIL NIL (RETURN))
-    ("start" NIL NIL NIL)
-    ("stop" NIL NIL NIL)
-    ("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("run()V" NIL NIL (RETURN))
+    ("start()V" NIL NIL NIL)
+    ("stop()V" NIL NIL NIL)
+    ("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 2))
   ("java.lang.String"
    ("java.lang.Object")
    ("strcontents")
    NIL NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 3))
   ("java.lang.Class" ("java.lang.Object")
    NIL NIL NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 4))
   ("Demo" ("java.lang.Object")
    NIL ("ans")
    NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN))
-    ("fact" (INT)
+    ("fact(I)I" (INT)
      NIL (ILOAD_0)
      (IFLE 12)
      (ILOAD_0)
      (ILOAD_0)
      (ICONST_1)
      (ISUB)
-     (INVOKESTATIC "Demo" "fact" 1)
+     (INVOKESTATIC "Demo" "fact(I)I" 1)
      (IMUL)
      (IRETURN)
      (ICONST_1)
      (IRETURN))
-    ("main" (|JAVA.LANG.STRING[]|)
+    ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|)
      NIL (ICONST_4)
      (ISTORE_1)
      (ILOAD_1)
      (ICONST_1)
      (IADD)
-     (INVOKESTATIC "Demo" "fact" 1)
+     (INVOKESTATIC "Demo" "fact(I)I" 1)
      (PUTSTATIC "Demo" "ans" NIL)
      (RETURN)))
    (REF 5))))
@@ -276,7 +276,7 @@ Below is the output of jvm2acl2 for M5.
                (ILOAD\_1)
                (ICONST\_1)
                (IADD)
-               (INVOKESTATIC "Demo" "fact" 1)
+               (INVOKESTATIC "Demo" "fact(I)I" 1)
                (PUTSTATIC "Demo" "ans" NIL)
                (RETURN))
              'UNLOCKED
@@ -330,7 +330,7 @@ Below is the output of jvm2acl2 for M5.
      ("monitor" "mcount" "wait-set")
      NIL
      NIL
-     (("<init>" NIL NIL (RETURN)))
+     (("<init>()V" NIL NIL (RETURN)))
      (REF 0))
     ("ARRAY"
      ("java.lang.Object")
@@ -344,11 +344,11 @@ Below is the output of jvm2acl2 for M5.
      NIL
      NIL
      NIL
-     (("run" NIL NIL (RETURN))
-      ("start" NIL NIL NIL)
-      ("stop" NIL NIL NIL)
-      ("<init>" NIL NIL (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+     (("run()V" NIL NIL (RETURN))
+      ("start()V" NIL NIL NIL)
+      ("stop()V" NIL NIL NIL)
+      ("<init>()V" NIL NIL (ALOAD\_0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 2))
     ("java.lang.String"
@@ -356,9 +356,9 @@ Below is the output of jvm2acl2 for M5.
      ("strcontents")
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 3))
     ("java.lang.Class"
@@ -366,9 +366,9 @@ Below is the output of jvm2acl2 for M5.
      NIL
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 4))
     ("Demo"
@@ -376,29 +376,29 @@ Below is the output of jvm2acl2 for M5.
      NIL
      ("ans")
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN))
-      ("fact" (INT) NIL
+      ("fact(I)I" (INT) NIL
        (ILOAD\_0)
        (IFLE 12)
        (ILOAD\_0)
        (ILOAD\_0)
        (ICONST\_1)
        (ISUB)
-       (INVOKESTATIC "Demo" "fact" 1)
+       (INVOKESTATIC "Demo" "fact(I)I" 1)
        (IMUL)
        (IRETURN)
        (ICONST\_1)
        (IRETURN))
-      ("main" (|JAVA.LANG.STRING[]|) NIL
+      ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|) NIL
        (ICONST\_4)
        (ISTORE\_1)
        (ILOAD\_1)
        (ICONST\_1)
        (IADD)
-       (INVOKESTATIC "Demo" "fact" 1)
+       (INVOKESTATIC "Demo" "fact(I)I" 1)
        (PUTSTATIC "Demo" "ans" NIL)
        (RETURN)))
      (REF 5))))
@@ -488,7 +488,7 @@ Below is the output of jvm2acl2 for M5.
                        (list n)
                        nil
                        '((ILOAD\_0)
-                         (INVOKESTATIC "Demo" "fact" 1)
+                         (INVOKESTATIC "Demo" "fact(I)I" 1)
                          (PUTSTATIC "Demo" "ans" NIL)
                          (RETURN))
                        'UNLOCKED
@@ -512,14 +512,14 @@ T
 ; Proving Fact Correct
 
 (defconst *fact-def*
-  '("fact" (INT) NIL
+  '("fact(I)I" (INT) NIL
     (ILOAD_0)                         ;;;  0
     (IFLE 12)                         ;;;  1
     (ILOAD_0)                         ;;;  4
     (ILOAD_0)                         ;;;  5
     (ICONST_1)                        ;;;  6
     (ISUB)                            ;;;  7
-    (INVOKESTATIC "Demo" "fact" 1)    ;;;  8
+    (INVOKESTATIC "Demo" "fact(I)I" 1)    ;;;  8
     (IMUL)                            ;;; 11
     (IRETURN)                         ;;; 12
     (ICONST_1)                        ;;; 13
@@ -527,10 +527,10 @@ T
 
 (defun poised-to-invoke-fact (th s n)
   (and (equal (status th s) 'SCHEDULED)
-       (equal (next-inst th s) '(invokestatic "Demo" "fact" 1))
+       (equal (next-inst th s) '(invokestatic "Demo" "fact(I)I" 1))
        (equal n (top (stack (top-frame th s))))
        (intp n)
-       (equal (lookup-method "fact" "Demo" (class-table s))
+       (equal (lookup-method "fact(I)I" "Demo" (class-table s))
               *fact-def*)))
 
 (defun induction-hint (th s n)
@@ -649,7 +649,7 @@ T
                                  (iload_3)
                                  (iconst_1)
                                  (iadd)
-                                 (invokestatic "Demo" "fact" 1)
+                                 (invokestatic "Demo" "fact(I)I" 1)
                                  (imul)
                                  (istore_3))
                                'UNLOCKED
@@ -673,7 +673,7 @@ T
                         (iload_3)
                         (iconst_1)
                         (iadd)
-                        (invokestatic "Demo" "fact" 1)
+                        (invokestatic "Demo" "fact(I)I" 1)
                         (imul)
                         (istore_3))
                       'UNLOCKED

--- a/books/models/jvm/m5/idemo.lisp
+++ b/books/models/jvm/m5/idemo.lisp
@@ -80,7 +80,7 @@ Method int ifact(int)
              '((ICONST\_4)
                (ICONST\_4)
                (IADD)
-               (INVOKESTATIC "IDemo" "ifact" 1)
+               (INVOKESTATIC "IDemo" "ifact(I)I" 1)
                (HALT))
              'UNLOCKED
              "IDemo")
@@ -132,7 +132,7 @@ Method int ifact(int)
      ("monitor" "mcount" "wait-set")
      NIL
      NIL
-     (("<init>" NIL NIL (RETURN)))
+     (("<init>()V" NIL NIL (RETURN)))
      (REF 0))
     ("ARRAY"
      ("java.lang.Object")
@@ -146,11 +146,11 @@ Method int ifact(int)
      NIL
      NIL
      NIL
-     (("run" NIL NIL (RETURN))
-      ("start" NIL NIL NIL)
-      ("stop" NIL NIL NIL)
-      ("<init>" NIL NIL (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+     (("run()V" NIL NIL (RETURN))
+      ("start()V" NIL NIL NIL)
+      ("stop()V" NIL NIL NIL)
+      ("<init>()V" NIL NIL (ALOAD\_0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 2))
     ("java.lang.String"
@@ -158,9 +158,9 @@ Method int ifact(int)
      ("strcontents")
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 3))
     ("java.lang.Class"
@@ -168,9 +168,9 @@ Method int ifact(int)
      NIL
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 4))
     ("IDemo"
@@ -178,11 +178,11 @@ Method int ifact(int)
      NIL
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN))
-      ("ifact" (INT) NIL
+      ("ifact(I)I" (INT) NIL
        (ICONST\_1)
        (ISTORE\_1)
        (GOTO 11)
@@ -258,7 +258,7 @@ Method int ifact(int)
     (ifactorial (- n 1) (int-fix (* n temp)))))
 
 (defconst *ifact-def*
-  (lookup-method "ifact" "IDemo" *IDemo-class-table*))
+  (lookup-method "ifact(I)I" "IDemo" *IDemo-class-table*))
 
 (defun poised-at-ifact-loop (th s n)
   (and (equal (status th s) 'SCHEDULED)
@@ -324,10 +324,10 @@ Method int ifact(int)
 
 (defun poised-to-invoke-ifact (th s n)
   (and (equal (status th s) 'SCHEDULED)
-       (equal (next-inst th s) '(invokestatic "IDemo" "ifact" 1))
+       (equal (next-inst th s) '(invokestatic "IDemo" "ifact(I)I" 1))
        (equal n (top (stack (top-frame th s))))
        (intp n)
-       (equal (lookup-method "ifact" "IDemo" (class-table s))
+       (equal (lookup-method "ifact(I)I" "IDemo" (class-table s))
               *ifact-def*)))
 
 (defthm ifact-is-correct

--- a/books/models/jvm/m5/isort.lisp
+++ b/books/models/jvm/m5/isort.lisp
@@ -201,7 +201,7 @@ Method ListProc()
      ("monitor" "mcount" "wait-set")
      NIL
      NIL
-     (("<init>" NIL NIL (RETURN)))
+     (("<init>()V" NIL NIL (RETURN)))
      (REF 0))
     ("ARRAY"
      ("java.lang.Object")
@@ -215,11 +215,11 @@ Method ListProc()
      NIL
      NIL
      NIL
-     (("run" NIL NIL (RETURN))
-      ("start" NIL NIL NIL)
-      ("stop" NIL NIL NIL)
-      ("<init>" NIL NIL (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+     (("run()V" NIL NIL (RETURN))
+      ("start()V" NIL NIL NIL)
+      ("stop()V" NIL NIL NIL)
+      ("<init>()V" NIL NIL (ALOAD\_0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 2))
     ("java.lang.String"
@@ -227,9 +227,9 @@ Method ListProc()
      ("strcontents")
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 3))
     ("java.lang.Class"
@@ -237,9 +237,9 @@ Method ListProc()
      NIL
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 4))
     ("Cons"
@@ -247,14 +247,14 @@ Method ListProc()
      ("car" "cdr")
      nil
      nil
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN))
-      ("cons" (int java.lang.Object) nil
+      ("cons(ILjava/lang/Object;)LCons;" (int java.lang.Object) nil
        (NEW "Cons")
        (DUP)
-       (INVOKESPECIAL "Cons" "<init>" 0)
+       (INVOKESPECIAL "Cons" "<init>()V" 0)
        (ASTORE_2)
        (ALOAD_2)
        (ILOAD_0)
@@ -269,16 +269,16 @@ Method ListProc()
      nil
      nil
      nil
-     (("<init>" nil nil
+     (("<init>()V" nil nil
        (ALOAD\_0)
-       (INVOKESPECIAL "Cons" "<init>" 0)
+       (INVOKESPECIAL "Cons" "<init>()V" 0)
        (RETURN))
-      ("insert" (int java.lang.Object) nil
+      ("insert(ILjava/lang/Object;)LCons;" (int java.lang.Object) nil
         (aload_1)
         (ifnonnull 9)
         (iload_0)
         (aload_1)
-        (invokestatic "Cons" "cons" 2)
+        (invokestatic "Cons" "cons(ILjava/lang/Object;)LCons;" 2)
         (areturn)
         (iload_0)
         (aload_1)
@@ -287,7 +287,7 @@ Method ListProc()
         (if_icmpgt 9)
         (iload_0)
         (aload_1)
-        (invokestatic "Cons" "cons" 2)
+        (invokestatic "Cons" "cons(ILjava/lang/Object;)LCons;" 2)
         (areturn)
         (aload_1)
                                   ;;; checkcast "Cons" ommitted
@@ -296,10 +296,10 @@ Method ListProc()
         (aload_1)
                                   ;;; checkcast "Cons" ommitted
         (getfield "Cons" "cdr")
-        (invokestatic "ListProc" "insert" 2)
-        (invokestatic "Cons" "cons" 2)
+        (invokestatic "ListProc" "insert(ILjava/lang/Object;)LCons;" 2)
+        (invokestatic "Cons" "cons(ILjava/lang/Object;)LCons;" 2)
         (areturn))
-      ("isort" (java.lang.Object) nil
+      ("isort(Ljava/lang/Object;)Ljava/Lang/Object;" (java.lang.Object) nil
        (aload_0)
        (ifnonnull 5)
        (aload_0)
@@ -310,8 +310,8 @@ Method ListProc()
        (aload_0)
                                   ;;; checkcast "Cons" ommitted
        (getfield "Cons" "cdr")
-       (invokestatic "ListProc" "isort" 1)
-       (invokestatic "ListProc" "insert" 2)
+       (invokestatic "ListProc" "isort(Ljava/lang/Object;)Ljava/Lang/Object;" 1)
+       (invokestatic "ListProc" "insert(ILjava/lang/Object;)LCons;" 2)
        (areturn)))))))
 
 ; Now we will name some parts of the state for future use.
@@ -326,13 +326,13 @@ Method ListProc()
   (bound? "ListProc" (class-table *Isort-state*)))
 
 (defconst *cons-def*
-  (lookup-method "cons" "Cons" (class-table *Isort-state*)))
+  (lookup-method "cons(ILjava/lang/Object;)LCons;" "Cons" (class-table *Isort-state*)))
 
 (defconst *insert-def*
-  (lookup-method "insert" "ListProc" (class-table *Isort-state*)))
+  (lookup-method "insert(ILjava/lang/Object;)LCons;" "ListProc" (class-table *Isort-state*)))
 
 (defconst *isort-def*
-  (lookup-method "isort" "ListProc" (class-table *Isort-state*)))
+  (lookup-method "isort(Ljava/lang/Object;)Ljava/Lang/Object;" "ListProc" (class-table *Isort-state*)))
 
 (defconst *Isort-heap0*
   (heap *Isort-state*))
@@ -822,10 +822,10 @@ Method ListProc()
                        (bipush 2)
                        (bipush 1)
                        (aload_0)
-                       (invokestatic "Cons" "cons" 2)
-                       (invokestatic "Cons" "cons" 2)
-                       (invokestatic "Cons" "cons" 2)
-                       (invokestatic "ListProc" "isort" 1)
+                       (invokestatic "Cons" "cons(ILjava/lang/Object;)LCons;" 2)
+                       (invokestatic "Cons" "cons(ILjava/lang/Object;)LCons;" 2)
+                       (invokestatic "Cons" "cons(ILjava/lang/Object;)LCons;" 2)
+                       (invokestatic "ListProc" "isort(Ljava/lang/Object;)Ljava/Lang/Object;" 1)
                        (halt))
                      'UNLOCKED
                      "ListProc")
@@ -924,7 +924,7 @@ Method ListProc()
 
 (defun poised-to-invoke-cons (th s)
   (and (standard-hyps th s)
-       (equal (next-inst th s) '(INVOKESTATIC "Cons" "cons" 2))
+       (equal (next-inst th s) '(INVOKESTATIC "Cons" "cons(ILjava/lang/Object;)LCons;" 2))
 ;      (intp (top (pop (stack (top-frame th s)))))
 ;      (ok-refp (top (stack (top-frame th s))) (heap s))
        ))
@@ -1053,7 +1053,7 @@ Method ListProc()
 (defun poised-to-invoke-insert (th s e x heap)
   (and (standard-hyps th s)
        (equal heap (heap s))
-       (equal (next-inst th s) '(INVOKESTATIC "ListProc" "insert" 2))
+       (equal (next-inst th s) '(INVOKESTATIC "ListProc" "insert(ILjava/lang/Object;)LCons;" 2))
        (equal e (top (pop (stack (top-frame th s)))))
        (equal x (top (stack (top-frame th s))))
 ;      (intp e)
@@ -1237,7 +1237,7 @@ Method ListProc()
 (defun poised-to-invoke-isort (th s x heap)
   (and (standard-hyps th s)
        (equal heap (heap s))
-       (equal (next-inst th s) '(INVOKESTATIC "ListProc" "isort" 1))
+       (equal (next-inst th s) '(INVOKESTATIC "ListProc" "isort(Ljava/lang/Object;)Ljava/Lang/Object;" 1))
        (equal x (top (stack (top-frame th s))))
        (ok-refp x (heap s))))
 

--- a/books/models/jvm/m5/jvm-fact-setup.lisp
+++ b/books/models/jvm/m5/jvm-fact-setup.lisp
@@ -107,29 +107,29 @@ Below is the output of jvm2acl2 for M5.
      '("ans")
      '()
      (list
-      '("<init>" () nil
+      '("<init>()V" () nil
         (aload_0)
-        (invokespecial "java.lang.Object" "<init>" 0)
+        (invokespecial "java.lang.Object" "<init>()V" 0)
         (return))
-      '("fact" (int) nil
+      '("fact(I)I" (int) nil
         (iload_0)
         (ifle LABEL::TAG_0)
         (iload_0)
         (iload_0)
         (iconst_1)
         (isub)
-        (invokestatic "Demo" "fact" 1)
+        (invokestatic "Demo" "fact(I)I" 1)
         (imul)
         (ireturn)
         (LABEL::TAG_0 iconst_1)
         (ireturn))
-      '("main" (java.lang.String[]) nil
+      '("main([Ljava/lang/String;)V" (java.lang.String[]) nil
         (iconst_4)
         (istore_1)
         (iload_1)
         (iconst_1)
         (iadd)
-        (invokestatic "Demo" "fact" 1)
+        (invokestatic "Demo" "fact(I)I" 1)
         (putstatic "Demo" "ans" nil)
         (return)))
      '(REF -1)))))
@@ -140,7 +140,7 @@ Below is the output of jvm2acl2 for M5.
     (iload_1)
     (iconst_1)
     (iadd)
-    (invokestatic "Demo" "fact" 1)
+    (invokestatic "Demo" "fact(I)I" 1)
     (putstatic "Demo" "ans" nil)
     (return)))
 
@@ -167,7 +167,7 @@ Below is the output of jvm2acl2 for M5.
           (ILOAD_1)
           (ICONST_1)
           (IADD)
-          (INVOKESTATIC "Demo" "fact" 1)
+          (INVOKESTATIC "Demo" "fact(I)I" 1)
           (PUTSTATIC "Demo" "ans" NIL)
           (RETURN))
          UNLOCKED "Demo"))
@@ -198,7 +198,7 @@ Below is the output of jvm2acl2 for M5.
       ("mcount" . 0)
       ("wait-set" . 0))))
  (("java.lang.Object" NIL ("monitor" "mcount" "wait-set")
-   NIL NIL (("<init>" NIL NIL (RETURN)))
+   NIL NIL (("<init>()V" NIL NIL (RETURN)))
    (REF 0))
   ("ARRAY" ("java.lang.Object")
    (("<array>" . *ARRAY*))
@@ -206,32 +206,32 @@ Below is the output of jvm2acl2 for M5.
   ("java.lang.Thread"
    ("java.lang.Object")
    NIL NIL NIL
-   (("run" NIL NIL (RETURN))
-    ("start" NIL NIL NIL)
-    ("stop" NIL NIL NIL)
-    ("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("run()V" NIL NIL (RETURN))
+    ("start()V" NIL NIL NIL)
+    ("stop()V" NIL NIL NIL)
+    ("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 2))
   ("java.lang.String"
    ("java.lang.Object")
    ("strcontents")
    NIL NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 3))
   ("java.lang.Class" ("java.lang.Object")
    NIL NIL NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 4))
   ("Demo" ("java.lang.Object")
    NIL ("ans")
    NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN))
     ("fact" (INT)
      NIL (ILOAD_0)
@@ -240,18 +240,18 @@ Below is the output of jvm2acl2 for M5.
      (ILOAD_0)
      (ICONST_1)
      (ISUB)
-     (INVOKESTATIC "Demo" "fact" 1)
+     (INVOKESTATIC "Demo" "fact(I)I" 1)
      (IMUL)
      (IRETURN)
      (ICONST_1)
      (IRETURN))
-    ("main" (|JAVA.LANG.STRING[]|)
+    ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|)
      NIL (ICONST_4)
      (ISTORE_1)
      (ILOAD_1)
      (ICONST_1)
      (IADD)
-     (INVOKESTATIC "Demo" "fact" 1)
+     (INVOKESTATIC "Demo" "fact(I)I" 1)
      (PUTSTATIC "Demo" "ans" NIL)
      (RETURN)))
    (REF 5))))
@@ -276,7 +276,7 @@ Below is the output of jvm2acl2 for M5.
                (ILOAD\_1)
                (ICONST\_1)
                (IADD)
-               (INVOKESTATIC "Demo" "fact" 1)
+               (INVOKESTATIC "Demo" "fact(I)I" 1)
                (PUTSTATIC "Demo" "ans" NIL)
                (RETURN))
              'UNLOCKED
@@ -330,7 +330,7 @@ Below is the output of jvm2acl2 for M5.
      ("monitor" "mcount" "wait-set")
      NIL
      NIL
-     (("<init>" NIL NIL (RETURN)))
+     (("<init>()V" NIL NIL (RETURN)))
      (REF 0))
     ("ARRAY"
      ("java.lang.Object")
@@ -344,11 +344,11 @@ Below is the output of jvm2acl2 for M5.
      NIL
      NIL
      NIL
-     (("run" NIL NIL (RETURN))
-      ("start" NIL NIL NIL)
-      ("stop" NIL NIL NIL)
-      ("<init>" NIL NIL (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+     (("run()V" NIL NIL (RETURN))
+      ("start()V" NIL NIL NIL)
+      ("stop()V" NIL NIL NIL)
+      ("<init>()V" NIL NIL (ALOAD\_0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 2))
     ("java.lang.String"
@@ -356,9 +356,9 @@ Below is the output of jvm2acl2 for M5.
      ("strcontents")
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 3))
     ("java.lang.Class"
@@ -366,9 +366,9 @@ Below is the output of jvm2acl2 for M5.
      NIL
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 4))
     ("Demo"
@@ -376,29 +376,29 @@ Below is the output of jvm2acl2 for M5.
      NIL
      ("ans")
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN))
-      ("fact" (INT) NIL
+      ("fact(I)I" (INT) NIL
        (ILOAD\_0)
        (IFLE 12)
        (ILOAD\_0)
        (ILOAD\_0)
        (ICONST\_1)
        (ISUB)
-       (INVOKESTATIC "Demo" "fact" 1)
+       (INVOKESTATIC "Demo" "fact(I)I" 1)
        (IMUL)
        (IRETURN)
        (ICONST\_1)
        (IRETURN))
-      ("main" (|JAVA.LANG.STRING[]|) NIL
+      ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|) NIL
        (ICONST\_4)
        (ISTORE\_1)
        (ILOAD\_1)
        (ICONST\_1)
        (IADD)
-       (INVOKESTATIC "Demo" "fact" 1)
+       (INVOKESTATIC "Demo" "fact(I)I" 1)
        (PUTSTATIC "Demo" "ans" NIL)
        (RETURN)))
      (REF 5))))
@@ -488,7 +488,7 @@ Below is the output of jvm2acl2 for M5.
                        (list n)
                        nil
                        '((ILOAD\_0)
-                         (INVOKESTATIC "Demo" "fact" 1)
+                         (INVOKESTATIC "Demo" "fact(I)I" 1)
                          (PUTSTATIC "Demo" "ans" NIL)
                          (RETURN))
                        'UNLOCKED
@@ -512,14 +512,14 @@ T
 ; Proving Fact Correct
 
 (defconst *fact-def*
-  '("fact" (INT) NIL
+  '("fact(I)I" (INT) NIL
     (ILOAD_0)                         ;;;  0
     (IFLE 12)                         ;;;  1
     (ILOAD_0)                         ;;;  4
     (ILOAD_0)                         ;;;  5
     (ICONST_1)                        ;;;  6
     (ISUB)                            ;;;  7
-    (INVOKESTATIC "Demo" "fact" 1)    ;;;  8
+    (INVOKESTATIC "Demo" "fact(I)I" 1)    ;;;  8
     (IMUL)                            ;;; 11
     (IRETURN)                         ;;; 12
     (ICONST_1)                        ;;; 13
@@ -527,10 +527,10 @@ T
 
 (defun poised-to-invoke-fact (th s n)
   (and (equal (status th s) 'SCHEDULED)
-       (equal (next-inst th s) '(invokestatic "Demo" "fact" 1))
+       (equal (next-inst th s) '(invokestatic "Demo" "fact(I)I" 1))
        (equal n (top (stack (top-frame th s))))
        (intp n)
-       (equal (lookup-method "fact" "Demo" (class-table s))
+       (equal (lookup-method "fact(I)I" "Demo" (class-table s))
               *fact-def*)))
 
 (defun induction-hint (th s n)
@@ -600,7 +600,7 @@ T
                                     (ILOAD_0)
                                     (ICONST_1)
                                     (ISUB)
-                                    (INVOKESTATIC "Demo" "fact" 1)
+                                    (INVOKESTATIC "Demo" "fact(I)I" 1)
                                     (IMUL)
                                     (IRETURN)
                                     (ICONST_1)

--- a/books/models/jvm/m5/partial.lisp
+++ b/books/models/jvm/m5/partial.lisp
@@ -497,14 +497,14 @@
 ; Here is the (redundant) definition of the program.
 
 (defconst *fact-def*
-  '("fact" (INT) NIL
+  '("fact(I)I" (INT) NIL
     (ILOAD_0)                         ;;;  0
     (IFLE 12)                         ;;;  1
     (ILOAD_0)                         ;;;  4
     (ILOAD_0)                         ;;;  5
     (ICONST_1)                        ;;;  6
     (ISUB)                            ;;;  7
-    (INVOKESTATIC "Demo" "fact" 1)    ;;;  8
+    (INVOKESTATIC "Demo" "fact(I)I" 1) ;;;  8
     (IMUL)                            ;;; 11
     (IRETURN)                         ;;; 12
     (ICONST_1)                        ;;; 13
@@ -598,7 +598,7 @@
    (t
     (let ((n (nth 0 (locals (top-frame th s)))))
       (and (equal (program (top-frame th s)) (cdddr *fact-def*))
-           (equal (lookup-method "fact" "Demo" (class-table s))
+           (equal (lookup-method "fact(I)I" "Demo" (class-table s))
                   *fact-def*)
            (equal (sync-flg (top-frame th s)) 'UNLOCKED)
            (intp n0)
@@ -785,7 +785,7 @@
                   (equal (program (top-frame th s0))
                          (cdddr *fact-def*))
                   (equal (sync-flg (top-frame th s0)) 'unlocked)
-                  (equal (lookup-method "fact" "Demo" (class-table s0))
+                  (equal (lookup-method "fact(I)I" "Demo" (class-table s0))
                          *fact-def*)
 
                   (< 1 (sdepth (call-stack th s0)))

--- a/books/models/jvm/m5/universal.lisp
+++ b/books/models/jvm/m5/universal.lisp
@@ -66,7 +66,7 @@ Sun Jun 30 23:21:06 2002
 
 (defconst *universal-state*
   '(((0 ((0 NIL NIL
-            ((INVOKESTATIC "Universal" "universal" 0)
+            ((INVOKESTATIC "Universal" "universal()V" 0)
              (POP)
              (RETURN))
             JVM::UNLOCKED "Universal"))
@@ -96,7 +96,7 @@ Sun Jun 30 23:21:06 2002
          ("mcount" . 0)
          ("wait-set" . 0))))
     (("java.lang.Object" NIL ("monitor" "mcount" "wait-set")
-      NIL NIL (("<init>" NIL NIL (RETURN)))
+      NIL NIL (("<init>()V" NIL NIL (RETURN)))
       (REF 0))
      ("ARRAY" ("java.lang.Object")
       (("<array>" . *ARRAY*))
@@ -104,40 +104,40 @@ Sun Jun 30 23:21:06 2002
      ("java.lang.Thread"
       ("java.lang.Object")
       NIL NIL NIL
-      (("run" NIL NIL (RETURN))
-       ("start" NIL NIL NIL)
-       ("stop" NIL NIL NIL)
-       ("<init>" NIL NIL (ALOAD_0)
-        (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+      (("run()V" NIL NIL (RETURN))
+       ("start()V" NIL NIL NIL)
+       ("stop()V" NIL NIL NIL)
+       ("<init>()V" NIL NIL (ALOAD_0)
+        (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
         (RETURN)))
       (REF 2))
      ("java.lang.String"
       ("java.lang.Object")
       ("strcontents")
       NIL NIL
-      (("<init>" NIL NIL (ALOAD_0)
-        (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+      (("<init>()V" NIL NIL (ALOAD_0)
+        (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
         (RETURN)))
       (REF 3))
      ("java.lang.Class" ("java.lang.Object")
       NIL NIL NIL
-      (("<init>" NIL NIL (ALOAD_0)
-        (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+      (("<init>()V" NIL NIL (ALOAD_0)
+        (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
         (RETURN)))
       (REF 4))
      ("Universal" ("java.lang.Object")
       NIL NIL NIL
-      (("<init>" NIL NIL (ALOAD_0)
-        (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+      (("<init>()V" NIL NIL (ALOAD_0)
+        (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
         (RETURN))
-       ("universal" NIL NIL
+       ("universal()V" NIL NIL
         (ICONST_0)
         (ICONST_1)
         (IADD)
         (GOTO -2))
-       ("main" (|JAVA.LANG.STRING[]|)
+       ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|)
         NIL
-        (INVOKESTATIC "Universal" "universal" 0)
+        (INVOKESTATIC "Universal" "universal()V" 0)
         (POP)
         (RETURN)))
       (REF 5)))))
@@ -224,9 +224,9 @@ Sun Jun 30 23:21:06 2002
 
 (defun poised-to-invoke-universal (th s i)
   (and (equal (status th s) 'SCHEDULED)
-       (equal (next-inst th s) '(INVOKESTATIC "Universal" "universal" 0))
-       (equal (lookup-method "universal" "Universal" (class-table s))
-              '("universal" NIL NIL
+       (equal (next-inst th s) '(INVOKESTATIC "Universal" "universal()V" 0))
+       (equal (lookup-method "universal()V" "Universal" (class-table s))
+              '("universal()V" NIL NIL
                 (ICONST_0)
                 (ICONST_1)
                 (IADD)

--- a/books/models/jvm/m5/universal.lisp
+++ b/books/models/jvm/m5/universal.lisp
@@ -66,7 +66,7 @@ Sun Jun 30 23:21:06 2002
 
 (defconst *universal-state*
   '(((0 ((0 NIL NIL
-            ((INVOKESTATIC "Universal" "universal()V" 0)
+            ((INVOKESTATIC "Universal" "universal()I" 0)
              (POP)
              (RETURN))
             JVM::UNLOCKED "Universal"))
@@ -130,14 +130,14 @@ Sun Jun 30 23:21:06 2002
       (("<init>()V" NIL NIL (ALOAD_0)
         (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
         (RETURN))
-       ("universal()V" NIL NIL
+       ("universal()I" NIL NIL
         (ICONST_0)
         (ICONST_1)
         (IADD)
         (GOTO -2))
        ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|)
         NIL
-        (INVOKESTATIC "Universal" "universal()V" 0)
+        (INVOKESTATIC "Universal" "universal()I" 0)
         (POP)
         (RETURN)))
       (REF 5)))))
@@ -224,9 +224,9 @@ Sun Jun 30 23:21:06 2002
 
 (defun poised-to-invoke-universal (th s i)
   (and (equal (status th s) 'SCHEDULED)
-       (equal (next-inst th s) '(INVOKESTATIC "Universal" "universal()V" 0))
-       (equal (lookup-method "universal()V" "Universal" (class-table s))
-              '("universal()V" NIL NIL
+       (equal (next-inst th s) '(INVOKESTATIC "Universal" "universal()I" 0))
+       (equal (lookup-method "universal()I" "Universal" (class-table s))
+              '("universal()I" NIL NIL
                 (ICONST_0)
                 (ICONST_1)
                 (IADD)

--- a/books/projects/symbolic/generic/factorial-jvm-correct.lisp
+++ b/books/projects/symbolic/generic/factorial-jvm-correct.lisp
@@ -92,7 +92,7 @@ method referred to in "Inductive Assertions and Operational Semantics".
         (t
          (let ((n (nth 0 (locals (top-frame (th) s)))))
            (and (equal (program (top-frame (th) s)) (cdddr *fact-def*))
-                (equal (lookup-method "fact" "Demo" (class-table s))
+                (equal (lookup-method "fact(I)I" "Demo" (class-table s))
                        *fact-def*)
                 (equal (sync-flg (top-frame (th) s)) 'UNLOCKED)
                 (intp n0)
@@ -157,7 +157,7 @@ method referred to in "Inductive Assertions and Operational Semantics".
                (cdddr *fact-def*))
         (equal (status (th) s) 'scheduled)
         (equal (sync-flg (top-frame (th) s)) 'unlocked)
-        (equal (lookup-method "fact" "Demo" (class-table s))
+        (equal (lookup-method "fact(I)I" "Demo" (class-table s))
                *fact-def*)
         (equal (sdepth (call-stack (th) s)) d0)))
 

--- a/books/projects/symbolic/m5/demo.lisp
+++ b/books/projects/symbolic/m5/demo.lisp
@@ -107,29 +107,29 @@ Below is the output of jvm2acl2 for M5.
      '("ans")
      '()
      (list
-      '("<init>" () nil
+      '("<init>()V" () nil
         (aload_0)
-        (invokespecial "java.lang.Object" "<init>" 0)
+        (invokespecial "java.lang.Object" "<init>()V" 0)
         (return))
-      '("fact" (int) nil
+      '("fact(I)I" (int) nil
         (iload_0)
         (ifle LABEL::TAG_0)
         (iload_0)
         (iload_0)
         (iconst_1)
         (isub)
-        (invokestatic "Demo" "fact" 1)
+        (invokestatic "Demo" "fact(I)I" 1)
         (imul)
         (ireturn)
         (LABEL::TAG_0 iconst_1)
         (ireturn))
-      '("main" (java.lang.String[]) nil
+      '("main([Ljava/lang/String;)V" (java.lang.String[]) nil
         (iconst_4)
         (istore_1)
         (iload_1)
         (iconst_1)
         (iadd)
-        (invokestatic "Demo" "fact" 1)
+        (invokestatic "Demo" "fact(I)I" 1)
         (putstatic "Demo" "ans" nil)
         (return)))
      '(REF -1)))))
@@ -140,7 +140,7 @@ Below is the output of jvm2acl2 for M5.
     (iload_1)
     (iconst_1)
     (iadd)
-    (invokestatic "Demo" "fact" 1)
+    (invokestatic "Demo" "fact(I)I" 1)
     (putstatic "Demo" "ans" nil)
     (return)))
 
@@ -167,7 +167,7 @@ Below is the output of jvm2acl2 for M5.
           (ILOAD_1)
           (ICONST_1)
           (IADD)
-          (INVOKESTATIC "Demo" "fact" 1)
+          (INVOKESTATIC "Demo" "fact(I)I" 1)
           (PUTSTATIC "Demo" "ans" NIL)
           (RETURN))
          UNLOCKED "Demo"))
@@ -198,7 +198,7 @@ Below is the output of jvm2acl2 for M5.
       ("mcount" . 0)
       ("wait-set" . 0))))
  (("java.lang.Object" NIL ("monitor" "mcount" "wait-set")
-   NIL NIL (("<init>" NIL NIL (RETURN)))
+   NIL NIL (("<init>()V" NIL NIL (RETURN)))
    (REF 0))
   ("ARRAY" ("java.lang.Object")
    (("<array>" . *ARRAY*))
@@ -206,52 +206,52 @@ Below is the output of jvm2acl2 for M5.
   ("java.lang.Thread"
    ("java.lang.Object")
    NIL NIL NIL
-   (("run" NIL NIL (RETURN))
-    ("start" NIL NIL NIL)
-    ("stop" NIL NIL NIL)
-    ("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("run()V" NIL NIL (RETURN))
+    ("start()V" NIL NIL NIL)
+    ("stop()V" NIL NIL NIL)
+    ("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 2))
   ("java.lang.String"
    ("java.lang.Object")
    ("strcontents")
    NIL NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 3))
   ("java.lang.Class" ("java.lang.Object")
    NIL NIL NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN)))
    (REF 4))
   ("Demo" ("java.lang.Object")
    NIL ("ans")
    NIL
-   (("<init>" NIL NIL (ALOAD_0)
-     (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+   (("<init>()V" NIL NIL (ALOAD_0)
+     (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
      (RETURN))
-    ("fact" (INT)
+    ("fact(I)I" (INT)
      NIL (ILOAD_0)
      (IFLE 12)
      (ILOAD_0)
      (ILOAD_0)
      (ICONST_1)
      (ISUB)
-     (INVOKESTATIC "Demo" "fact" 1)
+     (INVOKESTATIC "Demo" "fact(I)I" 1)
      (IMUL)
      (IRETURN)
      (ICONST_1)
      (IRETURN))
-    ("main" (|JAVA.LANG.STRING[]|)
+    ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|)
      NIL (ICONST_4)
      (ISTORE_1)
      (ILOAD_1)
      (ICONST_1)
      (IADD)
-     (INVOKESTATIC "Demo" "fact" 1)
+     (INVOKESTATIC "Demo" "fact(I)I" 1)
      (PUTSTATIC "Demo" "ans" NIL)
      (RETURN)))
    (REF 5))))
@@ -276,7 +276,7 @@ Below is the output of jvm2acl2 for M5.
                (ILOAD\_1)
                (ICONST\_1)
                (IADD)
-               (INVOKESTATIC "Demo" "fact" 1)
+               (INVOKESTATIC "Demo" "fact(I)I" 1)
                (PUTSTATIC "Demo" "ans" NIL)
                (RETURN))
              'UNLOCKED
@@ -330,7 +330,7 @@ Below is the output of jvm2acl2 for M5.
      ("monitor" "mcount" "wait-set")
      NIL
      NIL
-     (("<init>" NIL NIL (RETURN)))
+     (("<init>()V" NIL NIL (RETURN)))
      (REF 0))
     ("ARRAY"
      ("java.lang.Object")
@@ -344,11 +344,11 @@ Below is the output of jvm2acl2 for M5.
      NIL
      NIL
      NIL
-     (("run" NIL NIL (RETURN))
-      ("start" NIL NIL NIL)
-      ("stop" NIL NIL NIL)
-      ("<init>" NIL NIL (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+     (("run()V" NIL NIL (RETURN))
+      ("start()V" NIL NIL NIL)
+      ("stop()V" NIL NIL NIL)
+      ("<init>()V" NIL NIL (ALOAD\_0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 2))
     ("java.lang.String"
@@ -356,9 +356,9 @@ Below is the output of jvm2acl2 for M5.
      ("strcontents")
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 3))
     ("java.lang.Class"
@@ -366,9 +366,9 @@ Below is the output of jvm2acl2 for M5.
      NIL
      NIL
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN)))
      (REF 4))
     ("Demo"
@@ -376,29 +376,29 @@ Below is the output of jvm2acl2 for M5.
      NIL
      ("ans")
      NIL
-     (("<init>" NIL NIL
+     (("<init>()V" NIL NIL
        (ALOAD\_0)
-       (INVOKESPECIAL "java.lang.Object" "<init>" 0)
+       (INVOKESPECIAL "java.lang.Object" "<init>()V" 0)
        (RETURN))
-      ("fact" (INT) NIL
+      ("fact(I)I" (INT) NIL
        (ILOAD\_0)
        (IFLE 12)
        (ILOAD\_0)
        (ILOAD\_0)
        (ICONST\_1)
        (ISUB)
-       (INVOKESTATIC "Demo" "fact" 1)
+       (INVOKESTATIC "Demo" "fact(I)I" 1)
        (IMUL)
        (IRETURN)
        (ICONST\_1)
        (IRETURN))
-      ("main" (|JAVA.LANG.STRING[]|) NIL
+      ("main([Ljava/lang/String;)V" (|JAVA.LANG.STRING[]|) NIL
        (ICONST\_4)
        (ISTORE\_1)
        (ILOAD\_1)
        (ICONST\_1)
        (IADD)
-       (INVOKESTATIC "Demo" "fact" 1)
+       (INVOKESTATIC "Demo" "fact(I)I" 1)
        (PUTSTATIC "Demo" "ans" NIL)
        (RETURN)))
      (REF 5))))
@@ -488,7 +488,7 @@ Below is the output of jvm2acl2 for M5.
                        (list n)
                        nil
                        '((ILOAD\_0)
-                         (INVOKESTATIC "Demo" "fact" 1)
+                         (INVOKESTATIC "Demo" "fact(I)I" 1)
                          (PUTSTATIC "Demo" "ans" NIL)
                          (RETURN))
                        'UNLOCKED
@@ -512,14 +512,14 @@ T
 ; Proving Fact Correct
 
 (defconst *fact-def*
-  '("fact" (INT) NIL
+  '("fact(I)I" (INT) NIL
     (ILOAD_0)                         ;;;  0
     (IFLE 12)                         ;;;  1
     (ILOAD_0)                         ;;;  4
     (ILOAD_0)                         ;;;  5
     (ICONST_1)                        ;;;  6
     (ISUB)                            ;;;  7
-    (INVOKESTATIC "Demo" "fact" 1)    ;;;  8
+    (INVOKESTATIC "Demo" "fact(I)I" 1) ;;;  8
     (IMUL)                            ;;; 11
     (IRETURN)                         ;;; 12
     (ICONST_1)                        ;;; 13
@@ -527,10 +527,10 @@ T
 
 (defun poised-to-invoke-fact (th s n)
   (and (equal (status th s) 'SCHEDULED)
-       (equal (next-inst th s) '(invokestatic "Demo" "fact" 1))
+       (equal (next-inst th s) '(invokestatic "Demo" "fact(I)I" 1))
        (equal n (top (stack (top-frame th s))))
        (intp n)
-       (equal (lookup-method "fact" "Demo" (class-table s))
+       (equal (lookup-method "fact(I)I" "Demo" (class-table s))
               *fact-def*)))
 
 (defun induction-hint (th s n)
@@ -649,7 +649,7 @@ T
                                  (iload_3)
                                  (iconst_1)
                                  (iadd)
-                                 (invokestatic "Demo" "fact" 1)
+                                 (invokestatic "Demo" "fact(I)I" 1)
                                  (imul)
                                  (istore_3))
                                'UNLOCKED
@@ -673,7 +673,7 @@ T
                         (iload_3)
                         (iconst_1)
                         (iadd)
-                        (invokestatic "Demo" "fact" 1)
+                        (invokestatic "Demo" "fact(I)I" 1)
                         (imul)
                         (istore_3))
                       'UNLOCKED


### PR DESCRIPTION
Method lookup in JVM searches method by class name, method name and method descriptor.
JVM M5 model searched method by class name and method name only. This pull request replaces method names by method name-and-types in all class-decls of JVM M5 which I found in acl2-books.