### PR TITLE
Fix divide-by-zero and convert-nan-to-ep in rtl excps.lisp:

### DIFF
--- a/books/rtl/rel11/support/excps.lisp
+++ b/books/rtl/rel11/support/excps.lisp
@@ -94,9 +94,11 @@
         0
       (if (binary-undefined-p op a f b f)
           (set-flag (ibit) 0)
-        (if (or (denormp a f) (denormp b f))
-            (set-flag (dbit) 0)
-          0)))))
+        (if (and (eql op 'div) (zerp b f))
+            (set-flag (zbit) 0)
+          (if (or (denormp a f) (denormp b f))
+              (set-flag (dbit) 0)
+            0))))))
 
 (defun sse-binary-pre-comp-val (op a b f)
   (if (nanp a f)
@@ -105,7 +107,9 @@
         (qnanize b f)
       (if (binary-undefined-p op a f b f)
           (indef f)
-        ()))))
+        (if (and (eql op 'div) (zerp b f))
+            (iencode (logxor (sgnf a f) (sgnf b f)) f)
+          ())))))
 
 (defun sse-binary-pre-comp (op a b mxcsr f)
   (let* ((daz (bitn mxcsr (daz)))
@@ -291,7 +295,7 @@
         (if (= u 0)
             (mv (zencode (if (= (logxor asgn bsgn) csgn)
                              csgn
-                           (if (eql (mxcsr-rc mxcsr)'rdn) 1 0))
+                           (if (eql (mxcsr-rc mxcsr) 'rdn) 1 0))
                          f)
                 0)
           (sse-round u mxcsr f))))))
@@ -354,15 +358,17 @@
         0
       (if (binary-undefined-p op a af b bf)
           (set-flag (ibit) 0)
-        (if (or (denormp a af) (pseudop a af) (denormp b bf) (pseudop b bf))
-            (set-flag (dbit) 0)
-          0)))))
+        (if (and (eql op 'div) (zerp b bf))
+            (set-flag (zbit) 0)
+          (if (or (denormp a af) (pseudop a af) (denormp b bf) (pseudop b bf))
+              (set-flag (dbit) 0)
+            0))))))
 
 (defun convert-nan-to-ep (x f)
   (cat (sgnf x f)
        1
        (1- (expt 2 15))
-       16
+       15
        1
        1
        (manf x f)
@@ -387,7 +393,9 @@
           (qnanize bep (ep))
         (if (binary-undefined-p op a af b bf)
             (indef (ep))
-          ())))))
+          (if (and (eql op 'div) (zerp b bf))
+              (iencode (logxor (sgnf a af) (sgnf b bf)) (ep))
+            ()))))))
 
 (defun x87-binary-pre-comp (op a af b bf)
     (mv (x87-binary-pre-comp-val op a af b bf) (x87-binary-pre-comp-excp op a af b bf)))


### PR DESCRIPTION
I found a pair of issues trying to prove guards in `rtl/rel11/support/excps.lisp `.
Here are suggested fixes:
- Divide operation raises divide-by-zero exception and returns infinity
  when divisor is zero;
- Fix width of `(ep)` exponent in `convert-nan-to-op`.

Here are some tests that demonstrates these issues
; expected behavior
```lisp
(thm (equal (rtl::sse-binary-spec 'rtl::div #x3f800000 #x00000000 #x1f80 (rtl::sp))
            '(#x7f800000 #x1f84)))

(thm (equal (rtl::x87-binary-spec 'rtl::div #x3f800000 (rtl::sp) #x00000000 (rtl::sp) #x3f 0)
            '(#ux7fff_8000_0000_0000_0000 #x04)))

(thm (equal (rtl::x87-sqrt-spec #xffc00000 (rtl::sp) #x3f 0)
            '(#uxffff_c000_0000_0000_0000 #x00)))`
```
; actual behavior
```lisp
(thm (equal (rtl::sse-binary-spec 'rtl::div #x3f800000 #x00000000 #x1f80 (rtl::sp))
            '(#x00000000 #x1f80)))

(thm (equal (rtl::x87-binary-spec 'rtl::div #x3f800000 (rtl::sp) #x00000000 (rtl::sp) #x3f 0)
            '(#ux0000_0000_0000_0000_0000 #x00)))

(thm (equal (rtl::x87-sqrt-spec #xffc00000 (rtl::sp) 0 0)
            '(#ux1_7fff_c000_0000_0000_0000 #x00)))
```