### PR TITLE
Fix x86isa doc topics without proper parents and some other misc. changes

### DIFF
--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/gather-paging-structures-thms.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/gather-paging-structures-thms.lisp
@@ -9,16 +9,18 @@
 
 (local (include-book "centaur/gl/gl" :dir :system))
 
+(local (xdoc::set-default-parents gather-paging-structures))
+
 (local (in-theory (e/d (entry-found-p-and-lin-addr
-                        entry-found-p-and-good-paging-structures-x86p)
-                       ())))
+			entry-found-p-and-good-paging-structures-x86p)
+		       ())))
 
 (defthmd xlate-equiv-entries-open
   (implies (and (xlate-equiv-entries e1 e2)
-                (unsigned-byte-p 64 e1)
-                (unsigned-byte-p 64 e2))
-           (and (equal (loghead 5 e1) (loghead 5 e2))
-                (equal (logtail 7 e1) (logtail 7 e2))))
+		(unsigned-byte-p 64 e1)
+		(unsigned-byte-p 64 e2))
+	   (and (equal (loghead 5 e1) (loghead 5 e2))
+		(equal (logtail 7 e1) (logtail 7 e2))))
   :hints (("Goal" :in-theory (e/d* (xlate-equiv-entries) ()))))
 
 ;; ======================================================================
@@ -27,159 +29,159 @@
 
 (defthm non-nil-gather-pml4-table-qword-addresses
   (implies (and (equal pml4-table-base-addr
-                       (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (good-paging-structures-x86p x86))
-           (gather-pml4-table-qword-addresses x86))
+		       (mv-nth 1 (pml4-table-base-addr x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(good-paging-structures-x86p x86))
+	   (gather-pml4-table-qword-addresses x86))
   :hints (("Goal"
-           :in-theory (e/d* (pml4-table-base-addr
-                             pml4-table-entry-addr
-                             gather-pml4-table-qword-addresses)
-                            ()))))
+	   :in-theory (e/d* (pml4-table-base-addr
+			     pml4-table-entry-addr
+			     gather-pml4-table-qword-addresses)
+			    ()))))
 
 (defthm consp-gather-pml4-table-qword-addresses
   (implies (and (equal pml4-table-base-addr
-                       (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (good-paging-structures-x86p x86))
-           (consp (gather-pml4-table-qword-addresses x86)))
+		       (mv-nth 1 (pml4-table-base-addr x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(good-paging-structures-x86p x86))
+	   (consp (gather-pml4-table-qword-addresses x86)))
   :hints (("Goal"
-           :in-theory (e/d* (pml4-table-base-addr
-                             pml4-table-entry-addr
-                             gather-pml4-table-qword-addresses)
-                            ())))
+	   :in-theory (e/d* (pml4-table-base-addr
+			     pml4-table-entry-addr
+			     gather-pml4-table-qword-addresses)
+			    ())))
   :rule-classes (:type-prescription :rewrite))
 
 (defthm car-gather-pml4-table-qword-addresses
   (implies (and (equal pml4-table-base-addr
-                       (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (good-paging-structures-x86p x86))
-           (equal (car (gather-pml4-table-qword-addresses x86))
-                  pml4-table-base-addr))
+		       (mv-nth 1 (pml4-table-base-addr x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(good-paging-structures-x86p x86))
+	   (equal (car (gather-pml4-table-qword-addresses x86))
+		  pml4-table-base-addr))
   :hints (("Goal"
-           :expand (create-qword-address-list
-                    512
-                    (ash (loghead 40 (logtail 12 (xr :ctr *cr3* x86)))
-                         12))
-           :in-theory (e/d* (pml4-table-base-addr
-                             pml4-table-entry-addr
-                             gather-pml4-table-qword-addresses)
-                            ()))))
+	   :expand (create-qword-address-list
+		    512
+		    (ash (loghead 40 (logtail 12 (xr :ctr *cr3* x86)))
+			 12))
+	   :in-theory (e/d* (pml4-table-base-addr
+			     pml4-table-entry-addr
+			     gather-pml4-table-qword-addresses)
+			    ()))))
 
 (defthm non-nil-gather-qword-addresses-corresponding-to-1-entry
   (implies (and (equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
-                (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
-                         12))))
-           (gather-qword-addresses-corresponding-to-1-entry paddr x86))
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
+		(physical-address-p
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
+			 12))))
+	   (gather-qword-addresses-corresponding-to-1-entry paddr x86))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
+			    ()))))
 
 (defthm consp-gather-qword-addresses-corresponding-to-1-entry
   (implies (and (equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
-                (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
-                         12))))
-           (consp (gather-qword-addresses-corresponding-to-1-entry paddr x86)))
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
+		(physical-address-p
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
+			 12))))
+	   (consp (gather-qword-addresses-corresponding-to-1-entry paddr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                            ())))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
+			    ())))
   :rule-classes (:type-prescription :rewrite))
 
 (defthm car-gather-qword-addresses-corresponding-to-1-entry
   (implies (and (equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
-                (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
-                         12))))
-           (equal (car (gather-qword-addresses-corresponding-to-1-entry paddr x86))
-                  (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
-                       12)))
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
+		(physical-address-p
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
+			 12))))
+	   (equal (car (gather-qword-addresses-corresponding-to-1-entry paddr x86))
+		  (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
+		       12)))
   :hints (("Goal"
-           :expand (create-qword-address-list
-                    512
-                    (ash (loghead 40 (logtail 12 (rm-low-64 paddr x86)))
-                         12))
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                            ()))))
+	   :expand (create-qword-address-list
+		    512
+		    (ash (loghead 40 (logtail 12 (rm-low-64 paddr x86)))
+			 12))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
+			    ()))))
 
 (defthm consp-gather-qword-addresses-corresponding-to-entries
   (implies (and (consp paddr-list)
-                (qword-paddr-listp paddr-list)
-                (equal (ia32e-page-tables-slice :p (rm-low-64 (car paddr-list) x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 (car paddr-list) x86)) 0)
-                (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 (car paddr-list) x86))
-                         12))))
-           (consp
-            (gather-qword-addresses-corresponding-to-entries
-             paddr-list
-             x86)))
+		(qword-paddr-listp paddr-list)
+		(equal (ia32e-page-tables-slice :p (rm-low-64 (car paddr-list) x86)) 1)
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 (car paddr-list) x86)) 0)
+		(physical-address-p
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 (car paddr-list) x86))
+			 12))))
+	   (consp
+	    (gather-qword-addresses-corresponding-to-entries
+	     paddr-list
+	     x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
-                            ())))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
+			    ())))
   :rule-classes (:type-prescription :rewrite))
 
 (defthm car-gather-qword-addresses-corresponding-to-entries
   (implies (and (consp paddr-list)
-                (qword-paddr-listp paddr-list)
-                (equal (ia32e-page-tables-slice :p (rm-low-64 (car paddr-list) x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 (car paddr-list) x86)) 0)
-                (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 (car paddr-list) x86))
-                         12))))
-           (equal
-            (car (gather-qword-addresses-corresponding-to-entries paddr-list x86))
-            (gather-qword-addresses-corresponding-to-1-entry (car paddr-list) x86)))
+		(qword-paddr-listp paddr-list)
+		(equal (ia32e-page-tables-slice :p (rm-low-64 (car paddr-list) x86)) 1)
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 (car paddr-list) x86)) 0)
+		(physical-address-p
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 (car paddr-list) x86))
+			 12))))
+	   (equal
+	    (car (gather-qword-addresses-corresponding-to-entries paddr-list x86))
+	    (gather-qword-addresses-corresponding-to-1-entry (car paddr-list) x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
+			    ()))))
 
 (defthm gather-qword-addresses-corresponding-to-1-entry-and-to-entries
   (implies (and (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
-                         12)))
-                (qword-paddr-listp paddrs)
-                (equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
-                (member-p paddr paddrs))
-           (subset-list-p
-            (gather-qword-addresses-corresponding-to-1-entry paddr x86)
-            (gather-qword-addresses-corresponding-to-entries paddrs x86)))
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
+			 12)))
+		(qword-paddr-listp paddrs)
+		(equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
+		(member-p paddr paddrs))
+	   (subset-list-p
+	    (gather-qword-addresses-corresponding-to-1-entry paddr x86)
+	    (gather-qword-addresses-corresponding-to-entries paddrs x86)))
 
   :hints (("Goal" :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                                    gather-qword-addresses-corresponding-to-entries
-                                    subset-p)
-                                   ()))))
+				    gather-qword-addresses-corresponding-to-entries
+				    subset-p)
+				   ()))))
 
 (defthm gather-qword-addresses-corresponding-to-entries-and-to-list-of-entries
   (implies (and (physical-address-p
-                 (+ (ash 512 3)
-                    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
-                         12)))
-                (qword-paddr-list-listp paddrs-list)
-                (equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
-                (equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
-                (member-list-p paddr paddrs-list))
-           (subset-list-p
-            (gather-qword-addresses-corresponding-to-1-entry paddr x86)
-            (gather-qword-addresses-corresponding-to-list-of-entries
-             paddrs-list x86)))
+		 (+ (ash 512 3)
+		    (ash (ia32e-page-tables-slice :reference-addr (rm-low-64 paddr x86))
+			 12)))
+		(qword-paddr-list-listp paddrs-list)
+		(equal (ia32e-page-tables-slice :p (rm-low-64 paddr x86)) 1)
+		(equal (ia32e-page-tables-slice :ps (rm-low-64 paddr x86)) 0)
+		(member-list-p paddr paddrs-list))
+	   (subset-list-p
+	    (gather-qword-addresses-corresponding-to-1-entry paddr x86)
+	    (gather-qword-addresses-corresponding-to-list-of-entries
+	     paddrs-list x86)))
 
   :hints (("Goal" :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
-                                    gather-qword-addresses-corresponding-to-list-of-entries
-                                    subset-p)
-                                   ()))))
+				    gather-qword-addresses-corresponding-to-list-of-entries
+				    subset-p)
+				   ()))))
 
 ;; ======================================================================
 
@@ -190,118 +192,118 @@
 
 (defthm pml4-table-base-addr-is-a-member-of-gather-pml4-table-qword-addresses
   (implies (and (physical-address-p (+ (ash 512 3)
-                                       (mv-nth 1 (pml4-table-base-addr x86))))
-                (good-paging-structures-x86p x86))
-           (member-p (mv-nth 1 (pml4-table-base-addr x86))
-                     (gather-pml4-table-qword-addresses x86)))
+				       (mv-nth 1 (pml4-table-base-addr x86))))
+		(good-paging-structures-x86p x86))
+	   (member-p (mv-nth 1 (pml4-table-base-addr x86))
+		     (gather-pml4-table-qword-addresses x86)))
   :hints (("Goal"
-           :in-theory (e/d* (pml4-table-base-addr
-                             gather-pml4-table-qword-addresses)
-                            ()))))
+	   :in-theory (e/d* (pml4-table-base-addr
+			     gather-pml4-table-qword-addresses)
+			    ()))))
 
 (local
  (def-gl-thm pml4-table-entry-addr-and-gather-pml4-table-qword-addresses-helper-1
    :hyp (and (unsigned-byte-p 52 x)
-             (equal (loghead 12 x) 0))
+	     (equal (loghead 12 x) 0))
    :concl (equal (logand 18446744073709547527 x)
-                 x)
+		 x)
    :g-bindings `((x (:g-number ,(gl-int 0 1 53))))))
 
 (local
  (def-gl-thm pml4-table-entry-addr-and-gather-pml4-table-qword-addresses-helper-2
    :hyp (and (canonical-address-p lin-addr)
-             (unsigned-byte-p 52 x))
+	     (unsigned-byte-p 52 x))
    :concl (< (logior (ash (loghead 9 (logtail 39 lin-addr))
-                          3)
-                     x)
-             (+ 4096 x))
+			  3)
+		     x)
+	     (+ 4096 x))
    :g-bindings `((lin-addr (:g-number ,(gl-int 0 2 65)))
-                 (x        (:g-number ,(gl-int 1 2 65))))))
+		 (x        (:g-number ,(gl-int 1 2 65))))))
 
 (defthm pml4-table-entry-addr-is-a-member-of-gather-pml4-table-qword-addresses
   (implies (pml4-table-entry-addr-found-p lin-addr x86)
-           (member-p (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                     (gather-pml4-table-qword-addresses x86)))
+	   (member-p (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
+		     (gather-pml4-table-qword-addresses x86)))
   :hints (("Goal"
-           :in-theory (e/d* (pml4-table-base-addr
-                             pml4-table-entry-addr
-                             gather-pml4-table-qword-addresses)
-                            ()))))
+	   :in-theory (e/d* (pml4-table-base-addr
+			     pml4-table-entry-addr
+			     gather-pml4-table-qword-addresses)
+			    ()))))
 
 (defthm pml4-table-base-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (and (physical-address-p
-                 (+ (ash 512 3)
-                    (mv-nth 1 (pml4-table-base-addr x86))))
-                (good-paging-structures-x86p x86))
-           (member-list-p (mv-nth 1 (pml4-table-base-addr x86))
-                          (gather-all-paging-structure-qword-addresses x86)))
+		 (+ (ash 512 3)
+		    (mv-nth 1 (pml4-table-base-addr x86))))
+		(good-paging-structures-x86p x86))
+	   (member-list-p (mv-nth 1 (pml4-table-base-addr x86))
+			  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            ()))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    ()))))
 
 (defthm pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (pml4-table-entry-addr-found-p lin-addr x86)
-           (member-list-p (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                          (gather-all-paging-structure-qword-addresses x86)))
+	   (member-list-p (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
+			  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            ()))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    ()))))
 
 ;; Relationship of PML4 Table with xlate-equiv-x86s:
 
 (defthm xlate-equiv-x86s-and-pml4-table-base-addr-address
   (implies (xlate-equiv-x86s x86-1 x86-2)
-           (equal (mv-nth 1 (pml4-table-base-addr x86-1))
-                  (mv-nth 1 (pml4-table-base-addr x86-2))))
+	   (equal (mv-nth 1 (pml4-table-base-addr x86-1))
+		  (mv-nth 1 (pml4-table-base-addr x86-2))))
   :hints (("Goal" :in-theory (e/d* (pml4-table-base-addr) ()))))
 
 (defthm xlate-equiv-x86s-and-pml4-table-entry-addr-address
   (implies (xlate-equiv-x86s x86-1 x86-2)
-           (equal (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-                  (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))))
+	   (equal (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+		  (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))))
   :hints (("Goal"
-           :use ((:instance xlate-equiv-x86s-and-pml4-table-base-addr-address))
-           :in-theory (e/d* (pml4-table-entry-addr
-                             xlate-equiv-x86s)
-                            (xlate-equiv-x86s-and-pml4-table-base-addr-address)))))
+	   :use ((:instance xlate-equiv-x86s-and-pml4-table-base-addr-address))
+	   :in-theory (e/d* (pml4-table-entry-addr
+			     xlate-equiv-x86s)
+			    (xlate-equiv-x86s-and-pml4-table-base-addr-address)))))
 
 (defthm xlate-equiv-x86s-and-pml4-table-entry-addr-value
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (pml4-table-entry-addr-found-p lin-addr x86-1))
-           (xlate-equiv-entries
-            (rm-low-64
-             (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-             x86-1)
-            (rm-low-64
-             (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
-             x86-2)))
+		(pml4-table-entry-addr-found-p lin-addr x86-1))
+	   (xlate-equiv-entries
+	    (rm-low-64
+	     (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+	     x86-1)
+	    (rm-low-64
+	     (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
+	     x86-2)))
   :hints (("Goal"
-           :use ((:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (pml4-table-entry-addr
-                                    lin-addr (mv-nth 1 (pml4-table-base-addr x86-1))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-1)))
-                 (:instance pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                            (x86 x86-1))
-                 (:instance xlate-equiv-x86s-and-pml4-table-base-addr-address))
-           :in-theory
-           (e/d* (xlate-equiv-x86s
-                  pml4-table-entry-addr-found-p)
-                 (xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  xlate-equiv-x86s-and-pml4-table-base-addr-address
-                  xlate-equiv-x86s-and-pml4-table-entry-addr-address
-                  pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  physical-address-p)))))
+	   :use ((:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (pml4-table-entry-addr
+				    lin-addr (mv-nth 1 (pml4-table-base-addr x86-1))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-1)))
+		 (:instance pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+			    (x86 x86-1))
+		 (:instance xlate-equiv-x86s-and-pml4-table-base-addr-address))
+	   :in-theory
+	   (e/d* (xlate-equiv-x86s
+		  pml4-table-entry-addr-found-p)
+		 (xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  xlate-equiv-x86s-and-pml4-table-base-addr-address
+		  xlate-equiv-x86s-and-pml4-table-entry-addr-address
+		  pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  physical-address-p)))))
 
 (defthm pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (pml4-table-entry-addr-found-p lin-addr x86-1))
-           (pml4-table-entry-addr-found-p lin-addr x86-2))
+		(pml4-table-entry-addr-found-p lin-addr x86-1))
+	   (pml4-table-entry-addr-found-p lin-addr x86-2))
   :hints (("Goal"
-           :use ((:instance xlate-equiv-x86s-and-pml4-table-base-addr-address))
-           :in-theory (e/d* (pml4-table-entry-addr-found-p)
-                            (physical-address-p
-                             xlate-equiv-x86s-and-pml4-table-base-addr-address
-                             bitops::logand-with-negated-bitmask)))))
+	   :use ((:instance xlate-equiv-x86s-and-pml4-table-base-addr-address))
+	   :in-theory (e/d* (pml4-table-entry-addr-found-p)
+			    (physical-address-p
+			     xlate-equiv-x86s-and-pml4-table-base-addr-address
+			     bitops::logand-with-negated-bitmask)))))
 
 ;; ======================================================================
 
@@ -313,237 +315,237 @@
 (local
  (def-gl-thm page-dir-ptr-table-entry-addr-is-in-a-table-pointed-to-by-a-pml4e-helper-1-1
    :hyp (and (unsigned-byte-p 64 x)
-             (canonical-address-p l))
+	     (canonical-address-p l))
    :concl (<=
-           (ash (loghead 40 (logtail 12 x)) 12)
-           (logior (ash (loghead 9 (logtail 30 l)) 3)
-                   (logand 18446744073709547527
-                           (ash (loghead 40 (logtail 12 x)) 12))))
+	   (ash (loghead 40 (logtail 12 x)) 12)
+	   (logior (ash (loghead 9 (logtail 30 l)) 3)
+		   (logand 18446744073709547527
+			   (ash (loghead 40 (logtail 12 x)) 12))))
    :g-bindings `((x (:g-number ,(gl-int 0 2 65)))
-                 (l (:g-number ,(gl-int 1 2 65))))
+		 (l (:g-number ,(gl-int 1 2 65))))
    :rule-classes :linear))
 
 (local
  (def-gl-thm page-dir-ptr-table-entry-addr-is-in-a-table-pointed-to-by-a-pml4e-helper-2-1
    :hyp (and (unsigned-byte-p 64 x)
-             (canonical-address-p l))
+	     (canonical-address-p l))
    :concl (<
-           (logior (ash (loghead 9 (logtail 30 l)) 3)
-                   (ash (loghead 40 (logtail 12 x)) 12))
-           (+ 4096 (ash (loghead 40 (logtail 12 x)) 12)))
+	   (logior (ash (loghead 9 (logtail 30 l)) 3)
+		   (ash (loghead 40 (logtail 12 x)) 12))
+	   (+ 4096 (ash (loghead 40 (logtail 12 x)) 12)))
    :g-bindings `((x (:g-number ,(gl-int 0 2 65)))
-                 (l (:g-number ,(gl-int 1 2 65))))
+		 (l (:g-number ,(gl-int 1 2 65))))
    :rule-classes :linear))
 
 (defthm page-dir-ptr-table-base-addr-is-in-a-table-pointed-to-by-a-pml4e
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p
-                 pml4-table-entry-addr x86)
-                (good-paging-structures-x86p x86))
-           (member-p
-            (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))
-            (gather-qword-addresses-corresponding-to-1-entry
-             pml4-table-entry-addr x86)))
+		(equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p
+		 pml4-table-entry-addr x86)
+		(good-paging-structures-x86p x86))
+	   (member-p
+	    (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))
+	    (gather-qword-addresses-corresponding-to-1-entry
+	     pml4-table-entry-addr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                             page-dir-ptr-table-entry-addr
-                             page-dir-ptr-table-base-addr)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			     page-dir-ptr-table-entry-addr
+			     page-dir-ptr-table-base-addr)
+			    ()))))
 
 (defthm page-dir-ptr-table-entry-addr-is-in-a-table-pointed-to-by-a-pml4e
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
-                (canonical-address-p lin-addr)
-                (good-paging-structures-x86p x86))
-           (member-p
-            (page-dir-ptr-table-entry-addr
-             lin-addr
-             (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-            (gather-qword-addresses-corresponding-to-1-entry
-             pml4-table-entry-addr x86)))
+		(equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
+		(canonical-address-p lin-addr)
+		(good-paging-structures-x86p x86))
+	   (member-p
+	    (page-dir-ptr-table-entry-addr
+	     lin-addr
+	     (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	    (gather-qword-addresses-corresponding-to-1-entry
+	     pml4-table-entry-addr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                             good-paging-structures-x86p
-                             page-dir-ptr-table-entry-addr
-                             page-dir-ptr-table-base-addr)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			     good-paging-structures-x86p
+			     page-dir-ptr-table-entry-addr
+			     page-dir-ptr-table-base-addr)
+			    ()))))
 
 (defthm pdpt-qword-paddrs-referred-to-by-pml4-base-addr-are-a-subset-of-those-by-all-pml4es
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-base-addr x86)
-                (good-paging-structures-x86p x86))
-           (subset-list-p
-            (gather-qword-addresses-corresponding-to-1-entry pml4-table-base-addr x86)
-            (gather-qword-addresses-corresponding-to-entries
-             (gather-pml4-table-qword-addresses x86)
-             x86))))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-base-addr x86)
+		(good-paging-structures-x86p x86))
+	   (subset-list-p
+	    (gather-qword-addresses-corresponding-to-1-entry pml4-table-base-addr x86)
+	    (gather-qword-addresses-corresponding-to-entries
+	     (gather-pml4-table-qword-addresses x86)
+	     x86))))
 
 (defthm pdpt-qword-paddrs-referred-to-by-a-pml4e-addr-are-a-subset-of-those-by-all-pml4es
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
-                (good-paging-structures-x86p x86)
-                (canonical-address-p lin-addr))
-           (subset-list-p
-            (gather-qword-addresses-corresponding-to-1-entry pml4-table-entry-addr x86)
-            (gather-qword-addresses-corresponding-to-entries
-             (gather-pml4-table-qword-addresses x86) x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
+		(good-paging-structures-x86p x86)
+		(canonical-address-p lin-addr))
+	   (subset-list-p
+	    (gather-qword-addresses-corresponding-to-1-entry pml4-table-entry-addr x86)
+	    (gather-qword-addresses-corresponding-to-entries
+	     (gather-pml4-table-qword-addresses x86) x86)))
   :hints (("Goal" :in-theory (e/d* () (subset-list-p)))))
 
 (defthm page-dir-ptr-table-base-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
-                (good-paging-structures-x86p x86)
-                (canonical-address-p lin-addr))
-           (member-list-p (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))
-                          (gather-all-paging-structure-qword-addresses x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
+		(good-paging-structures-x86p x86)
+		(canonical-address-p lin-addr))
+	   (member-list-p (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))
+			  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (pml4-table-entry-addr lin-addr pml4-table-base-addr)
-                                 x86))
-                            (xss (gather-qword-addresses-corresponding-to-entries
-                                  (gather-pml4-table-qword-addresses x86)
-                                  x86))))
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (pml4-table-entry-addr lin-addr pml4-table-base-addr)
+				 x86))
+			    (xss (gather-qword-addresses-corresponding-to-entries
+				  (gather-pml4-table-qword-addresses x86)
+				  x86))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    (subset-list-p-and-member-list-p)))))
 
 (defthm page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-           (member-list-p
-            (page-dir-ptr-table-entry-addr lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-            (gather-all-paging-structure-qword-addresses x86)))
+	   (member-list-p
+	    (page-dir-ptr-table-entry-addr lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	    (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (page-dir-ptr-table-entry-addr
-                                lin-addr
-                                (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                                 x86))
-                            (xss (gather-qword-addresses-corresponding-to-entries
-                                  (gather-pml4-table-qword-addresses x86)
-                                  x86))))
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (page-dir-ptr-table-entry-addr
+				lin-addr
+				(mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
+				 x86))
+			    (xss (gather-qword-addresses-corresponding-to-entries
+				  (gather-pml4-table-qword-addresses x86)
+				  x86))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    (subset-list-p-and-member-list-p)))))
 
 ;; Relationship of PDPT with xlate-equiv-x86s:
 
 (defthm xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (pml4-table-entry-addr-found-p lin-addr x86-1))
-           (equal (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1))
-                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2))))
+		(pml4-table-entry-addr-found-p lin-addr x86-1))
+	   (equal (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1))
+		  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2))))
   :hints (("Goal" :in-theory (e/d* (page-dir-ptr-table-base-addr
-                                    good-paging-structures-x86p
-                                    xlate-equiv-entries)
-                                   (xlate-equiv-x86s-and-pml4-table-entry-addr-address
-                                    xlate-equiv-x86s-and-pml4-table-base-addr-address
-                                    xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                                    pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                                    canonical-address-p
-                                    physical-address-p))
-           :use ((:instance logtail-bigger
-                            (m 7)
-                            (n 12)
-                            (e1 (rm-low-64
-                                 (pml4-table-entry-addr
-                                  lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (pml4-table-entry-addr
-                                  lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-                                 x86-2)))
-                 (:instance xlate-equiv-x86s-and-pml4-table-entry-addr-address)
-                 (:instance pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                            (x86 x86-1))
-                 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-1)))))))
+				    good-paging-structures-x86p
+				    xlate-equiv-entries)
+				   (xlate-equiv-x86s-and-pml4-table-entry-addr-address
+				    xlate-equiv-x86s-and-pml4-table-base-addr-address
+				    xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+				    pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+				    canonical-address-p
+				    physical-address-p))
+	   :use ((:instance logtail-bigger
+			    (m 7)
+			    (n 12)
+			    (e1 (rm-low-64
+				 (pml4-table-entry-addr
+				  lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (pml4-table-entry-addr
+				  lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+				 x86-2)))
+		 (:instance xlate-equiv-x86s-and-pml4-table-entry-addr-address)
+		 (:instance pml4-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+			    (x86 x86-1))
+		 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-1)))))))
 
 (defthm xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (pml4-table-entry-addr-found-p lin-addr x86-1))
-           (equal (page-dir-ptr-table-entry-addr
-                   lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                  (page-dir-ptr-table-entry-addr
-                   lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))))
+		(pml4-table-entry-addr-found-p lin-addr x86-1))
+	   (equal (page-dir-ptr-table-entry-addr
+		   lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+		  (page-dir-ptr-table-entry-addr
+		   lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))))
   :hints (("Goal" :in-theory (e/d* (page-dir-ptr-table-base-addr)
-                                   (xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address))
-           :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address)))))
+				   (xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address))
+	   :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address)))))
 
 (defthm xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-value
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
-           (xlate-equiv-entries
-            (rm-low-64
-             (page-dir-ptr-table-entry-addr
-              lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-             x86-1)
-            (rm-low-64
-             (page-dir-ptr-table-entry-addr
-              lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
-             x86-2)))
+		(page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
+	   (xlate-equiv-entries
+	    (rm-low-64
+	     (page-dir-ptr-table-entry-addr
+	      lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+	     x86-1)
+	    (rm-low-64
+	     (page-dir-ptr-table-entry-addr
+	      lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
+	     x86-2)))
   :hints (("Goal"
-           :in-theory
-           (e/d* ()
-                 (pml4-table-entry-addr-found-p
-                  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
-                  xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
+	   :in-theory
+	   (e/d* ()
+		 (pml4-table-entry-addr-found-p
+		  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
+		  xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
 
-                  physical-address-p))
-           :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address)
-                 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (page-dir-ptr-table-entry-addr
-                                    lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-2)))))))
+		  physical-address-p))
+	   :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address)
+		 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (page-dir-ptr-table-entry-addr
+				    lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-2)))))))
 
 (defthm page-dir-ptr-table-entry-addr-found-p-and-xlate-equiv-x86s
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
-           (page-dir-ptr-table-entry-addr-found-p lin-addr x86-2))
+		(page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
+	   (page-dir-ptr-table-entry-addr-found-p lin-addr x86-2))
   :hints (("Goal"
-           :use ((:instance pml4-table-entry-addr-found-p-and-xlate-equiv-x86s)
-                 (:instance xlate-equiv-x86s-and-pml4-table-entry-addr-value)
-                 (:instance logtail-bigger-and-logbitp
-                            (e1 (rm-low-64
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                 x86-2))
-                            (m 7)
-                            (n  7))
-                 (:instance xlate-equiv-entries-and-loghead
-                            (e1 (rm-low-64
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                 x86-2))
-                            (n 1))
-                 (:instance xlate-equiv-entries-and-logtail
-                            (e1 (rm-low-64
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                 x86-2))
-                            (n 12)))
-           :in-theory (e/d* (page-dir-ptr-table-entry-addr-found-p
-                             xlate-equiv-entries)
-                            (physical-address-p
-                             xlate-equiv-x86s-and-pml4-table-entry-addr-value
-                             pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
-                             bitops::logand-with-negated-bitmask)))))
+	   :use ((:instance pml4-table-entry-addr-found-p-and-xlate-equiv-x86s)
+		 (:instance xlate-equiv-x86s-and-pml4-table-entry-addr-value)
+		 (:instance logtail-bigger-and-logbitp
+			    (e1 (rm-low-64
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
+				 x86-2))
+			    (m 7)
+			    (n  7))
+		 (:instance xlate-equiv-entries-and-loghead
+			    (e1 (rm-low-64
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
+				 x86-2))
+			    (n 1))
+		 (:instance xlate-equiv-entries-and-logtail
+			    (e1 (rm-low-64
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86-2)))
+				 x86-2))
+			    (n 12)))
+	   :in-theory (e/d* (page-dir-ptr-table-entry-addr-found-p
+			     xlate-equiv-entries)
+			    (physical-address-p
+			     xlate-equiv-x86s-and-pml4-table-entry-addr-value
+			     pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
+			     bitops::logand-with-negated-bitmask)))))
 
 ;; ======================================================================
 
@@ -554,289 +556,289 @@
 
 (defthm page-directory-base-addr-is-in-a-table-pointed-to-by-a-pdpte
   (implies (and (equal page-dir-ptr-table-base-addr
-                       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                (equal page-dir-ptr-table-entry-addr
-                       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-                (good-paging-structures-x86p x86))
-           (member-p
-            (mv-nth 1 (page-directory-base-addr lin-addr x86))
-            (gather-qword-addresses-corresponding-to-1-entry
-             page-dir-ptr-table-entry-addr x86)))
+		       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		(equal page-dir-ptr-table-entry-addr
+		       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+		(good-paging-structures-x86p x86))
+	   (member-p
+	    (mv-nth 1 (page-directory-base-addr lin-addr x86))
+	    (gather-qword-addresses-corresponding-to-1-entry
+	     page-dir-ptr-table-entry-addr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                             page-directory-entry-addr
-                             page-directory-base-addr)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			     page-directory-entry-addr
+			     page-directory-base-addr)
+			    ()))))
 
 (local
  (def-gl-thm page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte-helper-1
    :hyp (and (unsigned-byte-p 64 x)
-             (canonical-address-p l))
+	     (canonical-address-p l))
    :concl (<
-           (logior (ash (loghead 9 (logtail 21 l)) 3)
-                   (ash (loghead 40 (logtail 12 x)) 12))
-           (+ 4096 (ash (loghead 40 (logtail 12 x)) 12)))
+	   (logior (ash (loghead 9 (logtail 21 l)) 3)
+		   (ash (loghead 40 (logtail 12 x)) 12))
+	   (+ 4096 (ash (loghead 40 (logtail 12 x)) 12)))
    :g-bindings `((x (:g-number ,(gl-int 0 2 65)))
-                 (l (:g-number ,(gl-int 1 2 65))))
+		 (l (:g-number ,(gl-int 1 2 65))))
    :rule-classes :linear))
 
 (defthm page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte
   (implies (and (equal page-dir-ptr-table-base-addr
-                       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                (equal page-dir-ptr-table-entry-addr
-                       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-                (canonical-address-p lin-addr)
-                (good-paging-structures-x86p x86))
-           (member-p
-            (page-directory-entry-addr
-             lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-            (gather-qword-addresses-corresponding-to-1-entry page-dir-ptr-table-entry-addr x86)))
+		       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		(equal page-dir-ptr-table-entry-addr
+		       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+		(canonical-address-p lin-addr)
+		(good-paging-structures-x86p x86))
+	   (member-p
+	    (page-directory-entry-addr
+	     lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	    (gather-qword-addresses-corresponding-to-1-entry page-dir-ptr-table-entry-addr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                             good-paging-structures-x86p
-                             page-directory-entry-addr
-                             page-directory-base-addr)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			     good-paging-structures-x86p
+			     page-directory-entry-addr
+			     page-directory-base-addr)
+			    ()))))
 
 (defthm page-dir-ptr-table-entry-addr-is-in-a-table-pointed-to-by-a-pml4e-alt
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
-                (canonical-address-p lin-addr)
-                (good-paging-structures-x86p x86))
-           (member-list-p
-            (page-dir-ptr-table-entry-addr
-             lin-addr
-             (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-            (gather-qword-addresses-corresponding-to-entries
-             (gather-pml4-table-qword-addresses x86)
-             x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
+		(canonical-address-p lin-addr)
+		(good-paging-structures-x86p x86))
+	   (member-list-p
+	    (page-dir-ptr-table-entry-addr
+	     lin-addr
+	     (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	    (gather-qword-addresses-corresponding-to-entries
+	     (gather-pml4-table-qword-addresses x86)
+	     x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (page-dir-ptr-table-entry-addr
-                                lin-addr
-                                (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (pml4-table-entry-addr lin-addr pml4-table-base-addr)
-                                 x86))
-                            (xss (gather-qword-addresses-corresponding-to-entries
-                                  (gather-pml4-table-qword-addresses x86)
-                                  x86))))
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (page-dir-ptr-table-entry-addr
+				lin-addr
+				(mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (pml4-table-entry-addr lin-addr pml4-table-base-addr)
+				 x86))
+			    (xss (gather-qword-addresses-corresponding-to-entries
+				  (gather-pml4-table-qword-addresses x86)
+				  x86))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
+			    (subset-list-p-and-member-list-p)))))
 
 (defthm page-directory-base-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (and (equal pml4-table-base-addr
-                       (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
-                (equal page-dir-ptr-table-base-addr
-                       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                (equal page-dir-ptr-table-entry-addr
-                       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-                (canonical-address-p lin-addr)
-                (good-paging-structures-x86p x86))
-           (member-list-p (mv-nth 1 (page-directory-base-addr lin-addr x86))
-                          (gather-all-paging-structure-qword-addresses x86)))
+		       (mv-nth 1 (pml4-table-base-addr x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(equal pml4-table-entry-addr (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
+		(equal page-dir-ptr-table-base-addr
+		       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		(equal page-dir-ptr-table-entry-addr
+		       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+		(canonical-address-p lin-addr)
+		(good-paging-structures-x86p x86))
+	   (member-list-p (mv-nth 1 (page-directory-base-addr lin-addr x86))
+			  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr)
-                                 x86))
-                            (xss (gather-all-paging-structure-qword-addresses x86))))
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr)
+				 x86))
+			    (xss (gather-all-paging-structure-qword-addresses x86))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    (subset-list-p-and-member-list-p)))))
 
 (defthm page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (page-directory-entry-addr-found-p lin-addr x86)
-           (member-list-p
-            (page-directory-entry-addr
-             lin-addr
-             (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-            (gather-all-paging-structure-qword-addresses x86)))
+	   (member-list-p
+	    (page-directory-entry-addr
+	     lin-addr
+	     (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	    (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (page-directory-entry-addr
-                                lin-addr
-                                (mv-nth 1 (page-directory-base-addr lin-addr x86))))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                                 x86))
-                            (xss (gather-all-paging-structure-qword-addresses x86))))
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (page-directory-entry-addr
+				lin-addr
+				(mv-nth 1 (page-directory-base-addr lin-addr x86))))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+				 x86))
+			    (xss (gather-all-paging-structure-qword-addresses x86))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    (subset-list-p-and-member-list-p)))))
 
 ;; Relationship of PD with xlate-equiv-x86s:
 
 (defthm xlate-equiv-x86s-and-page-directory-base-addr-address
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
-           (equal (mv-nth 1 (page-directory-base-addr lin-addr x86-1))
-                  (mv-nth 1 (page-directory-base-addr lin-addr x86-2))))
+		(page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
+	   (equal (mv-nth 1 (page-directory-base-addr lin-addr x86-1))
+		  (mv-nth 1 (page-directory-base-addr lin-addr x86-2))))
   :hints (("Goal" :in-theory
-           (e/d* (page-directory-base-addr)
-                 (xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
-                  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
-                  page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  canonical-address-p
-                  physical-address-p))
-           :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address)
-                 (:instance xlate-equiv-entries-open
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-2)))
-                 (:instance page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                            (x86 x86-1))
-                 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (page-dir-ptr-table-entry-addr
-                                    lin-addr
-                                    (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-1)))
-                 (:instance logtail-bigger-and-logbitp
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-2))
-                            (m 7)
-                            (n 7))
-                 (:instance logtail-bigger
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-2))
-                            (m 7)
-                            (n 12))))))
+	   (e/d* (page-directory-base-addr)
+		 (xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
+		  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
+		  page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  canonical-address-p
+		  physical-address-p))
+	   :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address)
+		 (:instance xlate-equiv-entries-open
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-2)))
+		 (:instance page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+			    (x86 x86-1))
+		 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (page-dir-ptr-table-entry-addr
+				    lin-addr
+				    (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-1)))
+		 (:instance logtail-bigger-and-logbitp
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-2))
+			    (m 7)
+			    (n 7))
+		 (:instance logtail-bigger
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-2))
+			    (m 7)
+			    (n 12))))))
 
 (defthm xlate-equiv-x86s-and-page-directory-entry-addr-address
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
-           (equal (page-directory-entry-addr
-                   lin-addr
-                   (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                  (page-directory-entry-addr
-                   lin-addr
-                   (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))))
+		(page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
+	   (equal (page-directory-entry-addr
+		   lin-addr
+		   (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+		  (page-directory-entry-addr
+		   lin-addr
+		   (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))))
   :hints (("Goal" :in-theory (e/d* (page-directory-base-addr)
-                                   (xlate-equiv-x86s
-                                    xlate-equiv-x86s-and-page-directory-base-addr-address
-                                    xlate-equiv-x86s-and-pml4-table-base-addr-address
-                                    xlate-equiv-x86s-and-pml4-table-entry-addr-address
-                                    xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
-                                    xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
-                                    canonical-address-p
-                                    physical-address-p))
-           :use ((:instance xlate-equiv-x86s-and-page-directory-base-addr-address)))))
+				   (xlate-equiv-x86s
+				    xlate-equiv-x86s-and-page-directory-base-addr-address
+				    xlate-equiv-x86s-and-pml4-table-base-addr-address
+				    xlate-equiv-x86s-and-pml4-table-entry-addr-address
+				    xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
+				    xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
+				    canonical-address-p
+				    physical-address-p))
+	   :use ((:instance xlate-equiv-x86s-and-page-directory-base-addr-address)))))
 
 (defthm xlate-equiv-x86s-and-page-directory-entry-addr-value
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-directory-entry-addr-found-p lin-addr x86-1))
-           (xlate-equiv-entries
-            (rm-low-64
-             (page-directory-entry-addr
-              lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-             x86-1)
-            (rm-low-64
-             (page-directory-entry-addr
-              lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-             x86-2)))
+		(page-directory-entry-addr-found-p lin-addr x86-1))
+	   (xlate-equiv-entries
+	    (rm-low-64
+	     (page-directory-entry-addr
+	      lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+	     x86-1)
+	    (rm-low-64
+	     (page-directory-entry-addr
+	      lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+	     x86-2)))
   :hints (("Goal"
-           :use ((:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (page-directory-entry-addr
-                                    lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-2)))
-                 (:instance xlate-equiv-x86s-and-page-directory-entry-addr-address)
-                 (:instance page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                            (x86 x86-1)))
-           :in-theory
-           (e/d* (xlate-equiv-x86s)
-                 (xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  xlate-equiv-x86s-and-page-directory-base-addr-address
-                  page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  xlate-equiv-x86s-and-page-directory-entry-addr-address
-                  physical-address-p)))))
+	   :use ((:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (page-directory-entry-addr
+				    lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-2)))
+		 (:instance xlate-equiv-x86s-and-page-directory-entry-addr-address)
+		 (:instance page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+			    (x86 x86-1)))
+	   :in-theory
+	   (e/d* (xlate-equiv-x86s)
+		 (xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  xlate-equiv-x86s-and-page-directory-base-addr-address
+		  page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  xlate-equiv-x86s-and-page-directory-entry-addr-address
+		  physical-address-p)))))
 
 (defthm page-directory-entry-addr-found-p-and-xlate-equiv-x86s
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-directory-entry-addr-found-p lin-addr x86-1))
-           (page-directory-entry-addr-found-p lin-addr x86-2))
+		(page-directory-entry-addr-found-p lin-addr x86-1))
+	   (page-directory-entry-addr-found-p lin-addr x86-2))
   :hints (("Goal"
-           :use ((:instance page-dir-ptr-table-entry-addr-found-p-and-xlate-equiv-x86s)
-                 (:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-value)
-                 (:instance xlate-equiv-entries-open
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
-                                 x86-2)))
-                 (:instance logtail-bigger-and-logbitp
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (m 7)
-                            (n  7))
-                 (:instance xlate-equiv-entries-and-loghead
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (n 1))
-                 (:instance xlate-equiv-entries-and-logtail
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (n 12)))
-           :in-theory (e/d* (page-directory-entry-addr-found-p)
-                            (physical-address-p
-                             xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-value
-                             page-dir-ptr-table-entry-addr-found-p-and-xlate-equiv-x86s
-                             xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
-                             xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
-                             bitops::logand-with-negated-bitmask)))))
+	   :use ((:instance page-dir-ptr-table-entry-addr-found-p-and-xlate-equiv-x86s)
+		 (:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-value)
+		 (:instance xlate-equiv-entries-open
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
+				 x86-2)))
+		 (:instance logtail-bigger-and-logbitp
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (m 7)
+			    (n  7))
+		 (:instance xlate-equiv-entries-and-loghead
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (n 1))
+		 (:instance xlate-equiv-entries-and-logtail
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (n 12)))
+	   :in-theory (e/d* (page-directory-entry-addr-found-p)
+			    (physical-address-p
+			     xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-value
+			     page-dir-ptr-table-entry-addr-found-p-and-xlate-equiv-x86s
+			     xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
+			     xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
+			     bitops::logand-with-negated-bitmask)))))
 
 ;; ======================================================================
 
@@ -847,97 +849,97 @@
 
 (defthm page-table-base-addr-is-in-a-table-pointed-to-by-a-pde
   (implies (and
-            (equal page-dir-ptr-table-base-addr
-                   (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-            (equal
-             page-dir-ptr-table-entry-addr
-             (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-            (equal page-directory-base-addr
-                   (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-            (equal page-directory-entry-addr
-                   (page-directory-entry-addr lin-addr page-directory-base-addr))
-            ;; Why don't I need the following hyp?
-            ;; (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-            (equal
-             (ia32e-page-tables-slice
-              :ps
-              (rm-low-64 page-dir-ptr-table-entry-addr x86))
-             0)
-            (superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
-            (good-paging-structures-x86p x86))
-           (member-p
-            (mv-nth 1 (page-table-base-addr lin-addr x86))
-            (gather-qword-addresses-corresponding-to-1-entry
-             page-directory-entry-addr x86)))
+	    (equal page-dir-ptr-table-base-addr
+		   (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	    (equal
+	     page-dir-ptr-table-entry-addr
+	     (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+	    (equal page-directory-base-addr
+		   (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	    (equal page-directory-entry-addr
+		   (page-directory-entry-addr lin-addr page-directory-base-addr))
+	    ;; Why don't I need the following hyp?
+	    ;; (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+	    (equal
+	     (ia32e-page-tables-slice
+	      :ps
+	      (rm-low-64 page-dir-ptr-table-entry-addr x86))
+	     0)
+	    (superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
+	    (good-paging-structures-x86p x86))
+	   (member-p
+	    (mv-nth 1 (page-table-base-addr lin-addr x86))
+	    (gather-qword-addresses-corresponding-to-1-entry
+	     page-directory-entry-addr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                             page-directory-entry-addr
-                             page-directory-base-addr
-                             page-table-entry-addr
-                             page-table-base-addr)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			     page-directory-entry-addr
+			     page-directory-base-addr
+			     page-table-entry-addr
+			     page-table-base-addr)
+			    ()))))
 
 (local
  (def-gl-thm page-table-entry-addr-is-in-a-table-pointed-to-by-a-pde-helper-1
    :hyp (and (unsigned-byte-p 64 x)
-             (canonical-address-p l))
+	     (canonical-address-p l))
    :concl (<
-           (logior (ash (loghead 9 (logtail 12 l)) 3)
-                   (ash (loghead 40 (logtail 12 x)) 12))
-           (+ 4096 (ash (loghead 40 (logtail 12 x)) 12)))
+	   (logior (ash (loghead 9 (logtail 12 l)) 3)
+		   (ash (loghead 40 (logtail 12 x)) 12))
+	   (+ 4096 (ash (loghead 40 (logtail 12 x)) 12)))
    :g-bindings `((x (:g-number ,(gl-int 0 2 65)))
-                 (l (:g-number ,(gl-int 1 2 65))))
+		 (l (:g-number ,(gl-int 1 2 65))))
    :rule-classes :linear))
 
 (defthm page-table-entry-addr-is-in-a-table-pointed-to-by-a-pde
   (implies (and (equal page-dir-ptr-table-base-addr
-                       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                (equal page-dir-ptr-table-entry-addr
-                       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-                ;; Why don't I need the following hyp?
-                ;; (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-                (equal (ia32e-page-tables-slice
-                        :ps (rm-low-64 page-dir-ptr-table-entry-addr x86)) 0)
-                (equal page-directory-base-addr
-                       (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                (equal page-directory-entry-addr
-                       (page-directory-entry-addr lin-addr page-directory-base-addr))
-                (superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
-                (canonical-address-p lin-addr)
-                (good-paging-structures-x86p x86))
-           (member-p
-            (page-table-entry-addr
-             lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86)))
-            (gather-qword-addresses-corresponding-to-1-entry
-             (page-directory-entry-addr lin-addr page-directory-base-addr)
-             x86)))
+		       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		(equal page-dir-ptr-table-entry-addr
+		       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+		;; Why don't I need the following hyp?
+		;; (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+		(equal (ia32e-page-tables-slice
+			:ps (rm-low-64 page-dir-ptr-table-entry-addr x86)) 0)
+		(equal page-directory-base-addr
+		       (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+		(equal page-directory-entry-addr
+		       (page-directory-entry-addr lin-addr page-directory-base-addr))
+		(superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
+		(canonical-address-p lin-addr)
+		(good-paging-structures-x86p x86))
+	   (member-p
+	    (page-table-entry-addr
+	     lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86)))
+	    (gather-qword-addresses-corresponding-to-1-entry
+	     (page-directory-entry-addr lin-addr page-directory-base-addr)
+	     x86)))
   :hints (("Goal"
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                             good-paging-structures-x86p
-                             page-directory-entry-addr
-                             page-directory-base-addr
-                             page-table-entry-addr
-                             page-table-base-addr)
-                            ()))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			     good-paging-structures-x86p
+			     page-directory-entry-addr
+			     page-directory-base-addr
+			     page-table-entry-addr
+			     page-table-base-addr)
+			    ()))))
 
 (defthm page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte-alt
   (implies
    (and
     (equal pml4-table-base-addr
-           (mv-nth 1 (pml4-table-base-addr x86)))
+	   (mv-nth 1 (pml4-table-base-addr x86)))
     (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
     (equal pml4-table-entry-addr
-           (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+	   (pml4-table-entry-addr lin-addr pml4-table-base-addr))
     (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
     (equal page-dir-ptr-table-base-addr
-           (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	   (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
     (equal page-dir-ptr-table-entry-addr
-           (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+	   (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
     (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
     (equal page-directory-base-addr
-           (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	   (mv-nth 1 (page-directory-base-addr lin-addr x86)))
     (equal page-directory-entry-addr
-           (page-directory-entry-addr lin-addr page-directory-base-addr))
+	   (page-directory-entry-addr lin-addr page-directory-base-addr))
     (canonical-address-p lin-addr)
     (good-paging-structures-x86p x86))
    (member-list-p
@@ -948,42 +950,42 @@
       x86)
      x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (page-directory-entry-addr lin-addr page-directory-base-addr))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr page-dir-ptr-table-base-addr)
-                                 x86))
-                            (xss (gather-qword-addresses-corresponding-to-list-of-entries
-                                  (gather-qword-addresses-corresponding-to-entries
-                                   (gather-pml4-table-qword-addresses x86)
-                                   x86)
-                                  x86))))
-           :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
-                             gather-qword-addresses-corresponding-to-list-of-entries)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (page-directory-entry-addr lin-addr page-directory-base-addr))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr page-dir-ptr-table-base-addr)
+				 x86))
+			    (xss (gather-qword-addresses-corresponding-to-list-of-entries
+				  (gather-qword-addresses-corresponding-to-entries
+				   (gather-pml4-table-qword-addresses x86)
+				   x86)
+				  x86))))
+	   :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
+			     gather-qword-addresses-corresponding-to-list-of-entries)
+			    (subset-list-p-and-member-list-p)))))
 
 (defthm page-table-addresses-pointed-to-by-a-pde-are-in-those-pointed-to-by-all-pdes
   (implies
    (and (equal pml4-table-base-addr
-               (mv-nth 1 (pml4-table-base-addr x86)))
-        (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-        (equal pml4-table-entry-addr
-               (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-        (superior-entry-points-to-an-inferior-one-p
-         pml4-table-entry-addr x86)
-        (equal page-dir-ptr-table-base-addr
-               (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-        (equal page-dir-ptr-table-entry-addr
-               (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-        (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-        (equal page-directory-base-addr
-               (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-        (equal page-directory-entry-addr
-               (page-directory-entry-addr lin-addr page-directory-base-addr))
-        (superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
-        (canonical-address-p lin-addr)
-        (good-paging-structures-x86p x86))
+	       (mv-nth 1 (pml4-table-base-addr x86)))
+	(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+	(equal pml4-table-entry-addr
+	       (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+	(superior-entry-points-to-an-inferior-one-p
+	 pml4-table-entry-addr x86)
+	(equal page-dir-ptr-table-base-addr
+	       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	(equal page-dir-ptr-table-entry-addr
+	       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+	(superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+	(equal page-directory-base-addr
+	       (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	(equal page-directory-entry-addr
+	       (page-directory-entry-addr lin-addr page-directory-base-addr))
+	(superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
+	(canonical-address-p lin-addr)
+	(good-paging-structures-x86p x86))
    (subset-list-p
     ;; PT qword addresses corresponding to a PDE.
     (gather-qword-addresses-corresponding-to-1-entry
@@ -1001,327 +1003,327 @@
       x86)
      x86)))
   :hints (("Goal"
-           :in-theory (e/d* ()
-                            (page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte-alt))
-           :use ((:instance page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte-alt)))))
+	   :in-theory (e/d* ()
+			    (page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte-alt))
+	   :use ((:instance page-directory-entry-addr-is-in-a-table-pointed-to-by-a-pdpte-alt)))))
 
 (defthm page-table-base-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (and (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                (physical-address-p (+ (ash 512 3) pml4-table-base-addr))
-                (equal pml4-table-entry-addr
-                       (pml4-table-entry-addr lin-addr pml4-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
-                (equal page-dir-ptr-table-base-addr
-                       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                (equal page-dir-ptr-table-entry-addr
-                       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
-                (superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
-                (equal page-directory-base-addr
-                       (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                (equal page-directory-entry-addr
-                       (page-directory-entry-addr lin-addr page-directory-base-addr))
-                (superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
-                (canonical-address-p lin-addr)
-                (good-paging-structures-x86p x86))
-           (member-list-p (mv-nth 1 (page-table-base-addr lin-addr x86))
-                          (gather-all-paging-structure-qword-addresses x86)))
+		(physical-address-p (+ (ash 512 3) pml4-table-base-addr))
+		(equal pml4-table-entry-addr
+		       (pml4-table-entry-addr lin-addr pml4-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p pml4-table-entry-addr x86)
+		(equal page-dir-ptr-table-base-addr
+		       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		(equal page-dir-ptr-table-entry-addr
+		       (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr))
+		(superior-entry-points-to-an-inferior-one-p page-dir-ptr-table-entry-addr x86)
+		(equal page-directory-base-addr
+		       (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+		(equal page-directory-entry-addr
+		       (page-directory-entry-addr lin-addr page-directory-base-addr))
+		(superior-entry-points-to-an-inferior-one-p page-directory-entry-addr x86)
+		(canonical-address-p lin-addr)
+		(good-paging-structures-x86p x86))
+	   (member-list-p (mv-nth 1 (page-table-base-addr lin-addr x86))
+			  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (mv-nth 1 (page-table-base-addr lin-addr x86)))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (page-directory-entry-addr lin-addr page-directory-base-addr)
-                                 x86))
-                            (xss (gather-all-paging-structure-qword-addresses x86))))
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (mv-nth 1 (page-table-base-addr lin-addr x86)))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (page-directory-entry-addr lin-addr page-directory-base-addr)
+				 x86))
+			    (xss (gather-all-paging-structure-qword-addresses x86))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    (subset-list-p-and-member-list-p)))))
 
 (defthm page-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
   (implies (page-table-entry-addr-found-p lin-addr x86)
-           (member-list-p
-            (page-table-entry-addr
-             lin-addr
-             (mv-nth 1 (page-table-base-addr lin-addr x86)))
-            (gather-all-paging-structure-qword-addresses x86)))
+	   (member-list-p
+	    (page-table-entry-addr
+	     lin-addr
+	     (mv-nth 1 (page-table-base-addr lin-addr x86)))
+	    (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance subset-list-p-and-member-list-p
-                            (e (page-table-entry-addr
-                                lin-addr
-                                (mv-nth 1 (page-table-base-addr lin-addr x86))))
-                            (xs (gather-qword-addresses-corresponding-to-1-entry
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                                 x86))
-                            (xss (gather-all-paging-structure-qword-addresses x86))))
-           :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                            (subset-list-p-and-member-list-p)))))
+	   :use ((:instance subset-list-p-and-member-list-p
+			    (e (page-table-entry-addr
+				lin-addr
+				(mv-nth 1 (page-table-base-addr lin-addr x86))))
+			    (xs (gather-qword-addresses-corresponding-to-1-entry
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+				 x86))
+			    (xss (gather-all-paging-structure-qword-addresses x86))))
+	   :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			    (subset-list-p-and-member-list-p)))))
 
 ;; Relationship of PT with xlate-equiv-x86s:
 
 (defthmd xlate-equiv-x86s-and-page-directory-base-addr-error
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
-           (equal (mv-nth 0 (page-directory-base-addr lin-addr x86-1))
-                  (mv-nth 0 (page-directory-base-addr lin-addr x86-2))))
+		(page-dir-ptr-table-entry-addr-found-p lin-addr x86-1))
+	   (equal (mv-nth 0 (page-directory-base-addr lin-addr x86-1))
+		  (mv-nth 0 (page-directory-base-addr lin-addr x86-2))))
   :hints (("Goal" :in-theory
-           (e/d* (page-directory-base-addr)
-                 (xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
-                  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
-                  page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  canonical-address-p
-                  physical-address-p))
-           :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address)
-                 (:instance xlate-equiv-entries-open
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-2)))
-                 (:instance page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                            (x86 x86-1))
-                 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (page-dir-ptr-table-entry-addr
-                                    lin-addr
-                                    (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-1)))
-                 (:instance logtail-bigger-and-logbitp
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-2))
-                            (m 7)
-                            (n 7))
-                 (:instance logtail-bigger
-                            (e1 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-dir-ptr-table-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
-                                 x86-2))
-                            (m 7)
-                            (n 12))))))
+	   (e/d* (page-directory-base-addr)
+		 (xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
+		  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
+		  page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  canonical-address-p
+		  physical-address-p))
+	   :use ((:instance xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address)
+		 (:instance xlate-equiv-entries-open
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-2)))
+		 (:instance page-dir-ptr-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+			    (x86 x86-1))
+		 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (page-dir-ptr-table-entry-addr
+				    lin-addr
+				    (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-1)))
+		 (:instance logtail-bigger-and-logbitp
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-2))
+			    (m 7)
+			    (n 7))
+		 (:instance logtail-bigger
+			    (e1 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-dir-ptr-table-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86-1)))
+				 x86-2))
+			    (m 7)
+			    (n 12))))))
 
 (defthm xlate-equiv-x86s-and-page-table-base-addr-address
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-directory-entry-addr-found-p lin-addr x86-1))
-           (equal (mv-nth 1 (page-table-base-addr lin-addr x86-1))
-                  (mv-nth 1 (page-table-base-addr lin-addr x86-2))))
+		(page-directory-entry-addr-found-p lin-addr x86-1))
+	   (equal (mv-nth 1 (page-table-base-addr lin-addr x86-1))
+		  (mv-nth 1 (page-table-base-addr lin-addr x86-2))))
   :hints (("Goal" :in-theory
-           (e/d* (page-table-base-addr)
-                 (xlate-equiv-x86s-and-page-directory-entry-addr-address
-                  xlate-equiv-x86s-and-page-directory-base-addr-address
-                  page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  canonical-address-p
-                  physical-address-p))
-           :use ((:instance xlate-equiv-x86s-and-page-directory-entry-addr-address)
-                 (:instance xlate-equiv-x86s-and-page-directory-base-addr-error)
-                 (:instance page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                            (x86 x86-1))
-                 (:instance xlate-equiv-entries-open
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2)))
-                 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (page-directory-entry-addr
-                                    lin-addr
-                                    (mv-nth 1 (page-directory-base-addr lin-addr x86-1))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-1)))
-                 (:instance logtail-bigger-and-logbitp
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (m 7)
-                            (n 7))
-                 (:instance logtail-bigger
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (m 7)
-                            (n 12))))))
+	   (e/d* (page-table-base-addr)
+		 (xlate-equiv-x86s-and-page-directory-entry-addr-address
+		  xlate-equiv-x86s-and-page-directory-base-addr-address
+		  page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  canonical-address-p
+		  physical-address-p))
+	   :use ((:instance xlate-equiv-x86s-and-page-directory-entry-addr-address)
+		 (:instance xlate-equiv-x86s-and-page-directory-base-addr-error)
+		 (:instance page-directory-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+			    (x86 x86-1))
+		 (:instance xlate-equiv-entries-open
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2)))
+		 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (page-directory-entry-addr
+				    lin-addr
+				    (mv-nth 1 (page-directory-base-addr lin-addr x86-1))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-1)))
+		 (:instance logtail-bigger-and-logbitp
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (m 7)
+			    (n 7))
+		 (:instance logtail-bigger
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (m 7)
+			    (n 12))))))
 
 (defthm xlate-equiv-x86s-and-page-table-entry-addr-address
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-directory-entry-addr-found-p lin-addr x86-1))
-           (equal (page-table-entry-addr
-                   lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-1)))
-                  (page-table-entry-addr
-                   lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-2)))))
+		(page-directory-entry-addr-found-p lin-addr x86-1))
+	   (equal (page-table-entry-addr
+		   lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-1)))
+		  (page-table-entry-addr
+		   lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-2)))))
   :hints (("Goal" :in-theory
-           (e/d* (page-table-base-addr)
-                 (xlate-equiv-x86s
-                  xlate-equiv-x86s-and-page-directory-entry-addr-address
-                  xlate-equiv-x86s-and-page-directory-base-addr-error
-                  xlate-equiv-x86s-and-page-directory-base-addr-address
-                  xlate-equiv-x86s-and-page-table-base-addr-address
-                  xlate-equiv-x86s-and-page-directory-entry-addr-value
-                  xlate-equiv-x86s-and-pml4-table-base-addr-address
-                  xlate-equiv-x86s-and-pml4-table-entry-addr-address
-                  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
-                  xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
-                  canonical-address-p
-                  physical-address-p))
-           :use (:instance xlate-equiv-x86s-and-page-table-base-addr-address))))
+	   (e/d* (page-table-base-addr)
+		 (xlate-equiv-x86s
+		  xlate-equiv-x86s-and-page-directory-entry-addr-address
+		  xlate-equiv-x86s-and-page-directory-base-addr-error
+		  xlate-equiv-x86s-and-page-directory-base-addr-address
+		  xlate-equiv-x86s-and-page-table-base-addr-address
+		  xlate-equiv-x86s-and-page-directory-entry-addr-value
+		  xlate-equiv-x86s-and-pml4-table-base-addr-address
+		  xlate-equiv-x86s-and-pml4-table-entry-addr-address
+		  xlate-equiv-x86s-and-page-dir-ptr-table-base-addr-address
+		  xlate-equiv-x86s-and-page-dir-ptr-table-entry-addr-address
+		  canonical-address-p
+		  physical-address-p))
+	   :use (:instance xlate-equiv-x86s-and-page-table-base-addr-address))))
 
 (defthm xlate-equiv-x86s-and-page-table-entry-addr-value
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-table-entry-addr-found-p lin-addr x86-1))
-           (xlate-equiv-entries
-            (rm-low-64
-             (page-table-entry-addr
-              lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-1)))
-             x86-1)
-            (rm-low-64
-             (page-table-entry-addr
-              lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-2)))
-             x86-2)))
+		(page-table-entry-addr-found-p lin-addr x86-1))
+	   (xlate-equiv-entries
+	    (rm-low-64
+	     (page-table-entry-addr
+	      lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-1)))
+	     x86-1)
+	    (rm-low-64
+	     (page-table-entry-addr
+	      lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-2)))
+	     x86-2)))
   :hints (("Goal"
-           :use ((:instance
-                  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  (index (page-table-entry-addr lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-2))))
-                  (addrs (gather-all-paging-structure-qword-addresses x86-2)))
-                 (:instance
-                  page-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  (x86 x86-1))
-                 (:instance xlate-equiv-x86s-and-page-table-entry-addr-address))
-           :in-theory
-           (e/d* (xlate-equiv-x86s)
-                 (xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                  page-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
-                  xlate-equiv-x86s-and-page-table-entry-addr-address
-                  xlate-equiv-x86s-and-page-directory-entry-addr-address
-                  xlate-equiv-x86s-and-page-table-base-addr-address
-                  physical-address-p)))))
+	   :use ((:instance
+		  xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  (index (page-table-entry-addr lin-addr (mv-nth 1 (page-table-base-addr lin-addr x86-2))))
+		  (addrs (gather-all-paging-structure-qword-addresses x86-2)))
+		 (:instance
+		  page-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  (x86 x86-1))
+		 (:instance xlate-equiv-x86s-and-page-table-entry-addr-address))
+	   :in-theory
+	   (e/d* (xlate-equiv-x86s)
+		 (xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+		  page-table-entry-addr-is-in-gather-all-paging-structure-qword-addresses
+		  xlate-equiv-x86s-and-page-table-entry-addr-address
+		  xlate-equiv-x86s-and-page-directory-entry-addr-address
+		  xlate-equiv-x86s-and-page-table-base-addr-address
+		  physical-address-p)))))
 
 (defthm page-table-entry-addr-found-p-and-xlate-equiv-x86s
   (implies (and (xlate-equiv-x86s x86-1 x86-2)
-                (page-table-entry-addr-found-p lin-addr x86-1))
-           (page-table-entry-addr-found-p lin-addr x86-2))
+		(page-table-entry-addr-found-p lin-addr x86-1))
+	   (page-table-entry-addr-found-p lin-addr x86-2))
   :hints (("Goal"
-           :use ((:instance page-directory-entry-addr-found-p-and-xlate-equiv-x86s)
-                 (:instance xlate-equiv-x86s-and-page-directory-entry-addr-value)
-                 (:instance xlate-equiv-entries-open
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr
-                                  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2)))
-                 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
-                            (index (page-directory-entry-addr
-                                    lin-addr
-                                    (mv-nth 1 (page-directory-base-addr lin-addr x86-1))))
-                            (addrs (gather-all-paging-structure-qword-addresses x86-1)))
-                 (:instance logtail-bigger-and-logbitp
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (m 7)
-                            (n 7))
-                 (:instance xlate-equiv-entries-and-loghead
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (n 1))
-                 (:instance xlate-equiv-entries-and-logtail
-                            (e1 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
-                                 x86-1))
-                            (e2 (rm-low-64
-                                 (page-directory-entry-addr
-                                  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
-                                 x86-2))
-                            (n 12)))
-           :in-theory (e/d* (page-table-entry-addr-found-p)
-                            (physical-address-p
-                             xlate-equiv-x86s-and-page-directory-entry-addr-value
-                             pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
-                             xlate-equiv-x86s-and-page-directory-base-addr-address
-                             xlate-equiv-x86s-and-page-directory-base-addr-error
-                             xlate-equiv-x86s-and-page-directory-entry-addr-address
-                             xlate-equiv-x86s-and-page-table-base-addr-address
-                             xlate-equiv-x86s-and-page-table-entry-addr-address
-                             unsigned-byte-p
-                             bitops::logand-with-negated-bitmask)))))
+	   :use ((:instance page-directory-entry-addr-found-p-and-xlate-equiv-x86s)
+		 (:instance xlate-equiv-x86s-and-page-directory-entry-addr-value)
+		 (:instance xlate-equiv-entries-open
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr
+				  (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2)))
+		 (:instance xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
+			    (index (page-directory-entry-addr
+				    lin-addr
+				    (mv-nth 1 (page-directory-base-addr lin-addr x86-1))))
+			    (addrs (gather-all-paging-structure-qword-addresses x86-1)))
+		 (:instance logtail-bigger-and-logbitp
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (m 7)
+			    (n 7))
+		 (:instance xlate-equiv-entries-and-loghead
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (n 1))
+		 (:instance xlate-equiv-entries-and-logtail
+			    (e1 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-1)))
+				 x86-1))
+			    (e2 (rm-low-64
+				 (page-directory-entry-addr
+				  lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86-2)))
+				 x86-2))
+			    (n 12)))
+	   :in-theory (e/d* (page-table-entry-addr-found-p)
+			    (physical-address-p
+			     xlate-equiv-x86s-and-page-directory-entry-addr-value
+			     pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
+			     xlate-equiv-x86s-and-page-directory-base-addr-address
+			     xlate-equiv-x86s-and-page-directory-base-addr-error
+			     xlate-equiv-x86s-and-page-directory-entry-addr-address
+			     xlate-equiv-x86s-and-page-table-base-addr-address
+			     xlate-equiv-x86s-and-page-table-entry-addr-address
+			     unsigned-byte-p
+			     bitops::logand-with-negated-bitmask)))))
 
 ;; ======================================================================
 
 (defthmd gather-all-paging-structure-qword-addresses-with-xlate-equiv-x86s
   (implies (and (good-paging-structures-x86p x86)
-                (xlate-equiv-x86s x86 x86-equiv))
-           (equal (gather-all-paging-structure-qword-addresses x86-equiv)
-                  (gather-all-paging-structure-qword-addresses x86)))
+		(xlate-equiv-x86s x86 x86-equiv))
+	   (equal (gather-all-paging-structure-qword-addresses x86-equiv)
+		  (gather-all-paging-structure-qword-addresses x86)))
   :hints
   (("Goal" :in-theory (e/d* (gather-all-paging-structure-qword-addresses) ()))))
 
 (defthmd xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
   (implies (and (good-paging-structures-x86p x86)
-                (xlate-equiv-x86s x86 x86-equiv)
-                (equal addrs (gather-all-paging-structure-qword-addresses x86)))
-           (xlate-equiv-entries-at-qword-addresses?
-            addrs addrs x86 x86-equiv))
+		(xlate-equiv-x86s x86 x86-equiv)
+		(equal addrs (gather-all-paging-structure-qword-addresses x86)))
+	   (xlate-equiv-entries-at-qword-addresses?
+	    addrs addrs x86 x86-equiv))
   :hints
   (("Goal" :in-theory (e/d* (xlate-equiv-entries-at-qword-addresses?
-                             good-paging-structures-x86p)
-                            ()))))
+			     good-paging-structures-x86p)
+			    ()))))
 
 ;; ======================================================================
 
 (in-theory (e/d* ()
-                 (pml4-table-entry-addr-found-p
-                  page-dir-ptr-table-entry-addr-found-p
-                  page-directory-entry-addr-found-p
-                  page-table-entry-addr-found-p)))
+		 (pml4-table-entry-addr-found-p
+		  page-dir-ptr-table-entry-addr-found-p
+		  page-directory-entry-addr-found-p
+		  page-table-entry-addr-found-p)))
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/gather-paging-structures.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/gather-paging-structures.lisp
@@ -9,73 +9,86 @@
 
 ;; ======================================================================
 
+(defsection gather-paging-structures
+  :parents (reasoning-about-page-tables)
+
+  :short "Gather physical addresses where paging data structures are located"
+
+  :long "<p>WORK IN PROGRESS...</p>
+
+<p>This doc topic will be updated in later commits...</p>"
+  )
+
+;; ======================================================================
+
 ;; Some misc. lemmas:
 
 (defthmd loghead-smaller-and-logbitp
   (implies (and (equal (loghead n e1) (loghead n e2))
-                (natp n)
-                (natp m)
-                (< m n))
-           (equal (logbitp m e1) (logbitp m e2)))
+		(natp n)
+		(natp m)
+		(< m n))
+	   (equal (logbitp m e1) (logbitp m e2)))
   :hints (("Goal" :in-theory (e/d* (bitops::ihsext-inductions
-                                    bitops::ihsext-recursive-redefs)
-                                   ()))))
+				    bitops::ihsext-recursive-redefs)
+				   ()))))
 
 (defthmd logtail-bigger
   (implies (and (equal (logtail m e1) (logtail m e2))
-                (integerp e2)
-                (natp n)
-                (<= m n))
-           (equal (logtail n e1) (logtail n e2)))
+		(integerp e2)
+		(natp n)
+		(<= m n))
+	   (equal (logtail n e1) (logtail n e2)))
   :hints (("Goal" :in-theory (e/d* (bitops::ihsext-inductions
-                                    bitops::ihsext-recursive-redefs)
-                                   ()))))
+				    bitops::ihsext-recursive-redefs)
+				   ()))))
 
 (defthmd logtail-bigger-and-logbitp
   (implies (and (equal (logtail m e1) (logtail m e2))
-                (integerp e2)
-                (natp n)
-                (<= m n))
-           (equal (logbitp n e1) (logbitp n e2)))
+		(integerp e2)
+		(natp n)
+		(<= m n))
+	   (equal (logbitp n e1) (logbitp n e2)))
   :hints (("Goal" :in-theory (e/d* (bitops::ihsext-inductions
-                                    bitops::ihsext-recursive-redefs)
-                                   ()))))
+				    bitops::ihsext-recursive-redefs)
+				   ()))))
 
 (defthm member-list-p-no-duplicates-list-p-and-member-p
   (implies (and (member-list-p index addrs-2)
-                (true-listp addrs-1)
-                (true-list-listp addrs-2)
-                (no-duplicates-list-p (append (list addrs-1) addrs-2)))
-           (not (member-p index addrs-1)))
+		(true-listp addrs-1)
+		(true-list-listp addrs-2)
+		(no-duplicates-list-p (append (list addrs-1) addrs-2)))
+	   (not (member-p index addrs-1)))
   :hints (("Goal" :in-theory (e/d* (member-p
-                                    member-list-p
-                                    acl2::flatten
-                                    no-duplicates-p)
-                                   ()))))
+				    member-list-p
+				    acl2::flatten
+				    no-duplicates-p)
+				   ()))))
 
 ;; ======================================================================
 
 (define qword-paddr-listp (xs)
+  :parents (reasoning-about-page-tables)
   :enabled t
   :short "Recognizer for a list of physical addresses that can
   accommodate a quadword"
   (if (consp xs)
       (and (physical-address-p (car xs))
-           (physical-address-p (+ 7 (car xs)))
-           (qword-paddr-listp (cdr xs)))
+	   (physical-address-p (+ 7 (car xs)))
+	   (qword-paddr-listp (cdr xs)))
     (equal xs nil))
 
   ///
 
   (defthm qword-paddr-listp-implies-true-listp
     (implies (qword-paddr-listp xs)
-             (true-listp xs))
+	     (true-listp xs))
     :rule-classes :forward-chaining)
 
   (defthm-usb qword-paddrp-element-of-qword-paddr-listp
     :hyp (and (qword-paddr-listp xs)
-              (natp m)
-              (< m (len xs)))
+	      (natp m)
+	      (< m (len xs)))
     :bound 52
     :concl (nth m xs)
     :gen-linear t
@@ -83,36 +96,38 @@
 
   (defthm nthcdr-qword-paddr-listp
     (implies (qword-paddr-listp xs)
-             (qword-paddr-listp (nthcdr n xs)))
+	     (qword-paddr-listp (nthcdr n xs)))
     :rule-classes (:rewrite :type-prescription)))
 
 (define qword-paddr-list-listp (xs)
+  :parents (reasoning-about-page-tables)
   :enabled t
   (cond ((atom xs) (eq xs nil))
-        (t (and (qword-paddr-listp (car xs))
-                (qword-paddr-list-listp (cdr xs)))))
+	(t (and (qword-paddr-listp (car xs))
+		(qword-paddr-list-listp (cdr xs)))))
 
   ///
 
   (defthm append-of-qword-paddr-list-listp
     (implies (and (qword-paddr-list-listp xs)
-                  (qword-paddr-list-listp ys))
-             (qword-paddr-list-listp (append xs ys))))
+		  (qword-paddr-list-listp ys))
+	     (qword-paddr-list-listp (append xs ys))))
 
   (defthm qword-paddr-list-listp-implies-true-list-listp
     (implies (qword-paddr-list-listp xs)
-             (true-list-listp xs))
+	     (true-list-listp xs))
     :rule-classes :forward-chaining))
 
 (defthm append-of-true-list-listp
   (implies (and (true-list-listp xs)
-                (true-list-listp ys))
-           (true-list-listp (append xs ys))))
+		(true-list-listp ys))
+	   (true-list-listp (append xs ys))))
 
-(define create-qword-address-list
+(define create-qword-address-list  
   ((count natp)
    (addr :type (unsigned-byte #.*physical-address-size*)))
 
+  :parents (reasoning-about-page-tables)
   :guard (physical-address-p (+ (ash count 3) addr))
 
   :prepwork
@@ -124,8 +139,8 @@
 
 
   (if (or (zp count)
-          (not (physical-address-p addr))
-          (not (physical-address-p (+ 7 addr))))
+	  (not (physical-address-p addr))
+	  (not (physical-address-p (+ 7 addr))))
       nil
     (cons addr (create-qword-address-list (1- count) (+ 8 addr))))
 
@@ -133,76 +148,77 @@
 
   (defthm nat-listp-create-qword-address-list
     (implies (natp addr)
-             (nat-listp (create-qword-address-list count addr)))
+	     (nat-listp (create-qword-address-list count addr)))
     :rule-classes :type-prescription)
 
   (defthm qword-paddr-listp-create-qword-address-list
     (implies (physical-address-p addr)
-             (qword-paddr-listp (create-qword-address-list count addr))))
+	     (qword-paddr-listp (create-qword-address-list count addr))))
 
   (defthm create-qword-address-list-1
     (implies (and (physical-address-p (+ 7 addr))
-                  (physical-address-p addr))
-             (equal (create-qword-address-list 1 addr)
-                    (list addr)))
+		  (physical-address-p addr))
+	     (equal (create-qword-address-list 1 addr)
+		    (list addr)))
     :hints (("Goal" :expand (create-qword-address-list 1 addr))))
 
   (defthm non-nil-create-qword-address-list
     (implies (and (posp count)
-                  (physical-address-p addr)
-                  (physical-address-p (+ 7 addr)))
-             (create-qword-address-list count addr)))
+		  (physical-address-p addr)
+		  (physical-address-p (+ 7 addr)))
+	     (create-qword-address-list count addr)))
 
   (defthm consp-create-qword-address-list
     (implies (and (physical-address-p addr)
-                  (physical-address-p (+ 7 addr))
-                  (posp count))
-             (consp (create-qword-address-list count addr)))
+		  (physical-address-p (+ 7 addr))
+		  (posp count))
+	     (consp (create-qword-address-list count addr)))
     :rule-classes (:type-prescription :rewrite))
 
   (defthm car-of-create-qword-address-list
     (implies (and (posp count)
-                  (physical-address-p addr)
-                  (physical-address-p (+ 7 addr)))
-             (equal (car (create-qword-address-list count addr))
-                    addr)))
+		  (physical-address-p addr)
+		  (physical-address-p (+ 7 addr)))
+	     (equal (car (create-qword-address-list count addr))
+		    addr)))
 
   (defthm member-p-create-qword-address-list
     (implies (and (<= addr x)
-                  (< x (+ (ash count 3) addr))
-                  (equal (loghead 3 addr) 0)
-                  (equal (loghead 3 x) 0)
-                  (physical-address-p x)
-                  (physical-address-p addr))
-             (equal (member-p x (create-qword-address-list count addr))
-                    t))
+		  (< x (+ (ash count 3) addr))
+		  (equal (loghead 3 addr) 0)
+		  (equal (loghead 3 x) 0)
+		  (physical-address-p x)
+		  (physical-address-p addr))
+	     (equal (member-p x (create-qword-address-list count addr))
+		    t))
     :hints (("Goal"
-             :induct (create-qword-address-list count addr)
-             :in-theory (e/d* (loghead) ())))))
+	     :induct (create-qword-address-list count addr)
+	     :in-theory (e/d* (loghead) ())))))
 
 (define mult-8-qword-paddr-listp (xs)
   :enabled t
+  :parents (reasoning-about-page-tables)
   :short "Recognizer for a list of physical addresses that can
   accommodate a quadword"
   (if (consp xs)
       (and (physical-address-p (car xs))
-           (physical-address-p (+ 7 (car xs)))
-           ;; Multiple of 8
-           (equal (loghead 3 (car xs)) 0)
-           (mult-8-qword-paddr-listp (cdr xs)))
+	   (physical-address-p (+ 7 (car xs)))
+	   ;; Multiple of 8
+	   (equal (loghead 3 (car xs)) 0)
+	   (mult-8-qword-paddr-listp (cdr xs)))
     (equal xs nil))
 
   ///
 
   (defthm mult-8-qword-paddr-listp-implies-true-listp
     (implies (mult-8-qword-paddr-listp xs)
-             (true-listp xs))
+	     (true-listp xs))
     :rule-classes :forward-chaining)
 
   (defthm-usb qword-paddrp-element-of-mult-8-qword-paddr-listp
     :hyp (and (mult-8-qword-paddr-listp xs)
-              (natp m)
-              (< m (len xs)))
+	      (natp m)
+	      (< m (len xs)))
     :bound 52
     :concl (nth m xs)
     :gen-linear t
@@ -212,14 +228,14 @@
 
   (defthm nthcdr-mult-8-qword-paddr-listp
     (implies (mult-8-qword-paddr-listp xs)
-             (mult-8-qword-paddr-listp (nthcdr n xs)))
+	     (mult-8-qword-paddr-listp (nthcdr n xs)))
     :rule-classes (:rewrite :type-prescription))
 
   (defthm member-p-and-mult-8-qword-paddr-listp
     (implies (and (member-p index addrs)
-                  (mult-8-qword-paddr-listp addrs))
-             (and (physical-address-p index)
-                  (equal (loghead 3 index) 0)))
+		  (mult-8-qword-paddr-listp addrs))
+	     (and (physical-address-p index)
+		  (equal (loghead 3 index) 0)))
     :rule-classes (:rewrite :forward-chaining)))
 
 (encapsulate
@@ -228,9 +244,9 @@
  (local
   (defthm open-addr-range
     (implies (natp x)
-             (equal (addr-range 8 x)
-                    (list x (+ 1 x) (+ 2 x) (+ 3 x)
-                          (+ 4 x) (+ 5 x) (+ 6 x) (+ 7 x))))))
+	     (equal (addr-range 8 x)
+		    (list x (+ 1 x) (+ 2 x) (+ 3 x)
+			  (+ 4 x) (+ 5 x) (+ 6 x) (+ 7 x))))))
 
  (local
   (encapsulate
@@ -240,90 +256,91 @@
 
    (defthm multiples-of-8-and-disjointness-of-physical-addresses-helper-1
      (implies (and (equal (loghead 3 x) 0)
-                   (equal (loghead 3 y) 0)
-                   (posp n)
-                   (<= n 7)
-                   (natp x)
-                   (natp y))
-              (not (equal (+ n x) y)))
+		   (equal (loghead 3 y) 0)
+		   (posp n)
+		   (<= n 7)
+		   (natp x)
+		   (natp y))
+	      (not (equal (+ n x) y)))
      :hints (("Goal" :in-theory (e/d* (loghead)
-                                      ()))))
+				      ()))))
 
    (defthm multiples-of-8-and-disjointness-of-physical-addresses-helper-2
      (implies (and (equal (loghead 3 x) 0)
-                   (equal (loghead 3 y) 0)
-                   (not (equal x y))
-                   (posp n)
-                   (<= n 7)
-                   (posp m)
-                   (<= m 7)
-                   (natp x)
-                   (natp y))
-              (not (equal (+ n x) (+ m y))))
+		   (equal (loghead 3 y) 0)
+		   (not (equal x y))
+		   (posp n)
+		   (<= n 7)
+		   (posp m)
+		   (<= m 7)
+		   (natp x)
+		   (natp y))
+	      (not (equal (+ n x) (+ m y))))
      :hints (("Goal" :in-theory (e/d* (loghead)
-                                      ()))))))
+				      ()))))))
 
  (defthm multiples-of-8-and-disjointness-of-physical-addresses-1
    (implies (and (equal (loghead 3 addr-1) 0)
-                 (equal (loghead 3 addr-2) 0)
-                 (not (equal addr-2 addr-1))
-                 (natp addr-1)
-                 (natp addr-2))
-            (disjoint-p (addr-range 8 addr-2)
-                        (addr-range 8 addr-1))))
+		 (equal (loghead 3 addr-2) 0)
+		 (not (equal addr-2 addr-1))
+		 (natp addr-1)
+		 (natp addr-2))
+	    (disjoint-p (addr-range 8 addr-2)
+			(addr-range 8 addr-1))))
 
  (defthm multiples-of-8-and-disjointness-of-physical-addresses-2
    (implies (and (equal (loghead 3 addr-1) 0)
-                 (equal (loghead 3 addr-2) 0)
-                 (not (equal addr-2 addr-1))
-                 (natp addr-1)
-                 (natp addr-2))
-            (disjoint-p (cons addr-2 nil)
-                        (addr-range 8 addr-1))))
+		 (equal (loghead 3 addr-2) 0)
+		 (not (equal addr-2 addr-1))
+		 (natp addr-1)
+		 (natp addr-2))
+	    (disjoint-p (cons addr-2 nil)
+			(addr-range 8 addr-1))))
 
  (defthm mult-8-qword-paddr-listp-and-disjoint-p
    (implies (and (member-p index addrs)
-                 (mult-8-qword-paddr-listp (cons addr addrs))
-                 (no-duplicates-p (cons addr addrs)))
-            (disjoint-p (addr-range 8 index)
-                        (addr-range 8 addr)))
+		 (mult-8-qword-paddr-listp (cons addr addrs))
+		 (no-duplicates-p (cons addr addrs)))
+	    (disjoint-p (addr-range 8 index)
+			(addr-range 8 addr)))
    :hints (("Goal" :in-theory (e/d* () (open-addr-range))))
    :rule-classes :forward-chaining))
 
 (define mult-8-qword-paddr-list-listp (xs)
+  :parents (reasoning-about-page-tables)
   :enabled t
   (cond ((atom xs) (eq xs nil))
-        (t (and (mult-8-qword-paddr-listp (car xs))
-                (mult-8-qword-paddr-list-listp (cdr xs)))))
+	(t (and (mult-8-qword-paddr-listp (car xs))
+		(mult-8-qword-paddr-list-listp (cdr xs)))))
 
   ///
 
   (defthm append-of-mult-8-qword-paddr-list-listp
     (implies (and (mult-8-qword-paddr-list-listp xs)
-                  (mult-8-qword-paddr-list-listp ys))
-             (mult-8-qword-paddr-list-listp (append xs ys))))
+		  (mult-8-qword-paddr-list-listp ys))
+	     (mult-8-qword-paddr-list-listp (append xs ys))))
 
   (defthm mult-8-qword-paddr-list-listp-implies-true-list-listp
     (implies (mult-8-qword-paddr-list-listp xs)
-             (true-list-listp xs))
+	     (true-list-listp xs))
     :rule-classes :forward-chaining)
 
   (defthm mult-8-qword-paddr-list-listp-and-append-1
     (implies (and (mult-8-qword-paddr-list-listp (append x y))
-                  (true-listp x))
-             (mult-8-qword-paddr-list-listp x))
+		  (true-listp x))
+	     (mult-8-qword-paddr-list-listp x))
     :rule-classes (:rewrite :forward-chaining))
 
   (defthm mult-8-qword-paddr-list-listp-and-append-2
     (implies (mult-8-qword-paddr-list-listp (append x y))
-             (mult-8-qword-paddr-list-listp y))
+	     (mult-8-qword-paddr-list-listp y))
     :rule-classes (:rewrite :forward-chaining))
 
   (defthm member-list-p-and-mult-8-qword-paddr-list-listp
     (implies (and (member-list-p index addrs)
-                  (mult-8-qword-paddr-list-listp addrs))
-             (and (physical-address-p index)
-                  (equal (loghead 3 index) 0)))
+		  (mult-8-qword-paddr-list-listp addrs))
+	     (and (physical-address-p index)
+		  (equal (loghead 3 index) 0)))
     :rule-classes (:rewrite :forward-chaining)))
 
 (local (in-theory (e/d* () (unsigned-byte-p))))
@@ -333,14 +350,15 @@
 (define xlate-equiv-entries
   ((entry-1 :type (unsigned-byte 64))
    (entry-2 :type (unsigned-byte 64)))
+  :parents (xlate-equiv-x86s)
   :long "<p>Two paging structure entries are @('xlate-equiv-entries')
   if they are equal for all bits except the accessed and dirty
   bits (bits 5 and 6, respectively).</p>"
   (and (equal (part-select entry-1 :low 0 :high 4)
-              (part-select entry-2 :low 0 :high 4))
+	      (part-select entry-2 :low 0 :high 4))
        ;; Bits 5 (accessed bit) and 6 (dirty bit) missing here.
        (equal (part-select entry-1 :low 7 :high 63)
-              (part-select entry-2 :low 7 :high 63)))
+	      (part-select entry-2 :low 7 :high 63)))
   ///
   (defequiv xlate-equiv-entries)
 
@@ -355,12 +373,12 @@
     ;; during rewriting that match this rule exactly. The same comment
     ;; applies to the rule XLATE-EQUIV-ENTRIES-SELF-SET-DIRTY-BIT.
     (and (xlate-equiv-entries e (set-accessed-bit e))
-         (xlate-equiv-entries (set-accessed-bit e) e))
+	 (xlate-equiv-entries (set-accessed-bit e) e))
     :hints (("Goal" :in-theory (e/d* (set-accessed-bit) ()))))
 
   (defthm xlate-equiv-entries-self-set-dirty-bit
     (and (xlate-equiv-entries e (set-dirty-bit e))
-         (xlate-equiv-entries (set-dirty-bit e) e))
+	 (xlate-equiv-entries (set-dirty-bit e) e))
     :hints (("Goal" :in-theory (e/d* (set-dirty-bit) ()))))
 
   (defun find-xlate-equiv-entries (e1-equiv e2-equiv)
@@ -380,89 +398,89 @@
     ;; set-dirty-bit, mainly because at this point, I'm reasonably
     ;; confident that that's a situation that won't occur.
     (cond ((equal e1-equiv e2-equiv)
-           `((e1 . ,e1-equiv)
-             (e2 . ,e2-equiv)))
-          ((equal (first e1-equiv) 'rm-low-64)
-           (cond ((equal (first e2-equiv) 'rm-low-64)
-                  `((e1 . ,e1-equiv)
-                    (e2 . ,e2-equiv)))
-                 ((equal (first e2-equiv) 'set-accessed-bit)
-                  (b* ((e2
-                        (if (equal (car (second e2-equiv)) 'set-dirty-bit)
-                            (second (second e2-equiv))
-                          (second e2-equiv))))
-                      `((e1 . ,e1-equiv)
-                        (e2 . ,e2))))
-                 ((equal (first e2-equiv) 'set-dirty-bit)
-                  (b* ((e2
-                        (if (equal (car (second e2-equiv)) 'set-accessed-bit)
-                            (second (second e2-equiv))
-                          (second (second e2-equiv)))))
-                      `((e1 . ,e1-equiv)
-                        (e2 . ,e2))))
-                 (t
-                  `((e1 . ,e1-equiv)
-                    (e2 . ,e2-equiv)))))
-          ((equal (first e2-equiv) 'rm-low-64)
-           (cond ((equal (first e1-equiv) 'rm-low-64)
-                  `((e2 . ,e2-equiv)
-                    (e1 . ,e1-equiv)))
-                 ((equal (first e1-equiv) 'set-accessed-bit)
-                  (b* ((e1
-                        (if (equal (car (second e1-equiv)) 'set-dirty-bit)
-                            (second (second e1-equiv))
-                          (second e1-equiv))))
-                      `((e2 . ,e2-equiv)
-                        (e1 . ,e1))))
-                 ((equal (first e1-equiv) 'set-dirty-bit)
-                  (b* ((e1
-                        (if (equal (car (second e1-equiv)) 'set-accessed-bit)
-                            (second (second e1-equiv))
-                          (second e1-equiv))))
-                      `((e2 . ,e2-equiv)
-                        (e1 . ,e1))))
-                 (t
-                  `((e2 . ,e2-equiv)
-                    (e1 . ,e1-equiv)))))))
+	   `((e1 . ,e1-equiv)
+	     (e2 . ,e2-equiv)))
+	  ((equal (first e1-equiv) 'rm-low-64)
+	   (cond ((equal (first e2-equiv) 'rm-low-64)
+		  `((e1 . ,e1-equiv)
+		    (e2 . ,e2-equiv)))
+		 ((equal (first e2-equiv) 'set-accessed-bit)
+		  (b* ((e2
+			(if (equal (car (second e2-equiv)) 'set-dirty-bit)
+			    (second (second e2-equiv))
+			  (second e2-equiv))))
+		      `((e1 . ,e1-equiv)
+			(e2 . ,e2))))
+		 ((equal (first e2-equiv) 'set-dirty-bit)
+		  (b* ((e2
+			(if (equal (car (second e2-equiv)) 'set-accessed-bit)
+			    (second (second e2-equiv))
+			  (second (second e2-equiv)))))
+		      `((e1 . ,e1-equiv)
+			(e2 . ,e2))))
+		 (t
+		  `((e1 . ,e1-equiv)
+		    (e2 . ,e2-equiv)))))
+	  ((equal (first e2-equiv) 'rm-low-64)
+	   (cond ((equal (first e1-equiv) 'rm-low-64)
+		  `((e2 . ,e2-equiv)
+		    (e1 . ,e1-equiv)))
+		 ((equal (first e1-equiv) 'set-accessed-bit)
+		  (b* ((e1
+			(if (equal (car (second e1-equiv)) 'set-dirty-bit)
+			    (second (second e1-equiv))
+			  (second e1-equiv))))
+		      `((e2 . ,e2-equiv)
+			(e1 . ,e1))))
+		 ((equal (first e1-equiv) 'set-dirty-bit)
+		  (b* ((e1
+			(if (equal (car (second e1-equiv)) 'set-accessed-bit)
+			    (second (second e1-equiv))
+			  (second e1-equiv))))
+		      `((e2 . ,e2-equiv)
+			(e1 . ,e1))))
+		 (t
+		  `((e2 . ,e2-equiv)
+		    (e1 . ,e1-equiv)))))))
 
   (defthm xlate-equiv-entries-and-set-accessed-and/or-dirty-bit
     (implies
      (and (bind-free (find-xlate-equiv-entries e1-equiv e2-equiv) (e1 e2))
-          (xlate-equiv-entries e1 e2)
-          (or (equal e1-equiv e1)
-              (equal e1-equiv (set-accessed-bit e1))
-              (equal e1-equiv (set-dirty-bit e1))
-              (equal e1-equiv
-                     (set-dirty-bit (set-accessed-bit e1))))
-          (or (equal e2-equiv e2)
-              (equal e2-equiv (set-accessed-bit e2))
-              (equal e2-equiv (set-dirty-bit e2))
-              (equal e2-equiv
-                     (set-dirty-bit (set-accessed-bit e2)))))
+	  (xlate-equiv-entries e1 e2)
+	  (or (equal e1-equiv e1)
+	      (equal e1-equiv (set-accessed-bit e1))
+	      (equal e1-equiv (set-dirty-bit e1))
+	      (equal e1-equiv
+		     (set-dirty-bit (set-accessed-bit e1))))
+	  (or (equal e2-equiv e2)
+	      (equal e2-equiv (set-accessed-bit e2))
+	      (equal e2-equiv (set-dirty-bit e2))
+	      (equal e2-equiv
+		     (set-dirty-bit (set-accessed-bit e2)))))
      (xlate-equiv-entries e1-equiv e2-equiv))
     :hints (("Goal" :in-theory (e/d* (set-accessed-bit
-                                      set-dirty-bit)
-                                     ()))))
+				      set-dirty-bit)
+				     ()))))
 
   (defthmd xlate-equiv-entries-and-loghead
     (implies (and (xlate-equiv-entries e1 e2)
-                  (syntaxp (quotep n))
-                  (natp n)
-                  (<= n 5))
-             (equal (loghead n e1) (loghead n e2)))
+		  (syntaxp (quotep n))
+		  (natp n)
+		  (<= n 5))
+	     (equal (loghead n e1) (loghead n e2)))
     :hints (("Goal" :use ((:instance loghead-smaller-equality
-                                     (x e1) (y e2) (n 5) (m n))))))
+				     (x e1) (y e2) (n 5) (m n))))))
 
   (defthmd xlate-equiv-entries-and-logtail
     (implies (and (xlate-equiv-entries e1 e2)
-                  (unsigned-byte-p 64 e1)
-                  (unsigned-byte-p 64 e2)
-                  (syntaxp (quotep n))
-                  (natp n)
-                  (<= 7 n))
-             (equal (logtail n e1) (logtail n e2)))
+		  (unsigned-byte-p 64 e1)
+		  (unsigned-byte-p 64 e2)
+		  (syntaxp (quotep n))
+		  (natp n)
+		  (<= 7 n))
+	     (equal (logtail n e1) (logtail n e2)))
     :hints (("Goal" :use ((:instance logtail-bigger
-                                     (n n) (m 7)))))))
+				     (n n) (m 7)))))))
 
 ;; ======================================================================
 
@@ -470,15 +488,16 @@
 ;; located:
 
 (define gather-pml4-table-qword-addresses (x86)
+  :parents (gather-paging-structures)
   :returns (list-of-addresses qword-paddr-listp)
   (b* ((cr3 (ctri *cr3* x86))
        (pml4-table-base-addr (ash (cr3-slice :cr3-pdb cr3) 12))
        ((when (not (physical-address-p
-                    (+ (ash 512 3) pml4-table-base-addr))))
-        ;; If the PML4 Table does not fit into the physical memory,
-        ;; something's wrong --- likely, the paging structures haven't
-        ;; been set up correctly.
-        nil))
+		    (+ (ash 512 3) pml4-table-base-addr))))
+	;; If the PML4 Table does not fit into the physical memory,
+	;; something's wrong --- likely, the paging structures haven't
+	;; been set up correctly.
+	nil))
       (create-qword-address-list 512 pml4-table-base-addr))
   ///
   (std::more-returns
@@ -486,36 +505,38 @@
 
   (defthm gather-pml4-table-qword-addresses-xw-fld!=ctr
     (implies (not (equal fld :ctr))
-             (equal (gather-pml4-table-qword-addresses (xw fld index val x86))
-                    (gather-pml4-table-qword-addresses x86)))
+	     (equal (gather-pml4-table-qword-addresses (xw fld index val x86))
+		    (gather-pml4-table-qword-addresses x86)))
     :hints (("Goal"
-             :cases ((equal fld :ctr))
-             :in-theory (e/d* (gather-pml4-table-qword-addresses)
-                              ()))))
+	     :cases ((equal fld :ctr))
+	     :in-theory (e/d* (gather-pml4-table-qword-addresses)
+			      ()))))
 
   (defthm gather-pml4-table-qword-addresses-wm-low-64
     (equal (gather-pml4-table-qword-addresses (wm-low-64 index val x86))
-           (gather-pml4-table-qword-addresses x86))
+	   (gather-pml4-table-qword-addresses x86))
     :hints (("Goal"
-             :in-theory (e/d* (gather-pml4-table-qword-addresses)
-                              ()))))
+	     :in-theory (e/d* (gather-pml4-table-qword-addresses)
+			      ()))))
 
   (defthm gather-pml4-table-qword-addresses-xw-fld=ctr
     (implies (and (equal fld :ctr)
-                  (not (equal index *cr3*)))
-             (equal (gather-pml4-table-qword-addresses (xw fld index val x86))
-                    (gather-pml4-table-qword-addresses x86)))
+		  (not (equal index *cr3*)))
+	     (equal (gather-pml4-table-qword-addresses (xw fld index val x86))
+		    (gather-pml4-table-qword-addresses x86)))
     :hints (("Goal"
-             :cases ((equal fld :ctr))
-             :in-theory (e/d* (gather-pml4-table-qword-addresses)
-                              ())))))
+	     :cases ((equal fld :ctr))
+	     :in-theory (e/d* (gather-pml4-table-qword-addresses)
+			      ())))))
 
 (define gather-qword-addresses-corresponding-to-1-entry
   ((superior-structure-paddr natp)
    x86)
 
+  :parents (gather-paging-structures)
+
   :guard (and (physical-address-p superior-structure-paddr)
-              (physical-address-p (+ 7 superior-structure-paddr)))
+	      (physical-address-p (+ 7 superior-structure-paddr)))
 
   :returns (list-of-addresses qword-paddr-listp)
 
@@ -524,140 +545,140 @@
   @('superior-structure-paddr')"
 
   (b* ((superior-structure-entry
-        (rm-low-64 superior-structure-paddr x86)))
+	(rm-low-64 superior-structure-paddr x86)))
       (if (and
-           (equal (ia32e-page-tables-slice :p  superior-structure-entry) 1)
-           (equal (ia32e-page-tables-slice :ps superior-structure-entry) 0))
-          ;; Gather the qword addresses of a paging structure only if a
-          ;; superior structure points to it, i.e., the
-          ;; superior-structure-entry should be present (P=1) and it
-          ;; should reference an inferior structure (PS=0).
-          (b* ((this-structure-base-addr
-                (ash (ia32e-page-tables-slice
-                      :reference-addr superior-structure-entry) 12))
-               ((when (not (physical-address-p
-                            (+ (ash 512 3) this-structure-base-addr))))
-                ;; If the inferior table doesn't fit into the
-                ;; physical memory, something's wrong likely, the
-                ;; paging structures haven't been set up correctly.
-                nil))
-              (create-qword-address-list 512 this-structure-base-addr))
-        nil))
+	   (equal (ia32e-page-tables-slice :p  superior-structure-entry) 1)
+	   (equal (ia32e-page-tables-slice :ps superior-structure-entry) 0))
+	  ;; Gather the qword addresses of a paging structure only if a
+	  ;; superior structure points to it, i.e., the
+	  ;; superior-structure-entry should be present (P=1) and it
+	  ;; should reference an inferior structure (PS=0).
+	  (b* ((this-structure-base-addr
+		(ash (ia32e-page-tables-slice
+		      :reference-addr superior-structure-entry) 12))
+	       ((when (not (physical-address-p
+			    (+ (ash 512 3) this-structure-base-addr))))
+		;; If the inferior table doesn't fit into the
+		;; physical memory, something's wrong likely, the
+		;; paging structures haven't been set up correctly.
+		nil))
+	      (create-qword-address-list 512 this-structure-base-addr))
+	nil))
   ///
   (std::more-returns
    (list-of-addresses true-listp))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-xw-fld!=mem
     (implies (not (equal fld :mem))
-             (equal (gather-qword-addresses-corresponding-to-1-entry
-                     n (xw fld index val x86))
-                    (gather-qword-addresses-corresponding-to-1-entry n x86)))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry
+		     n (xw fld index val x86))
+		    (gather-qword-addresses-corresponding-to-1-entry n x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-xw-fld=mem-disjoint
     (implies (and (disjoint-p (addr-range 1 index)
-                              (addr-range 8 addr))
-                  (natp addr))
-             (equal (gather-qword-addresses-corresponding-to-1-entry
-                     addr (xw :mem index val x86))
-                    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+			      (addr-range 8 addr))
+		  (natp addr))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry
+		     addr (xw :mem index val x86))
+		    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                              (addr-range
-                               addr-range-1)))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
+			      (addr-range
+			       addr-range-1)))))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-wm-low-64
     (implies (and (disjoint-p (addr-range 8 index)
-                              (addr-range 8 addr))
-                  (physical-address-p index)
-                  (physical-address-p addr))
-             (equal (gather-qword-addresses-corresponding-to-1-entry
-                     addr (wm-low-64 index val x86))
-                    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+			      (addr-range 8 addr))
+		  (physical-address-p index)
+		  (physical-address-p addr))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry
+		     addr (wm-low-64 index val x86))
+		    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-xw-fld=mem-superior-entry-addr
     (implies (and (equal index addr)
-                  ;; (or
-                  ;;  (equal val (set-accessed-bit (rm-low-64 addr x86)))
-                  ;;  (equal val (set-dirty-bit (rm-low-64 addr x86)))
-                  ;;  (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 addr x86)))))
-                  (xlate-equiv-entries val (rm-low-64 addr x86))
-                  (unsigned-byte-p 64 val)
-                  (physical-address-p index)
-                  (physical-address-p (+ 7 index))
-                  (x86p x86))
-             (equal (gather-qword-addresses-corresponding-to-1-entry
-                     addr (wm-low-64 index val x86))
-                    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+		  ;; (or
+		  ;;  (equal val (set-accessed-bit (rm-low-64 addr x86)))
+		  ;;  (equal val (set-dirty-bit (rm-low-64 addr x86)))
+		  ;;  (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 addr x86)))))
+		  (xlate-equiv-entries val (rm-low-64 addr x86))
+		  (unsigned-byte-p 64 val)
+		  (physical-address-p index)
+		  (physical-address-p (+ 7 index))
+		  (x86p x86))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry
+		     addr (wm-low-64 index val x86))
+		    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
     :hints (("Goal"
-             :in-theory (e/d* (member-p)
-                              (xlate-equiv-entries))
-             :use ((:instance xlate-equiv-entries-and-loghead
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 1))
-                   (:instance logtail-bigger-and-logbitp
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7)
-                              (m 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 12))))))
+	     :in-theory (e/d* (member-p)
+			      (xlate-equiv-entries))
+	     :use ((:instance xlate-equiv-entries-and-loghead
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 1))
+		   (:instance logtail-bigger-and-logbitp
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7)
+			      (m 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 12))))))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-with-different-x86-entries
     (implies (and (xlate-equiv-entries (rm-low-64 addr x86-equiv)
-                                       (rm-low-64 addr x86))
-                  (x86p x86)
-                  (x86p x86-equiv))
-             (equal (gather-qword-addresses-corresponding-to-1-entry addr x86-equiv)
-                    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+				       (rm-low-64 addr x86))
+		  (x86p x86)
+		  (x86p x86-equiv))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry addr x86-equiv)
+		    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
     :hints (("Goal" :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                                     (unsigned-byte-p))
-             :use ((:instance xlate-equiv-entries-and-loghead
-                              (e1 (rm-low-64 addr x86-equiv))
-                              (e2 (rm-low-64 addr x86))
-                              (n 1))
-                   (:instance logtail-bigger-and-logbitp
-                              (e1 (rm-low-64 addr x86-equiv))
-                              (e2 (rm-low-64 addr x86))
-                              (n 7)
-                              (m 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 (rm-low-64 addr x86-equiv))
-                              (e2 (rm-low-64 addr x86))
-                              (n 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 (rm-low-64 addr x86-equiv))
-                              (e2 (rm-low-64 addr x86))
-                              (n 12))))))
+				     (unsigned-byte-p))
+	     :use ((:instance xlate-equiv-entries-and-loghead
+			      (e1 (rm-low-64 addr x86-equiv))
+			      (e2 (rm-low-64 addr x86))
+			      (n 1))
+		   (:instance logtail-bigger-and-logbitp
+			      (e1 (rm-low-64 addr x86-equiv))
+			      (e2 (rm-low-64 addr x86))
+			      (n 7)
+			      (m 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 (rm-low-64 addr x86-equiv))
+			      (e2 (rm-low-64 addr x86))
+			      (n 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 (rm-low-64 addr x86-equiv))
+			      (e2 (rm-low-64 addr x86))
+			      (n 12))))))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-wm-low-64-with-different-x86-disjoint
     (implies (and (disjoint-p (addr-range 8 index) (addr-range 8 addr))
-                  (physical-address-p addr)
-                  (physical-address-p index)
-                  (equal (gather-qword-addresses-corresponding-to-1-entry addr x86-equiv)
-                         (gather-qword-addresses-corresponding-to-1-entry addr x86)))
-             ;; (xlate-equiv-entries (rm-low-64 addr x86-equiv)
-             ;;                      (rm-low-64 addr x86))
-             (equal (gather-qword-addresses-corresponding-to-1-entry
-                     addr (wm-low-64 index val x86-equiv))
-                    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+		  (physical-address-p addr)
+		  (physical-address-p index)
+		  (equal (gather-qword-addresses-corresponding-to-1-entry addr x86-equiv)
+			 (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+	     ;; (xlate-equiv-entries (rm-low-64 addr x86-equiv)
+	     ;;                      (rm-low-64 addr x86))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry
+		     addr (wm-low-64 index val x86-equiv))
+		    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
     :hints (("Goal" :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                                     (gather-qword-addresses-corresponding-to-1-entry-wm-low-64
-                                      unsigned-byte-p))
-             :use ((:instance gather-qword-addresses-corresponding-to-1-entry-wm-low-64
-                              (x86 x86-equiv))))))
+				     (gather-qword-addresses-corresponding-to-1-entry-wm-low-64
+				      unsigned-byte-p))
+	     :use ((:instance gather-qword-addresses-corresponding-to-1-entry-wm-low-64
+			      (x86 x86-equiv))))))
 
   (defthm gather-qword-addresses-corresponding-to-1-entry-wm-low-64-with-different-x86
     ;; This is a surprising theorem. Even if we write an
@@ -670,35 +691,37 @@
     ;; simply in terms of create-qword-address-list once the entry at
     ;; addr is read from the x86 (or x86-equiv) state.
     (implies (and (xlate-equiv-entries val (rm-low-64 addr x86))
-                  (unsigned-byte-p 64 val)
-                  (physical-address-p addr)
-                  (physical-address-p (+ 7 addr))
-                  (x86p x86))
-             (equal (gather-qword-addresses-corresponding-to-1-entry
-                     addr (wm-low-64 addr val x86-equiv))
-                    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
+		  (unsigned-byte-p 64 val)
+		  (physical-address-p addr)
+		  (physical-address-p (+ 7 addr))
+		  (x86p x86))
+	     (equal (gather-qword-addresses-corresponding-to-1-entry
+		     addr (wm-low-64 addr val x86-equiv))
+		    (gather-qword-addresses-corresponding-to-1-entry addr x86)))
     :hints (("Goal" :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry)
-                                     ())
-             :use ((:instance xlate-equiv-entries-and-loghead
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 1))
-                   (:instance logtail-bigger-and-logbitp
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7)
-                              (m 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 12)))))))
+				     ())
+	     :use ((:instance xlate-equiv-entries-and-loghead
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 1))
+		   (:instance logtail-bigger-and-logbitp
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7)
+			      (m 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 12)))))))
 
 (define gather-qword-addresses-corresponding-to-entries
   (superior-structure-paddrs x86)
+
+  :parents (gather-paging-structures)
 
   :guard (qword-paddr-listp superior-structure-paddrs)
 
@@ -711,137 +734,139 @@
   (if (endp superior-structure-paddrs)
       nil
     (b* ((superior-structure-paddr-1 (car superior-structure-paddrs))
-         (superior-structure-paddrs-rest (cdr superior-structure-paddrs))
-         ((when (not (physical-address-p (+ 7 superior-structure-paddr-1))))
-          ;; Each of the superior-structure-paddrs should point to a qword.
-          nil)
-         (inferior-addresses
-          (gather-qword-addresses-corresponding-to-1-entry
-           superior-structure-paddr-1 x86))
-         ((when (not inferior-addresses))
-          (gather-qword-addresses-corresponding-to-entries
-           superior-structure-paddrs-rest x86)))
-        (cons
-         inferior-addresses
-         (gather-qword-addresses-corresponding-to-entries
-          superior-structure-paddrs-rest x86))))
+	 (superior-structure-paddrs-rest (cdr superior-structure-paddrs))
+	 ((when (not (physical-address-p (+ 7 superior-structure-paddr-1))))
+	  ;; Each of the superior-structure-paddrs should point to a qword.
+	  nil)
+	 (inferior-addresses
+	  (gather-qword-addresses-corresponding-to-1-entry
+	   superior-structure-paddr-1 x86))
+	 ((when (not inferior-addresses))
+	  (gather-qword-addresses-corresponding-to-entries
+	   superior-structure-paddrs-rest x86)))
+	(cons
+	 inferior-addresses
+	 (gather-qword-addresses-corresponding-to-entries
+	  superior-structure-paddrs-rest x86))))
   ///
   (std::more-returns
    (list-of-lists-of-addresses true-list-listp))
 
   (defthm gather-qword-addresses-corresponding-to-entries-xw-fld!=mem
     (implies (not (equal fld :mem))
-             (equal (gather-qword-addresses-corresponding-to-entries
-                     addrs (xw fld index val x86))
-                    (gather-qword-addresses-corresponding-to-entries addrs x86)))
+	     (equal (gather-qword-addresses-corresponding-to-entries
+		     addrs (xw fld index val x86))
+		    (gather-qword-addresses-corresponding-to-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-entries-xw-fld=mem-disjoint
     (implies (and (not (member-p index addrs))
-                  (equal (loghead 3 index) 0)
-                  (physical-address-p index)
-                  (mult-8-qword-paddr-listp addrs))
-             (equal (gather-qword-addresses-corresponding-to-entries
-                     addrs (xw :mem index val x86))
-                    (gather-qword-addresses-corresponding-to-entries addrs x86)))
+		  (equal (loghead 3 index) 0)
+		  (physical-address-p index)
+		  (mult-8-qword-paddr-listp addrs))
+	     (equal (gather-qword-addresses-corresponding-to-entries
+		     addrs (xw :mem index val x86))
+		    (gather-qword-addresses-corresponding-to-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
-                               ifix)
-                              (addr-range
-                               (addr-range))))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
+			       ifix)
+			      (addr-range
+			       (addr-range))))))
 
   (defthm gather-qword-addresses-corresponding-to-entries-wm-low-64
     (implies (and (not (member-p index addrs))
-                  (equal (loghead 3 index) 0)
-                  (physical-address-p index)
-                  (mult-8-qword-paddr-listp addrs))
-             (equal (gather-qword-addresses-corresponding-to-entries
-                     addrs (wm-low-64 index val x86))
-                    (gather-qword-addresses-corresponding-to-entries addrs x86)))
+		  (equal (loghead 3 index) 0)
+		  (physical-address-p index)
+		  (mult-8-qword-paddr-listp addrs))
+	     (equal (gather-qword-addresses-corresponding-to-entries
+		     addrs (wm-low-64 index val x86))
+		    (gather-qword-addresses-corresponding-to-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
-                               ifix)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
+			       ifix)
+			      ()))))
 
   (local
    (defthm gather-qword-addresses-corresponding-to-entries-xw-fld=mem-superior-entry-addr-helper
      (implies (and (member-p index (cdr addrs))
-                   (no-duplicates-p addrs))
-              (not (equal index (car addrs))))))
+		   (no-duplicates-p addrs))
+	      (not (equal index (car addrs))))))
 
   (defthm gather-qword-addresses-corresponding-to-entries-xw-fld=mem-superior-entry-addr
     (implies (and (member-p index addrs)
-                  (mult-8-qword-paddr-listp addrs)
-                  (no-duplicates-p addrs)
-                  ;; (or
-                  ;;  (equal val (set-accessed-bit (rm-low-64 index x86)))
-                  ;;  (equal val (set-dirty-bit (rm-low-64 index x86)))
-                  ;;  (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
-                  (xlate-equiv-entries val (rm-low-64 index x86))
-                  (unsigned-byte-p 64 val)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0)
-                  (x86p x86))
-             (equal (gather-qword-addresses-corresponding-to-entries
-                     addrs (wm-low-64 index val x86))
-                    (gather-qword-addresses-corresponding-to-entries addrs x86)))
+		  (mult-8-qword-paddr-listp addrs)
+		  (no-duplicates-p addrs)
+		  ;; (or
+		  ;;  (equal val (set-accessed-bit (rm-low-64 index x86)))
+		  ;;  (equal val (set-dirty-bit (rm-low-64 index x86)))
+		  ;;  (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
+		  (xlate-equiv-entries val (rm-low-64 index x86))
+		  (unsigned-byte-p 64 val)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0)
+		  (x86p x86))
+	     (equal (gather-qword-addresses-corresponding-to-entries
+		     addrs (wm-low-64 index val x86))
+		    (gather-qword-addresses-corresponding-to-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (member-p)
-                              (xlate-equiv-entries))
-             :use ((:instance xlate-equiv-entries-and-loghead
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 1))
-                   (:instance logtail-bigger-and-logbitp
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7)
-                              (m 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 12))))))
+	     :in-theory (e/d* (member-p)
+			      (xlate-equiv-entries))
+	     :use ((:instance xlate-equiv-entries-and-loghead
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 1))
+		   (:instance logtail-bigger-and-logbitp
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7)
+			      (m 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 12))))))
 
   (defthm gather-qword-addresses-corresponding-to-entries-wm-low-64-with-different-x86-disjoint
     (implies (and (equal (gather-qword-addresses-corresponding-to-entries addrs x86-equiv)
-                         (gather-qword-addresses-corresponding-to-entries addrs x86))
-                  (not (member-p index addrs))
-                  (equal (loghead 3 index) 0)
-                  (physical-address-p index)
-                  (mult-8-qword-paddr-listp addrs))
-             (equal (gather-qword-addresses-corresponding-to-entries
-                     addrs (wm-low-64 index val x86-equiv))
-                    (gather-qword-addresses-corresponding-to-entries addrs x86)))
+			 (gather-qword-addresses-corresponding-to-entries addrs x86))
+		  (not (member-p index addrs))
+		  (equal (loghead 3 index) 0)
+		  (physical-address-p index)
+		  (mult-8-qword-paddr-listp addrs))
+	     (equal (gather-qword-addresses-corresponding-to-entries
+		     addrs (wm-low-64 index val x86-equiv))
+		    (gather-qword-addresses-corresponding-to-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
-                               ifix)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
+			       ifix)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-entries-wm-low-64-with-different-x86
     (implies (and (equal (gather-qword-addresses-corresponding-to-entries addrs x86-equiv)
-                         (gather-qword-addresses-corresponding-to-entries addrs x86))
-                  (member-p index addrs)
-                  (mult-8-qword-paddr-listp addrs)
-                  (no-duplicates-p addrs)
-                  (xlate-equiv-entries val (rm-low-64 index x86-equiv))
-                  (unsigned-byte-p 64 val)
-                  (x86p x86-equiv))
-             (equal (gather-qword-addresses-corresponding-to-entries
-                     addrs (wm-low-64 index val x86-equiv))
-                    (gather-qword-addresses-corresponding-to-entries addrs x86)))
+			 (gather-qword-addresses-corresponding-to-entries addrs x86))
+		  (member-p index addrs)
+		  (mult-8-qword-paddr-listp addrs)
+		  (no-duplicates-p addrs)
+		  (xlate-equiv-entries val (rm-low-64 index x86-equiv))
+		  (unsigned-byte-p 64 val)
+		  (x86p x86-equiv))
+	     (equal (gather-qword-addresses-corresponding-to-entries
+		     addrs (wm-low-64 index val x86-equiv))
+		    (gather-qword-addresses-corresponding-to-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
-                               member-p)
-                              (unsigned-byte-p))))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-entries
+			       member-p)
+			      (unsigned-byte-p))))))
 
 (define gather-qword-addresses-corresponding-to-list-of-entries
   (list-of-superior-structure-entries x86)
+
+  :parents (gather-paging-structures)
 
   :guard (qword-paddr-list-listp list-of-superior-structure-entries)
 
@@ -864,109 +889,111 @@
 
   (defthm gather-qword-addresses-corresponding-to-list-of-entries-xw-fld!=mem
     (implies (not (equal fld :mem))
-             (equal (gather-qword-addresses-corresponding-to-list-of-entries
-                     addrs (xw fld index val x86))
-                    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
+	     (equal (gather-qword-addresses-corresponding-to-list-of-entries
+		     addrs (xw fld index val x86))
+		    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
     (implies (and (pairwise-disjoint-p-aux (list index) addrs)
-                  (mult-8-qword-paddr-list-listp addrs)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0))
-             (equal (gather-qword-addresses-corresponding-to-list-of-entries
-                     addrs (xw :mem index val x86))
-                    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
+		  (mult-8-qword-paddr-list-listp addrs)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0))
+	     (equal (gather-qword-addresses-corresponding-to-list-of-entries
+		     addrs (xw :mem index val x86))
+		    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-list-of-entries-wm-low-64
     (implies (and (pairwise-disjoint-p-aux (list index) addrs)
-                  (mult-8-qword-paddr-list-listp addrs)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0))
-             (equal (gather-qword-addresses-corresponding-to-list-of-entries
-                     addrs (wm-low-64 index val x86))
-                    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
+		  (mult-8-qword-paddr-list-listp addrs)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0))
+	     (equal (gather-qword-addresses-corresponding-to-list-of-entries
+		     addrs (wm-low-64 index val x86))
+		    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries)
-                              ()))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries)
+			      ()))))
 
   (defthm gather-qword-addresses-corresponding-to-list-of-entries-xw-superior-entry-addr
     (implies (and (member-list-p index addrs)
-                  (mult-8-qword-paddr-list-listp addrs)
-                  (no-duplicates-list-p addrs)
-                  ;; (or
-                  ;;  (equal val (set-accessed-bit (rm-low-64 index x86)))
-                  ;;  (equal val (set-dirty-bit (rm-low-64 index x86)))
-                  ;;  (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
-                  (xlate-equiv-entries val (rm-low-64 index x86))
-                  (unsigned-byte-p 64 val)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0)
-                  (x86p x86))
-             (equal (gather-qword-addresses-corresponding-to-list-of-entries
-                     addrs (wm-low-64 index val x86))
-                    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
+		  (mult-8-qword-paddr-list-listp addrs)
+		  (no-duplicates-list-p addrs)
+		  ;; (or
+		  ;;  (equal val (set-accessed-bit (rm-low-64 index x86)))
+		  ;;  (equal val (set-dirty-bit (rm-low-64 index x86)))
+		  ;;  (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
+		  (xlate-equiv-entries val (rm-low-64 index x86))
+		  (unsigned-byte-p 64 val)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0)
+		  (x86p x86))
+	     (equal (gather-qword-addresses-corresponding-to-list-of-entries
+		     addrs (wm-low-64 index val x86))
+		    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
-                               member-p)
-                              (xlate-equiv-entries))
-             :use ((:instance xlate-equiv-entries-and-loghead
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 1))
-                   (:instance logtail-bigger-and-logbitp
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7)
-                              (m 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 7))
-                   (:instance xlate-equiv-entries-and-logtail
-                              (e1 val)
-                              (e2 (rm-low-64 addr x86))
-                              (n 12))))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-1-entry
+			       member-p)
+			      (xlate-equiv-entries))
+	     :use ((:instance xlate-equiv-entries-and-loghead
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 1))
+		   (:instance logtail-bigger-and-logbitp
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7)
+			      (m 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 7))
+		   (:instance xlate-equiv-entries-and-logtail
+			      (e1 val)
+			      (e2 (rm-low-64 addr x86))
+			      (n 12))))))
 
   (defthm gather-qword-addresses-corresponding-to-list-of-entries-wm-low-64-with-different-x86-disjoint
     (implies (and (equal (gather-qword-addresses-corresponding-to-list-of-entries addrs x86-equiv)
-                         (gather-qword-addresses-corresponding-to-list-of-entries addrs x86))
-                  (pairwise-disjoint-p-aux (list index) addrs)
-                  (mult-8-qword-paddr-list-listp addrs)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0))
-             (equal (gather-qword-addresses-corresponding-to-list-of-entries
-                     addrs (wm-low-64 index val x86-equiv))
-                    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
+			 (gather-qword-addresses-corresponding-to-list-of-entries addrs x86))
+		  (pairwise-disjoint-p-aux (list index) addrs)
+		  (mult-8-qword-paddr-list-listp addrs)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0))
+	     (equal (gather-qword-addresses-corresponding-to-list-of-entries
+		     addrs (wm-low-64 index val x86-equiv))
+		    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries
-                               member-p)
-                              (physical-address-p)))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries
+			       member-p)
+			      (physical-address-p)))))
 
   (defthm gather-qword-addresses-corresponding-to-list-of-entries-wm-low-64-with-different-x86
     (implies (and (equal
-                   (gather-qword-addresses-corresponding-to-list-of-entries addrs x86-equiv)
-                   (gather-qword-addresses-corresponding-to-list-of-entries addrs x86))
-                  (member-list-p index addrs)
-                  (mult-8-qword-paddr-list-listp addrs)
-                  (no-duplicates-list-p addrs)
-                  (xlate-equiv-entries val (rm-low-64 index x86-equiv))
-                  (unsigned-byte-p 64 val)
-                  (x86p x86-equiv))
-             (equal (gather-qword-addresses-corresponding-to-list-of-entries
-                     addrs (wm-low-64 index val x86-equiv))
-                    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
+		   (gather-qword-addresses-corresponding-to-list-of-entries addrs x86-equiv)
+		   (gather-qword-addresses-corresponding-to-list-of-entries addrs x86))
+		  (member-list-p index addrs)
+		  (mult-8-qword-paddr-list-listp addrs)
+		  (no-duplicates-list-p addrs)
+		  (xlate-equiv-entries val (rm-low-64 index x86-equiv))
+		  (unsigned-byte-p 64 val)
+		  (x86p x86-equiv))
+	     (equal (gather-qword-addresses-corresponding-to-list-of-entries
+		     addrs (wm-low-64 index val x86-equiv))
+		    (gather-qword-addresses-corresponding-to-list-of-entries addrs x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries
-                               member-p)
-                              (unsigned-byte-p))))))
+	     :in-theory (e/d* (gather-qword-addresses-corresponding-to-list-of-entries
+			       member-p)
+			      (unsigned-byte-p))))))
 
 (define gather-all-paging-structure-qword-addresses (x86)
+
+  :parents (gather-paging-structures)
 
   :short "Returns a list of lists of qword addresses of all the active
   paging structures"
@@ -981,21 +1008,21 @@
 
   (b* ( ;; One Page Map Level-4 (PML4) Table:
        (pml4-table-qword-addresses
-        (gather-pml4-table-qword-addresses x86))
+	(gather-pml4-table-qword-addresses x86))
        ((when (not pml4-table-qword-addresses))
-        nil)
+	nil)
        ;; Up to 512 Page Directory Pointer Tables (PDPT):
        (list-of-pdpt-table-qword-addresses
-        (gather-qword-addresses-corresponding-to-entries
-         pml4-table-qword-addresses x86))
+	(gather-qword-addresses-corresponding-to-entries
+	 pml4-table-qword-addresses x86))
        ;; Up to 512*512 Page Directories (PD):
        (list-of-pd-qword-addresses
-        (gather-qword-addresses-corresponding-to-list-of-entries
-         list-of-pdpt-table-qword-addresses x86))
+	(gather-qword-addresses-corresponding-to-list-of-entries
+	 list-of-pdpt-table-qword-addresses x86))
        ;; Up to 512*512*512 Page Tables (PT):
        (list-of-pt-qword-addresses
-        (gather-qword-addresses-corresponding-to-list-of-entries
-         list-of-pd-qword-addresses x86)))
+	(gather-qword-addresses-corresponding-to-list-of-entries
+	 list-of-pd-qword-addresses x86)))
       (append
        ;; Each item below is a qword-paddr-list-listp.
        (list pml4-table-qword-addresses)
@@ -1008,78 +1035,78 @@
 
   (defthm gather-all-paging-structure-qword-addresses-xw-fld!=mem-and-ctr
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :ctr)))
-             (equal (gather-all-paging-structure-qword-addresses
-                     (xw fld index val x86))
-                    (gather-all-paging-structure-qword-addresses x86)))
+		  (not (equal fld :ctr)))
+	     (equal (gather-all-paging-structure-qword-addresses
+		     (xw fld index val x86))
+		    (gather-all-paging-structure-qword-addresses x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                              ()))))
+	     :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			      ()))))
 
   (defthm gather-all-paging-structure-qword-addresses-xw-fld=ctr
     (implies (not (equal index *cr3*))
-             (equal (gather-all-paging-structure-qword-addresses
-                     (xw :ctr index val x86))
-                    (gather-all-paging-structure-qword-addresses x86)))
+	     (equal (gather-all-paging-structure-qword-addresses
+		     (xw :ctr index val x86))
+		    (gather-all-paging-structure-qword-addresses x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                              ()))))
+	     :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			      ()))))
 
   (defthm gather-all-paging-structure-qword-addresses-xw-fld=mem-disjoint
     (implies (and (mult-8-qword-paddr-list-listp addrs)
-                  (pairwise-disjoint-p-aux (list index) addrs)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0)
-                  (equal addrs (gather-all-paging-structure-qword-addresses x86)))
-             (equal (gather-all-paging-structure-qword-addresses (xw :mem index val x86))
-                    addrs))
+		  (pairwise-disjoint-p-aux (list index) addrs)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0)
+		  (equal addrs (gather-all-paging-structure-qword-addresses x86)))
+	     (equal (gather-all-paging-structure-qword-addresses (xw :mem index val x86))
+		    addrs))
     :hints (("Goal"
-             :use ((:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
-                              (addrs (gather-qword-addresses-corresponding-to-list-of-entries
-                                      (gather-qword-addresses-corresponding-to-entries
-                                       (gather-pml4-table-qword-addresses x86)
-                                       x86)
-                                      (xw :mem index val x86)))
-                              (index index)
-                              (val val)
-                              (x86 (xw :mem index val x86)))
-                   (:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
-                              (addrs (gather-qword-addresses-corresponding-to-list-of-entries
-                                      (gather-qword-addresses-corresponding-to-entries
-                                       (gather-pml4-table-qword-addresses x86)
-                                       x86)
-                                      x86))
-                              (index index)
-                              (val val)
-                              (x86 x86))
-                   (:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
-                              (addrs (gather-qword-addresses-corresponding-to-entries
-                                      (gather-pml4-table-qword-addresses x86)
-                                      x86))
-                              (index index)
-                              (val val)
-                              (x86 (xw :mem index val x86)))
-                   (:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
-                              (addrs (gather-qword-addresses-corresponding-to-entries
-                                      (gather-pml4-table-qword-addresses x86)
-                                      x86))
-                              (index index)
-                              (val val)
-                              (x86 x86)))
-             :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
-                              (gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint)))))
+	     :use ((:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
+			      (addrs (gather-qword-addresses-corresponding-to-list-of-entries
+				      (gather-qword-addresses-corresponding-to-entries
+				       (gather-pml4-table-qword-addresses x86)
+				       x86)
+				      (xw :mem index val x86)))
+			      (index index)
+			      (val val)
+			      (x86 (xw :mem index val x86)))
+		   (:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
+			      (addrs (gather-qword-addresses-corresponding-to-list-of-entries
+				      (gather-qword-addresses-corresponding-to-entries
+				       (gather-pml4-table-qword-addresses x86)
+				       x86)
+				      x86))
+			      (index index)
+			      (val val)
+			      (x86 x86))
+		   (:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
+			      (addrs (gather-qword-addresses-corresponding-to-entries
+				      (gather-pml4-table-qword-addresses x86)
+				      x86))
+			      (index index)
+			      (val val)
+			      (x86 (xw :mem index val x86)))
+		   (:instance gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint
+			      (addrs (gather-qword-addresses-corresponding-to-entries
+				      (gather-pml4-table-qword-addresses x86)
+				      x86))
+			      (index index)
+			      (val val)
+			      (x86 x86)))
+	     :in-theory (e/d* (gather-all-paging-structure-qword-addresses)
+			      (gather-qword-addresses-corresponding-to-list-of-entries-xw-fld=mem-disjoint)))))
 
   (defthm gather-all-paging-structure-qword-addresses-wm-low-64-disjoint
     (implies (and (mult-8-qword-paddr-list-listp addrs)
-                  (pairwise-disjoint-p-aux (list index) addrs)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0)
-                  (equal addrs (gather-all-paging-structure-qword-addresses x86)))
-             (equal (gather-all-paging-structure-qword-addresses
-                     (wm-low-64 index val x86))
-                    (gather-all-paging-structure-qword-addresses x86)))
+		  (pairwise-disjoint-p-aux (list index) addrs)
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0)
+		  (equal addrs (gather-all-paging-structure-qword-addresses x86)))
+	     (equal (gather-all-paging-structure-qword-addresses
+		     (wm-low-64 index val x86))
+		    (gather-all-paging-structure-qword-addresses x86)))
     :hints (("Goal"
-             :in-theory (e/d* (gather-all-paging-structure-qword-addresses) ()))))
+	     :in-theory (e/d* (gather-all-paging-structure-qword-addresses) ()))))
 
   (local
    (encapsulate
@@ -1087,169 +1114,169 @@
 
     (defthm no-duplicates-p-member-p-with-append-and-flatten
       (implies (and (no-duplicates-p (append x (acl2::flatten y)))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (member-list-p i y))
-               (not (member-p i x)))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (member-list-p i y))
+	       (not (member-p i x)))
       :rule-classes (:forward-chaining :rewrite))
 
     (defthm no-duplicates-p-member-list-p-with-append-and-flatten
       (implies (and (no-duplicates-p (acl2::flatten (append x y)))
-                    (true-list-listp x)
-                    (true-list-listp y)
-                    (member-list-p i y))
-               (not (member-list-p i x)))
+		    (true-list-listp x)
+		    (true-list-listp y)
+		    (member-list-p i y))
+	       (not (member-list-p i x)))
       :hints (("Goal" :in-theory (e/d () (acl2::flattenp-of-append))))
       :rule-classes (:forward-chaining :rewrite))
 
     (defthm no-duplicates-p-member-list-p-with-append-and-flatten-alt
       (implies (and (no-duplicates-p (append (acl2::flatten x) (acl2::flatten y)))
-                    (true-list-listp x)
-                    (true-list-listp y)
-                    (member-list-p i y))
-               (not (member-list-p i x)))
+		    (true-list-listp x)
+		    (true-list-listp y)
+		    (member-list-p i y))
+	       (not (member-list-p i x)))
       :hints (("Goal" :in-theory (e/d (member-list-p) ())))
       :rule-classes (:forward-chaining :rewrite))
 
     (defthmd no-duplicates-p-and-member-list-p-1-top-helper
       (implies (and (no-duplicates-p (append x (acl2::flatten (append y z w))))
-                    (or (member-list-p i y)
-                        (member-list-p i z)
-                        (member-list-p i w))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w))
-               (not (member-p i x)))
+		    (or (member-list-p i y)
+			(member-list-p i z)
+			(member-list-p i w))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w))
+	       (not (member-p i x)))
       :hints (("Goal" :in-theory (e/d* () (acl2::flattenp-of-append)))))
 
     (defthm no-duplicates-p-and-member-list-p-1-top
       (implies (and (no-duplicates-p (append x (acl2::flatten y) (acl2::flatten z) (acl2::flatten w)))
-                    (or (member-list-p i y)
-                        (member-list-p i z)
-                        (member-list-p i w))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w))
-               (not (member-p i x)))
+		    (or (member-list-p i y)
+			(member-list-p i z)
+			(member-list-p i w))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w))
+	       (not (member-p i x)))
       :hints (("Goal" :use ((:instance no-duplicates-p-and-member-list-p-1-top-helper))))
       :rule-classes (:forward-chaining :rewrite))
 
     (defthmd no-duplicates-p-and-member-list-p-2-top-helper
       (implies (and (no-duplicates-p (append x (acl2::flatten (append y z w))))
-                    (or (member-p i x)
-                        (member-list-p i z)
-                        (member-list-p i w))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w))
-               (not (member-list-p i y)))
+		    (or (member-p i x)
+			(member-list-p i z)
+			(member-list-p i w))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w))
+	       (not (member-list-p i y)))
       :hints (("Goal" :in-theory (e/d* () (acl2::flattenp-of-append)))))
 
     (defthm no-duplicates-p-and-member-list-p-2-top
       (implies (and (no-duplicates-p (append x (acl2::flatten y) (acl2::flatten z) (acl2::flatten w)))
-                    (or (member-p i x)
-                        (member-list-p i z)
-                        (member-list-p i w))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w))
-               (not (member-list-p i y)))
+		    (or (member-p i x)
+			(member-list-p i z)
+			(member-list-p i w))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w))
+	       (not (member-list-p i y)))
       :hints (("Goal" :use ((:instance no-duplicates-p-and-member-list-p-2-top-helper))))
       :rule-classes (:forward-chaining :rewrite))
 
     (defthmd no-duplicates-p-and-member-list-p-3-top-helper-1
       (implies (and (member-list-p i w)
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w)
-                    (no-duplicates-p (append x (acl2::flatten (append y z w)))))
-               (not (member-list-p i z))))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w)
+		    (no-duplicates-p (append x (acl2::flatten (append y z w)))))
+	       (not (member-list-p i z))))
 
     (defthmd no-duplicates-p-and-member-list-p-3-top-helper-2
       (implies (and (no-duplicates-p (append x (acl2::flatten (append y z w))))
-                    (or (member-p i x)
-                        (member-list-p i y)
-                        (member-list-p i w))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w))
-               (not (member-list-p i z)))
+		    (or (member-p i x)
+			(member-list-p i y)
+			(member-list-p i w))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w))
+	       (not (member-list-p i z)))
       :hints (("Goal" :in-theory (e/d* (no-duplicates-p-and-member-list-p-3-top-helper-1)
-                                       (acl2::flattenp-of-append)))))
+				       (acl2::flattenp-of-append)))))
 
     (defthm no-duplicates-p-and-member-list-p-3-top
       (implies (and (no-duplicates-p (append x (acl2::flatten y) (acl2::flatten z) (acl2::flatten w)))
-                    (or (member-p i x)
-                        (member-list-p i y)
-                        (member-list-p i w))
-                    (true-listp x)
-                    (true-list-listp y)
-                    (true-list-listp z)
-                    (true-list-listp w))
-               (not (member-list-p i z)))
+		    (or (member-p i x)
+			(member-list-p i y)
+			(member-list-p i w))
+		    (true-listp x)
+		    (true-list-listp y)
+		    (true-list-listp z)
+		    (true-list-listp w))
+	       (not (member-list-p i z)))
       :hints (("Goal" :use ((:instance no-duplicates-p-and-member-list-p-3-top-helper-2))))
       :rule-classes (:forward-chaining :rewrite))
 
     (defthmd gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr-helper
       (implies (and (equal addrs (gather-all-paging-structure-qword-addresses x86))
-                    (mult-8-qword-paddr-list-listp addrs)
-                    (no-duplicates-list-p addrs)
-                    (member-list-p index addrs)
-                    ;; (or (equal val (set-accessed-bit (rm-low-64 index x86)))
-                    ;;     (equal val (set-dirty-bit (rm-low-64 index x86)))
-                    ;;     (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
-                    (xlate-equiv-entries val (rm-low-64 index x86))
-                    (unsigned-byte-p 64 val)
-                    (physical-address-p index)
-                    (equal (loghead 3 index) 0)
-                    (x86p x86))
-               (equal (gather-all-paging-structure-qword-addresses
-                       (wm-low-64 index val x86))
-                      (gather-all-paging-structure-qword-addresses x86)))
+		    (mult-8-qword-paddr-list-listp addrs)
+		    (no-duplicates-list-p addrs)
+		    (member-list-p index addrs)
+		    ;; (or (equal val (set-accessed-bit (rm-low-64 index x86)))
+		    ;;     (equal val (set-dirty-bit (rm-low-64 index x86)))
+		    ;;     (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
+		    (xlate-equiv-entries val (rm-low-64 index x86))
+		    (unsigned-byte-p 64 val)
+		    (physical-address-p index)
+		    (equal (loghead 3 index) 0)
+		    (x86p x86))
+	       (equal (gather-all-paging-structure-qword-addresses
+		       (wm-low-64 index val x86))
+		      (gather-all-paging-structure-qword-addresses x86)))
       :hints (("Goal"
-               :in-theory (e/d* (member-p)
-                                (xlate-equiv-entries))
-               :use ((:instance xlate-equiv-entries-and-loghead
-                                (e1 val)
-                                (e2 (rm-low-64 addr x86))
-                                (n 1))
-                     (:instance logtail-bigger-and-logbitp
-                                (e1 val)
-                                (e2 (rm-low-64 addr x86))
-                                (n 7)
-                                (m 7))
-                     (:instance xlate-equiv-entries-and-logtail
-                                (e1 val)
-                                (e2 (rm-low-64 addr x86))
-                                (n 7))
-                     (:instance xlate-equiv-entries-and-logtail
-                                (e1 val)
-                                (e2 (rm-low-64 addr x86))
-                                (n 12))))))))
+	       :in-theory (e/d* (member-p)
+				(xlate-equiv-entries))
+	       :use ((:instance xlate-equiv-entries-and-loghead
+				(e1 val)
+				(e2 (rm-low-64 addr x86))
+				(n 1))
+		     (:instance logtail-bigger-and-logbitp
+				(e1 val)
+				(e2 (rm-low-64 addr x86))
+				(n 7)
+				(m 7))
+		     (:instance xlate-equiv-entries-and-logtail
+				(e1 val)
+				(e2 (rm-low-64 addr x86))
+				(n 7))
+		     (:instance xlate-equiv-entries-and-logtail
+				(e1 val)
+				(e2 (rm-low-64 addr x86))
+				(n 12))))))))
 
   (defthm gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr
     (implies (and (equal addrs (gather-all-paging-structure-qword-addresses x86))
-                  (mult-8-qword-paddr-list-listp addrs)
-                  (no-duplicates-list-p addrs)
-                  (member-list-p index addrs)
-                  ;; (or (equal val (set-accessed-bit (rm-low-64 index x86)))
-                  ;;     (equal val (set-dirty-bit (rm-low-64 index x86)))
-                  ;;     (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
-                  (xlate-equiv-entries val (rm-low-64 index x86))
-                  (unsigned-byte-p 64 val)
-                  (x86p x86))
-             (equal (gather-all-paging-structure-qword-addresses
-                     (wm-low-64 index val x86))
-                    (gather-all-paging-structure-qword-addresses x86)))
+		  (mult-8-qword-paddr-list-listp addrs)
+		  (no-duplicates-list-p addrs)
+		  (member-list-p index addrs)
+		  ;; (or (equal val (set-accessed-bit (rm-low-64 index x86)))
+		  ;;     (equal val (set-dirty-bit (rm-low-64 index x86)))
+		  ;;     (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
+		  (xlate-equiv-entries val (rm-low-64 index x86))
+		  (unsigned-byte-p 64 val)
+		  (x86p x86))
+	     (equal (gather-all-paging-structure-qword-addresses
+		     (wm-low-64 index val x86))
+		    (gather-all-paging-structure-qword-addresses x86)))
     :hints (("Goal"
-             :use ((:instance gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr-helper)
-                   (:instance member-list-p-and-mult-8-qword-paddr-list-listp))))))
+	     :use ((:instance gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr-helper)
+		   (:instance member-list-p-and-mult-8-qword-paddr-list-listp))))))
 
 ;; ======================================================================
 
@@ -1257,239 +1284,241 @@
 
 (define xlate-equiv-entries-at-qword-addresses-aux?
   (list-of-addresses-1 list-of-addresses-2 x86-1 x86-2)
+  :parents (xlate-equiv-x86s)
   :guard (and (qword-paddr-listp list-of-addresses-1)
-              (qword-paddr-listp list-of-addresses-2)
-              (equal (len list-of-addresses-1)
-                     (len list-of-addresses-2))
-              (x86p x86-1)
-              (x86p x86-2))
+	      (qword-paddr-listp list-of-addresses-2)
+	      (equal (len list-of-addresses-1)
+		     (len list-of-addresses-2))
+	      (x86p x86-1)
+	      (x86p x86-2))
   :non-executable t
 
   (if (endp list-of-addresses-1)
       t
     (b* ((addr-1 (car list-of-addresses-1))
-         (addr-2 (car list-of-addresses-2))
-         ((when (not (and (physical-address-p (+ 7 addr-1))
-                          (physical-address-p (+ 7 addr-2)))))
-          nil)
-         (qword-1 (rm-low-64 addr-1 x86-1))
-         (qword-2 (rm-low-64 addr-2 x86-2))
-         ((when (not (xlate-equiv-entries qword-1 qword-2)))
-          nil))
-        (xlate-equiv-entries-at-qword-addresses-aux?
-         (cdr list-of-addresses-1) (cdr list-of-addresses-2)
-         x86-1 x86-2)))
+	 (addr-2 (car list-of-addresses-2))
+	 ((when (not (and (physical-address-p (+ 7 addr-1))
+			  (physical-address-p (+ 7 addr-2)))))
+	  nil)
+	 (qword-1 (rm-low-64 addr-1 x86-1))
+	 (qword-2 (rm-low-64 addr-2 x86-2))
+	 ((when (not (xlate-equiv-entries qword-1 qword-2)))
+	  nil))
+	(xlate-equiv-entries-at-qword-addresses-aux?
+	 (cdr list-of-addresses-1) (cdr list-of-addresses-2)
+	 x86-1 x86-2)))
   ///
 
   (defthm xlate-equiv-entries-at-qword-addresses-aux?-reflexive
     (implies (qword-paddr-listp a)
-             (xlate-equiv-entries-at-qword-addresses-aux? a a x x)))
+	     (xlate-equiv-entries-at-qword-addresses-aux? a a x x)))
 
   (defthm xlate-equiv-entries-at-qword-addresses-aux?-commutative
     (implies (equal (len a) (len b))
-             (equal (xlate-equiv-entries-at-qword-addresses-aux? a b x y)
-                    (xlate-equiv-entries-at-qword-addresses-aux? b a y x))))
+	     (equal (xlate-equiv-entries-at-qword-addresses-aux? a b x y)
+		    (xlate-equiv-entries-at-qword-addresses-aux? b a y x))))
 
   (defthm xlate-equiv-entries-at-qword-addresses-aux?-transitive
     (implies (and (equal (len a) (len b))
-                  (equal (len b) (len c))
-                  (xlate-equiv-entries-at-qword-addresses-aux? a b x y)
-                  (xlate-equiv-entries-at-qword-addresses-aux? b c y z))
-             (xlate-equiv-entries-at-qword-addresses-aux? a c x z)))
+		  (equal (len b) (len c))
+		  (xlate-equiv-entries-at-qword-addresses-aux? a b x y)
+		  (xlate-equiv-entries-at-qword-addresses-aux? b c y z))
+	     (xlate-equiv-entries-at-qword-addresses-aux? a c x z)))
 
   (defthm xlate-equiv-entries-at-qword-addresses-aux?-with-xw-fld!=mem
     (implies (not (equal fld :mem))
-             (equal (xlate-equiv-entries-at-qword-addresses-aux?
-                     addrs-1 addrs-2
-                     x86-1
-                     (xw fld index val x86-2))
-                    (xlate-equiv-entries-at-qword-addresses-aux?
-                     addrs-1 addrs-2 x86-1 x86-2))))
+	     (equal (xlate-equiv-entries-at-qword-addresses-aux?
+		     addrs-1 addrs-2
+		     x86-1
+		     (xw fld index val x86-2))
+		    (xlate-equiv-entries-at-qword-addresses-aux?
+		     addrs-1 addrs-2 x86-1 x86-2))))
 
   (defthm xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-disjoint
     (implies (and (mult-8-qword-paddr-listp addrs)
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0)
-                  (not (member-p index addrs)))
-             (equal (xlate-equiv-entries-at-qword-addresses-aux?
-                     addrs addrs
-                     x86-1
-                     (wm-low-64 index val x86-2))
-                    (xlate-equiv-entries-at-qword-addresses-aux?
-                     addrs addrs
-                     x86-1
-                     x86-2)))
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0)
+		  (not (member-p index addrs)))
+	     (equal (xlate-equiv-entries-at-qword-addresses-aux?
+		     addrs addrs
+		     x86-1
+		     (wm-low-64 index val x86-2))
+		    (xlate-equiv-entries-at-qword-addresses-aux?
+		     addrs addrs
+		     x86-1
+		     x86-2)))
     :hints (("Goal" :in-theory (e/d* (member-p) (xlate-equiv-entries)))))
 
   (defthm xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64
     (implies (and (mult-8-qword-paddr-listp addrs)
-                  (no-duplicates-p addrs)
-                  (member-p index addrs)
-                  (xlate-equiv-entries val (rm-low-64 index x86-1))
-                  (unsigned-byte-p 64 val)
-                  (xlate-equiv-entries-at-qword-addresses-aux? addrs addrs x86-1 x86-2))
-             (xlate-equiv-entries-at-qword-addresses-aux?
-              addrs addrs
-              x86-1
-              (wm-low-64 index val x86-2)))
+		  (no-duplicates-p addrs)
+		  (member-p index addrs)
+		  (xlate-equiv-entries val (rm-low-64 index x86-1))
+		  (unsigned-byte-p 64 val)
+		  (xlate-equiv-entries-at-qword-addresses-aux? addrs addrs x86-1 x86-2))
+	     (xlate-equiv-entries-at-qword-addresses-aux?
+	      addrs addrs
+	      x86-1
+	      (wm-low-64 index val x86-2)))
     :hints (("Goal" :in-theory (e/d* (member-p)
-                                     (xlate-equiv-entries)))))
+				     (xlate-equiv-entries)))))
 
   (local
    (defthmd xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86-helper-1
      (implies
       (and (consp addrs)
-           (unsigned-byte-p 52 (+ 7 (car addrs)))
-           (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
-                                (rm-low-64 (car addrs) x86-2))
-           (unsigned-byte-p 52 index)
-           (unsigned-byte-p 52 (car addrs))
-           (equal (loghead 3 (car addrs)) 0)
-           (mult-8-qword-paddr-listp (cdr addrs))
-           (not (member-p (car addrs) (cdr addrs)))
-           (no-duplicates-p (cdr addrs))
-           (member-p index (cdr addrs))
-           (not (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
-                                     (rm-low-64 (car addrs)
-                                                (wm-low-64 index val x86-2)))))
+	   (unsigned-byte-p 52 (+ 7 (car addrs)))
+	   (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
+				(rm-low-64 (car addrs) x86-2))
+	   (unsigned-byte-p 52 index)
+	   (unsigned-byte-p 52 (car addrs))
+	   (equal (loghead 3 (car addrs)) 0)
+	   (mult-8-qword-paddr-listp (cdr addrs))
+	   (not (member-p (car addrs) (cdr addrs)))
+	   (no-duplicates-p (cdr addrs))
+	   (member-p index (cdr addrs))
+	   (not (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
+				     (rm-low-64 (car addrs)
+						(wm-low-64 index val x86-2)))))
       (not (xlate-equiv-entries-at-qword-addresses-aux? (cdr addrs)
-                                                        (cdr addrs)
-                                                        x86-1 x86-2)))
+							(cdr addrs)
+							x86-1 x86-2)))
      :hints (("Goal" :in-theory (e/d* () (mult-8-qword-paddr-listp-and-disjoint-p))
-              :use ((:instance mult-8-qword-paddr-listp-and-disjoint-p
-                               (index index)
-                               (addrs (cdr addrs))
-                               (addr (car addrs))))))))
+	      :use ((:instance mult-8-qword-paddr-listp-and-disjoint-p
+			       (index index)
+			       (addrs (cdr addrs))
+			       (addr (car addrs))))))))
 
   (local
    (defthmd xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86-helper-2
      (implies (and (consp addrs)
-                   (unsigned-byte-p 52 (+ 7 (car addrs)))
-                   (not (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
-                                             (rm-low-64 (car addrs) x86-2)))
-                   (unsigned-byte-p 52 index)
-                   (unsigned-byte-p 52 (car addrs))
-                   (equal (loghead 3 (car addrs)) 0)
-                   (mult-8-qword-paddr-listp (cdr addrs))
-                   (not (member-p (car addrs) (cdr addrs)))
-                   (no-duplicates-p (cdr addrs))
-                   (member-p index (cdr addrs))
-                   (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
-                                        (rm-low-64 (car addrs)
-                                                   (wm-low-64 index val x86-2))))
-              (not (xlate-equiv-entries-at-qword-addresses-aux?
-                    (cdr addrs)
-                    (cdr addrs)
-                    x86-1 (wm-low-64 index val x86-2))))
+		   (unsigned-byte-p 52 (+ 7 (car addrs)))
+		   (not (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
+					     (rm-low-64 (car addrs) x86-2)))
+		   (unsigned-byte-p 52 index)
+		   (unsigned-byte-p 52 (car addrs))
+		   (equal (loghead 3 (car addrs)) 0)
+		   (mult-8-qword-paddr-listp (cdr addrs))
+		   (not (member-p (car addrs) (cdr addrs)))
+		   (no-duplicates-p (cdr addrs))
+		   (member-p index (cdr addrs))
+		   (xlate-equiv-entries (rm-low-64 (car addrs) x86-1)
+					(rm-low-64 (car addrs)
+						   (wm-low-64 index val x86-2))))
+	      (not (xlate-equiv-entries-at-qword-addresses-aux?
+		    (cdr addrs)
+		    (cdr addrs)
+		    x86-1 (wm-low-64 index val x86-2))))
      :hints (("Goal" :in-theory (e/d* () (mult-8-qword-paddr-listp-and-disjoint-p))
-              :use ((:instance mult-8-qword-paddr-listp-and-disjoint-p
-                               (index index)
-                               (addrs (cdr addrs))
-                               (addr (car addrs))))))))
+	      :use ((:instance mult-8-qword-paddr-listp-and-disjoint-p
+			       (index index)
+			       (addrs (cdr addrs))
+			       (addr (car addrs))))))))
 
   (defthmd xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86
     (implies (and (mult-8-qword-paddr-listp addrs)
-                  (no-duplicates-p addrs)
-                  (member-p index addrs)
-                  (xlate-equiv-entries val (rm-low-64 index x86-2))
-                  (unsigned-byte-p 64 val))
-             (equal
-              (xlate-equiv-entries-at-qword-addresses-aux?
-               addrs addrs
-               x86-1
-               (wm-low-64 index val x86-2))
-              (xlate-equiv-entries-at-qword-addresses-aux? addrs addrs x86-1 x86-2)))
+		  (no-duplicates-p addrs)
+		  (member-p index addrs)
+		  (xlate-equiv-entries val (rm-low-64 index x86-2))
+		  (unsigned-byte-p 64 val))
+	     (equal
+	      (xlate-equiv-entries-at-qword-addresses-aux?
+	       addrs addrs
+	       x86-1
+	       (wm-low-64 index val x86-2))
+	      (xlate-equiv-entries-at-qword-addresses-aux? addrs addrs x86-1 x86-2)))
     :hints (("Goal"
-             :use ((:instance member-p-and-mult-8-qword-paddr-listp))
-             :in-theory (e/d* (member-p
-                               xlate-equiv-entries-at-qword-addresses-aux?)
-                              (xlate-equiv-entries)))
-            ;; Ugh, subgoal hints...
-            ("Subgoal *1/4"
-             :use
-             ((:instance xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86-helper-1)))
-            ("Subgoal *1/3"
-             :use
-             ((:instance xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86-helper-2))))))
+	     :use ((:instance member-p-and-mult-8-qword-paddr-listp))
+	     :in-theory (e/d* (member-p
+			       xlate-equiv-entries-at-qword-addresses-aux?)
+			      (xlate-equiv-entries)))
+	    ;; Ugh, subgoal hints...
+	    ("Subgoal *1/4"
+	     :use
+	     ((:instance xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86-helper-1)))
+	    ("Subgoal *1/3"
+	     :use
+	     ((:instance xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86-helper-2))))))
 
 (define xlate-equiv-entries-at-qword-addresses?
   (list-of-lists-of-addresses-1 list-of-lists-of-addresses-2 x86-1 x86-2)
+  :parents (xlate-equiv-x86s)
   :guard (and (qword-paddr-list-listp list-of-lists-of-addresses-1)
-              (qword-paddr-list-listp list-of-lists-of-addresses-2)
-              (equal (len list-of-lists-of-addresses-1)
-                     (len list-of-lists-of-addresses-2))
-              (x86p x86-1)
-              (x86p x86-2))
+	      (qword-paddr-list-listp list-of-lists-of-addresses-2)
+	      (equal (len list-of-lists-of-addresses-1)
+		     (len list-of-lists-of-addresses-2))
+	      (x86p x86-1)
+	      (x86p x86-2))
   :non-executable t
 
   (if (endp list-of-lists-of-addresses-1)
       t
     (b* ((list-of-addresses-1 (car list-of-lists-of-addresses-1))
-         (list-of-addresses-2 (car list-of-lists-of-addresses-2))
-         ((when (not (equal (len list-of-addresses-1)
-                            (len list-of-addresses-2))))
-          nil))
-        (and (xlate-equiv-entries-at-qword-addresses-aux?
-              list-of-addresses-1 list-of-addresses-2
-              x86-1 x86-2)
-             (xlate-equiv-entries-at-qword-addresses?
-              (cdr list-of-lists-of-addresses-1)
-              (cdr list-of-lists-of-addresses-2)
-              x86-1 x86-2))))
+	 (list-of-addresses-2 (car list-of-lists-of-addresses-2))
+	 ((when (not (equal (len list-of-addresses-1)
+			    (len list-of-addresses-2))))
+	  nil))
+	(and (xlate-equiv-entries-at-qword-addresses-aux?
+	      list-of-addresses-1 list-of-addresses-2
+	      x86-1 x86-2)
+	     (xlate-equiv-entries-at-qword-addresses?
+	      (cdr list-of-lists-of-addresses-1)
+	      (cdr list-of-lists-of-addresses-2)
+	      x86-1 x86-2))))
   ///
 
   (defthm xlate-equiv-entries-at-qword-addresses?-reflexive
     (implies (qword-paddr-list-listp a)
-             (xlate-equiv-entries-at-qword-addresses? a a x x)))
+	     (xlate-equiv-entries-at-qword-addresses? a a x x)))
 
   (defthm xlate-equiv-entries-at-qword-addresses?-commutative
     (implies (equal (len a) (len b))
-             (equal (xlate-equiv-entries-at-qword-addresses? a b x y)
-                    (xlate-equiv-entries-at-qword-addresses? b a y x))))
+	     (equal (xlate-equiv-entries-at-qword-addresses? a b x y)
+		    (xlate-equiv-entries-at-qword-addresses? b a y x))))
 
   (defthm xlate-equiv-entries-at-qword-addresses?-transitive-equal-len
     (implies (and (equal (len a) (len b))
-                  (equal (len b) (len c))
-                  (xlate-equiv-entries-at-qword-addresses? a b x y)
-                  (xlate-equiv-entries-at-qword-addresses? b c y z))
-             (xlate-equiv-entries-at-qword-addresses? a c x z)))
+		  (equal (len b) (len c))
+		  (xlate-equiv-entries-at-qword-addresses? a b x y)
+		  (xlate-equiv-entries-at-qword-addresses? b c y z))
+	     (xlate-equiv-entries-at-qword-addresses? a c x z)))
 
   (defthm xlate-equiv-entries-at-qword-addresses?-transitive
     (implies (and (equal a b)
-                  (equal b c)
-                  (xlate-equiv-entries-at-qword-addresses? a b x y)
-                  (xlate-equiv-entries-at-qword-addresses? b c y z))
-             (xlate-equiv-entries-at-qword-addresses? a c x z))
+		  (equal b c)
+		  (xlate-equiv-entries-at-qword-addresses? a b x y)
+		  (xlate-equiv-entries-at-qword-addresses? b c y z))
+	     (xlate-equiv-entries-at-qword-addresses? a c x z))
     :hints (("Goal" :in-theory
-             (e/d*
-              ()
-              (xlate-equiv-entries-at-qword-addresses?-transitive-equal-len))
-             :use ((:instance xlate-equiv-entries-at-qword-addresses?-transitive-equal-len)))))
+	     (e/d*
+	      ()
+	      (xlate-equiv-entries-at-qword-addresses?-transitive-equal-len))
+	     :use ((:instance xlate-equiv-entries-at-qword-addresses?-transitive-equal-len)))))
 
   (defthm xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries
     (implies (and (xlate-equiv-entries-at-qword-addresses?
-                   addrs addrs x86-1 x86-2)
-                  (member-list-p index addrs))
-             (xlate-equiv-entries (rm-low-64 index x86-1)
-                                  (rm-low-64 index x86-2)))
+		   addrs addrs x86-1 x86-2)
+		  (member-list-p index addrs))
+	     (xlate-equiv-entries (rm-low-64 index x86-1)
+				  (rm-low-64 index x86-2)))
     :hints (("Goal" :in-theory (e/d* (xlate-equiv-entries-at-qword-addresses?
-                                      xlate-equiv-entries-at-qword-addresses-aux?
-                                      member-list-p
-                                      member-p)
-                                     (xlate-equiv-entries)))))
+				      xlate-equiv-entries-at-qword-addresses-aux?
+				      member-list-p
+				      member-p)
+				     (xlate-equiv-entries)))))
 
   (defthm xlate-equiv-entries-at-qword-addresses?-with-xw-fld!=mem
     (implies (not (equal fld :mem))
-             (equal (xlate-equiv-entries-at-qword-addresses?
-                     addrs addrs
-                     x86
-                     (xw fld index val x86))
-                    (xlate-equiv-entries-at-qword-addresses?
-                     addrs addrs
-                     x86
-                     x86)))
+	     (equal (xlate-equiv-entries-at-qword-addresses?
+		     addrs addrs
+		     x86
+		     (xw fld index val x86))
+		    (xlate-equiv-entries-at-qword-addresses?
+		     addrs addrs
+		     x86
+		     x86)))
     :hints (("Goal" :in-theory (e/d* (xlate-equiv-entries-at-qword-addresses?)
-                                     ()))))
+				     ()))))
 
   ;; (defthm xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-disjoint
   ;;   (implies (and (mult-8-qword-paddr-list-listp addrs)
@@ -1510,98 +1539,100 @@
 
   (defthm xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-disjoint
     (implies (and (mult-8-qword-paddr-list-listp addrs)
-                  (not (member-list-p index addrs))
-                  (physical-address-p index)
-                  (equal (loghead 3 index) 0))
-             (equal (xlate-equiv-entries-at-qword-addresses?
-                     addrs
-                     addrs x86-1 (wm-low-64 index val x86-2))
-                    (xlate-equiv-entries-at-qword-addresses?
-                     addrs addrs x86-1 x86-2)))
+		  (not (member-list-p index addrs))
+		  (physical-address-p index)
+		  (equal (loghead 3 index) 0))
+	     (equal (xlate-equiv-entries-at-qword-addresses?
+		     addrs
+		     addrs x86-1 (wm-low-64 index val x86-2))
+		    (xlate-equiv-entries-at-qword-addresses?
+		     addrs addrs x86-1 x86-2)))
     :hints (("Goal" :in-theory (e/d* (xlate-equiv-entries-at-qword-addresses?
-                                      member-p member-list-p)
-                                     (xlate-equiv-entries)))))
+				      member-p member-list-p)
+				     (xlate-equiv-entries)))))
 
   (defthm xlate-equiv-entries-at-qword-addresses?-with-wm-low-64
     (implies (and (mult-8-qword-paddr-list-listp addrs)
-                  (no-duplicates-list-p addrs)
-                  (member-list-p index addrs)
-                  ;; (or (equal val (set-accessed-bit (rm-low-64 index x86)))
-                  ;;     (equal val (set-dirty-bit (rm-low-64 index x86)))
-                  ;;     (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
-                  (xlate-equiv-entries val (rm-low-64 index x86))
-                  (unsigned-byte-p 64 val)
-                  (xlate-equiv-entries-at-qword-addresses? addrs addrs x86 x86))
-             (xlate-equiv-entries-at-qword-addresses?
-              addrs addrs x86 (wm-low-64 index val x86)))
+		  (no-duplicates-list-p addrs)
+		  (member-list-p index addrs)
+		  ;; (or (equal val (set-accessed-bit (rm-low-64 index x86)))
+		  ;;     (equal val (set-dirty-bit (rm-low-64 index x86)))
+		  ;;     (equal val (set-dirty-bit (set-accessed-bit (rm-low-64 index x86)))))
+		  (xlate-equiv-entries val (rm-low-64 index x86))
+		  (unsigned-byte-p 64 val)
+		  (xlate-equiv-entries-at-qword-addresses? addrs addrs x86 x86))
+	     (xlate-equiv-entries-at-qword-addresses?
+	      addrs addrs x86 (wm-low-64 index val x86)))
     :hints (("Goal"
-             :in-theory (e/d* (xlate-equiv-entries-at-qword-addresses?
-                               member-p
-                               member-list-p)
-                              (xlate-equiv-entries
-                               xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries)))))
+	     :in-theory (e/d* (xlate-equiv-entries-at-qword-addresses?
+			       member-p
+			       member-list-p)
+			      (xlate-equiv-entries
+			       xlate-equiv-entries-at-qword-addresses?-implies-xlate-equiv-entries)))))
 
   (local
    (defthmd xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86-helper
      (implies (and (mult-8-qword-paddr-list-listp addrs)
-                   (no-duplicates-list-p addrs)
-                   (member-list-p index addrs)
-                   (physical-address-p index)  ;;
-                   (equal (loghead 3 index) 0) ;;
-                   (xlate-equiv-entries val (rm-low-64 index x86-2))
-                   (unsigned-byte-p 64 val)
-                   (xlate-equiv-entries-at-qword-addresses? addrs addrs x86-1 x86-2))
-              (xlate-equiv-entries-at-qword-addresses?
-               addrs addrs
-               x86-1
-               (wm-low-64 index val x86-2)))
+		   (no-duplicates-list-p addrs)
+		   (member-list-p index addrs)
+		   (physical-address-p index)  ;;
+		   (equal (loghead 3 index) 0) ;;
+		   (xlate-equiv-entries val (rm-low-64 index x86-2))
+		   (unsigned-byte-p 64 val)
+		   (xlate-equiv-entries-at-qword-addresses? addrs addrs x86-1 x86-2))
+	      (xlate-equiv-entries-at-qword-addresses?
+	       addrs addrs
+	       x86-1
+	       (wm-low-64 index val x86-2)))
      :hints (("Goal"
-              :in-theory (e/d* (member-p
-                                xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86
-                                xlate-equiv-entries-at-qword-addresses?)
-                               (xlate-equiv-entries
-                                physical-address-p
-                                unsigned-byte-p))))))
+	      :in-theory (e/d* (member-p
+				xlate-equiv-entries-at-qword-addresses-aux?-with-wm-low-64-different-x86
+				xlate-equiv-entries-at-qword-addresses?)
+			       (xlate-equiv-entries
+				physical-address-p
+				unsigned-byte-p))))))
 
   (defthmd xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86
     (implies (and (mult-8-qword-paddr-list-listp addrs)
-                  (no-duplicates-list-p addrs)
-                  (member-list-p index addrs)
-                  (xlate-equiv-entries val (rm-low-64 index x86-1))
-                  (unsigned-byte-p 64 val)
-                  (xlate-equiv-entries-at-qword-addresses? addrs addrs x86-1 x86-2))
-             (xlate-equiv-entries-at-qword-addresses?
-              addrs addrs
-              x86-1
-              (wm-low-64 index val x86-2)))
+		  (no-duplicates-list-p addrs)
+		  (member-list-p index addrs)
+		  (xlate-equiv-entries val (rm-low-64 index x86-1))
+		  (unsigned-byte-p 64 val)
+		  (xlate-equiv-entries-at-qword-addresses? addrs addrs x86-1 x86-2))
+	     (xlate-equiv-entries-at-qword-addresses?
+	      addrs addrs
+	      x86-1
+	      (wm-low-64 index val x86-2)))
     :hints (("Goal"
-             :use
-             ((:instance member-list-p-and-mult-8-qword-paddr-list-listp)
-              (:instance xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86-helper))))))
+	     :use
+	     ((:instance member-list-p-and-mult-8-qword-paddr-list-listp)
+	      (:instance xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86-helper))))))
 
 (define good-paging-structures-x86p (x86)
+  :parents (xlate-equiv-x86s reasoning-about-page-tables)
   (and (x86p x86)
        (let* ((paging-addresses (gather-all-paging-structure-qword-addresses x86)))
-         (and (mult-8-qword-paddr-list-listp paging-addresses)
-              (no-duplicates-list-p paging-addresses))))
+	 (and (mult-8-qword-paddr-list-listp paging-addresses)
+	      (no-duplicates-list-p paging-addresses))))
   ///
 
   (defthm good-paging-structures-x86p-implies-x86p
     (implies (good-paging-structures-x86p x86)
-             (x86p x86))
+	     (x86p x86))
     :hints (("Goal" :in-theory (e/d* (good-paging-structures-x86p) ()))))
 
   (defthm good-paging-structures-x86p-xw-fld!=mem-and-ctr
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :ctr))
-                  (x86p x86)
-                  (x86p (xw fld index val x86)))
-             (equal (good-paging-structures-x86p (xw fld index val x86))
-                    (good-paging-structures-x86p x86)))))
+		  (not (equal fld :ctr))
+		  (x86p x86)
+		  (x86p (xw fld index val x86)))
+	     (equal (good-paging-structures-x86p (xw fld index val x86))
+		    (good-paging-structures-x86p x86)))))
 
 (define xlate-equiv-x86s (x86-1 x86-2)
+  :parents (reasoning-about-page-tables)
   :guard (and (x86p x86-1)
-              (x86p x86-2))
+	      (x86p x86-2))
   :non-executable t
   :enabled t
   :long "<p>Two x86 states are @('xlate-equiv-x86s') if their paging
@@ -1613,17 +1644,24 @@
 
       (if (good-paging-structures-x86p x86-2)
 
-          (let* ((paging-qword-addresses-1
-                  (gather-all-paging-structure-qword-addresses x86-1))
-                 (paging-qword-addresses-2
-                  (gather-all-paging-structure-qword-addresses x86-2)))
+	  (let* ((paging-qword-addresses-1
+		  (gather-all-paging-structure-qword-addresses x86-1))
+		 (paging-qword-addresses-2
+		  (gather-all-paging-structure-qword-addresses x86-2)))
 
-            (and (equal (ctri *cr3* x86-1) (ctri *cr3* x86-2))
-                 (equal paging-qword-addresses-1 paging-qword-addresses-2)
-                 (xlate-equiv-entries-at-qword-addresses?
-                  paging-qword-addresses-1 paging-qword-addresses-2 x86-1 x86-2)))
+	    (and (equal (cr0-slice :cr0-wp (n32 (ctri *cr0* x86-1)))
+                        (cr0-slice :cr0-wp (n32 (ctri *cr0* x86-2))))
+                 (equal (cr3-slice :cr3-pdb (ctri *cr3* x86-1))
+			(cr3-slice :cr3-pdb (ctri *cr3* x86-2)))
+		 (equal (cr4-slice :cr4-smep (n21 (ctri *cr4* x86-1)))
+			(cr4-slice :cr4-smep (n21 (ctri *cr4* x86-2))))
+		 (equal (ia32_efer-slice :ia32_efer-nxe (n12 (msri *ia32_efer-idx* x86-1)))
+			(ia32_efer-slice :ia32_efer-nxe (n12 (msri *ia32_efer-idx* x86-2))))
+		 (equal paging-qword-addresses-1 paging-qword-addresses-2)
+		 (xlate-equiv-entries-at-qword-addresses?
+		  paging-qword-addresses-1 paging-qword-addresses-2 x86-1 x86-2)))
 
-        nil)
+	nil)
 
     (not (good-paging-structures-x86p x86-2)))
 
@@ -1632,20 +1670,20 @@
   (local
    (defthm xlate-equiv-x86s-is-transitive-helper
      (implies (and (xlate-equiv-x86s x y)
-                   (xlate-equiv-x86s y z))
-              (xlate-equiv-x86s x z))
+		   (xlate-equiv-x86s y z))
+	      (xlate-equiv-x86s x z))
      :hints (("Goal"
-              :in-theory (e/d* () (xlate-equiv-entries-at-qword-addresses?-transitive))
-              :use
-              ((:instance
-                xlate-equiv-entries-at-qword-addresses?-transitive
-                (a (gather-all-paging-structure-qword-addresses x))
-                (b (gather-all-paging-structure-qword-addresses y))
-                (c (gather-all-paging-structure-qword-addresses z))))))))
+	      :in-theory (e/d* () (xlate-equiv-entries-at-qword-addresses?-transitive))
+	      :use
+	      ((:instance
+		xlate-equiv-entries-at-qword-addresses?-transitive
+		(a (gather-all-paging-structure-qword-addresses x))
+		(b (gather-all-paging-structure-qword-addresses y))
+		(c (gather-all-paging-structure-qword-addresses z))))))))
 
   (defequiv xlate-equiv-x86s
     :hints (("Goal" :in-theory (e/d* () (xlate-equiv-x86s-is-transitive-helper))
-             :use ((:instance xlate-equiv-x86s-is-transitive-helper))))))
+	     :use ((:instance xlate-equiv-x86s-is-transitive-helper))))))
 
 ;; =====================================================================
 
@@ -1654,33 +1692,33 @@
 
 (defthm gather-all-paging-structure-qword-addresses-wm-low-64-different-x86-disjoint
   (implies (and (xlate-equiv-x86s x86 x86-equiv)
-                (good-paging-structures-x86p x86)
-                (equal addrs (gather-all-paging-structure-qword-addresses x86))
-                (pairwise-disjoint-p-aux (list index) addrs)
-                (mult-8-qword-paddr-list-listp addrs)
-                (physical-address-p index)
-                (equal (loghead 3 index) 0))
-           (equal (gather-all-paging-structure-qword-addresses
-                   (wm-low-64 index val x86-equiv))
-                  (gather-all-paging-structure-qword-addresses x86))))
+		(good-paging-structures-x86p x86)
+		(equal addrs (gather-all-paging-structure-qword-addresses x86))
+		(pairwise-disjoint-p-aux (list index) addrs)
+		(mult-8-qword-paddr-list-listp addrs)
+		(physical-address-p index)
+		(equal (loghead 3 index) 0))
+	   (equal (gather-all-paging-structure-qword-addresses
+		   (wm-low-64 index val x86-equiv))
+		  (gather-all-paging-structure-qword-addresses x86))))
 
 (defthm gather-all-paging-structure-qword-addresses-wm-low-64-different-x86
   (implies (and (xlate-equiv-x86s x86 x86-equiv)
-                (good-paging-structures-x86p x86)
-                (equal addrs (gather-all-paging-structure-qword-addresses x86))
-                (member-list-p index addrs)
-                (xlate-equiv-entries val (rm-low-64 index x86))
-                (mult-8-qword-paddr-list-listp addrs)
-                (no-duplicates-list-p addrs)
-                (unsigned-byte-p 64 val))
-           (equal (gather-all-paging-structure-qword-addresses
-                   (wm-low-64 index val x86-equiv))
-                  (gather-all-paging-structure-qword-addresses x86)))
+		(good-paging-structures-x86p x86)
+		(equal addrs (gather-all-paging-structure-qword-addresses x86))
+		(member-list-p index addrs)
+		(xlate-equiv-entries val (rm-low-64 index x86))
+		(mult-8-qword-paddr-list-listp addrs)
+		(no-duplicates-list-p addrs)
+		(unsigned-byte-p 64 val))
+	   (equal (gather-all-paging-structure-qword-addresses
+		   (wm-low-64 index val x86-equiv))
+		  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal" :in-theory (e/d* ()
-                                   (gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr))
-           :use ((:instance gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr
-                            (x86 x86-equiv))
-                 (:instance gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr
-                            (x86 x86))))))
+				   (gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr))
+	   :use ((:instance gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr
+			    (x86 x86-equiv))
+		 (:instance gather-all-paging-structure-qword-addresses-wm-low-64-entry-addr
+			    (x86 x86))))))
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/paging-basics.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/paging-basics.lisp
@@ -9,6 +9,20 @@
 
 ;; ======================================================================
 
+(defsection paging-basics
+  :parents (reasoning-about-page-tables)
+
+  :short "Gather physical addresses where paging data structures are located"
+
+  :long "<p>WORK IN PROGRESS...</p>
+
+<p>This doc topic will be updated in later commits...</p>"
+  )
+
+(local (xdoc::set-default-parents paging-basics))
+
+;; ======================================================================
+
 ;; Some helper rules:
 
 (local (in-theory (e/d* () (greater-logbitp-of-unsigned-byte-p not))))

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/paging-pml4-table-lemmas.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/paging-pml4-table-lemmas.lisp
@@ -8,8 +8,8 @@
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 
 (local (in-theory (e/d (entry-found-p-and-lin-addr
-                        entry-found-p-and-good-paging-structures-x86p)
-                       ())))
+			entry-found-p-and-good-paging-structures-x86p)
+		       ())))
 
 ;; ======================================================================
 
@@ -17,239 +17,239 @@
  (defthmd ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s
    ;; TO-DO: Speed this up.
    (implies (xlate-equiv-x86s x86-1 x86-2)
-            (and
-             (equal (mv-nth
-                     0
-                     (ia32e-la-to-pa-PML4T
-                      lin-addr wp smep nxe r-w-x cpl x86-1))
-                    (mv-nth
-                     0
-                     (ia32e-la-to-pa-PML4T
-                      lin-addr wp smep nxe r-w-x cpl x86-2)))
-             (equal (mv-nth
-                     1
-                     (ia32e-la-to-pa-PML4T
-                      lin-addr wp smep nxe r-w-x cpl x86-1))
-                    (mv-nth
-                     1
-                     (ia32e-la-to-pa-PML4T
-                      lin-addr wp smep nxe r-w-x cpl x86-2)))))
+	    (and
+	     (equal (mv-nth
+		     0
+		     (ia32e-la-to-pa-PML4T
+		      lin-addr wp smep nxe r-w-x cpl x86-1))
+		    (mv-nth
+		     0
+		     (ia32e-la-to-pa-PML4T
+		      lin-addr wp smep nxe r-w-x cpl x86-2)))
+	     (equal (mv-nth
+		     1
+		     (ia32e-la-to-pa-PML4T
+		      lin-addr wp smep nxe r-w-x cpl x86-1))
+		    (mv-nth
+		     1
+		     (ia32e-la-to-pa-PML4T
+		      lin-addr wp smep nxe r-w-x cpl x86-2)))))
    :hints (("Goal"
-            :in-theory (e/d* (ia32e-la-to-pa-pml4-table
-                              entry-found-p-and-lin-addr
-                              PML4-TABLE-ENTRY-ADDR-FOUND-P
-                              PAGING-ENTRY-NO-PAGE-FAULT-P
-                              PAGE-FAULT-EXCEPTION)
-                             (xlate-equiv-x86s
-                              xlate-equiv-x86s-and-page-table-entry-addr-address
-                              page-table-entry-addr-found-p-and-xlate-equiv-x86s
-                              ia32e-la-to-pa-PT-with-xlate-equiv-x86s
-                              xlate-equiv-x86s-and-pml4-table-entry-addr-value
-                              xlate-equiv-x86s-and-pml4-table-base-addr-address
-                              xlate-equiv-x86s-and-pml4-table-entry-addr-address
-                              xlate-equiv-x86s-and-page-table-base-addr-address
-                              pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
-                              bitops::logand-with-negated-bitmask
-                              unsigned-byte-p
-                              signed-byte-p
-                              bitops::logior-equal-0))
-            :use ((:instance xlate-equiv-x86s-and-pml4-table-entry-addr-value)
-                  (:instance xlate-equiv-x86s-and-pml4-table-base-addr-address)
-                  (:instance pml4-table-entry-addr-found-p-and-xlate-equiv-x86s)
-                  (:instance pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
-                             (x86-1 x86-2)
-                             (x86-2 x86-1))
-                  (:instance xlate-equiv-entries-open
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2)))
-                  ;; (:instance page-table-entry-addr-found-p-and-xlate-equiv-x86s)
-                  ;; xlate-equiv-entries-and-loghead
-                  (:instance xlate-equiv-entries-and-loghead
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (n 1))
-                  ;; xlate-equiv-entries-and-logtail
-                  (:instance xlate-equiv-entries-and-logtail
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (n 13))
-                  (:instance xlate-equiv-entries-and-logtail
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (n 30))
-                  (:instance xlate-equiv-entries-and-logtail
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (n 52))
-                  ;; loghead-smaller-and-logbitp
-                  (:instance loghead-smaller-and-logbitp
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (m 1)
-                             (n 5))
-                  (:instance loghead-smaller-and-logbitp
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (m 2)
-                             (n 5))
-                  ;; logtail-bigger-and-logbitp
-                  (:instance logtail-bigger-and-logbitp
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (m 7)
-                             (n 7))
-                  (:instance logtail-bigger-and-logbitp
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (m 7)
-                             (n 52))
-                  (:instance logtail-bigger-and-logbitp
-                             (e1 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-1))
-                             (e2 (rm-low-64
-                                  (pml4-table-entry-addr
-                                   lin-addr
-                                   (mv-nth 1 (pml4-table-base-addr x86-2)))
-                                  x86-2))
-                             (m 7)
-                             (n 63)))))))
+	    :in-theory (e/d* (ia32e-la-to-pa-pml4-table
+			      entry-found-p-and-lin-addr
+			      PML4-TABLE-ENTRY-ADDR-FOUND-P
+			      PAGING-ENTRY-NO-PAGE-FAULT-P
+			      PAGE-FAULT-EXCEPTION)
+			     (xlate-equiv-x86s
+			      xlate-equiv-x86s-and-page-table-entry-addr-address
+			      page-table-entry-addr-found-p-and-xlate-equiv-x86s
+			      ia32e-la-to-pa-PT-with-xlate-equiv-x86s
+			      xlate-equiv-x86s-and-pml4-table-entry-addr-value
+			      xlate-equiv-x86s-and-pml4-table-base-addr-address
+			      xlate-equiv-x86s-and-pml4-table-entry-addr-address
+			      xlate-equiv-x86s-and-page-table-base-addr-address
+			      pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
+			      bitops::logand-with-negated-bitmask
+			      unsigned-byte-p
+			      signed-byte-p
+			      bitops::logior-equal-0))
+	    :use ((:instance xlate-equiv-x86s-and-pml4-table-entry-addr-value)
+		  (:instance xlate-equiv-x86s-and-pml4-table-base-addr-address)
+		  (:instance pml4-table-entry-addr-found-p-and-xlate-equiv-x86s)
+		  (:instance pml4-table-entry-addr-found-p-and-xlate-equiv-x86s
+			     (x86-1 x86-2)
+			     (x86-2 x86-1))
+		  (:instance xlate-equiv-entries-open
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2)))
+		  ;; (:instance page-table-entry-addr-found-p-and-xlate-equiv-x86s)
+		  ;; xlate-equiv-entries-and-loghead
+		  (:instance xlate-equiv-entries-and-loghead
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (n 1))
+		  ;; xlate-equiv-entries-and-logtail
+		  (:instance xlate-equiv-entries-and-logtail
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (n 13))
+		  (:instance xlate-equiv-entries-and-logtail
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (n 30))
+		  (:instance xlate-equiv-entries-and-logtail
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (n 52))
+		  ;; loghead-smaller-and-logbitp
+		  (:instance loghead-smaller-and-logbitp
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (m 1)
+			     (n 5))
+		  (:instance loghead-smaller-and-logbitp
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (m 2)
+			     (n 5))
+		  ;; logtail-bigger-and-logbitp
+		  (:instance logtail-bigger-and-logbitp
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (m 7)
+			     (n 7))
+		  (:instance logtail-bigger-and-logbitp
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (m 7)
+			     (n 52))
+		  (:instance logtail-bigger-and-logbitp
+			     (e1 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-1))
+			     (e2 (rm-low-64
+				  (pml4-table-entry-addr
+				   lin-addr
+				   (mv-nth 1 (pml4-table-base-addr x86-2)))
+				  x86-2))
+			     (m 7)
+			     (n 63)))))))
 
 (defthm mv-nth-0-ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s
   (implies (xlate-equiv-x86s x86-1 x86-2)
-           (equal (mv-nth
-                   0
-                   (ia32e-la-to-pa-PML4T
-                    lin-addr wp smep nxe r-w-x cpl x86-1))
-                  (mv-nth
-                   0
-                   (ia32e-la-to-pa-PML4T
-                    lin-addr wp smep nxe r-w-x cpl x86-2))))
+	   (equal (mv-nth
+		   0
+		   (ia32e-la-to-pa-PML4T
+		    lin-addr wp smep nxe r-w-x cpl x86-1))
+		  (mv-nth
+		   0
+		   (ia32e-la-to-pa-PML4T
+		    lin-addr wp smep nxe r-w-x cpl x86-2))))
   :hints (("Goal"
-           :use ((:instance ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s))))
+	   :use ((:instance ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s))))
   :rule-classes :congruence)
 
 (defthm mv-nth-1-ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s
   (implies (xlate-equiv-x86s x86-1 x86-2)
-           (equal (mv-nth
-                   1
-                   (ia32e-la-to-pa-PML4T
-                    lin-addr wp smep nxe r-w-x cpl x86-1))
-                  (mv-nth
-                   1
-                   (ia32e-la-to-pa-PML4T
-                    lin-addr wp smep nxe r-w-x cpl x86-2))))
+	   (equal (mv-nth
+		   1
+		   (ia32e-la-to-pa-PML4T
+		    lin-addr wp smep nxe r-w-x cpl x86-1))
+		  (mv-nth
+		   1
+		   (ia32e-la-to-pa-PML4T
+		    lin-addr wp smep nxe r-w-x cpl x86-2))))
   :hints (("Goal"
-           :use ((:instance ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s))))
+	   :use ((:instance ia32e-la-to-pa-PML4T-with-xlate-equiv-x86s))))
   :rule-classes :congruence)
 
 (local (in-theory (e/d* (gather-all-paging-structure-qword-addresses-with-xlate-equiv-x86s
-                         xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
-                         xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86)
-                        ())))
+			 xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
+			 xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86)
+			())))
 
 (defthm xlate-equiv-x86s-with-mv-nth-2-ia32e-la-to-pa-PML4T
   (xlate-equiv-x86s
    (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86))
    x86)
   :hints (("Goal"
-           :use ((:instance entry-found-p-and-good-paging-structures-x86p)
-                 (:instance gather-all-paging-structure-qword-addresses-wm-low-64-different-x86
-                            (x86-equiv (mv-nth
-                                        2
-                                        (ia32e-la-to-pa-PDPT
-                                         lin-addr wp smep nxe r-w-x cpl x86)))
-                            (index (pml4-table-entry-addr
-                                    lin-addr (mv-nth 1 (pml4-table-base-addr x86))))
-                            (val (set-accessed-bit
-                                  (rm-low-64 (pml4-table-entry-addr
-                                              lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                                             x86)))
-                            (addrs (gather-all-paging-structure-qword-addresses x86))
-                            (x86 x86)))
-           :in-theory (e/d* (ia32e-la-to-pa-pml4-table
-                             entry-found-p-and-lin-addr
-                             good-paging-structures-x86p)
-                            (bitops::logand-with-negated-bitmask
-                             entry-found-p-and-good-paging-structures-x86p
-                             xlate-equiv-x86s-and-page-table-entry-addr-address
-                             xlate-equiv-x86s-and-page-table-base-addr-address
-                             no-duplicates-list-p
-                             gather-all-paging-structure-qword-addresses-wm-low-64-different-x86)))))
+	   :use ((:instance entry-found-p-and-good-paging-structures-x86p)
+		 (:instance gather-all-paging-structure-qword-addresses-wm-low-64-different-x86
+			    (x86-equiv (mv-nth
+					2
+					(ia32e-la-to-pa-PDPT
+					 lin-addr wp smep nxe r-w-x cpl x86)))
+			    (index (pml4-table-entry-addr
+				    lin-addr (mv-nth 1 (pml4-table-base-addr x86))))
+			    (val (set-accessed-bit
+				  (rm-low-64 (pml4-table-entry-addr
+					      lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
+					     x86)))
+			    (addrs (gather-all-paging-structure-qword-addresses x86))
+			    (x86 x86)))
+	   :in-theory (e/d* (ia32e-la-to-pa-pml4-table
+			     entry-found-p-and-lin-addr
+			     good-paging-structures-x86p)
+			    (bitops::logand-with-negated-bitmask
+			     entry-found-p-and-good-paging-structures-x86p
+			     xlate-equiv-x86s-and-page-table-entry-addr-address
+			     xlate-equiv-x86s-and-page-table-base-addr-address
+			     no-duplicates-list-p
+			     gather-all-paging-structure-qword-addresses-wm-low-64-different-x86)))))
 
 
 (defthm two-page-table-walks-ia32e-la-to-pa-PML4T
@@ -263,7 +263,7 @@
       (mv-nth
        2
        (ia32e-la-to-pa-PML4T
-        lin-addr-2 wp-2 smep-2 nxe-2 r-w-x-2 cpl-2 x86))))
+	lin-addr-2 wp-2 smep-2 nxe-2 r-w-x-2 cpl-2 x86))))
     (mv-nth
      0
      (ia32e-la-to-pa-PML4T
@@ -277,7 +277,7 @@
       (mv-nth
        2
        (ia32e-la-to-pa-PML4T
-        lin-addr-2 wp-2 smep-2 nxe-2 r-w-x-2 cpl-2 x86))))
+	lin-addr-2 wp-2 smep-2 nxe-2 r-w-x-2 cpl-2 x86))))
     (mv-nth
      1
      (ia32e-la-to-pa-PML4T
@@ -286,9 +286,9 @@
   :hints (("Goal" :in-theory (e/d* () (ia32e-la-to-pa-PML4T)))))
 
 (local (in-theory (e/d* ()
-                        (gather-all-paging-structure-qword-addresses-with-xlate-equiv-x86s
-                         xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
-                         xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86))))
+			(gather-all-paging-structure-qword-addresses-with-xlate-equiv-x86s
+			 xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
+			 xlate-equiv-entries-at-qword-addresses?-with-wm-low-64-with-different-x86))))
 
 (in-theory (e/d* () (ia32e-la-to-pa-PML4T)))
 
@@ -296,27 +296,27 @@
 
 (defthm gather-all-paging-structure-qword-addresses-mv-nth-2-ia32e-la-to-pa-PML4T
   (implies (good-paging-structures-x86p x86)
-           (equal (gather-all-paging-structure-qword-addresses
-                   (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)))
-                  (gather-all-paging-structure-qword-addresses x86)))
+	   (equal (gather-all-paging-structure-qword-addresses
+		   (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)))
+		  (gather-all-paging-structure-qword-addresses x86)))
   :hints (("Goal"
-           :use ((:instance
-                  gather-all-paging-structure-qword-addresses-with-xlate-equiv-x86s
-                  (x86-equiv (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86))))))))
+	   :use ((:instance
+		  gather-all-paging-structure-qword-addresses-with-xlate-equiv-x86s
+		  (x86-equiv (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86))))))))
 
 (defthm xlate-equiv-entries-at-qword-addresses?-mv-nth-2-ia32e-la-to-pa-PML4T
   (implies (and (good-paging-structures-x86p x86)
-                (equal addrs (gather-all-paging-structure-qword-addresses x86)))
-           (equal (xlate-equiv-entries-at-qword-addresses?
-                   addrs addrs
-                   x86
-                   (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)))
-                  (xlate-equiv-entries-at-qword-addresses? addrs addrs x86 x86)))
+		(equal addrs (gather-all-paging-structure-qword-addresses x86)))
+	   (equal (xlate-equiv-entries-at-qword-addresses?
+		   addrs addrs
+		   x86
+		   (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)))
+		  (xlate-equiv-entries-at-qword-addresses? addrs addrs x86 x86)))
   :hints (("Goal"
-           :use ((:instance xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
-                            (addrs addrs)
-                            (x86 x86)
-                            (x86-equiv
-                             (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86))))))))
+	   :use ((:instance xlate-equiv-x86s-and-xlate-equiv-entries-at-qword-addresses?
+			    (addrs addrs)
+			    (x86 x86)
+			    (x86-equiv
+			     (mv-nth 2 (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86))))))))
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/paging-top.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/paging-top.lisp
@@ -5,6 +5,11 @@
 (include-book "paging-pml4-table-lemmas" :ttags :all)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
+(local (include-book "centaur/bitops/signed-byte-p" :dir :system))
+
+(local (in-theory (e/d (entry-found-p-and-lin-addr
+			entry-found-p-and-good-paging-structures-x86p)
+		       ())))
 
 ;; ======================================================================
 
@@ -19,5 +24,126 @@
   )
 
 (local (xdoc::set-default-parents reasoning-about-page-tables))
+
+;; ======================================================================
+
+(defthmd not-good-paging-structures-x86p-and-ia32e-la-to-pa-PML4T
+  (implies (not (good-paging-structures-x86p x86))
+	   (and (equal (mv-nth
+			0
+			(ia32e-la-to-pa-PML4T
+			 lin-addr wp smep nxe r-w-x cpl x86))
+		       t)
+		(equal (mv-nth
+			1
+			(ia32e-la-to-pa-PML4T
+			 lin-addr wp smep nxe r-w-x cpl x86))
+		       0)
+		(equal (mv-nth
+			2
+			(ia32e-la-to-pa-PML4T
+			 lin-addr wp smep nxe r-w-x cpl x86))
+		       x86)))
+  :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-PML4T) ()))))
+
+(defthmd xlate-equiv-x86s-open-for-ctr-and-msr
+  (implies (and (xlate-equiv-x86s x86-1 x86-2)
+		(good-paging-structures-x86p x86-1))
+	   (and (equal (cr0-slice :cr0-wp (n32 (ctri *cr0* x86-1)))
+		       (cr0-slice :cr0-wp (n32 (ctri *cr0* x86-2))))
+		(equal (cr4-slice :cr4-smep (n21 (ctri *cr4* x86-1)))
+		       (cr4-slice :cr4-smep (n21 (ctri *cr4* x86-2))))
+		(equal
+		 (ia32_efer-slice
+		  :ia32_efer-nxe (n12 (msri *ia32_efer-idx* x86-1)))
+		 (ia32_efer-slice
+		  :ia32_efer-nxe (n12 (msri *ia32_efer-idx* x86-2)))))))
+
+(defthmd xlate-equiv-x86s-open-for-not-good-paging-structures-x86p
+  (implies (and (not (good-paging-structures-x86p x86-1))
+		(xlate-equiv-x86s x86-1 x86-2))
+	   (not (good-paging-structures-x86p x86-2))))
+
+(in-theory (e/d () (xlate-equiv-x86s)))
+
+;; ======================================================================
+
+(defthm mv-nth-0-ia32e-entries-found-la-to-pa-with-xlate-equiv-x86s
+  (implies (xlate-equiv-x86s x86-1 x86-2)
+	   (equal (mv-nth
+		   0
+		   (ia32e-entries-found-la-to-pa
+		    lin-addr r-w-x cpl x86-1))
+		  (mv-nth
+		   0
+		   (ia32e-entries-found-la-to-pa
+		    lin-addr r-w-x cpl x86-2))))
+  :hints (("Goal"
+	   :use ((:instance xlate-equiv-x86s-open-for-ctr-and-msr)
+		 (:instance xlate-equiv-x86s-open-for-not-good-paging-structures-x86p))
+	   :in-theory (e/d* (ia32e-entries-found-la-to-pa
+			     not-good-paging-structures-x86p-and-ia32e-la-to-pa-PML4T)
+			    ())))
+  :rule-classes :congruence)
+
+(defthm mv-nth-1-ia32e-entries-found-la-to-pa-with-xlate-equiv-x86s
+  (implies (xlate-equiv-x86s x86-1 x86-2)
+	   (equal (mv-nth
+		   1
+		   (ia32e-entries-found-la-to-pa
+		    lin-addr r-w-x cpl x86-1))
+		  (mv-nth
+		   1
+		   (ia32e-entries-found-la-to-pa
+		    lin-addr r-w-x cpl x86-2))))
+  :hints (("Goal"
+	   :use ((:instance xlate-equiv-x86s-open-for-ctr-and-msr)
+		 (:instance xlate-equiv-x86s-open-for-not-good-paging-structures-x86p))
+	   :in-theory (e/d* (ia32e-entries-found-la-to-pa
+			     not-good-paging-structures-x86p-and-ia32e-la-to-pa-PML4T)
+			    ())))
+  :rule-classes :congruence)
+
+(defthm xlate-equiv-x86s-with-mv-nth-2-ia32e-entries-found-la-to-pa
+  (xlate-equiv-x86s
+   (mv-nth 2 (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl x86))
+   x86)
+  :hints (("Goal"
+	   :use ((:instance xlate-equiv-x86s-open-for-ctr-and-msr)
+		 (:instance xlate-equiv-x86s-open-for-not-good-paging-structures-x86p))
+	   :in-theory (e/d* (ia32e-entries-found-la-to-pa
+			     not-good-paging-structures-x86p-and-ia32e-la-to-pa-PML4T)
+			    ()))))
+
+(defthm two-page-table-walks-ia32e-entries-found-la-to-pa
+  (and
+
+   (equal
+    (mv-nth
+     0
+     (ia32e-entries-found-la-to-pa
+      lin-addr-1 r-w-x-1 cpl-1
+      (mv-nth
+       2
+       (ia32e-entries-found-la-to-pa
+	lin-addr-2 r-w-x-2 cpl-2 x86))))
+    (mv-nth
+     0
+     (ia32e-entries-found-la-to-pa
+      lin-addr-1 r-w-x-1 cpl-1 x86)))
+
+   (equal
+    (mv-nth
+     1
+     (ia32e-entries-found-la-to-pa
+      lin-addr-1 r-w-x-1 cpl-1
+      (mv-nth
+       2
+       (ia32e-entries-found-la-to-pa
+	lin-addr-2 r-w-x-2 cpl-2 x86))))
+    (mv-nth
+     1
+     (ia32e-entries-found-la-to-pa
+      lin-addr-1 r-w-x-1 cpl-1 x86)))))
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/x86-ia32e-paging-alt.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging-lib/x86-ia32e-paging-alt.lisp
@@ -13,21 +13,28 @@
 (local
  (def-gl-thm 4K-aligned-physical-address-helper
    :hyp (and (unsigned-byte-p 52 x)
-             (equal (loghead 12 x) 0))
+	     (equal (loghead 12 x) 0))
    :concl (equal (logand 18446744073709547520 x)
-                 x)
+		 x)
    :g-bindings `((x (:g-number ,(gl-int 0 1 53))))))
 
 (local (in-theory (e/d* () (signed-byte-p unsigned-byte-p))))
 
 ;; ======================================================================
 
-;; In this book, we provide another interface to the paging
-;; specification functions (in machine/x86-ia32e-paging.lisp). Unlike
-;; the old specification functions, these functions do not take the
-;; base-addr as input --- base-addr is computed from lin-addr and x86
-;; state for every paging structure traversal function. We intend to
-;; use these functions only for reasoning.
+(defsection alternate-paging-functions
+  :parents (reasoning-about-page-tables)
+
+  :short "Alternate versions of paging structure traversal functions"
+
+  :long "<p>We provide another interface to the paging specification
+functions (in @('machine/x86-ia32e-paging.lisp')). Unlike the old
+specification functions, these functions do not take the
+@('base-addr') as input --- @('base-addr') is computed from
+@('lin-addr') and @('x86') state for every paging structure traversal
+function. We intend to use these functions only for reasoning.</p>" )
+
+(local (xdoc::set-default-parents alternate-paging-functions))
 
 ;; ======================================================================
 
@@ -49,21 +56,21 @@
       (+
        (ash 512 3)
        (ash (ia32e-page-tables-slice :reference-addr superior-entry)
-            12)))))
+	    12)))))
 
   ///
 
   (defthm superior-entry-points-to-an-inferior-one-p-xw
     (implies (not (equal fld :mem))
-             (equal (superior-entry-points-to-an-inferior-one-p addr (xw fld index val x86))
-                    (superior-entry-points-to-an-inferior-one-p addr x86)))))
+	     (equal (superior-entry-points-to-an-inferior-one-p addr (xw fld index val x86))
+		    (superior-entry-points-to-an-inferior-one-p addr x86)))))
 
 (define pml4-table-base-addr (x86)
   (if (good-paging-structures-x86p x86)
       (b* ((cr3 (ctri *cr3* x86))
-           ;; PML4 Table:
-           (pml4-base-addr (ash (cr3-slice :cr3-pdb cr3) 12)))
-          (mv nil pml4-base-addr))
+	   ;; PML4 Table:
+	   (pml4-base-addr (ash (cr3-slice :cr3-pdb cr3) 12)))
+	  (mv nil pml4-base-addr))
     (mv t 0))
 
   ///
@@ -79,29 +86,29 @@
 
   (defthm loghead-12-of-mv-nth-1-pml4-table-base-addr=0
     (implies (x86p x86)
-             (equal (loghead 12 (mv-nth 1 (pml4-table-base-addr x86)))
-                    0)))
+	     (equal (loghead 12 (mv-nth 1 (pml4-table-base-addr x86)))
+		    0)))
 
   (defthm pml4-table-base-addr-no-error
     (implies (good-paging-structures-x86p x86)
-             (equal (mv-nth 0 (pml4-table-base-addr x86)) nil)))
+	     (equal (mv-nth 0 (pml4-table-base-addr x86)) nil)))
 
   (defthm logand--4096-of-pml4-table-base-addr
     (equal (logand -4096 (mv-nth 1 (pml4-table-base-addr x86)))
-           (mv-nth 1 (pml4-table-base-addr x86))))
+	   (mv-nth 1 (pml4-table-base-addr x86))))
 
   (defthm logand-positive-of-pml4-table-base-addr
     (equal (logand 18446744073709547520
-                   (loghead 52 (mv-nth 1 (pml4-table-base-addr x86))))
-           (mv-nth 1 (pml4-table-base-addr x86))))
+		   (loghead 52 (mv-nth 1 (pml4-table-base-addr x86))))
+	   (mv-nth 1 (pml4-table-base-addr x86))))
 
   (defthm pml4-table-base-addr-and-xw
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :ctr))
-                  (x86p x86)
-                  (x86p (xw fld index val x86)))
-             (equal (mv-nth 1 (pml4-table-base-addr (xw fld index val x86)))
-                    (mv-nth 1 (pml4-table-base-addr x86))))))
+		  (not (equal fld :ctr))
+		  (x86p x86)
+		  (x86p (xw fld index val x86)))
+	     (equal (mv-nth 1 (pml4-table-base-addr (xw fld index val x86)))
+		    (mv-nth 1 (pml4-table-base-addr x86))))))
 
 (define page-dir-ptr-table-base-addr
   ((lin-addr :type (signed-byte #.*max-linear-address-size*))
@@ -109,23 +116,23 @@
 
   (if (good-paging-structures-x86p x86)
       (b* ( ;; PML4 Table:
-           ((mv & pml4-base-addr)
-            (pml4-table-base-addr x86))
-           (pml4-entry-addr
-            (pml4-table-entry-addr lin-addr pml4-base-addr))
-           (pml4-entry (rm-low-64 pml4-entry-addr x86))
+	   ((mv & pml4-base-addr)
+	    (pml4-table-base-addr x86))
+	   (pml4-entry-addr
+	    (pml4-table-entry-addr lin-addr pml4-base-addr))
+	   (pml4-entry (rm-low-64 pml4-entry-addr x86))
 
-           ;; Page-Dir-Ptr Directory Pointer Table:
-           (ptr-table-base-addr
-            (ash (ia32e-pml4e-slice :pml4e-pdpt pml4-entry) 12)))
-          (mv nil ptr-table-base-addr))
+	   ;; Page-Dir-Ptr Directory Pointer Table:
+	   (ptr-table-base-addr
+	    (ash (ia32e-pml4e-slice :pml4e-pdpt pml4-entry) 12)))
+	  (mv nil ptr-table-base-addr))
     (mv t 0))
 
   ///
 
   (defthm-usb n52p-mv-nth-1-page-dir-ptr-table-base-addr
     :hyp (and (canonical-address-p lin-addr)
-              (x86p x86))
+	      (x86p x86))
     :bound 52
     :concl (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))
     :gen-linear t
@@ -135,18 +142,18 @@
 
   (defthm loghead-12-of-mv-nth-1-page-dir-ptr-table-base-addr=0
     (implies (and (canonical-address-p lin-addr)
-                  (x86p x86))
-             (equal (loghead 12 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                    0)))
+		  (x86p x86))
+	     (equal (loghead 12 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		    0)))
 
   (defthm logand--4096-of-page-dir-ptr-table-base-addr
     (equal (logand -4096 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-           (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
+	   (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
 
   (defthm logand-positive-of-page-dir-ptr-table-base-addr
     (equal (logand 18446744073709547520
-                   (loghead 52 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
-           (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))))
+		   (loghead 52 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
+	   (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))))
 
 (define page-directory-base-addr
   ((lin-addr :type (signed-byte #.*max-linear-address-size*))
@@ -154,23 +161,23 @@
 
   (if (good-paging-structures-x86p x86)
       (b* ( ;; Page-Directory Directory Pointer Table:
-           ((mv & ptr-table-base-addr)
-            (page-dir-ptr-table-base-addr lin-addr x86))
-           (ptr-table-entry-addr
-            (page-dir-ptr-table-entry-addr lin-addr ptr-table-base-addr))
-           (ptr-table-entry (rm-low-64 ptr-table-entry-addr x86))
+	   ((mv & ptr-table-base-addr)
+	    (page-dir-ptr-table-base-addr lin-addr x86))
+	   (ptr-table-entry-addr
+	    (page-dir-ptr-table-entry-addr lin-addr ptr-table-base-addr))
+	   (ptr-table-entry (rm-low-64 ptr-table-entry-addr x86))
 
-           (pdpte-ps? (equal (ia32e-page-tables-slice :ps ptr-table-entry) 1))
+	   (pdpte-ps? (equal (ia32e-page-tables-slice :ps ptr-table-entry) 1))
 
-           ;; 1G pages:
-           ((when pdpte-ps?)
-            (mv t 0))
+	   ;; 1G pages:
+	   ((when pdpte-ps?)
+	    (mv t 0))
 
-           ;; Page Directory:
-           (page-directory-base-addr
-            (ash (ia32e-pdpte-pg-dir-slice :pdpte-pd ptr-table-entry) 12)))
+	   ;; Page Directory:
+	   (page-directory-base-addr
+	    (ash (ia32e-pdpte-pg-dir-slice :pdpte-pd ptr-table-entry) 12)))
 
-          (mv nil page-directory-base-addr))
+	  (mv nil page-directory-base-addr))
 
     (mv t 0))
 
@@ -178,7 +185,7 @@
 
   (defthm-usb n52p-mv-nth-1-page-directory-base-addr
     :hyp (and (canonical-address-p lin-addr)
-              (x86p x86))
+	      (x86p x86))
     :bound 52
     :concl (mv-nth 1 (page-directory-base-addr lin-addr x86))
     :gen-linear t
@@ -188,18 +195,18 @@
 
   (defthm loghead-12-of-mv-nth-1-page-directory-base-addr=0
     (implies (and (canonical-address-p lin-addr)
-                  (x86p x86))
-             (equal (loghead 12 (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                    0)))
+		  (x86p x86))
+	     (equal (loghead 12 (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+		    0)))
 
   (defthm logand--4096-of-page-directory-base-addr
     (equal (logand -4096 (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-           (mv-nth 1 (page-directory-base-addr lin-addr x86))))
+	   (mv-nth 1 (page-directory-base-addr lin-addr x86))))
 
   (defthm logand-positive-of-page-directory-base-addr
     (equal (logand 18446744073709547520
-                   (loghead 52 (mv-nth 1 (page-directory-base-addr lin-addr x86))))
-           (mv-nth 1 (page-directory-base-addr lin-addr x86)))))
+		   (loghead 52 (mv-nth 1 (page-directory-base-addr lin-addr x86))))
+	   (mv-nth 1 (page-directory-base-addr lin-addr x86)))))
 
 (define page-table-base-addr
   ((lin-addr :type (signed-byte #.*max-linear-address-size*))
@@ -207,31 +214,31 @@
 
   (if (good-paging-structures-x86p x86)
       (b* ( ;; Page Directory:
-           ((mv flg page-directory-base-addr)
-            (page-directory-base-addr lin-addr x86))
-           ((when flg)
-            (mv flg 0))
-           ;; 2M pages:
-           (page-directory-entry-addr
-            (page-directory-entry-addr lin-addr page-directory-base-addr))
-           (page-directory-entry (rm-low-64 page-directory-entry-addr x86))
+	   ((mv flg page-directory-base-addr)
+	    (page-directory-base-addr lin-addr x86))
+	   ((when flg)
+	    (mv flg 0))
+	   ;; 2M pages:
+	   (page-directory-entry-addr
+	    (page-directory-entry-addr lin-addr page-directory-base-addr))
+	   (page-directory-entry (rm-low-64 page-directory-entry-addr x86))
 
-           (pde-ps? (equal (ia32e-page-tables-slice :ps page-directory-entry) 1))
-           ((when pde-ps?)
-            (mv t 0))
+	   (pde-ps? (equal (ia32e-page-tables-slice :ps page-directory-entry) 1))
+	   ((when pde-ps?)
+	    (mv t 0))
 
-           ;; Page Table
-           ;; 4K pages
-           (page-table-base-addr
-            (ash (ia32e-pde-pg-table-slice :pde-pt page-directory-entry) 12)))
-          (mv nil page-table-base-addr))
+	   ;; Page Table
+	   ;; 4K pages
+	   (page-table-base-addr
+	    (ash (ia32e-pde-pg-table-slice :pde-pt page-directory-entry) 12)))
+	  (mv nil page-table-base-addr))
     (mv t 0))
 
   ///
 
   (defthm-usb n52p-mv-nth-1-page-table-base-addr
     :hyp (and (canonical-address-p lin-addr)
-              (x86p x86))
+	      (x86p x86))
     :bound 52
     :concl (mv-nth 1 (page-table-base-addr lin-addr x86))
     :gen-linear t
@@ -241,18 +248,18 @@
 
   (defthm loghead-12-of-mv-nth-1-page-table-base-addr=0
     (implies (and (canonical-address-p lin-addr)
-                  (x86p x86))
-             (equal (loghead 12 (mv-nth 1 (page-table-base-addr lin-addr x86)))
-                    0)))
+		  (x86p x86))
+	     (equal (loghead 12 (mv-nth 1 (page-table-base-addr lin-addr x86)))
+		    0)))
 
   (defthm logand--4096-of-page-table-base-addr
     (equal (logand -4096 (mv-nth 1 (page-table-base-addr lin-addr x86)))
-           (mv-nth 1 (page-table-base-addr lin-addr x86))))
+	   (mv-nth 1 (page-table-base-addr lin-addr x86))))
 
   (defthm logand-positive-of-page-table-base-addr
     (equal (logand 18446744073709547520
-                   (loghead 52 (mv-nth 1 (page-table-base-addr lin-addr x86))))
-           (mv-nth 1 (page-table-base-addr lin-addr x86)))))
+		   (loghead 52 (mv-nth 1 (page-table-base-addr lin-addr x86))))
+	   (mv-nth 1 (page-table-base-addr lin-addr x86)))))
 
 ;; ======================================================================
 
@@ -272,17 +279,17 @@
   :enabled t
   (and (pml4-table-entry-addr-found-p lin-addr x86)
        (superior-entry-points-to-an-inferior-one-p
-        (pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
-        x86)
+	(pml4-table-entry-addr lin-addr (mv-nth 1 (pml4-table-base-addr x86)))
+	x86)
        (x86p x86))
   ///
   (defthm page-dir-ptr-table-entry-addr-found-p-implies-pml4-table-entry-addr-found-p
     (implies (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-             (pml4-table-entry-addr-found-p lin-addr x86)))
+	     (pml4-table-entry-addr-found-p lin-addr x86)))
 
   (defthm page-dir-ptr-table-entry-addr-found-p-and-page-dir-ptr-table-base-addr-no-error
     (implies (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-             (not (mv-nth 0 (page-dir-ptr-table-base-addr lin-addr x86))))
+	     (not (mv-nth 0 (page-dir-ptr-table-base-addr lin-addr x86))))
     :hints (("Goal" :in-theory (e/d* (page-dir-ptr-table-base-addr) ())))))
 
 (define page-directory-entry-addr-found-p
@@ -292,16 +299,16 @@
   :enabled t
   (and (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
        (superior-entry-points-to-an-inferior-one-p
-        (page-dir-ptr-table-entry-addr lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-        x86))
+	(page-dir-ptr-table-entry-addr lin-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	x86))
   ///
   (defthm page-directory-entry-addr-found-p-implies-page-dir-ptr-table-entry-addr-found-p
     (implies (page-directory-entry-addr-found-p lin-addr x86)
-             (page-dir-ptr-table-entry-addr-found-p lin-addr x86)))
+	     (page-dir-ptr-table-entry-addr-found-p lin-addr x86)))
 
   (defthm page-directory-entry-addr-found-p-and-page-directory-base-addr-no-error
     (implies (page-directory-entry-addr-found-p lin-addr x86)
-             (not (mv-nth 0 (page-directory-base-addr lin-addr x86))))
+	     (not (mv-nth 0 (page-directory-base-addr lin-addr x86))))
     :hints (("Goal" :in-theory (e/d* (page-directory-base-addr) ())))))
 
 (define page-table-entry-addr-found-p
@@ -311,71 +318,94 @@
   :enabled t
   (and (page-directory-entry-addr-found-p lin-addr x86)
        (superior-entry-points-to-an-inferior-one-p
-        (page-directory-entry-addr lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-        x86))
+	(page-directory-entry-addr lin-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	x86))
   ///
   (defthm page-table-entry-addr-found-p-implies-page-directory-entry-addr-found-p
     (implies (page-table-entry-addr-found-p lin-addr x86)
-             (page-directory-entry-addr-found-p lin-addr x86)))
+	     (page-directory-entry-addr-found-p lin-addr x86)))
 
   (defthm page-table-entry-addr-found-p-and-page-table-base-addr-no-error
     (implies (page-table-entry-addr-found-p lin-addr x86)
-             (not (mv-nth 0 (page-table-base-addr lin-addr x86))))
+	     (not (mv-nth 0 (page-table-base-addr lin-addr x86))))
     :hints (("Goal" :in-theory (e/d* (page-table-base-addr)
-                                     ())))))
+				     ())))))
+
+(define paging-entries-found-p
+  ((lin-addr :type (signed-byte #.*max-linear-address-size*))
+   x86)
+  :non-executable t
+  (or
+   ;; 4K Pages
+   (page-table-entry-addr-found-p lin-addr x86)
+   ;; 2M Pages
+   (b* ((PD-base-addr
+	 (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+	(PD-entry-addr
+	 (page-directory-entry-addr lin-addr PD-base-addr))
+	(PD-entry
+	 (rm-low-64 PD-entry-addr x86)))
+       (and (page-directory-entry-addr-found-p lin-addr x86)
+	    (equal (ia32e-page-tables-slice :ps PD-entry) 1)))
+   ;; 1 GB Pages
+   (b* ((PDPT-base-addr
+	 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+	(PDPT-entry-addr
+	 (page-dir-ptr-table-entry-addr lin-addr PDPT-base-addr))
+	(PDPT-entry (rm-low-64 PDPT-entry-addr x86)))
+       (and (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
+	    (equal (ia32e-page-tables-slice :ps PDPT-entry) 1)))))
 
 (defun find-binding-from-entry-found-p-aux (var calls)
   (if (endp calls)
       nil
     (b* ((call (car calls))
-         (var-val (if (equal var 'lin-addr)
-                      (second call)
-                    (if (equal var 'x86)
-                        (third call)
-                      nil))))
-        (append `((,var . ,var-val))
-                (find-binding-from-entry-found-p-aux var (cdr calls))))))
+	 (var-val (if (equal var 'lin-addr)
+		      (second call)
+		    (if (equal var 'x86)
+			(third call)
+		      nil))))
+	(append `((,var . ,var-val))
+		(find-binding-from-entry-found-p-aux var (cdr calls))))))
 
 (defun find-binding-from-entry-found-p (var mfc state)
   (declare (xargs :stobjs (state) :mode :program)
-           (ignorable state))
+	   (ignorable state))
   (b* ((calls (acl2::find-calls-of-fns-lst
-               '(page-table-entry-addr-found-p
-                 page-directory-entry-addr-found-p
-                 page-dir-ptr-table-entry-addr-found-p
-                 pml4-table-entry-addr-found-p)
-               (acl2::mfc-clause mfc))))
+	       '(page-table-entry-addr-found-p
+		 page-directory-entry-addr-found-p
+		 page-dir-ptr-table-entry-addr-found-p
+		 pml4-table-entry-addr-found-p
+		 paging-entries-found-p)
+	       (acl2::mfc-clause mfc))))
       (find-binding-from-entry-found-p-aux var calls)))
 
 (defthmd entry-found-p-and-lin-addr
   (implies (and (bind-free (find-binding-from-entry-found-p 'x86 mfc state) (x86))
-                (or (page-table-entry-addr-found-p lin-addr x86)
-                    (page-directory-entry-addr-found-p lin-addr x86)
-                    (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-                    (pml4-table-entry-addr-found-p lin-addr x86)))
-           (equal (logext 48 lin-addr) lin-addr))
-  :hints (("Goal" :in-theory (e/d* (page-table-entry-addr-found-p
-                                    page-directory-entry-addr-found-p
-                                    page-dir-ptr-table-entry-addr-found-p
-                                    pml4-table-entry-addr-found-p)
-                                   ()))))
+		(or (page-table-entry-addr-found-p lin-addr x86)
+		    (page-directory-entry-addr-found-p lin-addr x86)
+		    (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
+		    (pml4-table-entry-addr-found-p lin-addr x86)
+		    (paging-entries-found-p lin-addr x86)))
+	   (and (signed-byte-p *max-linear-address-size* lin-addr)
+		(equal (logext 48 lin-addr) lin-addr)))
+  :hints (("Goal" :in-theory (e/d* (paging-entries-found-p)
+				   ()))))
 
 (defthmd entry-found-p-and-good-paging-structures-x86p
   (implies (and (bind-free (find-binding-from-entry-found-p 'lin-addr mfc state) (lin-addr))
-                (or (page-table-entry-addr-found-p lin-addr x86)
-                    (page-directory-entry-addr-found-p lin-addr x86)
-                    (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-                    (pml4-table-entry-addr-found-p lin-addr x86)))
-           (good-paging-structures-x86p x86))
-  :hints (("Goal" :in-theory (e/d* (page-table-entry-addr-found-p
-                                    page-directory-entry-addr-found-p
-                                    page-dir-ptr-table-entry-addr-found-p
-                                    pml4-table-entry-addr-found-p)
-                                   ()))))
+		(or (page-table-entry-addr-found-p lin-addr x86)
+		    (page-directory-entry-addr-found-p lin-addr x86)
+		    (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
+		    (pml4-table-entry-addr-found-p lin-addr x86)
+		    (paging-entries-found-p lin-addr x86)))
+	   (good-paging-structures-x86p x86))
+  :hints (("Goal" :in-theory (e/d* (paging-entries-found-p)
+				   ()))))
 
 (local (in-theory (e/d (entry-found-p-and-lin-addr
-                        entry-found-p-and-good-paging-structures-x86p)
-                       ())))
+			entry-found-p-and-good-paging-structures-x86p)
+		       ())))
 
 ;; ======================================================================
 
@@ -395,9 +425,9 @@
 
   (if (page-table-entry-addr-found-p lin-addr x86)
       (b* (((mv & base-addr)
-            (page-table-base-addr lin-addr x86)))
-          (ia32e-la-to-pa-page-table
-           lin-addr base-addr u-s-acc wp smep nxe r-w-x cpl x86))
+	    (page-table-base-addr lin-addr x86)))
+	  (ia32e-la-to-pa-page-table
+	   lin-addr base-addr u-s-acc wp smep nxe r-w-x cpl x86))
     (mv t 0 x86))
 
   ///
@@ -405,9 +435,9 @@
   (defthmd ia32e-la-to-pa-PT-and-ia32e-la-to-pa-page-table
     ;; Sanity check for ia32e-la-to-pa-PT.
     (implies (and (page-table-entry-addr-found-p lin-addr x86)
-                  (equal base-addr (mv-nth 1 (page-table-base-addr lin-addr x86))))
-             (equal (ia32e-la-to-pa-PT lin-addr u-s-acc wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-page-table lin-addr base-addr u-s-acc wp smep nxe r-w-x cpl x86))))
+		  (equal base-addr (mv-nth 1 (page-table-base-addr lin-addr x86))))
+	     (equal (ia32e-la-to-pa-PT lin-addr u-s-acc wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-page-table lin-addr base-addr u-s-acc wp smep nxe r-w-x cpl x86))))
 
   (local (in-theory (e/d () (page-table-entry-addr-found-p))))
 
@@ -415,29 +445,29 @@
     :hyp t
     :bound *physical-address-size*
     :concl (mv-nth 1
-                   (ia32e-la-to-pa-PT
-                    lin-addr u-s-acc wp smep nxe r-w-x cpl
-                    x86))
+		   (ia32e-la-to-pa-PT
+		    lin-addr u-s-acc wp smep nxe r-w-x cpl
+		    x86))
     :gen-linear t
     :gen-type t)
 
   (defthm x86p-mv-nth-2-ia32e-la-to-pa-PT
     (implies (x86p x86)
-             (x86p
-              (mv-nth 2
-                      (ia32e-la-to-pa-PT
-                       lin-addr u-s-acc wp smep nxe r-w-x cpl
-                       x86)))))
+	     (x86p
+	      (mv-nth 2
+		      (ia32e-la-to-pa-PT
+		       lin-addr u-s-acc wp smep nxe r-w-x cpl
+		       x86)))))
 
   (defthm xr-ia32e-la-to-pa-PT
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :fault)))
-             (equal (xr fld index
-                        (mv-nth 2
-                                (ia32e-la-to-pa-PT
-                                 lin-addr u-s-acc wp smep nxe r-w-x cpl
-                                 x86)))
-                    (xr fld index x86))))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index
+			(mv-nth 2
+				(ia32e-la-to-pa-PT
+				 lin-addr u-s-acc wp smep nxe r-w-x cpl
+				 x86)))
+		    (xr fld index x86))))
 
   ;; Need lemmas about
   ;; page-table-base-addr and xw
@@ -494,41 +524,41 @@
   (if (page-directory-entry-addr-found-p lin-addr x86)
 
       (b* (((mv & base-addr)
-            (page-directory-base-addr lin-addr x86))
-           (p-entry-addr
-            (page-directory-entry-addr lin-addr base-addr))
-           (entry (rm-low-64 p-entry-addr x86)))
+	    (page-directory-base-addr lin-addr x86))
+	   (p-entry-addr
+	    (page-directory-entry-addr lin-addr base-addr))
+	   (entry (rm-low-64 p-entry-addr x86)))
 
-          (if (equal (ia32e-page-tables-slice :ps entry) 1)
-              ;; 2MB page
-              (ia32e-la-to-pa-page-directory
-               lin-addr base-addr wp smep nxe r-w-x cpl x86)
-            ;; 4K page
-            (b* (((mv fault-flg val x86)
-                  (paging-entry-no-page-fault-p lin-addr entry wp smep nxe r-w-x cpl x86))
-                 ((when fault-flg)
-                  (mv 'Page-Fault val x86))
-                 ;; No errors at this level.
-                 ((mv flg address x86)
-                  (ia32e-la-to-pa-PT
-                   lin-addr (ia32e-page-tables-slice :u/s entry)
-                   wp smep nxe r-w-x cpl x86))
-                 ((when flg)
-                  ;; Error, so do not update accessed bit.
-                  (mv flg 0 x86))
+	  (if (equal (ia32e-page-tables-slice :ps entry) 1)
+	      ;; 2MB page
+	      (ia32e-la-to-pa-page-directory
+	       lin-addr base-addr wp smep nxe r-w-x cpl x86)
+	    ;; 4K page
+	    (b* (((mv fault-flg val x86)
+		  (paging-entry-no-page-fault-p lin-addr entry wp smep nxe r-w-x cpl x86))
+		 ((when fault-flg)
+		  (mv 'Page-Fault val x86))
+		 ;; No errors at this level.
+		 ((mv flg address x86)
+		  (ia32e-la-to-pa-PT
+		   lin-addr (ia32e-page-tables-slice :u/s entry)
+		   wp smep nxe r-w-x cpl x86))
+		 ((when flg)
+		  ;; Error, so do not update accessed bit.
+		  (mv flg 0 x86))
 
-                 ;; Get accessed bit.  Dirty bit is ignored when PDE
-                 ;; references the PT.
-                 (accessed        (ia32e-page-tables-slice :a entry))
-                 ;; Update accessed bit, if needed.
-                 (entry (if (equal accessed 0)
-                            (set-accessed-bit entry)
-                          entry))
-                 ;; Update x86, if needed.
-                 (x86 (if (equal accessed 0)
-                          (wm-low-64 p-entry-addr entry x86)
-                        x86)))
-                (mv nil address x86))))
+		 ;; Get accessed bit.  Dirty bit is ignored when PDE
+		 ;; references the PT.
+		 (accessed        (ia32e-page-tables-slice :a entry))
+		 ;; Update accessed bit, if needed.
+		 (entry (if (equal accessed 0)
+			    (set-accessed-bit entry)
+			  entry))
+		 ;; Update x86, if needed.
+		 (x86 (if (equal accessed 0)
+			  (wm-low-64 p-entry-addr entry x86)
+			x86)))
+		(mv nil address x86))))
 
     (mv t 0 x86))
 
@@ -537,61 +567,61 @@
   (defthmd ia32e-la-to-pa-PD-and-ia32e-la-to-pa-page-directory-only-2M-pages
     ;; Sanity check for ia32e-la-to-pa-PD.
     (implies (and (page-directory-entry-addr-found-p lin-addr x86)
-                  (equal base-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                  (equal entry (rm-low-64 (page-directory-entry-addr lin-addr base-addr) x86))
-                  (equal (ia32e-page-tables-slice :ps entry) 1))
-             (equal (ia32e-la-to-pa-PD
-                     lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-page-directory
-                     lin-addr base-addr wp smep nxe r-w-x cpl x86))))
+		  (equal base-addr (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+		  (equal entry (rm-low-64 (page-directory-entry-addr lin-addr base-addr) x86))
+		  (equal (ia32e-page-tables-slice :ps entry) 1))
+	     (equal (ia32e-la-to-pa-PD
+		     lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-page-directory
+		     lin-addr base-addr wp smep nxe r-w-x cpl x86))))
 
   (defthmd ia32e-la-to-pa-PD-and-ia32e-la-to-pa-page-directory-2M-and-4K-pages
     ;; Sanity check for ia32e-la-to-pa-PD.
     (implies (and (page-table-entry-addr-found-p lin-addr x86)
-                  (equal page-directory-base-addr
-                         (mv-nth 1 (page-directory-base-addr lin-addr x86))))
-             (equal (ia32e-la-to-pa-PD lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-page-directory
-                     lin-addr page-directory-base-addr wp smep nxe r-w-x cpl x86)))
+		  (equal page-directory-base-addr
+			 (mv-nth 1 (page-directory-base-addr lin-addr x86))))
+	     (equal (ia32e-la-to-pa-PD lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-page-directory
+		     lin-addr page-directory-base-addr wp smep nxe r-w-x cpl x86)))
     :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-page-directory
-                                      page-table-base-addr
-                                      ia32e-la-to-pa-PT)
-                                     (page-directory-entry-addr-found-p
-                                      page-table-entry-addr-found-p
-                                      ia32e-la-to-pa-page-table
-                                      bitops::logand-with-negated-bitmask)))))
+				      page-table-base-addr
+				      ia32e-la-to-pa-PT)
+				     (page-directory-entry-addr-found-p
+				      page-table-entry-addr-found-p
+				      ia32e-la-to-pa-page-table
+				      bitops::logand-with-negated-bitmask)))))
 
   (local (in-theory (e/d ()
-                         (ia32e-la-to-pa-PT
-                          page-directory-entry-addr-found-p))))
+			 (ia32e-la-to-pa-PT
+			  page-directory-entry-addr-found-p))))
 
   (defthm-usb n52p-mv-nth-1-ia32e-la-to-pa-PD
     :hyp t
     :bound *physical-address-size*
     :concl (mv-nth 1
-                   (ia32e-la-to-pa-PD
-                    lin-addr wp smep nxe r-w-x cpl
-                    x86))
+		   (ia32e-la-to-pa-PD
+		    lin-addr wp smep nxe r-w-x cpl
+		    x86))
     :gen-linear t
     :gen-type t)
 
   (defthm x86p-mv-nth-2-ia32e-la-to-pa-PD
     (implies (x86p x86)
-             (x86p
-              (mv-nth 2
-                      (ia32e-la-to-pa-PD
-                       lin-addr wp smep nxe r-w-x cpl
-                       x86)))))
+	     (x86p
+	      (mv-nth 2
+		      (ia32e-la-to-pa-PD
+		       lin-addr wp smep nxe r-w-x cpl
+		       x86)))))
 
   (defthm xr-ia32e-la-to-pa-PD
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :fault)))
-             (equal (xr fld index
-                        (mv-nth 2
-                                (ia32e-la-to-pa-PD
-                                 lin-addr wp smep nxe r-w-x cpl
-                                 x86)))
-                    (xr fld index x86))))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index
+			(mv-nth 2
+				(ia32e-la-to-pa-PD
+				 lin-addr wp smep nxe r-w-x cpl
+				 x86)))
+		    (xr fld index x86))))
 
 
   ;; Need lemmas about
@@ -649,38 +679,38 @@
   (if (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
 
       (b* (((mv & base-addr)
-            (page-dir-ptr-table-base-addr lin-addr x86))
-           (p-entry-addr
-            (page-dir-ptr-table-entry-addr lin-addr base-addr))
-           (entry (rm-low-64 p-entry-addr x86)))
-          (if (equal (ia32e-page-tables-slice :ps entry) 1)
-              ;; 1GB page
-              (ia32e-la-to-pa-page-dir-ptr-table
-               lin-addr base-addr wp smep nxe r-w-x cpl x86)
-            ;; 2M or 4K page
-            (b* (((mv fault-flg val x86)
-                  (paging-entry-no-page-fault-p lin-addr entry wp smep nxe r-w-x cpl x86))
-                 ((when fault-flg)
-                  (mv 'Page-Fault val x86))
-                 ;; No errors at this level.
-                 ((mv flg address x86)
-                  (ia32e-la-to-pa-PD lin-addr wp smep nxe r-w-x cpl x86))
-                 ((when flg)
-                  ;; Error, so do not update accessed bit.
-                  (mv flg 0 x86))
+	    (page-dir-ptr-table-base-addr lin-addr x86))
+	   (p-entry-addr
+	    (page-dir-ptr-table-entry-addr lin-addr base-addr))
+	   (entry (rm-low-64 p-entry-addr x86)))
+	  (if (equal (ia32e-page-tables-slice :ps entry) 1)
+	      ;; 1GB page
+	      (ia32e-la-to-pa-page-dir-ptr-table
+	       lin-addr base-addr wp smep nxe r-w-x cpl x86)
+	    ;; 2M or 4K page
+	    (b* (((mv fault-flg val x86)
+		  (paging-entry-no-page-fault-p lin-addr entry wp smep nxe r-w-x cpl x86))
+		 ((when fault-flg)
+		  (mv 'Page-Fault val x86))
+		 ;; No errors at this level.
+		 ((mv flg address x86)
+		  (ia32e-la-to-pa-PD lin-addr wp smep nxe r-w-x cpl x86))
+		 ((when flg)
+		  ;; Error, so do not update accessed bit.
+		  (mv flg 0 x86))
 
-                 ;; Get accessed bit.  Dirty bit is ignored when PDE
-                 ;; references the PT.
-                 (accessed        (ia32e-page-tables-slice :a entry))
-                 ;; Update accessed bit, if needed.
-                 (entry (if (equal accessed 0)
-                            (set-accessed-bit entry)
-                          entry))
-                 ;; Update x86, if needed.
-                 (x86 (if (equal accessed 0)
-                          (wm-low-64 p-entry-addr entry x86)
-                        x86)))
-                (mv nil address x86))))
+		 ;; Get accessed bit.  Dirty bit is ignored when PDE
+		 ;; references the PT.
+		 (accessed        (ia32e-page-tables-slice :a entry))
+		 ;; Update accessed bit, if needed.
+		 (entry (if (equal accessed 0)
+			    (set-accessed-bit entry)
+			  entry))
+		 ;; Update x86, if needed.
+		 (x86 (if (equal accessed 0)
+			  (wm-low-64 p-entry-addr entry x86)
+			x86)))
+		(mv nil address x86))))
 
 
     (mv t 0 x86))
@@ -690,97 +720,97 @@
   (defthmd ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-only-1G-pages
     ;; Sanity check for ia32e-la-to-pa-PDPT.
     (implies (and (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-                  (equal base-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                  (equal entry (rm-low-64 (page-dir-ptr-table-entry-addr lin-addr base-addr) x86))
-                  (equal (ia32e-page-tables-slice :ps entry) 1))
-             (equal (ia32e-la-to-pa-PDPT
-                     lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-page-dir-ptr-table
-                     lin-addr base-addr wp smep nxe r-w-x cpl x86))))
+		  (equal base-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		  (equal entry (rm-low-64 (page-dir-ptr-table-entry-addr lin-addr base-addr) x86))
+		  (equal (ia32e-page-tables-slice :ps entry) 1))
+	     (equal (ia32e-la-to-pa-PDPT
+		     lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-page-dir-ptr-table
+		     lin-addr base-addr wp smep nxe r-w-x cpl x86))))
 
   (defthmd ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-2M-pages
     ;; Sanity check for ia32e-la-to-pa-PDPT.
     (implies (and (page-directory-entry-addr-found-p lin-addr x86)
-                  (equal page-dir-ptr-table-base-addr
-                         (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                  (equal page-directory-base-addr
-                         (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                  (equal page-directory-entry
-                         (rm-low-64
-                          (page-directory-entry-addr lin-addr page-directory-base-addr)
-                          x86))
-                  (equal (ia32e-page-tables-slice :ps page-directory-entry) 1))
-             (equal (ia32e-la-to-pa-PDPT lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-page-dir-ptr-table
-                     lin-addr page-dir-ptr-table-base-addr wp smep nxe r-w-x cpl x86)))
+		  (equal page-dir-ptr-table-base-addr
+			 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		  (equal page-directory-base-addr
+			 (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+		  (equal page-directory-entry
+			 (rm-low-64
+			  (page-directory-entry-addr lin-addr page-directory-base-addr)
+			  x86))
+		  (equal (ia32e-page-tables-slice :ps page-directory-entry) 1))
+	     (equal (ia32e-la-to-pa-PDPT lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-page-dir-ptr-table
+		     lin-addr page-dir-ptr-table-base-addr wp smep nxe r-w-x cpl x86)))
     :hints (("Goal"
-             :use ((:instance ia32e-la-to-pa-PD-and-ia32e-la-to-pa-page-directory-only-2M-pages
-                              (base-addr
-                               (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                              (entry (rm-low-64 (page-directory-entry-addr
-                                                 lin-addr
-                                                 (mv-nth 1 (page-directory-base-addr lin-addr x86))) x86))))
-             :in-theory (e/d* (ia32e-la-to-pa-page-dir-ptr-table
-                               page-directory-base-addr)
-                              (ia32e-la-to-pa-PT
-                               ia32e-la-to-pa-PD
-                               page-dir-ptr-table-entry-addr-found-p
-                               page-directory-entry-addr-found-p
-                               page-table-entry-addr-found-p
-                               bitops::logand-with-negated-bitmask)))))
+	     :use ((:instance ia32e-la-to-pa-PD-and-ia32e-la-to-pa-page-directory-only-2M-pages
+			      (base-addr
+			       (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+			      (entry (rm-low-64 (page-directory-entry-addr
+						 lin-addr
+						 (mv-nth 1 (page-directory-base-addr lin-addr x86))) x86))))
+	     :in-theory (e/d* (ia32e-la-to-pa-page-dir-ptr-table
+			       page-directory-base-addr)
+			      (ia32e-la-to-pa-PT
+			       ia32e-la-to-pa-PD
+			       page-dir-ptr-table-entry-addr-found-p
+			       page-directory-entry-addr-found-p
+			       page-table-entry-addr-found-p
+			       bitops::logand-with-negated-bitmask)))))
 
   (defthmd ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-4K-pages
     ;; Sanity check for ia32e-la-to-pa-PDPT.
     (implies (and (page-table-entry-addr-found-p lin-addr x86)
-                  (equal page-dir-ptr-table-base-addr
-                         (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
-             (equal (ia32e-la-to-pa-PDPT lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-page-dir-ptr-table
-                     lin-addr page-dir-ptr-table-base-addr wp smep nxe r-w-x cpl x86)))
+		  (equal page-dir-ptr-table-base-addr
+			 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86))))
+	     (equal (ia32e-la-to-pa-PDPT lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-page-dir-ptr-table
+		     lin-addr page-dir-ptr-table-base-addr wp smep nxe r-w-x cpl x86)))
     :hints (("Goal"
-             :use ((:instance ia32e-la-to-pa-PD-and-ia32e-la-to-pa-page-directory-2M-and-4K-pages
-                              (page-directory-base-addr
-                               (mv-nth 1 (page-directory-base-addr lin-addr x86)))))
-             :in-theory (e/d* (ia32e-la-to-pa-page-dir-ptr-table
-                               page-directory-base-addr)
-                              (ia32e-la-to-pa-PT
-                               ia32e-la-to-pa-PD
-                               page-dir-ptr-table-entry-addr-found-p
-                               page-directory-entry-addr-found-p
-                               page-table-entry-addr-found-p
-                               bitops::logand-with-negated-bitmask)))))
+	     :use ((:instance ia32e-la-to-pa-PD-and-ia32e-la-to-pa-page-directory-2M-and-4K-pages
+			      (page-directory-base-addr
+			       (mv-nth 1 (page-directory-base-addr lin-addr x86)))))
+	     :in-theory (e/d* (ia32e-la-to-pa-page-dir-ptr-table
+			       page-directory-base-addr)
+			      (ia32e-la-to-pa-PT
+			       ia32e-la-to-pa-PD
+			       page-dir-ptr-table-entry-addr-found-p
+			       page-directory-entry-addr-found-p
+			       page-table-entry-addr-found-p
+			       bitops::logand-with-negated-bitmask)))))
 
   (local (in-theory (e/d ()
-                         (ia32e-la-to-pa-PD
-                          page-dir-ptr-table-entry-addr-found-p))))
+			 (ia32e-la-to-pa-PD
+			  page-dir-ptr-table-entry-addr-found-p))))
 
   (defthm-usb n52p-mv-nth-1-ia32e-la-to-pa-PDPT
     :hyp t
     :bound *physical-address-size*
     :concl (mv-nth 1
-                   (ia32e-la-to-pa-PDPT
-                    lin-addr wp smep nxe r-w-x cpl
-                    x86))
+		   (ia32e-la-to-pa-PDPT
+		    lin-addr wp smep nxe r-w-x cpl
+		    x86))
     :gen-linear t
     :gen-type t)
 
   (defthm x86p-mv-nth-2-ia32e-la-to-pa-PDPT
     (implies (x86p x86)
-             (x86p
-              (mv-nth 2
-                      (ia32e-la-to-pa-PDPT
-                       lin-addr wp smep nxe r-w-x cpl
-                       x86)))))
+	     (x86p
+	      (mv-nth 2
+		      (ia32e-la-to-pa-PDPT
+		       lin-addr wp smep nxe r-w-x cpl
+		       x86)))))
 
   (defthm xr-ia32e-la-to-pa-PDPT
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :fault)))
-             (equal (xr fld index
-                        (mv-nth 2
-                                (ia32e-la-to-pa-PDPT
-                                 lin-addr wp smep nxe r-w-x cpl
-                                 x86)))
-                    (xr fld index x86))))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index
+			(mv-nth 2
+				(ia32e-la-to-pa-PDPT
+				 lin-addr wp smep nxe r-w-x cpl
+				 x86)))
+		    (xr fld index x86))))
 
 
   ;; Need lemmas about
@@ -839,28 +869,28 @@
   (if (pml4-table-entry-addr-found-p lin-addr x86)
 
       (b* (((mv & base-addr)
-            (pml4-table-base-addr x86))
-           (p-entry-addr
-            (pml4-table-entry-addr lin-addr base-addr))
-           (entry (rm-low-64 p-entry-addr x86))
-           ((mv fault-flg val x86)
-            (paging-entry-no-page-fault-p lin-addr entry wp smep nxe r-w-x cpl x86))
-           ((when fault-flg)
-            (mv 'Page-Fault val x86))
-           ((mv flag address x86)
-            (ia32e-la-to-pa-PDPT lin-addr wp smep nxe r-w-x cpl x86))
-           ((when flag)
-            (mv flag 0 x86))
+	    (pml4-table-base-addr x86))
+	   (p-entry-addr
+	    (pml4-table-entry-addr lin-addr base-addr))
+	   (entry (rm-low-64 p-entry-addr x86))
+	   ((mv fault-flg val x86)
+	    (paging-entry-no-page-fault-p lin-addr entry wp smep nxe r-w-x cpl x86))
+	   ((when fault-flg)
+	    (mv 'Page-Fault val x86))
+	   ((mv flag address x86)
+	    (ia32e-la-to-pa-PDPT lin-addr wp smep nxe r-w-x cpl x86))
+	   ((when flag)
+	    (mv flag 0 x86))
 
-           (accessed (ia32e-page-tables-slice :a entry))
-           (entry (if (equal accessed 0)
-                      (set-accessed-bit entry)
-                    entry))
-           ;; Update x86, if needed.
-           (x86 (if (equal accessed 0)
-                    (wm-low-64 p-entry-addr entry x86)
-                  x86)))
-          (mv nil address x86))
+	   (accessed (ia32e-page-tables-slice :a entry))
+	   (entry (if (equal accessed 0)
+		      (set-accessed-bit entry)
+		    entry))
+	   ;; Update x86, if needed.
+	   (x86 (if (equal accessed 0)
+		    (wm-low-64 p-entry-addr entry x86)
+		  x86)))
+	  (mv nil address x86))
 
     (mv t 0 x86))
 
@@ -869,121 +899,121 @@
   (defthmd ia32e-la-to-pa-PML4T-and-ia32e-la-to-pa-pml4-table-1G-pages
     ;; Sanity check for ia32e-la-to-pa-PML4T.
     (implies (and (page-dir-ptr-table-entry-addr-found-p lin-addr x86)
-                  (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                  (equal page-dir-ptr-table-base-addr
-                         (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                  (equal
-                   page-dir-ptr-table-entry
-                   (rm-low-64
-                    (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr)
-                    x86))
-                  (equal (ia32e-page-tables-slice :ps page-dir-ptr-table-entry) 1))
-             (equal (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-pml4-table
-                     lin-addr pml4-table-base-addr wp smep nxe r-w-x cpl x86)))
+		  (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
+		  (equal page-dir-ptr-table-base-addr
+			 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		  (equal
+		   page-dir-ptr-table-entry
+		   (rm-low-64
+		    (page-dir-ptr-table-entry-addr lin-addr page-dir-ptr-table-base-addr)
+		    x86))
+		  (equal (ia32e-page-tables-slice :ps page-dir-ptr-table-entry) 1))
+	     (equal (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-pml4-table
+		     lin-addr pml4-table-base-addr wp smep nxe r-w-x cpl x86)))
     :hints (("Goal"
-             :use ((:instance ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-only-1G-pages
-                              (base-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                              (entry (rm-low-64 (page-dir-ptr-table-entry-addr
-                                                 lin-addr
-                                                 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                                                x86))))
-             :in-theory (e/d* (ia32e-la-to-pa-pml4-table
-                               page-dir-ptr-table-base-addr)
-                              (ia32e-la-to-pa-PT
-                               ia32e-la-to-pa-PD
-                               ia32e-la-to-pa-PDPT
-                               pml4-table-entry-addr-found-p
-                               page-dir-ptr-table-entry-addr-found-p
-                               page-directory-entry-addr-found-p
-                               page-table-entry-addr-found-p
-                               bitops::logand-with-negated-bitmask)))))
+	     :use ((:instance ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-only-1G-pages
+			      (base-addr (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+			      (entry (rm-low-64 (page-dir-ptr-table-entry-addr
+						 lin-addr
+						 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+						x86))))
+	     :in-theory (e/d* (ia32e-la-to-pa-pml4-table
+			       page-dir-ptr-table-base-addr)
+			      (ia32e-la-to-pa-PT
+			       ia32e-la-to-pa-PD
+			       ia32e-la-to-pa-PDPT
+			       pml4-table-entry-addr-found-p
+			       page-dir-ptr-table-entry-addr-found-p
+			       page-directory-entry-addr-found-p
+			       page-table-entry-addr-found-p
+			       bitops::logand-with-negated-bitmask)))))
 
   (defthmd ia32e-la-to-pa-PML4T-and-ia32e-la-to-pa-pml4-table-2M-pages
     ;; Sanity check for ia32e-la-to-pa-PML4T.
     (implies (and (page-directory-entry-addr-found-p lin-addr x86)
-                  (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
-                  (equal page-dir-ptr-table-base-addr
-                         (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
-                  (equal page-directory-base-addr
-                         (mv-nth 1 (page-directory-base-addr lin-addr x86)))
-                  (equal page-directory-entry
-                         (rm-low-64
-                          (page-directory-entry-addr lin-addr page-directory-base-addr)
-                          x86))
-                  (equal (ia32e-page-tables-slice :ps page-directory-entry) 1))
-             (equal (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-pml4-table
-                     lin-addr pml4-table-base-addr wp smep nxe r-w-x cpl x86)))
+		  (equal pml4-table-base-addr (mv-nth 1 (pml4-table-base-addr x86)))
+		  (equal page-dir-ptr-table-base-addr
+			 (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))
+		  (equal page-directory-base-addr
+			 (mv-nth 1 (page-directory-base-addr lin-addr x86)))
+		  (equal page-directory-entry
+			 (rm-low-64
+			  (page-directory-entry-addr lin-addr page-directory-base-addr)
+			  x86))
+		  (equal (ia32e-page-tables-slice :ps page-directory-entry) 1))
+	     (equal (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-pml4-table
+		     lin-addr pml4-table-base-addr wp smep nxe r-w-x cpl x86)))
     :hints (("Goal"
-             :use ((:instance ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-2M-pages))
-             :in-theory (e/d* (ia32e-la-to-pa-pml4-table
-                               page-dir-ptr-table-base-addr)
-                              (ia32e-la-to-pa-PT
-                               ia32e-la-to-pa-PD
-                               ia32e-la-to-pa-PDPT
-                               pml4-table-entry-addr-found-p
-                               page-dir-ptr-table-entry-addr-found-p
-                               page-directory-entry-addr-found-p
-                               page-table-entry-addr-found-p
-                               bitops::logand-with-negated-bitmask)))))
+	     :use ((:instance ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-2M-pages))
+	     :in-theory (e/d* (ia32e-la-to-pa-pml4-table
+			       page-dir-ptr-table-base-addr)
+			      (ia32e-la-to-pa-PT
+			       ia32e-la-to-pa-PD
+			       ia32e-la-to-pa-PDPT
+			       pml4-table-entry-addr-found-p
+			       page-dir-ptr-table-entry-addr-found-p
+			       page-directory-entry-addr-found-p
+			       page-table-entry-addr-found-p
+			       bitops::logand-with-negated-bitmask)))))
 
   (defthmd ia32e-la-to-pa-PML4T-and-ia32e-la-to-pa-pml4-table-4K-pages
     ;; Sanity check for ia32e-la-to-pa-PML4T.
     (implies (and (page-table-entry-addr-found-p lin-addr x86)
-                  (equal pml4-table-base-addr
-                         (mv-nth 1 (pml4-table-base-addr x86))))
-             (equal (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)
-                    (ia32e-la-to-pa-pml4-table
-                     lin-addr pml4-table-base-addr wp smep nxe r-w-x cpl x86)))
+		  (equal pml4-table-base-addr
+			 (mv-nth 1 (pml4-table-base-addr x86))))
+	     (equal (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86)
+		    (ia32e-la-to-pa-pml4-table
+		     lin-addr pml4-table-base-addr wp smep nxe r-w-x cpl x86)))
     :hints (("Goal"
-             :use ((:instance ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-4K-pages
-                              (page-dir-ptr-table-base-addr
-                               (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))))
-             :in-theory (e/d* (ia32e-la-to-pa-pml4-table
-                               page-dir-ptr-table-base-addr)
-                              (ia32e-la-to-pa-PT
-                               ia32e-la-to-pa-PD
-                               ia32e-la-to-pa-PDPT
-                               pml4-table-entry-addr-found-p
-                               page-dir-ptr-table-entry-addr-found-p
-                               page-directory-entry-addr-found-p
-                               page-table-entry-addr-found-p
-                               bitops::logand-with-negated-bitmask)))))
+	     :use ((:instance ia32e-la-to-pa-PDPT-and-ia32e-la-to-pa-page-dir-ptr-table-4K-pages
+			      (page-dir-ptr-table-base-addr
+			       (mv-nth 1 (page-dir-ptr-table-base-addr lin-addr x86)))))
+	     :in-theory (e/d* (ia32e-la-to-pa-pml4-table
+			       page-dir-ptr-table-base-addr)
+			      (ia32e-la-to-pa-PT
+			       ia32e-la-to-pa-PD
+			       ia32e-la-to-pa-PDPT
+			       pml4-table-entry-addr-found-p
+			       page-dir-ptr-table-entry-addr-found-p
+			       page-directory-entry-addr-found-p
+			       page-table-entry-addr-found-p
+			       bitops::logand-with-negated-bitmask)))))
 
   (local (in-theory (e/d ()
-                         (ia32e-la-to-pa-PDPT
-                          pml4-table-entry-addr-found-p))))
+			 (ia32e-la-to-pa-PDPT
+			  pml4-table-entry-addr-found-p))))
 
   (defthm-usb n52p-mv-nth-1-ia32e-la-to-pa-PML4T
     :hyp t
     :bound *physical-address-size*
     :concl (mv-nth 1
-                   (ia32e-la-to-pa-PML4T
-                    lin-addr wp smep nxe r-w-x cpl
-                    x86))
+		   (ia32e-la-to-pa-PML4T
+		    lin-addr wp smep nxe r-w-x cpl
+		    x86))
     :gen-linear t
     :gen-type t)
 
   (defthm x86p-mv-nth-2-ia32e-la-to-pa-PML4T
     (implies (x86p x86)
-             (x86p
-              (mv-nth 2
-                      (ia32e-la-to-pa-PML4T
-                       lin-addr wp smep nxe r-w-x cpl
-                       x86))))
+	     (x86p
+	      (mv-nth 2
+		      (ia32e-la-to-pa-PML4T
+		       lin-addr wp smep nxe r-w-x cpl
+		       x86))))
     :hints (("Goal" :in-theory (e/d* ()
-                                     ((:meta acl2::mv-nth-cons-meta))))))
+				     ((:meta acl2::mv-nth-cons-meta))))))
 
   (defthm xr-ia32e-la-to-pa-PML4T
     (implies (and (not (equal fld :mem))
-                  (not (equal fld :fault)))
-             (equal (xr fld index
-                        (mv-nth 2
-                                (ia32e-la-to-pa-PML4T
-                                 lin-addr wp smep nxe r-w-x cpl
-                                 x86)))
-                    (xr fld index x86))))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index
+			(mv-nth 2
+				(ia32e-la-to-pa-PML4T
+				 lin-addr wp smep nxe r-w-x cpl
+				 x86)))
+		    (xr fld index x86))))
 
 
   ;; Need lemmas about
@@ -1023,6 +1053,259 @@
   ;;                               (ia32e-la-to-pa-PML4T
   ;;                                lin-addr wp smep nxe r-w-x cpl
   ;;                                x86))))))
+  )
+
+;; ======================================================================
+
+(define ia32e-entries-found-la-to-pa
+  ((lin-addr :type (signed-byte   #.*max-linear-address-size*)
+	     "Canonical linear address to be mapped to a physical address")
+   (r-w-x     :type (member  :r :w :x)
+	      "Indicates whether this translation is on the behalf of a read, write, or instruction fetch")
+   (cpl       :type (unsigned-byte  2)
+	      "Current privilege level (0-3), obtained from the CS segment selector [1:0]")
+   (x86 "x86 state"))
+
+  (b* ((lin-addr (mbe :logic (logext 48 (loghead 48 lin-addr))
+		      :exec lin-addr))
+       (cr0
+	;; CR0 is still a 32-bit register in 64-bit mode.
+	(n32 (ctri *cr0* x86)))
+       (cr4
+	;; CR4 has all but the low 21 bits reserved.
+	(n21 (ctri *cr4* x86)))
+       ;; ia32-efer has all but the low 12 bits reserved.
+       (ia32-efer (n12 (msri *ia32_efer-idx* x86)))
+       (wp        (cr0-slice :cr0-wp cr0))
+       (smep      (cr4-slice :cr4-smep cr4))
+       (nxe       (ia32_efer-slice :ia32_efer-nxe ia32-efer)))
+      (ia32e-la-to-pa-PML4T lin-addr wp smep nxe r-w-x cpl x86))
+
+  ///
+
+  (local (in-theory (e/d* (paging-entries-found-p)
+			  (ia32e-la-to-pa-PML4T
+			   pml4-table-entry-addr-found-p
+			   page-dir-ptr-table-entry-addr-found-p
+			   page-directory-entry-addr-found-p
+			   page-table-entry-addr-found-p))))
+
+  (defthmd ia32e-la-to-pa-and-ia32e-entries-found-la-to-pa
+    ;; Sanity check
+    (implies (paging-entries-found-p lin-addr x86)
+	     (equal (ia32e-la-to-pa lin-addr r-w-x cpl x86)
+		    (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl x86)))
+    :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-PML4T-and-ia32e-la-to-pa-pml4-table-1G-pages
+				      ia32e-la-to-pa-PML4T-and-ia32e-la-to-pa-pml4-table-2M-pages
+				      ia32e-la-to-pa-PML4T-and-ia32e-la-to-pa-pml4-table-4K-pages
+				      ia32e-la-to-pa
+				      pml4-table-base-addr)
+				     (signed-byte-p)))))
+
+  (defthm-usb n52p-mv-nth-1-ia32e-entries-found-la-to-pa
+    :hyp t
+    :bound *physical-address-size*
+    :concl (mv-nth 1 (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl x86))
+
+    :hints (("Goal" :in-theory (e/d ()
+				    (force (force) unsigned-byte-p))))
+    :gen-linear t
+    :hints-l (("Goal" :in-theory (e/d (unsigned-byte-p) (force (force)))))
+    :gen-type t
+    :hints-t (("Goal" :in-theory (e/d (unsigned-byte-p)
+				      (force (force) not)))))
+
+  (defthm x86p-mv-nth-2-ia32e-entries-found-la-to-pa
+    (implies (x86p x86)
+	     (x86p (mv-nth 2 (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl x86)))))
+
+  (defthm xr-ia32e-entries-found-la-to-pa
+    (implies (and (not (equal fld :mem))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index
+			(mv-nth 2
+				(ia32e-entries-found-la-to-pa
+				 lin-addr r-w-x cpl x86)))
+		    (xr fld index x86)))
+    :hints (("Goal" :in-theory (e/d* () (force (force))))))
+
+  ;; (defthm ia32e-entries-found-la-to-pa-xw-values
+  ;;   (implies (and (not (equal fld :mem))
+  ;;                 (not (equal fld :fault))
+  ;;                 (not (equal fld :ctr))
+  ;;                 (not (equal fld :msr)))
+  ;;            (and (equal (mv-nth 0
+  ;;                                (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl
+  ;;                                                              (xw fld index value
+  ;;                                                                  x86)))
+  ;;                        (mv-nth 0
+  ;;                                (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl
+  ;;                                                              x86)))
+  ;;                 (equal (mv-nth 1
+  ;;                                (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl
+  ;;                                                              (xw fld index value x86)))
+  ;;                        (mv-nth 1
+  ;;                                (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl
+  ;;                                                              x86))))))
+
+  ;; (defthm ia32e-entries-found-la-to-pa-xw-state
+  ;;   (implies (and (not (equal fld :mem))
+  ;;                 (not (equal fld :fault))
+  ;;                 (not (equal fld :ctr))
+  ;;                 (not (equal fld :msr)))
+  ;;            (equal (mv-nth 2
+  ;;                           (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl
+  ;;                                                         (xw fld index value x86)))
+  ;;                   (xw fld index value
+  ;;                       (mv-nth 2
+  ;;                               (ia32e-entries-found-la-to-pa
+  ;;                                lin-addr r-w-x cpl x86)))))
+  ;;   :hints (("Goal" :in-theory (e/d* () (force (force))))))
+
+  )
+
+;; ======================================================================
+
+(define rm08-mapped
+  ((lin-addr :type (signed-byte #.*max-linear-address-size*))
+   (r-w-x    :type (member  :r :w :x))
+   (x86))
+
+  :non-executable t
+
+  (if (programmer-level-mode x86)
+
+      ;; Use this function only in the system-level mode.
+      (mv t 0 x86)
+
+    (b* ((cs-segment (the (unsigned-byte 16) (seg-visiblei *cs* x86)))
+	 (cpl (the (unsigned-byte 2) (seg-sel-layout-slice :rpl cs-segment)))
+	 ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr) x86)
+	  (ia32e-entries-found-la-to-pa lin-addr r-w-x cpl x86))
+	 ((when flag)
+	  (mv (list 'rm08 flag) 0 x86))
+	 (byte (the (unsigned-byte 8) (memi p-addr x86))))
+	(mv nil byte x86)))
+
+  ///
+
+  (defthmd rm08-and-rm08-mapped
+    (implies (and (paging-entries-found-p lin-addr x86)
+		  (not (programmer-level-mode x86)))
+	     (equal (rm08        lin-addr r-w-x x86)
+		    (rm08-mapped lin-addr r-w-x x86)))
+    :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-and-ia32e-entries-found-la-to-pa
+				      rm08)
+				     ()))))
+
+  (defthm-usb n08p-mv-nth-1-rm08-mapped
+    :hyp (and (signed-byte-p *max-linear-address-size* lin-addr)
+	      (x86p x86))
+    :bound 8
+    :concl (mv-nth 1 (rm08-mapped lin-addr r-w-x x86))
+    :hints (("Goal" :in-theory (e/d () (unsigned-byte-p))))
+    :gen-linear t
+    :hints-l (("Goal" :in-theory (e/d (unsigned-byte-p) ())))
+    ;; If the hyps in the :type-prescription corollary aren't forced,
+    ;; we run into natp vs integerp/<= 0.. problems.
+    :hyp-t (forced-and (integerp lin-addr)
+		       (x86p x86))
+    :gen-type t)
+
+  (defthm x86p-rm08-mapped
+    (implies (force (x86p x86))
+	     (x86p (mv-nth 2 (rm08-mapped lin-addr r-w-x x86))))
+    :rule-classes (:rewrite :type-prescription))
+
+  (defthm rm08-mapped-value-when-error
+    (implies (mv-nth 0 (rm08-mapped addr :x x86))
+	     (equal (mv-nth 1 (rm08-mapped addr :x x86)) 0))
+    :hints (("Goal" :in-theory (e/d (rvm08) (force (force))))))
+
+  (defthm xr-rm08-mapped-state-in-system-level-mode
+    (implies (and (not (programmer-level-mode x86))
+		  (not (equal fld :mem))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index (mv-nth 2 (rm08-mapped addr r-w-x x86)))
+		    (xr fld index x86)))
+    :hints (("Goal" :in-theory (e/d* () (force (force))))))
+
+  ;; (defthm rm08-mapped-xw-system-mode
+  ;;   (implies (and (not (programmer-level-mode x86))
+  ;;		  (not (equal fld :fault))
+  ;;		  (not (equal fld :seg-visible))
+  ;;		  (not (equal fld :mem))
+  ;;		  (not (equal fld :ctr))
+  ;;		  (not (equal fld :msr))
+  ;;		  (not (equal fld :programmer-level-mode)))
+  ;;            (and (equal (mv-nth 0 (rm08-mapped addr r-w-x (xw fld index value x86)))
+  ;;			 (mv-nth 0 (rm08-mapped addr r-w-x x86)))
+  ;;		  (equal (mv-nth 1 (rm08-mapped addr r-w-x (xw fld index value x86)))
+  ;;			 (mv-nth 1 (rm08-mapped addr r-w-x x86)))
+  ;;		  (equal (mv-nth 2 (rm08-mapped addr r-w-x (xw fld index value x86)))
+  ;;			 (xw fld index value (mv-nth 2 (rm08-mapped addr r-w-x x86)))))))
+  )
+
+(define wm08-mapped
+  ((lin-addr :type (signed-byte   #.*max-linear-address-size*))
+   (val      :type (unsigned-byte 8))
+   (x86))
+
+  :non-executable t
+
+  (if (programmer-level-mode x86)
+      ;; Use this function only in the system-level mode.
+      (mv t x86)
+
+    (b* ((cs-segment (the (unsigned-byte 16) (seg-visiblei *cs* x86)))
+	 (cpl (the (unsigned-byte 2) (seg-sel-layout-slice :rpl cs-segment)))
+	 ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr) x86)
+	  (ia32e-entries-found-la-to-pa lin-addr :w cpl x86))
+	 ((when flag)
+	  (mv (list 'wm08 flag) x86))
+	 (byte (mbe :logic (n08 val)
+		    :exec val))
+	 (x86 (!memi p-addr byte x86)))
+	(mv nil x86)))
+
+  ///
+
+  (defthmd wm08-and-wm08-mapped
+    (implies (and (paging-entries-found-p lin-addr x86)
+		  (not (programmer-level-mode x86)))
+	     (equal (wm08        lin-addr val x86)
+		    (wm08-mapped lin-addr val x86)))
+    :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-and-ia32e-entries-found-la-to-pa
+				      wm08)
+				     ()))))
+
+  (defthm x86p-wm08-mapped
+    (implies (force (x86p x86))
+	     (x86p (mv-nth 1 (wm08-mapped lin-addr val x86))))
+    :hints (("Goal" :in-theory (e/d () (force (force)))))
+    :rule-classes (:rewrite :type-prescription))
+
+  (defthm xr-wm08-mapped-system-level-mode
+    (implies (and (not (programmer-level-mode x86))
+		  (not (equal fld :mem))
+		  (not (equal fld :fault)))
+	     (equal (xr fld index (mv-nth 1 (wm08-mapped addr val x86)))
+		    (xr fld index x86)))
+    :hints (("Goal" :in-theory (e/d* () (force (force))))))
+
+  ;; (defthm wm08-mapped-xw-system-mode
+  ;;   (implies (and (not (programmer-level-mode x86))
+  ;;		  (not (equal fld :fault))
+  ;;		  (not (equal fld :seg-visible))
+  ;;		  (not (equal fld :mem))
+  ;;		  (not (equal fld :ctr))
+  ;;		  (not (equal fld :msr))
+  ;;		  (not (equal fld :programmer-level-mode)))
+  ;;            (and (equal (mv-nth 0 (wm08-mapped addr val (xw fld index value x86)))
+  ;;			 (mv-nth 0 (wm08-mapped addr val x86)))
+  ;;		  (equal (mv-nth 1 (wm08-mapped addr val (xw fld index value x86)))
+  ;;			 (xw fld index value (mv-nth 1 (wm08-mapped addr val x86))))))
+  ;;   :hints (("Goal" :in-theory (e/d* () (force (force))))))
   )
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/system-level-memory-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/system-level-memory-utils.lisp
@@ -17,21 +17,35 @@
 
 (local (xdoc::set-default-parents system-level-memory-utils))
 
+(local (in-theory (e/d* (entry-found-p-and-good-paging-structures-x86p
+			 entry-found-p-and-lin-addr)
+			())))
+
 ;; ======================================================================
 
 ;; [Shilpi]: RoW with rb and wb will be obtained when
 ;; paging-lib/paging-top.lisp is ready.
 
-;; [Shilpi]: I need to defined a well-formed page tables predicate...
+;; [Shilpi]: I need to define a well-formed page tables predicate...
+;; I also need to re-define rm08/rb and wm08/wb in terms of the alt
+;; traversal functions...
 
-;; (defthm rm08-wm08
-;;   (implies (and (x86p x86)
-;;                 ;; Well-Formed Page Tables Hypothesis Here...
-;;                 )
-;;            (equal (mv-nth 1 (rm08 addr1 r-x (mv-nth 1 (wm08 addr2 val x86))))
-;;                   (mv-nth 1 (rm08 addr1 r-x x86)))
-;;            :hints (("Goal" :in-theory (e/d* (rm08 wm08)
-;;                                             ())))))
+;; (defthm rm08-wm08-disjoint-in-system-level-mode
+;;   (implies (and (not (programmer-level-mode x86))
+;;		(disjoint-p (addr-range 8 addr-1)
+;;			    (addr-range 8 addr-2))
+;;		(paging-entries-found-p addr-1 x86)
+;;		(paging-entries-found-p addr-2 x86)
+;;		(pairwise-disjoint-p-aux
+;;		 ;; The write isn't being done to the page tables.
+;;		 (list addr-2)
+;;		 (gather-all-paging-structure-qword-addresses x86)))
+;;	   (equal (mv-nth 1 (rm08 addr-1 r-x (mv-nth 1 (wm08 addr-2 val x86))))
+;;		  (mv-nth 1 (rm08 addr-1 r-x x86))))
+;;   :hints (("Goal"
+;;	   :in-theory (e/d* (rm08-and-rm08-mapped
+;;			     wm08-and-wm08-mapped)
+;;			    (signed-byte-p)))))
 
 
 ;; The events below are similar to those in


### PR DESCRIPTION
Some quick misc. edits to x86isa paging-lib books

- Fixed x86isa doc topics without proper parents, as pointed out by
  Matt Kaufmann and Eric Smith (thanks!).

- Included the equality of certain bits of cr0, cr4, and ia32_efer in
  the definition of xlate-equiv-x86s.

- Defined alternate versions of rm08 and wm08, called rm08-mapped and
  wm08-mapped respectively, for reasoning in the system-level mode.