### PR TITLE
Add theorems about ACL2-COUNT of NTH.

### DIFF
--- a/books/std/lists/nth.lisp
+++ b/books/std/lists/nth.lisp
@@ -323,4 +323,22 @@
 (defmacro equal-by-nths-hint ()
   '(equal-by-nths-hint-fn clause))
 
+(defthm acl2-count-of-nth-linear
+  ;; Added by Alessandro Coglio (coglio@kestrel.edu), Kestrel Institute.
+  (implies (consp x)
+           (< (acl2-count (nth i x))
+              (acl2-count x)))
+  :rule-classes :linear)
 
+(defthm acl2-count-of-nth-linear-weak
+  ;; Added by Alessandro Coglio (coglio@kestrel.edu), Kestrel Institute.
+  (<= (acl2-count (nth i x))
+      (acl2-count x))
+  :rule-classes :linear)
+
+(defthm acl2-count-of-nth-rewrite
+  ;; Added by Alessandro Coglio (coglio@kestrel.edu), Kestrel Institute.
+  (equal (< (acl2-count (nth i x))
+            (acl2-count x))
+         (or (consp x)
+             (> (acl2-count x) 0))))


### PR DESCRIPTION
I saw the comment in std/lists/acl2-count.lisp about whether theorems like these should go into that file or into the files for the various list functions. Perhaps they could go into the files for the various list functions, as is already the case in nthcdr.lisp. So this is why I added these to nth.lisp.
