### PR TITLE
Fixing a typo

### DIFF
--- a/books/centaur/gl/glcp-templates.lisp
+++ b/books/centaur/gl/glcp-templates.lisp
@@ -225,7 +225,7 @@
                   :stobjs ,*glcp-stobjs*))
         (b* ((pathcond (lbfr-hyp-fix pathcond))
              ((when (zp clk))
-              (glcp-interp-error "The clock ran out.~%"))
+              (glcp-interp-error "The clock ran out."))
              ((glcp-er xobj)
               (interp-term x alist contexts . ,*glcp-common-inputs*))
              ((unless (glcp-term-obj-p xobj))


### PR DESCRIPTION
@solswords I don't know why the ~% didn't get interpreted, but it didn't in the following error message:

```
| ACL2 Error in ( DEFTHM SOME-THEOREM-THAT-USES-GL ...):  The clock
| ran out.~%
```