### PR TITLE
rtl/rel11/support: Radix-aware versions of functions in bits.lisp and…

### DIFF
--- a/books/projects/curve25519/ecp.lisp
+++ b/books/projects/curve25519/ecp.lisp
@@ -106,7 +106,7 @@
   :hints (("Goal" :use ((:instance mod*rewrite-2 (a (* a b)) (b c))))))
 
 (defthm mod*rewrite-4
-  (implies (and (integerp a) (integerp b) (integerp c))
+  (implies (and (integerp a) (integerp b) (integerp c) (integerp d))
            (equal (mod (* a b c (mod d (p))) (p))
                   (mod (* a b c d) (p))))
   :hints (("Goal" :use ((:instance mod*rewrite-2 (a (* a b c)) (b d))))))
@@ -124,7 +124,7 @@
   :hints (("Goal" :use ((:instance mod*rewrite-5 (b (* b c d)) (c e))))))
 
 (defthm mod*rewrite-7
-  (implies (and (integerp a) (integerp b) (integerp c) (integerp d))
+  (implies (and (integerp a) (integerp b) (integerp c) (integerp d) (integerp e))
            (equal (mod (* a b c d (mod e (p))) (p))
                   (mod (* a b c d e) (p))))
   :hints (("Goal" :use ((:instance mod*rewrite-2 (a (* a b c d)) (b e))))))

--- a/books/projects/quadratic-reciprocity/support/euclid.lisp
+++ b/books/projects/quadratic-reciprocity/support/euclid.lisp
@@ -6,8 +6,8 @@
 
 ;;   (2) If p is a prime divisor of a*b, then p divides either a or b.
 
-(include-book "rtl/rel11/lib/basic" :dir :system) ;; Properties of fl and mod
-(include-book "rtl/rel11/lib/util" :dir :system)  ;; Utility macros
+(include-book "rtl/rel11/support/basic" :dir :system) ;; Properties of fl and mod
+(include-book "rtl/rel11/support/util" :dir :system)  ;; Utility macros
 (local (include-book "arithmetic-5/top" :dir :system)) ;; It's hard to do any arithmetic without something like this
 
 ;; We first list some basic properties of divisibility.

--- a/books/rtl/rel11/support/basic.lisp
+++ b/books/rtl/rel11/support/basic.lisp
@@ -6,13 +6,6 @@
 (local (acl2::allow-arith5-help))
 (local (in-theory (acl2::enable-arith5)))
 
-;; The following lemmas from arithmetic-5 have given me trouble:
-#|
-(local (in-theory #!acl2(disable |(mod (+ x y) z) where (<= 0 z)| |(mod (+ x (- (mod a b))) y)| |(mod (mod x y) z)| |(mod (+ x (mod a b)) y)|
-                    simplify-products-gather-exponents-equal mod-cancel-*-const cancel-mod-+ reduce-additive-constant-<
-                    |(floor x 2)| |(equal x (if a b c))| |(equal (if a b c) x)|)))
-|#
-
 ;;;**********************************************************************
 ;;;                       FLOOR and CEILING
 ;;;**********************************************************************
@@ -510,8 +503,13 @@
 ;;;                         CHOP-R
 ;;;**********************************************************************
 
-(defmacro radixp (r)
-  `(and (integerp ,r) (>= ,r 2)))
+(defnd radixp (b)
+  (and (integerp b) (>= b 2)))
+
+(defrule radixp-forward
+  (implies (radixp b)
+           (and (integerp b) (>= b 2)))
+  :rule-classes :forward-chaining)
 
 (defund chop-r (x k r)
   (declare (xargs :guard (and (real/rationalp x)

--- a/books/rtl/rel11/support/bits.lisp
+++ b/books/rtl/rel11/support/bits.lisp
@@ -1,69 +1,91 @@
 (in-package "RTL")
 
-(local (include-book "../rel9-rtl-pkg/lib/top"))
+(include-book "tools/with-arith5-help" :dir :system)
+(local (acl2::allow-arith5-help))
+(local (in-theory (acl2::enable-arith5)))
 
-(include-book "../rel9-rtl-pkg/lib/util")
+(local (include-book "basic"))
+(include-book "definitions")
 
-(local (include-book "arithmetic-5/top" :dir :system))
+;;;**********************************************************************
+;;;				DVECP
+;;;**********************************************************************
 
-;; The following lemmas from arithmetic-5 have given me trouble:
+(defund dvecp (x k b)
+  (declare (xargs :guard (and (natp k) (radixp b))))
+  (and (integerp x)
+       (<= 0 x)
+       (< x (expt b k))))
 
-(local-in-theory #!acl2(disable |(mod (+ x y) z) where (<= 0 z)| |(mod (+ x (- (mod a b))) y)| |(mod (mod x y) z)| |(mod (+ x (mod a b)) y)|
-                    simplify-products-gather-exponents-equal mod-cancel-*-const cancel-mod-+ reduce-additive-constant-<
-                    |(floor x 2)| |(equal x (if a b c))| |(equal (if a b c) x)|))
+(defrule dvecp-forward
+  (implies (dvecp x k b)
+           (and (integerp x)
+                (<= 0 x)
+                (< x (expt b k))))
+  :enable (dvecp)
+  :rule-classes :forward-chaining)
 
-(local-defthm fl-half-int
-  (implies (and (integerp n)
-                (not (= n 0))
-                (not (= n -1)))
-           (< (abs (fl (/ n 2))) (abs n)))
+(local
+ (defrule |dvecp when not posp k|
+   (implies (and (not (posp k))
+                 (radixp b))
+            (equal (dvecp x k b)
+                   (equal x 0)))
+   :enable dvecp))
+
+(defrule dvecp-0
+  (implies (radixp b)
+           (dvecp 0 k b))
+  :enable dvecp)
+
+(defrule dvecp-member
+  (implies (and (dvecp x n b)
+                (natp n)
+                (radixp b))
+           (member x (nats (expt b n))))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (natp x)
+                    (natp n)
+                    (< x n))
+               (member-equal x (nats n)))
+      :induct (nats n)))
+  :enable dvecp
   :rule-classes ())
 
-(local-defun bit-diff (x y)
-  (declare (xargs :measure (+ (abs (ifix x)) (abs (ifix y)))
-                  :hints (("Goal" :use ((:instance fl-half-int (n x))
-                                        (:instance fl-half-int (n y)))))))
-  (if (or (not (integerp x)) (not (integerp y)) (= x y))
-      ()
-    (if (= (bitn x 0) (bitn y 0))
-        (1+ (bit-diff (fl (/ x 2)) (fl (/ y 2))))
-      0)))
+(defruled dvecp-monotone
+  (implies (and (dvecp x n b)
+                (<= n m)
+                (case-split (integerp m))
+                (radixp b))
+           (dvecp x m b))
+  :enable dvecp)
 
-(local-defthmd bdd-1
-  (implies (integerp x)
-           (equal (bitn x 0)
-                  (mod x 2)))
-  :hints (("Goal" :use ((:instance bitn (n 0))
-                        (:instance bits (i 0) (j 0))))))
+(acl2::with-arith5-nonlinear-help
+ (defruled dvecp-shift-down
+   (implies (and (dvecp x n b)
+                 (integerp k)
+                 (radixp b))
+            (dvecp (fl (/ x (expt b k))) (- n k) b))
+   :enable dvecp))
 
-(local-defthmd bdd-2
-  (implies (integerp x)
-           (equal (bitn x 0)
-                  (- x (* 2 (fl (/ x 2))))))
-  :hints (("Goal" :use ((:instance mod-def (y 2)))
-                  :in-theory (enable bdd-1))))
+(acl2::with-arith5-nonlinear++-help
+ (defruled dvecp-shift-up
+  (implies (and (dvecp x (- n k) b)
+                (natp k)
+                (integerp n)
+                (radixp b))
+           (dvecp (* x (expt b k)) n b))
+  :enable dvecp))
 
-(local-defthm bit-diff-diff
-  (implies (and (integerp x)
-                (integerp y)
-                (not (= x y)))
-           (let ((n (bit-diff x y)))
-             (and (natp n)
-                  (not (= (bitn x n) (bitn y n))))))
-  :rule-classes ()
-  :hints (("Subgoal *1/2" :in-theory (enable bdd-2))
-          ("Subgoal *1/1.2" :in-theory (enable bdd-2))
-          ("Subgoal *1/1.1" :use ((:instance bitn-shift-down (k 1)
-                                                             (i (BIT-DIFF (FL (* X 1/2)) (FL (* Y 1/2)))))
-                                  (:instance bitn-shift-down (k 1)
-                                                             (x y)
-                                                             (i (BIT-DIFF (FL (* X 1/2)) (FL (* Y 1/2)))))))))
-
-
-
-(defund fl (x)
-  (declare (xargs :guard (real/rationalp x)))
-  (floor x 1))
+(acl2::with-arith5-nonlinear-help
+ (defrule dvecp-product
+  (implies (and (dvecp x m b)
+                (dvecp y n b)
+                (radixp b))
+           (dvecp (* x y) (+ m n) b))
+  :enable (dvecp radixp)
+  :rule-classes ()))
 
 ;;;**********************************************************************
 ;;;				BVECP
@@ -75,7 +97,14 @@
        (<= 0 x)
        (< x (expt 2 k))))
 
-(defthm bvecp-forward
+(local
+ (defrule bvecp-as-dvecp
+  (equal
+    (bvecp x k)
+    (dvecp x k 2))
+  :enable (bvecp dvecp)))
+
+(defrule bvecp-forward
   (implies (bvecp x k)
 	   (and (integerp x)
 		(<= 0 x)
@@ -84,48 +113,614 @@
 
 (defun nats (n) (if (zp n) () (cons (1- n) (nats (1- n)))))
 
-(defthm bvecp-member
+(defrule bvecp-member
   (implies (and (natp n)
                 (bvecp x n))
            (member x (nats (expt 2 n))))
+  :use (:instance dvecp-member (b 2))
   :rule-classes ())
 
-(defthmd bvecp-monotone
+(defruled bvecp-monotone
     (implies (and (bvecp x n)
 		  (<= n m)
 		  (case-split (integerp m)))
-	     (bvecp x m)))
+	     (bvecp x m))
+    :enable dvecp-monotone)
 
-(defthmd bvecp-shift-down
+(defruled bvecp-shift-down
     (implies (and (bvecp x n)
 		  (natp n)
 		  (natp k))
-	     (bvecp (fl (/ x (expt 2 k))) (- n k))))
+	     (bvecp (fl (/ x (expt 2 k))) (- n k)))
+    :use (:instance dvecp-shift-down (b 2)))
 
-(defthmd bvecp-shift-up
+(defruled bvecp-shift-up
     (implies (and (bvecp x (- n k))
 		  (natp k)
 		  (integerp n))
-	     (bvecp (* x (expt 2 k)) n)))
+	     (bvecp (* x (expt 2 k)) n))
+    :enable dvecp-shift-up)
 
-(defthm bvecp-product
+(defrule bvecp-product
     (implies (and (bvecp x m)
 		  (bvecp y n))
 	     (bvecp (* x y) (+ m n)))
+  :use (:instance dvecp-product (b 2))
   :rule-classes ())
 
-(defthm bvecp-1-0
+(defrule bvecp-1-0
   (implies (and (bvecp x 1)
 		(not (equal x 1)))
 	   (equal x 0))
   :rule-classes :forward-chaining)
 
-(defthm bvecp-0-1
+(defrule bvecp-0-1
   (implies (and (bvecp x 1)
 		(not (equal x 0)))
 	   (equal x 1))
   :rule-classes :forward-chaining)
 
+;;;**********************************************************************
+;;;			    DIGITS
+;;;**********************************************************************
+
+(defund digits (x i j b)
+  (declare (xargs :guard (and (real/rationalp x)
+                              (integerp i)
+                              (integerp j)
+                              (radixp b))))
+  (if (or (not (integerp i))
+          (not (integerp j)))
+      0
+      (fl (* (mod x (expt b (1+ i))) (expt b (- j))))))
+
+(defruled digits-def-2
+  (implies (radixp b)
+           (equal (digits x i j b)
+                  (if (or (not (integerp i)) (not (integerp j)))
+                      0
+                    (mod (fl (* x (expt b (- j))))
+                         (expt b (+ 1 i (- j)))))))
+  :prep-lemmas (
+    (defrule mod-fl
+      (implies (and (real/rationalp x)
+                    (integerp n)
+                    (radixp b))
+               (equal (mod (fl x) (expt b n))
+                      (fl (mod x (expt b n)))))
+      :cases ((natp n))))
+  :enable (digits)
+  :cases ((real/rationalp x))
+  :hints (("subgoal 2" :in-theory (enable fl))))
+
+(local
+ (defrule digits-default
+   (implies
+    (or (and (not (real/rationalp x))
+             (radixp b))
+        (not (integerp i))
+        (not (integerp j)))
+    (equal (digits x i j b) 0))
+   :enable (digits fl)))
+
+(defrule digits-reverse-indices
+  (implies (and (< i j)
+                (radixp b))
+           (equal (digits x i j b)
+                  0))
+  :enable digits-def-2)
+
+(defrule digits-dvecp
+  (implies (and (<= (+ 1 i (- j)) k)
+                (case-split (integerp k))
+                (radixp b))
+           (dvecp (digits x i j b) k b))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (real/rationalp x)
+                    (<= m n)
+                    (integerp m)
+                    (integerp n)
+                    (radixp b))
+               (< (mod x (expt b m))
+                  (expt b n)))))
+  :enable (dvecp digits-def-2)
+  :cases ((not (natp (+ 1 i (- j))))
+          (not (real/rationalp x))))
+
+;;Here is a variation of digits-dvecp that is less general but does not
+;;require an integerp hypothesis:
+
+(defrule digits-dvecp-simple
+  (implies (and (equal k (+ 1 i (* -1 j)))
+                (radixp b))
+           (dvecp (digits x i j b) k b))
+  :cases ((and (integerp i) (integerp j)))
+  :hints (("subgoal 2" :in-theory (enable dvecp))))
+
+(defrule digits-bounds
+    (implies (and (integerp i)
+                  (integerp j)
+                  (radixp b))
+             (and (natp (digits x i j b))
+                  (< (digits x i j b) (expt b (1+ (- i j))))))
+  :enable (dvecp)
+  :cases ((dvecp (digits x i j b) (1+ (- i j)) b))
+  :rule-classes ())
+
+(defrule mod-digits-equal
+  (implies (and (= (mod x (expt b (1+ i)))
+                   (mod y (expt b (1+ i))))
+                (radixp b))
+           (= (digits x i j b) (digits y i j b)))
+  :enable digits
+  :rule-classes ())
+
+(defruled mod-digits-equal-cor
+  (implies (and (< i n)
+                (integerp n)
+                (integerp i)
+                (integerp j)
+                (radixp b))
+           (equal (digits (mod x (expt b n)) i j b)
+                  (digits x i j b)))
+  :cases ((natp (+ 1 i (- j))))
+  :hints (("subgoal 1" :in-theory (enable digits-def-2))))
+
+(defruled digits-mod
+  (implies (and (case-split (integerp x))
+                (case-split (integerp i))
+                (radixp b))
+           (equal (digits x i 0 b)
+                  (mod x (expt b (1+ i)))))
+  :enable digits-def-2)
+
+(defrule digits-diff-equal
+    (implies (and (natp n)
+                  (integerp x)
+                  (integerp y)
+                  (< (abs (- x y)) (expt b n))
+                  (radixp b))
+             (iff (= x y)
+                  (= (digits (- x y) (1- n) 0 b) 0)))
+  :enable (digits-mod)
+  :disable (abs)
+  :use (:instance mod-force-equal
+         (a (- x y))
+         (b 0)
+         (n (expt b n)))
+  :rule-classes ())
+
+(defrule digits-tail
+  (implies (and (dvecp x (1+ i) b)
+                (case-split (acl2-numberp i))
+                (radixp b))
+           (equal (digits x i 0 b) x))
+  :enable digits-def-2)
+
+(defrule digits-tail-gen
+  (implies (and (integerp x)
+                (natp i)
+                (< x (expt b (1+ i)))
+                (>= x (- (expt b (1+ i))))
+                (radixp b))
+           (equal (digits x i 0 b)
+                  (if (>= x 0)
+                      x
+                    (+ x (expt b (1+ i))))))
+  :enable digits-mod
+  :use (:instance mod-force
+         (m x)
+         (n (expt b (1+ i)))
+         (a -1)))
+
+(defruled neg-digits-1
+  (implies (and (integerp x)
+                (natp i)
+                (natp j)
+                (< x 0)
+                (>= x (- (expt b j)))
+                (>= i j)
+                (radixp b))
+           (equal (digits x i j b)
+                  (1- (expt b (1+ (- i j))))))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help
+     (defrule lemma
+       (implies (and (real/rationalp x)
+                     (< x 0)
+                     (>= x (- (expt b j)))
+                     (radixp b))
+                (equal (fl (* x (expt b (- j)))) -1))
+       :use (:instance fl-unique
+                       (x (* x (expt b (- j))))
+                       (n -1)))))
+  :enable digits-def-2)
+
+(defruled digits-minus-1
+  (implies (and (natp i)
+                (natp j)
+                (>= i j)
+                (radixp b))
+           (equal (digits -1 i j b)
+                  (1- (expt b (1+ (- i j))))))
+  :enable neg-digits-1)
+
+(defrule digits-digits-sum
+  (implies (and (integerp x)
+                (integerp y)
+                (integerp i)
+                (integerp j)
+                (integerp k)
+                (>= j 0)
+                (>= k i)
+                (radixp b))
+           (equal (digits (+ (digits x k 0 b) y) i j b)
+                  (digits (+ x y) i j b)))
+  :enable (digits-mod)
+  :use ((:instance mod-digits-equal
+          (x (+ (digits x k 0 b) y))
+          (y (+ x y)))
+        (:instance  mod-sum
+          (a y)
+          (b (mod x (expt b (1+ k))))
+          (n (expt b (1+ i))))
+        (:instance  mod-sum
+          (a y)
+          (b x)
+          (n (expt b (1+ i))))))
+
+(defrule digits-digits-sum-alt
+  (implies (and (integerp x)
+                (integerp y)
+                (integerp i)
+                (integerp j)
+                (integerp k)
+                (>= j 0)
+                (>= k i)
+                (radixp b))
+           (equal (digits (+ x (digits y k 0 b)) i j b)
+                  (digits (+ x y) i j b)))
+  :use (:instance digits-digits-sum
+         (x y)
+         (y x)))
+
+(defruled digits-digits-diff
+  (implies (and (integerp x)
+                (integerp y)
+                (integerp i)
+                (integerp j)
+                (integerp k)
+                (>= j 0)
+                (>= k i)
+                (radixp b))
+           (equal (digits (+ x (- (digits y k 0 b))) i j b)
+                  (digits (- x y) i j b)))
+ :enable digits-mod
+  :use ((:instance mod-digits-equal
+          (x (- x (digits y k 0 b)))
+          (y (- x y)))
+        (:instance  mod-diff
+          (a x)
+          (b (mod y (expt b (1+ k))))
+          (n (expt b (1+ i))))
+        (:instance  mod-diff
+          (a x)
+          (b y)
+          (n (expt b (1+ i))))))
+
+(defruled digits-digits-prod
+  (implies (and (integerp x)
+                (integerp y)
+                (integerp i)
+                (integerp j)
+                (integerp k)
+                (>= j 0)
+                (>= k i)
+                (radixp b))
+           (equal (digits (* x (digits y k 0 b)) i j b)
+                  (digits (* x y) i j b)))
+  :enable digits-mod
+  :use (:instance mod-digits-equal
+          (x (* x (digits y k 0 b)))
+          (y (* x y))))
+
+(defrule digits-fl-diff
+  (implies (and (real/rationalp x)
+                (integerp i)
+                (integerp j)
+                (>= i j)
+                (radixp b))
+           (equal (digits x (1- i) j b)
+                  (- (fl (* x (expt b (- j))))
+                     (* (fl (* x (expt b (- i)))) (expt b (- i j))))))
+  :prep-lemmas (
+    (defrule lemma1
+      (implies
+       (and (acl2-numberp x)
+            (radixp b))
+        (equal (mod x (expt b n))
+               (- x (* (fl (/ x (expt b n))) (expt b n)))))
+      :use ((:instance mod-def
+              (x x)
+              (y (expt b n)))))
+    (defrule lemma2
+      (implies (and (integerp k)
+                    (<= k 0)
+                    (radixp b))
+               (equal (fl (* (expt b k) (fl x)))
+                      (fl (* x (expt b k)))))
+      :use (:instance fl/int-rewrite
+                      (n (expt b (- k))))
+      :cases ((real/rationalp x))
+      :hints (("subgoal 2" :in-theory (enable fl)))))
+  :cases ((natp (- i j)))
+  :hints (("subgoal 1" :in-theory (enable digits-def-2)))
+  :rule-classes ())
+
+(defrule digits-mod-fl
+  (implies (and (integerp x)
+                (integerp i)
+                (integerp j)
+                (>= i j)
+                (radixp b))
+           (equal (digits x (1- i) j b)
+                  (mod (fl (/ x (expt b j)))
+                       (expt b (- i j)))))
+  :enable digits-def-2
+  :rule-classes ())
+
+(defrule digits-neg-indices
+  (implies (and (< i 0)
+                (integerp x)
+                (radixp b))
+           (equal (digits x i j b) 0))
+  :enable digits)
+
+(defruled dvecp-digits-0
+  (implies (and (dvecp x j b)
+                (radixp b))
+           (equal (digits x i j b) 0))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help
+     (defrule lemma
+       (implies (and (dvecp x j b)
+                     (integerp j)
+                     (radixp b))
+                (< (* x (expt b (- j))) 1)))))
+  :enable digits-def-2
+  :use (:instance fl-unique
+                  (x (* x (expt b (- j))))
+                  (n 0)))
+
+(defrule digits-0
+  (equal (digits 0 i j b) 0)
+  :enable digits)
+
+(defruled digits-fl
+  (implies (and (>= j 0)
+                (radixp b))
+           (equal (digits (fl x) i j b)
+                  (digits x i j b)))
+  :enable (digits-def-2 fl-default)
+  :use (:instance fl/int-rewrite
+         (x x)
+         (n (expt b j))))
+
+(defruled digits-shift-down-1
+  (implies (and (integerp i)
+                (integerp j)
+                (integerp k)
+                (radixp b))
+           (equal (digits (/ x (expt b k)) i j b)
+                  (digits x (+ i k) (+ j k) b)))
+  :enable digits-def-2)
+
+(defruled digits-shift-down-2
+  (implies (and (integerp x)
+                (natp i)
+                (natp k)
+                (radixp b))
+           (equal (fl (/ (digits x (+ i k) 0 b) (expt b k)))
+                  (digits (/ x (expt b k)) i 0 b)))
+  :enable digits)
+
+(defruled digits-shift-up-1
+  (implies (and (integerp k)
+                (integerp i)
+                (integerp j)
+                (radixp b))
+           (equal (digits (* x (expt b k)) i j b)
+                          (digits x (- i k) (- j k) b)))
+  :enable digits-def-2)
+
+(defruled digits-shift-up-2
+  (implies (and (integerp x)
+                (natp k)
+                (integerp i)
+                (radixp b))
+           (equal (* (digits x i 0 b) (expt b k))
+                  (digits (* x (expt b k)) (+ i k) 0 b)))
+  :enable digits-mod)
+
+(defruled digits-plus-mult-1
+  (implies (and (dvecp x k b)
+                (<= k m)
+                (integerp y)
+                (case-split (integerp m))
+                (case-split (integerp n))
+                (case-split (integerp k))
+                (radixp b))
+           (equal (digits (+ x (* y (expt b k))) n m b)
+                  (digits y (- n k) (- m k) b)))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear++-help
+     (defrule lemma
+       (implies (and (real/rationalp x)
+                     (>= x 0)
+                     (< x (expt b i))
+                     (integerp y)
+                     (integerp i)
+                     (<= i 0)
+                     (radixp b))
+                (equal (fl (+ x (* y (expt b i))))
+                       (fl (* y (expt b i)))))
+       :cases ((<= y (1- (* (1+ (fl (* y (expt b i))))
+                            (expt b (- i))))))
+       :hints (
+         ("subgoal 2" :cases ((< y (* (1+ (fl (* y (expt b i))))
+                                      (expt b (- i))))))
+         ("subgoal 2.2" :use (:instance fl-def
+                                        (x (* y (expt b i)))))
+         ("subgoal 1" :use (:instance fl-unique
+                                      (x (+ x (* y (expt b i))))
+                                      (n (fl (* y (expt b i))))))))))
+  :enable digits-def-2)
+
+(defruled digits-plus-mult-1-alt
+  (implies (and (dvecp x k b)
+                (<= k m)
+                (integerp y)
+                (case-split (integerp m))
+                (case-split (integerp n))
+                (case-split (integerp k))
+                (radixp b))
+           (equal (digits (+ x (* (expt b k) y)) n m b)
+                  (digits y (- n k) (- m k) b)))
+  :use digits-plus-mult-1)
+
+(defruled digits-plus-mult-2
+  (implies (and (< n k)
+                (integerp y)
+                (integerp k)
+                (radixp b))
+           (equal (digits (+ x (* y (expt b k))) n m b)
+                  (digits x n m b)))
+  :enable digits
+  :cases ((not (acl2-numberp x))
+          (real/rationalp x)))
+
+(defruled digits-plus-mult-2-alt
+  (implies (and (< n k)
+                (integerp y)
+                (integerp k)
+                (radixp b))
+           (equal (digits (+ x (* (expt b k) y)) n m b)
+                  (digits x n m b)))
+  :use digits-plus-mult-2)
+
+(defruled digits-plus-mult-2-rewrite
+  (implies (and (syntaxp (quotep c))
+                (equal (mod c (expt b (1+ n))) 0)
+                (radixp b))
+           (equal (digits (+ c x) n m b)
+                  (digits x n m b)))
+  :enable digits
+  :cases ((and (integerp m) (integerp n)))
+  :hints (
+    ("subgoal 1" :cases ((real/rationalp x)))
+    ("subgoal 1.2" :in-theory (enable fl))))
+
+(defrule digits-plus-digits
+    (implies (and (integerp m)
+                  (integerp p)
+                  (integerp n)
+                  (<= m p)
+                  (<= p n)
+                  (radixp b))
+             (= (digits x n m b)
+                (+ (digits x (1- p) m b)
+                   (* (digits x n p b) (expt b (- p m))))))
+  :cases ((real/rationalp x))
+  :use (
+    (:instance digits-fl-diff
+      (i (1+ n))
+      (j m))
+    (:instance digits-fl-diff
+      (i p)
+      (j m))
+    (:instance digits-fl-diff
+      (i (1+ n))
+      (j p)))
+  :rule-classes ())
+
+(defrule digits-digits
+  (implies (and (case-split (<= 0 l))
+                (case-split (integerp i))
+                (case-split (integerp j))
+                (case-split (integerp k))
+                (case-split (integerp l))
+              (radixp b))
+           (equal (digits (digits x i j b) k l b)
+                  (if (<= k (- i j))
+                      (digits x (+ k j) (+ l j) b)
+                    (digits x i (+ l j) b))))
+  :prep-lemmas (
+    (defrule lemma1
+      (implies (and (integerp m)
+                    (integerp n)
+                    (<= m n)
+                    (radixp b))
+               (equal (mod (mod x (expt b m)) (expt b n))
+                      (mod x (expt b m)))))
+    (defrule lemma2
+      (implies (and (integerp i)
+                    (integerp j)
+                    (<= i k)
+                    (integerp k)
+                    (radixp b))
+               (equal (digits (mod x (expt b (1+ i))) k j b)
+                      (digits x i j b)))
+      :enable digits
+      :cases ((<= (expt b (1+ i)) (expt b (1+ k))))))
+  :enable (digits-fl mod-digits-equal-cor)
+  :cases ((<= k (- i j)))
+  :expand (digits x i j b)
+  :use (:instance digits-shift-up-1
+         (x (mod x (expt b (1+ i))))
+         (k (- j))
+         (i k)
+         (j l)))
+
+;;digits-match can prove things like this:
+;;(thm (implies (equal 12 (digits x 15 6 2))
+;;		(equal 4 (digits x 8 6 2))))
+
+(defruled digits-match
+  (implies (and (syntaxp (and (quotep i)
+                              (quotep j)
+                              (quotep k)))
+                (equal (digits x i2 j2 b) k2) ;i2, j2, and k2 are free variables
+                (syntaxp (and (quotep i2)
+                              (quotep j2)
+                              (quotep k2)))
+                (<= j2 j) (<= j i) (<= i i2)
+                (equal k (digits k2 (+ i (- j2)) (+ (- j2) j) b))
+                (<= 0 i) (<= 0 j) (<= 0 k) (<= 0 i2) (<= 0 j2) (<= 0 k2)
+                (integerp i) (integerp j)  (integerp k) (integerp i2) (integerp j2) (integerp k2)
+                (radixp b))
+           (equal (equal k (digits x i j b))
+                  t)))
+
+;;digits-dont-match can prove things like this:
+;;(thm (implies (equal 7 (digits x 8 6 2))
+;;		(not (equal 4 (digits x 15 6 2)))))
+
+(defruled digits-dont-match
+  (implies (and (syntaxp (and (quotep i)
+                              (quotep j)
+                              (quotep k)))
+                (equal (digits x i2 j2 b) k2) ;i2, j2, and k2 are free vars
+                (syntaxp (and (quotep i2)
+                              (quotep j2)
+                              (quotep k2)))
+                (<= j2 j) (<= j i) (<= i i2)
+                (not (equal k (digits k2 (+ i (- j2)) (+ (- j2) j) b)))
+                (<= 0 i) (<= 0 j) (<= 0 k) (<= 0 i2) (<= 0 j2) (<= 0 k2)
+                (integerp i) (integerp j)  (integerp k) (integerp i2) (integerp j2) (integerp k2)
+                (radixp b))
+           (equal (equal k (digits x i j b))
+                  nil)))
 
 ;;;**********************************************************************
 ;;;			    BITS
@@ -143,14 +738,14 @@
                   0
                 (logand (ash x (- j)) (1- (ash 1 (1+ (- i j))))))))
 
-(defthm bits-nonnegative-integerp-type
-  (and (<= 0 (bits x i j))
-       (integerp (bits x i j)))
-  :rule-classes (:type-prescription))
+(local
+ (defrule bits-as-digits
+  (equal
+   (bits x i j)
+   (digits x i j 2))
+  :enable (bits digits)))
 
-(in-theory (disable (:type-prescription bits)))
-
-(defthm bits-bvecp
+(defrule bits-bvecp
     (implies (and (<= (+ 1 i (- j)) k)
 		  (case-split (integerp k)))
 	     (bvecp (bits x i j) k)))
@@ -158,53 +753,58 @@
 ;;Here is a variation of bits-bvecp that is less general but does not
 ;;require an integerp hypothesis:
 
-(defthm bits-bvecp-simple
+(defrule bits-bvecp-simple
   (implies (equal k (+ 1 i (* -1 j)))
            (bvecp (bits x i j) k)))
 
-(defthm bits-bounds
+(defrule bits-bounds
     (implies (and (integerp i)
 		  (integerp j))
 	     (and (natp (bits x i j))
 		  (< (bits x i j) (expt 2 (1+ (- i j))))))
+  :use (:instance digits-bounds (b 2))
   :rule-classes())
 
-(defthm mod-bits-equal
+(defrule mod-bits-equal
   (implies (= (mod x (expt 2 (1+ i)))
 	      (mod y (expt 2 (1+ i))))
 	   (= (bits x i j) (bits y i j)))
+  :use (:instance mod-digits-equal (b 2))
   :rule-classes ())
 
-(defthmd mod-bits-equal-cor
+(defruled mod-bits-equal-cor
     (implies (and (integerp x)
 		  (integerp n)
 		  (integerp i)
 		  (integerp j)
 		  (< i n))
 	     (equal (bits (mod x (expt 2 n)) i j)
-		    (bits x i j))))
+		    (bits x i j)))
+    :enable mod-digits-equal-cor)
 
-(defthmd bits-mod
+(defruled bits-mod
   (implies (and (case-split (integerp x))
 		(case-split (integerp i)))
 	   (equal (bits x i 0)
-		  (mod x (expt 2 (1+ i))))))
+		  (mod x (expt 2 (1+ i)))))
+  :enable digits-mod)
 
-(defthm bits-diff-equal
+(defrule bits-diff-equal
     (implies (and (natp n)
 		  (integerp x)
 		  (integerp y)
 		  (< (abs (- x y)) (expt 2 n)))
 	     (iff (= x y)
 		  (= (bits (- x y) (1- n) 0) 0)))
+  :use (:instance digits-diff-equal (b 2))
   :rule-classes ())
 
-(defthm bits-tail
+(defrule bits-tail
   (implies (and (bvecp x (1+ i))
 		(case-split (acl2-numberp i)))
 	   (equal (bits x i 0) x)))
 
-(defthm bits-tail-gen
+(defrule bits-tail-gen
     (implies (and (integerp x)
 		  (natp i)
 		  (< x (expt 2 i))
@@ -212,9 +812,16 @@
 	     (equal (bits x i 0)
 		    (if (>= x 0)
 			x
-		      (+ x (expt 2 (+ 1 i)))))))
+		      (+ x (expt 2 (+ 1 i))))))
+    :prep-lemmas (
+      (defrule lemma
+        (implies (and (natp i)
+                      (< x (expt 2 i)))
+                 (< x (expt 2 (1+ i))))
+        :cases ((<= (expt 2 i) (expt 2 (1+ i))))))
+    :use (:instance digits-tail-gen (b 2)))
 
-(defthmd neg-bits-1
+(defruled neg-bits-1
     (implies (and (integerp x)
 		  (natp i)
 		  (natp j)
@@ -222,16 +829,18 @@
 		  (>= x (- (expt 2 j)))
 		  (>= i j))
 	     (equal (bits x i j)
-                    (1- (expt 2 (1+ (- i j)))))))
+                    (1- (expt 2 (1+ (- i j))))))
+    :enable neg-digits-1)
 
-(defthmd bits-minus-1
+(defruled bits-minus-1
     (implies (and (natp i)
 		  (natp j)
 		  (>= i j))
 	     (equal (bits -1 i j)
-                    (1- (expt 2 (1+ (- i j)))))))
+                    (1- (expt 2 (1+ (- i j))))))
+    :enable digits-minus-1)
 
-(defthm bits-bits-sum
+(defrule bits-bits-sum
   (implies (and (integerp x)
                 (integerp y)
                 (integerp i)
@@ -242,7 +851,7 @@
 	   (equal (bits (+ (bits x k 0) y) i j)
 		  (bits (+ x y) i j))))
 
-(defthm bits-bits-sum-alt
+(defrule bits-bits-sum-alt
   (implies (and (integerp x)
                 (integerp y)
                 (integerp i)
@@ -253,7 +862,7 @@
 	   (equal (bits (+ x (bits y k 0)) i j)
 		  (bits (+ x y) i j))))
 
-(defthmd bits-bits-diff
+(defruled bits-bits-diff
   (implies (and (integerp x)
                 (integerp y)
                 (integerp i)
@@ -262,9 +871,10 @@
                 (>= j 0)
                 (>= k i))
 	   (equal (bits (+ x (- (bits y k 0))) i j)
-		  (bits (- x y) i j))))
+		  (bits (- x y) i j)))
+  :enable digits-digits-diff)
 
-(defthmd bits-bits-prod
+(defruled bits-bits-prod
   (implies (and (integerp x)
                 (integerp y)
                 (integerp i)
@@ -273,10 +883,10 @@
                 (>= j 0)
                 (>= k i))
 	   (equal (bits (* x (bits y k 0)) i j)
-		  (bits (* x y) i j))))
+		  (bits (* x y) i j)))
+  :enable digits-digits-prod)
 
-
-(defthm bits-fl-diff
+(defrule bits-fl-diff
   (implies (and (integerp x)
                 (integerp i)
                 (integerp j)
@@ -285,11 +895,10 @@
                   (- (fl (/ x (expt 2 j)))
                      (* (expt 2 (- i j))
                         (fl (/ x (expt 2 i)))))))
+  :use (:instance digits-fl-diff (b 2))
   :rule-classes ())
 
-(local (in-theory (disable fl/int-rewrite fl/int-rewrite-alt)))
-
-(defthm bits-mod-fl
+(defrule bits-mod-fl
   (implies (and (integerp x)
                 (integerp i)
                 (integerp j)
@@ -297,60 +906,63 @@
            (equal (bits x (1- i) j)
                   (mod (fl (/ x (expt 2 j)))
                        (expt 2 (- i j)))))
-  :hints (("Goal" :use (bits-fl-diff
-                        (:instance mod-def (x (fl (/ x (expt 2 j)))) (y (expt 2 (- i j))))
-                        (:instance fl/int-rewrite (x (/ x (expt 2 j))) (n (expt 2 (- i j)))))))
+  :use (:instance digits-mod-fl (b 2))
   :rule-classes ())
 
-
-
-(defthm bits-neg-indices
+(defrule bits-neg-indices
   (implies (and (< i 0)
                 (integerp x))
            (equal (bits x i j) 0)))
 
-(defthm bits-reverse-indices
+(defrule bits-reverse-indices
   (implies (< i j)
 	   (equal (bits x i j)
 		  0)))
 
-(defthmd bvecp-bits-0
+(defruled bvecp-bits-0
   (implies (bvecp x j)
-	   (equal (bits x i j) 0)))
+	   (equal (bits x i j) 0))
+  :enable dvecp-digits-0)
 
-(defthm bits-0
+(defrule bits-0
   (equal (bits 0 i j) 0))
 
-(defthmd bits-shift-down-1
+(defruled bits-shift-down-1
   (implies (and (<= 0 j)
 		(integerp i)
 		(integerp j)
 		(integerp k))
 	   (equal (bits (fl (/ x (expt 2 k))) i j)
-		  (bits x (+ i k) (+ j k)))))
+		  (bits x (+ i k) (+ j k))))
+  :enable digits-fl
+  :use (:instance digits-shift-down-1 (b 2)))
 
-(defthmd bits-shift-down-2
+(defruled bits-shift-down-2
   (implies (and (integerp x)
 		(natp i)
 		(natp k))
 	   (equal (fl (/ (bits x (+ i k) 0) (expt 2 k)))
-		  (bits (fl (/ x (expt 2 k))) i 0))))
+		  (bits (fl (/ x (expt 2 k))) i 0)))
+  :enable digits-fl
+  :use (:instance digits-shift-down-2 (b 2)))
 
-(defthmd bits-shift-up-1
+(defruled bits-shift-up-1
   (implies (and (integerp k)
 		(integerp i)
 		(integerp j))
 	   (equal (bits (* (expt 2 k) x) i j)
-		  (bits x (- i k) (- j k)))))
+		  (bits x (- i k) (- j k))))
+  :use (:instance digits-shift-up-1 (b 2)))
 
-(defthmd bits-shift-up-2
+(defruled bits-shift-up-2
   (implies (and (integerp x)
 		(natp k)
 		(integerp i))
 	   (equal (* (expt 2 k) (bits x i 0))
-		  (bits (* (expt 2 k) x) (+ i k) 0))))
+		  (bits (* (expt 2 k) x) (+ i k) 0)))
+  :use (:instance digits-shift-up-2 (b 2)))
 
-(defthmd bits-plus-mult-1
+(defruled bits-plus-mult-1
   (implies (and (bvecp x k)
 		(<= k m)
 		(integerp y)
@@ -358,22 +970,25 @@
 		(case-split (integerp n))
 		(case-split (integerp k)))
 	   (equal (bits (+ x (* y (expt 2 k))) n m)
-		  (bits y (- n k) (- m k)))))
+		  (bits y (- n k) (- m k))))
+  :enable digits-plus-mult-1)
 
-(defthmd bits-plus-mult-2
+(defruled bits-plus-mult-2
   (implies (and (< n k)
 		(integerp y)
 		(integerp k))
 	   (equal (bits (+ x (* y (expt 2 k))) n m)
-		  (bits x n m))))
+		  (bits x n m)))
+  :use (:instance digits-plus-mult-2 (b 2)))
 
-(defthmd bits-plus-mult-2-rewrite
+(defruled bits-plus-mult-2-rewrite
    (implies (and (syntaxp (quotep c))
                  (equal (mod c (expt 2 (1+ n))) 0))
             (equal (bits (+ c x) n m)
-                   (bits x n m))))
+                   (bits x n m)))
+   :use (:instance digits-plus-mult-2-rewrite (b 2)))
 
-(defthm bits-plus-bits
+(defrule bits-plus-bits
     (implies (and (integerp m)
 		  (integerp p)
 		  (integerp n)
@@ -382,9 +997,10 @@
 	     (= (bits x n m)
 		(+ (bits x (1- p) m)
 		   (* (expt 2 (- p m)) (bits x n p)))))
+  :use (:instance digits-plus-digits (b 2))
   :rule-classes ())
 
-(defthm bits-bits
+(defrule bits-bits
   (implies (and (case-split (<= 0 l))
 		(case-split (integerp i))
 		(case-split (integerp j))
@@ -399,7 +1015,7 @@
 ;;(thm (implies (equal 12 (bits x 15 6))
 ;;		(equal 4 (bits x 8 6))))
 
-(defthmd bits-match
+(defruled bits-match
   (implies (and (syntaxp (and (quotep i)
 			      (quotep j)
 			      (quotep k)))
@@ -418,7 +1034,7 @@
 ;;(thm (implies (equal 7 (bits x 8 6))
 ;;		(not (equal 4 (bits x 15 6)))))
 
-(defthmd bits-dont-match
+(defruled bits-dont-match
   (implies (and (syntaxp (and (quotep i)
 			      (quotep j)
 			      (quotep k)))
@@ -433,6 +1049,478 @@
 	   (equal (equal k (bits x i j))
 		  nil)))
 
+;;;**********************************************************************
+;;;				DIGITN
+;;;**********************************************************************
+
+(defund digitn (x n b)
+  (declare (xargs :guard (and (real/rationalp x)
+                              (integerp n)
+                              (radixp b))))
+  (digits x n n b))
+
+(local
+ (defrule digitn-default
+   (implies
+    (or (and (not (real/rationalp x))
+             (radixp b))
+        (not (integerp n)))
+    (equal (digitn x n b) 0))
+   :enable digitn))
+
+(defrule digitn-bounds
+   (implies (radixp b)
+            (< (digitn x n b) b))
+   :enable digitn
+   :use (:instance digits-bounds (i n) (j n))
+   :rule-classes :linear)
+
+(defrule digits-n-n-rewrite
+  (equal (digits x n n radix)
+         (digitn x n radix))
+  :enable digitn)
+
+(local (in-theory (disable digits-n-n-rewrite)))
+
+(defruled digitn-def
+  (implies (and (case-split (integerp n))
+                (radixp b))
+           (equal (digitn x n b)
+                  (mod (fl (* x (expt b (- n)))) b)))
+  :enable (digitn digits-def-2))
+
+(defruled digitn-fl
+  (implies (and (>= n 0)
+                (radixp b))
+           (equal (digitn (fl x) n b)
+                  (digitn x n b)))
+  :enable (digitn digits-fl))
+
+;;A recursive formulation:
+
+(defruled digitn-rec-0
+  (implies (and (integerp x)
+                (radixp b))
+           (equal (digitn x 0 b) (mod x b)))
+  :enable digitn-def)
+
+(defruled digitn-rec
+  (implies (radixp b)
+           (equal (digitn x n b)
+                  (cond ((not (integerp n)) 0)
+                        ((> n 0) (digitn (/ x b) (1- n) b))
+                        ((< n 0) (digitn (* x b) (1+ n) b))
+                        (t (mod (fl x) b)))))
+  :enable (radixp digitn digits-def-2)
+  :rule-classes ((:definition :controller-alist ((digitn t t nil)))))
+
+(defrule digitn-dvecp
+  (implies (and (<= 1 k)
+                (case-split (integerp k))
+                (radixp b))
+           (dvecp (digitn x n b) k b))
+  :enable (digitn dvecp))
+
+;;The following is a special case of bitn-bvecp.
+;;It is useful as a :forward-chaining rule in concert with dvecp-1.
+
+(defrule digitn-dvecp-forward
+  (implies (radixp b)
+           (dvecp (digitn x n b) 1 b))
+  :rule-classes ((:forward-chaining :trigger-terms ((digitn x n b)))))
+
+(defrule digitn-neg
+  (implies (and (< n 0)
+                (integerp x)
+                (radixp b))
+           (equal (digitn x n b) 0))
+  :enable digitn)
+
+(defrule digitn-0
+  (equal (digitn 0 k b) 0)
+  :enable digitn)
+
+(defrule digitn-dvecp-1
+  (implies (and (dvecp x 1 b)
+                (radixp b))
+           (equal (digitn x 0 b) x))
+  :enable digitn)
+
+(defrule digitn-digitn-0
+  (implies (radixp b)
+           (equal (digitn (digitn x n b) 0 b)
+                  (digitn x n b))))
+
+(defruled digitn-mod
+  (implies (and (< k n)
+                (integerp n)
+                (integerp k)
+                (radixp b))
+           (equal (digitn (mod x (expt b n)) k b)
+                  (digitn x k b)))
+  :enable (digitn digits))
+
+(defrule dvecp-digitn-0
+  (implies (and (dvecp x n b)
+                (radixp b))
+           (equal (digitn x n b) 0))
+  :enable digitn)
+
+(defrule neg-digitn-1
+  (implies (and (integerp x)
+                (integerp n)
+                (< x 0)
+                (>= x (- (expt b n)))
+                (radixp b))
+           (equal (digitn x n b) (1- b)))
+  :enable (digitn neg-digits-1)
+  :cases ((natp n)))
+
+(defruled digitn-minus-1
+  (implies (and (natp i)
+                (radixp b))
+           (equal (digitn -1 i b) (1- b))))
+
+;; The rewrite rule neg-digitn-2 has the hypotheses (integerp n) and (< x (- (expt b k) (expt b n))),
+;; where n does not occur in the lhs.  When n is bound to a large integer, (expt b n) blows up.
+
+(defruled neg-digitn-2
+  (implies (and (integerp x)
+                (integerp n)
+                (integerp k)
+                (< k n)
+                (< x (- (expt b k) (expt b n)))
+                (>= x (- (expt b n)))
+                (radixp b))
+           (equal (digitn x k b) 0))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear++-help
+     (defrule lemma
+       (implies (and (real/rationalp x)
+                     (natp k)
+                     (integerp n)
+                     (< k n)
+                     (< x (- (expt b k) (expt b n)))
+                     (>= x (- (expt b n)))
+                     (radixp b))
+                (equal (fl (* x (expt b (- k))))
+                       (- (expt b (- n k)))))
+       :use (:instance fl-unique
+                       (x (* x (expt b (- k))))
+                       (n (- (expt b (- n k))))))))
+  :cases ((and (real/rationalp x) (natp k)))
+  :hints (("subgoal 2" :in-theory (enable digitn))
+          ("subgoal 1" :in-theory (enable digitn-def))))
+
+(defrule neg-digitn-0
+    (implies (and (integerp x)
+                  (natp n)
+                  (< x (- (* (1- b) (expt b n))))
+                  (>= x (- (expt b (1+ n))))
+                (radixp b))
+             (equal (digitn x n b) 0))
+  :use (:instance neg-digitn-2
+                      (k n)
+                      (n (1+ n))))
+
+(defruled digitn-shift-up
+  (implies (and (integerp n)
+                (integerp k)
+                (radixp b))
+           (equal (digitn (* x (expt b k)) (+ n k) b)
+                  (digitn x n b)))
+  :enable (digitn digits-shift-up-1))
+
+(defruled digitn-shift-down
+  (implies (and (natp i)
+                (integerp k)
+                (radixp b))
+           (equal (digitn (/ x (expt b k)) i b)
+                  (digitn x (+ i k) b)))
+  :enable (digitn digits-shift-up-1))
+
+(defruled digitn-digits
+  (implies (and (<= k (- i j))
+                (case-split (<= 0 k))
+                (case-split (integerp i))
+                (case-split (integerp j))
+                (case-split (integerp k))
+                (radixp b))
+           (equal (digitn (digits x i j b) k b)
+                  (digitn x (+ j k) b)))
+  :enable digitn)
+
+(defrule digitn-plus-digits
+    (implies (and (<= m n)
+                  (integerp m)
+                  (integerp n)
+                  (radixp b))
+             (= (digits x n m b)
+                (+ (* (digitn x n b) (expt b (- n m)))
+                   (digits x (1- n) m b))))
+  :enable digitn
+  :use (:instance digits-plus-digits
+         (p n))
+  :rule-classes ())
+
+(defrule digits-plus-digitn
+    (implies (and (<= m n)
+                  (integerp m)
+                  (integerp n)
+                  (radixp b))
+             (= (digits x n m b)
+                (+ (digitn x m b)
+                   (* b (digits x n (1+ m) b)))))
+  :enable (digitn)
+  :use (:instance digits-plus-digits
+         (p (1+ m)))
+  :rule-classes ())
+
+(defun sumdigits (x n b)
+  (if (zp n)
+      0
+    (+ (* (expt b (1- n)) (digitn x (1- n) b))
+       (sumdigits x (1- n) b))))
+
+(defruled sumdigits-digits
+  (implies (and (integerp x)
+                (posp n)
+                (radixp b))
+           (equal (sumdigits x n b)
+                  (digits x (1- n) 0 b)))
+  :prep-lemmas (
+    (defrule lemma1
+      (equal (digitn x 0 b) (digits x 0 0 b))
+      :enable digitn)
+    (defrule lemma2
+      (implies
+        (and (> (+ -1 n) 0) (integerp n) (radixp b))
+        (equal
+          (+ (digits x (+ -2 n) 0 b)
+             (* (expt b (1- n)) (digitn x (+ -1 n) b)))
+          (digits x (+ -1 n) 0 b)))
+        :use (:instance digitn-plus-digits
+               (n (1- n))
+               (m 0))))
+  :induct (sumdigits x n b))
+
+(defruled sumdigits-thm
+  (implies (and (dvecp x n b)
+                (natp n)
+                (> n 0)
+                (radixp b))
+           (equal (sumdigits x n b)
+                  x))
+  :enable sumdigits-digits)
+
+(defun all-digits-p (list k b)
+  (if (zp k)
+      t
+    (and (digitp (nth (1- k) list) b)
+         (all-digits-p list (1- k) b))))
+
+(defrule digitp-of-all-digits-p
+  (implies (and (all-digits-p list n b)
+                (< k n)
+                (natp k)
+                (natp n))
+           (digitp (nth k list) b))
+  :induct (sub1-induction n)
+  :rule-classes ())
+
+(defun sum-d (list k b)
+  (if (zp k)
+      0
+    (+ (* (expt b (1- k)) (nth (1- k) list))
+       (sum-d list (1- k) b))))
+
+(acl2::with-arith5-nonlinear-help
+ (defruled dvecp-sum-d
+   (implies (and (all-digits-p list n b)
+                 (natp n)
+                 (radixp b))
+            (dvecp (sum-d list n b) n b))
+   :enable (dvecp)
+   :induct (sub1-induction n)))
+
+(defruled sum-digitn
+  (implies (and (natp n)
+                (all-digits-p list n b)
+                (natp k)
+                (< k n)
+                (radixp b))
+           (equal (digitn (sum-d list n b) k b)
+                  (nth k list)))
+  :prep-lemmas (
+    (defrule lemma1
+      (implies (and (natp k)
+                    (dvecp x k b)
+                    (digitp d b)
+                    (radixp b))
+               (equal (digitn (+ x (* (expt b k) d)) k b) d))
+      :enable (digitn-def fl))
+    (defrule lemma2
+      (implies (and
+                (natp k)
+                (natp n)
+                (< k n)
+                (integerp dn)
+                (dvecp sum n b)
+                (radixp b))
+               (equal (digitn (+ sum (* (expt b n) dn)) k b)
+                      (digitn sum k b)))
+      :enable digitn-def))
+  :enable (dvecp-sum-d)
+  :induct (sub1-induction n)
+  :hints (("subgoal *1/2" :cases ((= k (1- n))))))
+
+;; The next lemma can be used to prove equality of two digit vectors by
+;; proving that they have the same value at digit n for all n.
+
+(defun digit-diff (x y b)
+  (declare (xargs :guard (and (integerp x)
+                              (integerp y)
+                              (radixp b))
+                  :measure (+ (abs (ifix x)) (abs (ifix y)))
+                  :hints (("goal" :use digit-diff-measure-lemma))))
+  (if (or (not (mbt (integerp x)))
+          (not (mbt (integerp y)))
+          (not (mbt (radixp b)))
+          (= x y))
+      ()
+    (if (= (digitn x 0 b) (digitn y 0 b))
+        (1+ (digit-diff (fl (/ x b)) (fl (/ y b)) b))
+      0)))
+
+(defrule digit-diff-diff
+  (implies (and (integerp x)
+                (integerp y)
+                (not (= x y))
+                (radixp b))
+           (let ((n (digit-diff x y b)))
+             (and (natp n)
+                  (not (= (digitn x n b) (digitn y n b))))))
+  :prep-lemmas (
+    (defrule bdd-2
+      (implies (and (integerp x)
+                    (radixp b))
+               (equal (digitn x 0 b)
+                      (- x (* b (fl (/ x b))))))
+      :enable (digitn)
+      :use (:instance digits-fl-diff
+             (i 1)
+             (j 0))))
+  :enable (digitn-fl bdd-2)
+  :induct (digit-diff x y b)
+  :hints (("subgoal *1/1"
+           :use ((:instance digitn-shift-down
+                            (k 1)
+                            (i (digit-diff (fl (/ x b)) (fl (/ y b)) b)))
+                 (:instance digitn-shift-down
+                            (k 1)
+                            (x y)
+                            (i (digit-diff (fl (/ x b)) (fl (/ y b)) b))))))
+  :rule-classes ())
+
+(defruled dvecp-digitn-1
+  (implies (and (dvecp x (1+ n) b)
+                (<= (expt b n) x)
+                (natp n)
+                (radixp b))
+           (>= (digitn x n b) 1))
+  :cases ((= (digitn x n b) 0))
+  :hints (("subgoal 1" :use (
+    (:instance digitn-plus-digits
+      (m 0))
+    (:instance digits-dvecp
+      (i (1- n))
+      (j 0)
+      (k n))))))
+
+(defruled dvecp-digitn-2
+  (implies (and (dvecp x n b)
+                (< k n)
+                (<= (- (expt b n) (expt b k)) x)
+                (integerp n)
+                (integerp k)
+                (radixp b))
+           (= (digitn x k b) (1- b)))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help
+     (defrule lemma1
+       (implies (and (natp k)
+                     (posp n)
+                     (< k n)
+                     (real/rationalp x)
+                     (<= (- (expt b n) (expt b k)) x)
+                     (< x (expt b n))
+                     (radixp b))
+                (equal (fl (* x (expt b (- k))))
+                       (1- (expt b (- n k)))))
+       :use (:instance fl-unique
+                       (x (* x (expt b (- k))))
+                       (n (1- (expt b (- n k))))))))
+  :enable (radixp digitn-def)
+  :cases ((not (natp k))
+          (not (real/rationalp x)))
+  :hints (
+    ("subgoal 2" :cases ((<= x (1- (expt b n)))))
+    ("subgoal 2.2" :cases ((natp n))
+                   :in-theory (enable dvecp)))
+  :rule-classes ((:rewrite :match-free :all)))
+
+(defruled digitn-expt
+  (implies (and (case-split (integerp n))
+                (radixp b))
+           (equal (digitn (expt b n) n b)
+                  1))
+  :enable digitn-def)
+(defruled digitn-expt-0
+  (implies (and (not (equal i n))
+                (case-split (integerp i))
+                (radixp b))
+           (equal (digitn (expt b i) n b)
+                  0))
+  :enable digitn
+  :cases ((integerp n))
+  :hints (
+    ("subgoal 1" :cases ((<= i (1- n))
+                         (>= i (1+ n))))
+    ("subgoal 1.2" :in-theory (enable digits-def-2))
+    ("subgoal 1.1" :in-theory (enable digits))))
+
+(defrule digitn-plus-expt-1
+  (implies (and (real/rationalp x)
+                (integerp n)
+                (radixp b))
+           (not (equal (digitn (+ x (expt b n)) n b)
+                       (digitn x n b))))
+  :enable (digitn digits-def-2)
+  :use (:instance fl+int-rewrite
+                  (x (* x (expt b (- n))))
+                  (n 1))
+  :rule-classes ())
+
+(defruled digitn-plus-mult
+  (implies (and (< n m)
+                (integerp m)
+                (integerp k)
+                (radixp b))
+           (equal (digitn (+ x (* k (expt b m))) n b)
+                  (digitn x n b)))
+  :enable (digitn digits-plus-mult-2 digits)
+  :cases ((real/rationalp x))
+  :hints (("subgoal 2" :in-theory (enable fl))))
+
+(defruled digitn-plus-mult-rewrite
+    (implies (and (syntaxp (quotep c))
+		  (equal (mod c (expt b (1+ n))) 0)
+                  (radixp b))
+	     (equal (digitn (+ c x) n b)
+		    (digitn x n b)))
+    :use (:instance digitn-plus-mult
+           (k (/ c (expt b (1+ n))))
+           (m (1+ n))))
 
 ;;;**********************************************************************
 ;;;				BITN
@@ -444,42 +1532,49 @@
   (mbe :logic (bits x n n)
        :exec  (if (evenp (ash x (- n))) 0 1)))
 
-(defthm bitn-nonnegative-integer
-  (and (integerp (bitn x n))
-       (<= 0 (bitn x n)))
-  :rule-classes (:type-prescription))
+(local
+ (defrule bitn-as-digitn
+   (equal (bitn x n)
+          (digitn x n 2))
+   :enable (bitn digitn)))
 
-(in-theory (disable (:type-prescription bitn)))
-
-(defthm bits-n-n-rewrite
+(defrule bits-n-n-rewrite
   (equal (bits x n n)
-	 (bitn x n)))
+	 (bitn x n))
+  :enable digits-n-n-rewrite)
 
-(defthmd bitn-def
+(local (in-theory (disable bits-n-n-rewrite)))
+
+(defruled bitn-def
   (implies (case-split (integerp n))
 	   (equal (bitn x n)
-		  (mod (fl (/ x (expt 2 n))) 2))))
+		  (mod (fl (/ x (expt 2 n))) 2)))
+  :enable digitn-def)
 
 ;;A recursive formulation:
 
-(defthmd bitn-rec-0
+(defruled bitn-rec-0
   (implies (integerp x)
-	   (equal (bitn x 0) (mod x 2))))
+	   (equal (bitn x 0) (mod x 2)))
+  :enable digitn-rec-0)
 
-(defthmd bitn-rec-pos
+(defruled bitn-rec-pos
     (implies (< 0 n)
 	     (equal (bitn x n)
 		    (bitn (fl (/ x 2)) (1- n))))
+  :enable (digitn-rec digitn-fl)
+  :cases ((integerp n))
+  :disable digits-n-n-rewrite
   :rule-classes ((:definition :controller-alist ((bitn t t)))))
 
 ;;Use this to induce case-splitting:
 
-(defthm bitn-0-1
+(defrule bitn-0-1
     (or (equal (bitn x n) 0)
 	(equal (bitn x n) 1))
   :rule-classes ())
 
-(defthm bitn-bvecp
+(defrule bitn-bvecp
   (implies (and (<= 1 k)
 		(case-split (integerp k)))
 	   (bvecp (bitn x n) k)))
@@ -488,104 +1583,112 @@
 ;;It is useful as a :forward-chaining rule in concert with bvecp-0-1 and
 ;;bvecp-1-0.
 
-(defthm bitn-bvecp-forward
+(defrule bitn-bvecp-forward
   (bvecp (bitn x n) 1)
   :rule-classes ((:forward-chaining :trigger-terms ((bitn x n)))))
 
-(defthm bitn-neg
+(defrule bitn-neg
   (implies (and (< n 0)
                 (integerp x))
            (equal (bitn x n) 0)))
 
-(defthm bitn-0
+(defrule bitn-0
   (equal (bitn 0 k) 0))
 
-(defthm bitn-bvecp-1
+(defrule bitn-bvecp-1
     (implies (bvecp x 1)
 	     (equal (bitn x 0) x)))
 
-(defthm bitn-bitn-0
+(defrule bitn-bitn-0
     (equal (bitn (bitn x n) 0)
 	   (bitn x n)))
 
-(defthmd bitn-mod
+(defruled bitn-mod
     (implies (and (< k n)
 		  (integerp n)
 		  (integerp k))
 	     (equal (bitn (mod x (expt 2 n)) k)
-		    (bitn x k))))
+		    (bitn x k)))
+    :use (:instance digitn-mod (b 2)))
 
-(defthm bvecp-bitn-0
+(defrule bvecp-bitn-0
     (implies (bvecp x n)
 	     (equal (bitn x n) 0)))
 
-(defthm neg-bitn-1
+(defrule neg-bitn-1
     (implies (and (integerp x)
                   (integerp n)
                   (< x 0)
 		  (>= x (- (expt 2 n))))
 	     (equal (bitn x n) 1)))
 
-(defthmd bitn-minus-1
+(defruled bitn-minus-1
     (implies (natp i)
 	     (equal (bitn -1 i) 1)))
 
 ;; The rewrite rule neg-bitn-2 has the hypotheses (integerp n) and (< x (- (expt 2 k) (expt 2 n))),
 ;; where n does not occur in the lhs.  When n is bound to a large integer, (expt 2 n) blows up.
 
-(defthmd neg-bitn-2
+(defruled neg-bitn-2
     (implies (and (integerp x)
 		  (integerp n)
 		  (integerp k)
 		  (< k n)
 		  (< x (- (expt 2 k) (expt 2 n)))
 		  (>= x (- (expt 2 n))))
-	     (equal (bitn x k) 0)))
+	     (equal (bitn x k) 0))
+    :enable neg-digitn-2)
 
-(defthm neg-bitn-0
+(defrule neg-bitn-0
     (implies (and (integerp x)
 		  (natp n)
 		  (< x (- (expt 2 n)))
 		  (>= x (- (expt 2 (1+ n)))))
 	     (equal (bitn x n) 0)))
 
-(defthmd bitn-shift-up
+(defruled bitn-shift-up
   (implies (and (integerp n)
 		(integerp k))
 	   (equal (bitn (* x (expt 2 k)) (+ n k))
-		  (bitn x n))))
+		  (bitn x n)))
+  :use (:instance digitn-shift-up (b 2)))
 
-(defthmd bitn-shift-down
+(defruled bitn-shift-down
   (implies (and (natp i)
 		(integerp k))
 	   (equal (bitn (fl (/ x (expt 2 k))) i)
-		  (bitn x (+ i k)))))
+		  (bitn x (+ i k))))
+  :enable digitn-fl
+  :use (:instance digitn-shift-down (b 2)))
 
-(defthmd bitn-bits
+(defruled bitn-bits
   (implies (and (<= k (- i j))
 		(case-split (<= 0 k))
 		(case-split (integerp i))
 		(case-split (integerp j))
 		(case-split (integerp k)))
 	   (equal (bitn (bits x i j) k)
-		  (bitn x (+ j k)))))
+		  (bitn x (+ j k))))
+  :enable digitn-digits)
 
-(defthm bitn-plus-bits
+(defrule bitn-plus-bits
     (implies (and (<= m n)
 		  (integerp m)
 		  (integerp n))
 	     (= (bits x n m)
 		(+ (* (bitn x n) (expt 2 (- n m)))
 		   (bits x (1- n) m))))
+  :use (:instance digitn-plus-digits (b 2))
   :rule-classes ())
 
-(defthm bits-plus-bitn
+(defrule bits-plus-bitn
     (implies (and (<= m n)
 		  (integerp m)
 		  (integerp n))
 	     (= (bits x n m)
 		(+ (bitn x m)
 		   (* 2 (bits x n (1+ m))))))
+  :use (:instance digits-plus-digitn (b 2))
   :rule-classes ())
 
 (defun sumbits (x n)
@@ -594,19 +1697,26 @@
     (+ (* (expt 2 (1- n)) (bitn x (1- n)))
        (sumbits x (1- n)))))
 
-(defthmd sumbits-bits
+(local
+ (defrule sumbits-as-sumdigits
+   (equal (sumbits x n)
+          (sumdigits x n 2))))
+
+(defruled sumbits-bits
     (implies (and (integerp x)
 		  (natp n)
 		  (> n 0))
 	     (equal (sumbits x n)
-		    (bits x (1- n) 0))))
+		    (bits x (1- n) 0)))
+    :enable sumdigits-digits)
 
-(defthmd sumbits-thm
+(defruled sumbits-thm
     (implies (and (bvecp x n)
 		  (natp n)
 		  (> n 0))
 	     (equal (sumbits x n)
-		    x)))
+		    x))
+    :enable sumdigits-thm)
 
 (defun all-bits-p (b k)
   (if (zp k)
@@ -615,86 +1725,517 @@
 	     (= (nth (1- k) b) 1))
 	 (all-bits-p b (1- k)))))
 
+(local
+ (defrule all-bits-p-as-all-digits-p
+   (equal (all-bits-p b k)
+          (all-digits-p b k 2))))
+
 (defun sum-b (b k)
   (if (zp k)
       0
     (+ (* (expt 2 (1- k)) (nth (1- k) b))
        (sum-b b (1- k)))))
 
-(defthmd sum-bitn
+(local
+ (defrule sum-b-as-sum-d
+   (equal (sum-b b k)
+          (sum-d b k 2))))
+
+(defruled sum-bitn
   (implies (and (natp n)
 		(all-bits-p b n)
 	        (natp k)
 		(< k n))
            (equal (bitn (sum-b b n) k)
-	          (nth k b))))
+	          (nth k b)))
+  :enable sum-digitn)
 
 ;; The next lemma can be used to prove equality of two bit vectors by
 ;; proving that they have the same value at bit n for all n.
 
 (defun bit-diff (x y)
-  (declare (xargs :measure (+ (abs (ifix x)) (abs (ifix y)))))
+  (declare (xargs :measure (+ (abs (ifix x)) (abs (ifix y)))
+                  :hints (("goal" :use digit-diff-measure-lemma (b 2)))))
   (if (or (not (integerp x)) (not (integerp y)) (= x y))
       ()
     (if (= (bitn x 0) (bitn y 0))
         (1+ (bit-diff (fl (/ x 2)) (fl (/ y 2))))
       0)))
 
-(defthm bit-diff-diff
+(local
+ (defrule bit-diff-as-digit-diff
+   (equal (bit-diff x y)
+          (digit-diff x y 2))))
+
+(defrule bit-diff-diff
   (implies (and (integerp x)
                 (integerp y)
                 (not (= x y)))
            (let ((n (bit-diff x y)))
              (and (natp n)
                   (not (= (bitn x n) (bitn y n))))))
+  :use (:instance digit-diff-diff (b 2))
   :rule-classes ())
 
-(defthmd bvecp-bitn-1
+(defruled bvecp-bitn-1
     (implies (and (bvecp x (1+ n))
 		  (<= (expt 2 n) x)
 		  (natp n))
-	     (equal (bitn x n) 1)))
+	     (equal (bitn x n) 1))
+    :enable dvecp-digitn-1)
 
-(defthmd bvecp-bitn-2
+(defruled bvecp-bitn-2
   (implies (and (bvecp x n)
 		(< k n)
 		(<= (- (expt 2 n) (expt 2 k)) x)
 		(integerp n)
 		(integerp k))
 	   (equal (bitn x k) 1))
+  :enable dvecp-digitn-2
   :rule-classes ((:rewrite :match-free :all)))
 
-(defthmd bitn-expt
+(defruled bitn-expt
     (implies (case-split (integerp n))
 	     (equal (bitn (expt 2 n) n)
-		    1)))
+		    1))
+    :enable digitn-expt)
 
-(defthmd bitn-expt-0
+(defruled bitn-expt-0
   (implies (and (not (equal i n))
 		(case-split (integerp i)))
 	   (equal (bitn (expt 2 i) n)
-		  0)))
+		  0))
+  :enable digitn-expt-0)
 
-(defthm bitn-plus-expt-1
+(defrule bitn-plus-expt-1
     (implies (and (rationalp x)
 		  (integerp n))
 	     (not (equal (bitn (+ x (expt 2 n)) n)
 			 (bitn x n))))
+  :use (:instance digitn-plus-expt-1 (b 2))
   :rule-classes ())
 
-(defthmd bitn-plus-mult
+(defruled bitn-plus-mult
     (implies (and (< n m)
 		  (integerp m)
 		  (integerp k))
 	     (equal (bitn (+ x (* k (expt 2 m))) n)
-		    (bitn x n))))
+		    (bitn x n)))
+    :use (:instance digitn-plus-mult (b 2)))
 
-(defthmd bitn-plus-mult-rewrite
+(defruled bitn-plus-mult-rewrite
     (implies (and (syntaxp (quotep c))
 		  (equal (mod c (expt 2 (1+ n))) 0))
 	     (equal (bitn (+ c x) n)
-		    (bitn x n))))
+		    (bitn x n)))
+    :use (:instance digitn-plus-mult-rewrite (b 2)))
 
+;;;**********************************************************************
+;;;			     CAT-R
+;;;**********************************************************************
+
+(defund radix-cat (b x m y n)
+  (declare (xargs :guard (and (radixp b)
+                              (integerp x)
+                              (integerp y)
+                              (natp m)
+                              (natp n))))
+  (if (and (natp m) (natp n))
+      (+ (* (digits x (1- m) 0 b) (expt b n))
+         (digits y (1- n) 0 b))
+    0))
+
+(local
+ (defruled radix-cat-aux
+   (implies (and (natp m)
+                 (natp n)
+                 (dvecp x m b)
+                 (dvecp y n b)
+                 (radixp b))
+            (equal (radix-cat b x m y n)
+                   (+ (* x (expt b n)) y)))
+   :enable radix-cat))
+
+(defmacro cat-r (b &rest x)
+  (declare (xargs :guard (and x (true-listp x) (evenp (length x)))))
+  (cond ((endp (cddr x))
+         `(digits ,(car x) ,(formal-+ -1 (cadr x)) 0 ,b))
+        ((endp (cddddr x))
+         `(radix-cat ,b ,@x))
+        (t
+         `(radix-cat ,b
+                     ,(car x)
+                     ,(cadr x)
+                     (cat-r ,b ,@(cddr x))
+                     ,(cat-size (cddr x))))))
+
+(defrule cat-r-dvecp
+  (implies (and (<= (+ m n) k)
+                (case-split (integerp k))
+                (radixp b))
+           (dvecp (cat-r b x m y n) k b))
+  :prep-lemmas (
+   (acl2::with-arith5-nonlinear-help
+    (defrule lemma
+      (implies (and (natp m)
+                    (natp n)
+                    (integerp x)
+                    (integerp y)
+                    (< x (expt b m))
+                    (< y (expt b n))
+                    (radixp b))
+               (< (+ y (* (expt b n) x)) (expt b (+ m n))))
+      ))
+    )
+  :enable (radix-cat dvecp)
+  :cases ((and (natp m) (natp n)))
+  :hints (("subgoal 1" :use (
+    (:instance lemma
+      (x (digits x (1- m) 0 b))
+      (y (digits y (1- n) 0 b)))
+    (:instance digits-bounds
+      (x x)
+      (i (1- m))
+      (j 0))
+    (:instance digits-bounds
+      (x y)
+      (i (1- n))
+      (j 0))))))
+
+(defrule cat-r-with-n-0
+  (implies (radixp b)
+           (equal (radix-cat b x m y 0)
+                  (digits x (1- m) 0 b)))
+  :enable radix-cat)
+
+(defrule cat-r-with-m-0
+  (implies (radixp b)
+           (equal (radix-cat b x 0 y n)
+                  (digits y (1- n) 0 b)))
+  :enable radix-cat)
+
+(defruled cat-r-0
+  (implies (and (case-split (dvecp y n b))
+                (case-split (integerp n))
+                (case-split (integerp m))
+                (case-split (<= 0 m))
+                (radixp b))
+           (equal (cat-r b 0 m y n) y))
+  :enable radix-cat)
+
+(defruled cat-r-digits-1
+  (implies (radixp b)
+           (equal (cat-r b (digits x (1- m) 0 b) m y n)
+                  (cat-r b x m y n)))
+  :enable radix-cat)
+
+(defruled cat-r-digits-2
+  (implies (radixp b)
+           (equal (cat-r b x m (digits y (1- n) 0 b) n)
+                  (cat-r b x m y n)))
+  :enable radix-cat)
+
+(defrule cat-r-associative
+  (implies (and (case-split (<= (+ m n) p))
+                (case-split (<= 0 m))
+                (case-split (<= 0 n))
+                (case-split (<= 0 q))
+                (case-split (integerp m))
+                (case-split (integerp n))
+                (case-split (integerp p))
+                (case-split (integerp q))
+                (radixp b))
+           (equal (cat-r b (cat-r b x m y n) p z q)
+                  (cat-r b x m (cat-r b y n z q) (+ n q))))
+  :prep-lemmas (
+   (defrule lemma
+     (implies (and (natp m)
+                   (natp n)
+                   (natp q)
+                   (integerp p)
+                   (<= (+ m n) p)
+                   (dvecp x m b)
+                   (dvecp y n b)
+                   (dvecp z q b)
+                   (radixp b))
+              (equal (cat-r b (cat-r b x m y n) p z q)
+                     (cat-r b x m (cat-r b y n z q) (+ n q))))
+     :cases ((not (dvecp (cat-r b x m y n) p b))
+             (not (dvecp (cat-r b y n z q) (+ n q) b)))
+     :hints (("subgoal 3" :in-theory (enable radix-cat-aux)))
+     :rule-classes ()))
+  :enable (cat-r-digits-1 cat-r-digits-2)
+  :use ((:instance lemma
+          (x (digits x (1- m) 0 b))
+          (y (digits y (1- n) 0 b))
+          (z (digits z (1- q) 0 b)))))
+
+(defruled cat-r-equal-constant
+  (implies (and (syntaxp (and (quotep k)
+                              (quotep m)
+                              (quotep n)))
+                (case-split (dvecp y n b))
+                (case-split (dvecp x m b))
+                (case-split (< k (expt b (+ m n)))) ;not a problem hyp, since k, m and n are constants
+                (case-split (integerp k))
+                (case-split (<= 0 k))
+                (case-split (integerp m))
+                (case-split (<= 0 m))
+                (case-split (integerp n))
+                (case-split (<= 0 n))
+                (radixp b))
+           (equal (equal k (cat-r b x m y n))
+                  (and (equal y (digits k (1- n) 0 b))
+                       (equal x (digits k (+ -1 m n) n b)))))
+  :enable radix-cat-aux
+  :cases ((equal k (cat-r b x m y n)))
+   :hints (
+    ("subgoal 2"
+     :in-theory (enable dvecp)
+     :use ((:instance digits-plus-digits
+                      (x k)
+                      (n (+ -1 m n))
+                      (p n)
+                      (m 0))))
+    ("subgoal 1" :in-theory (enable digits-plus-mult-1 digits-plus-mult-2))))
+
+(defruled cat-r-equal-rewrite
+  (implies (and (case-split (dvecp x1 m b))
+                (case-split (dvecp y1 n b))
+                (case-split (dvecp x2 m b))
+                (case-split (dvecp y2 n b))
+                (case-split (integerp n))
+                (case-split (<= 0 n))
+                (case-split (integerp m))
+                (case-split (<= 0 m))
+                (radixp b))
+           (equal (equal (cat-r b x1 m y1 n)
+                         (cat-r b x2 m y2 n))
+                  (and (equal x1 x2)
+                       (equal y1 y2))))
+  :disable cat-r-dvecp
+  :cases ((equal (cat-r b x1 m y1 n) (cat-r b x2 m y2 n)))
+  :hints (("subgoal 1" :use (
+    (:instance cat-r-dvecp
+      (k (+ m n))
+      (x x1)
+      (y y1))
+    (:instance cat-r-equal-constant
+      (k (cat-r b x2 m y2 n))
+      (x x1)
+      (y y1))
+    (:instance cat-r-equal-constant
+      (k (cat-r b x1 m y1 n))
+      (x x2)
+      (y y2))))))
+
+(defrule cat-r-digits-digits
+  (implies (and (equal j (1+ k))
+                (equal n (+ 1 (- l) k))
+                (case-split (<= (+ 1 (- j) i) m))
+                (case-split (<= j i))
+                (case-split (<= l k))
+                (case-split (integerp i))
+                (case-split (integerp k))
+                (case-split (integerp l))
+                (case-split (integerp m))
+                (radixp b))
+           (equal (cat-r b (digits x i j b) m (digits x k l b) n)
+                  (digits x i l b)))
+  :enable radix-cat-aux
+  :use (:instance digits-plus-digits
+         (n i)
+         (m l)
+         (p (1+ k))))
+
+(defrule cat-r-digitn-digits
+    (implies (and (equal j (1+ k))
+                  (equal n (+ 1 (- l) k))
+                  (case-split (<= 1 m))
+                  (case-split (<= l k))
+                  (case-split (integerp j))
+                  (case-split (integerp k))
+                  (case-split (integerp l))
+                  (case-split (integerp m))
+                  (radixp b))
+             (equal (cat-r b (digitn x j b) m (digits x k l b) n)
+                    (digits x j l b)))
+    :enable digitn)
+
+(defrule cat-r-digits-digitn
+  (implies (and (equal j (1+ k))
+                (case-split (<= (+ 1 (- j) i) m))
+                (case-split (<= j i))
+                (case-split (integerp i))
+                (case-split (integerp j))
+                (case-split (integerp k))
+                (case-split (integerp m))
+                (radixp b))
+           (equal (cat-r b (digits x i j b) m (digitn x k b) 1)
+                  (digits x i k b)))
+  :enable digitn)
+
+(defrule cat-r-digitn-digitn
+  (implies (and (equal i (1+ j))
+                (case-split (integerp i))
+                (case-split (integerp j))
+                (radixp b))
+           (equal (cat-r b (digitn x i b) 1 (digitn x j b) 1)
+                  (digits x i j b)))
+  :enable digitn)
+
+(defruled digits-cat-r
+  (implies (and (case-split (natp n))
+                (case-split (natp m))
+                (case-split (natp i))
+                (case-split (natp j))
+                (radixp b))
+           (equal (digits (cat-r b x m y n) i j b)
+                  (if (< i n)
+                      (digits y i j b)
+                    (if (>= j n)
+                        (digits x (if (< i (+ m n))
+                                      (- i n)
+                                    (1- m))
+                                (- j n) b)
+                      (cat-r b (digits x (if (< i (+ m n))
+                                             (- i n)
+                                           (1- m)) 0 b)
+                             (1+ (- i n))
+                             (digits y (1- n) j b)
+                             (- n j))))))
+  :enable (radix-cat digits-plus-mult-1-alt digits-plus-mult-2-alt)
+  :cases ((< i n)
+          (>= j n))
+  :hints (("subgoal 3" :use (:instance digits-plus-digits
+                                       (x (cat-r b x m y n))
+                                       (n i)
+                                       (m j)
+                                       (p n)))))
+
+(defrule digits-cat-r-constants
+  (implies (and (syntaxp (quotep n))
+                (syntaxp (quotep m))
+                (syntaxp (quotep i))
+                (syntaxp (quotep j))
+                (natp n)
+                (natp m)
+                (natp i)
+                (natp j)
+                (radixp b))
+           (equal (digits (cat-r b x m y n) i j b)
+                  (if (< i n)
+                      (digits y i j b)
+                    (if (>= j n)
+                        (digits x (if (< i (+ m n))
+                                      (- i n)
+                                    (1- m))
+                                (- j n) b)
+                      (cat-r b (digits x (if (< i (+ m n))
+                                             (- i n)
+                                           (1- m)) 0 b)
+                             (1+ (- i n))
+                             (digits y (1- n) j b)
+                             (- n j))))))
+  :use digits-cat-r)
+
+(defruled digitn-cat-r
+  (implies (and (case-split (natp n))
+                (case-split (natp m))
+                (case-split (natp i))
+                (radixp b))
+           (equal (digitn (cat-r b x m y n) i b)
+                  (if (< i n)
+                      (digitn y i b)
+                    (if (< i (+ m n))
+                        (digitn x (- i n) b)
+                      0))))
+  :enable (digitn digits-cat-r))
+
+(defrule digitn-cat-r-constants
+  (implies (and (syntaxp (quotep n))
+                (syntaxp (quotep m))
+                (syntaxp (quotep i))
+                (natp n)
+                (natp m)
+                (natp i)
+                (radixp b))
+           (equal (digitn (cat-r b x m y n) i b)
+                  (if (< i n)
+                      (digitn y i b)
+                    (if (< i (+ m n))
+                        (digitn x (- i n) b)
+                      0))))
+  :use digitn-cat-r)
+
+(defund mulcat-r (l n x b)
+  (declare (xargs :guard (and (integerp l) (< 0 l) (acl2-numberp n) (natp x)
+                              (radixp b))))
+  (if (and (integerp n) (> n 0))
+                  (cat-r b (mulcat-r l (1- n) x b)
+                       (* l (1- n))
+                       x
+                       l)
+                0))
+
+(defruled mulcat-r-digits
+  (implies (and (integerp l)
+                (integerp x)
+                (radixp b))
+           (equal (mulcat-r l n (digits x (1- l) 0 b) b)
+                  (mulcat-r l n x b)))
+  :enable (mulcat-r cat-r-digits-2)
+  :induct (sub1-induction n))
+
+(defrule mulcat-r-dvecp
+  (implies (and (>= p (* l n))
+                (case-split (integerp p))
+                (case-split (natp l))
+                (radixp b))
+           (dvecp (mulcat-r l n x b) p b))
+  :enable mulcat-r
+  :induct (sub1-induction n))
+
+(defrule mulcat-r-1
+  (implies (and (natp l)
+                (radixp b))
+           (equal (mulcat-r l 1 x b)
+                  (digits x (1- l) 0 b)))
+  :enable mulcat-r)
+
+(defrule mulcat-r-0
+  (equal (mulcat-r l n 0 b) 0)
+  :enable (mulcat-r radix-cat)
+  :induct (sub1-induction n))
+
+(defrule mulcat-r-n-b1
+  (implies (and (case-split (<= 0 n))
+                (= b1 (1- b))
+                (radixp b))
+	   (equal (mulcat-r 1 n b1 b)
+		  (1- (expt b n))))
+  :enable (mulcat-r radix-cat)
+  :induct (sub1-induction n))
+
+(defrule digbitn-mulcat-r-1
+  (implies (and (< m n)
+                (case-split (dvecp x 1 b))
+                (case-split (natp m))
+                (case-split (integerp n))
+                (radixp b))
+           (equal (digitn (mulcat-r 1 n x b) m b)
+                  x))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (dvecp x 1 b)
+                    (natp m)
+                    (posp k)
+                    (radixp b))
+               (equal (digitn (mulcat-r 1 (+ k m) x b) m b)
+                      x))
+      :enable (mulcat-r digitn-cat-r)
+      :induct (sub1-induction m)))
+  :use (:instance lemma (k (- n m))))
 
 ;;;**********************************************************************
 ;;;			     CAT
@@ -710,72 +2251,44 @@
          (bits y (1- n) 0))
     0))
 
-;; We define a macro, CAT, that takes a list of alternating data values and
-;; sizes.  CAT-SIZE returns the formal sum of the sizes.  The list must contain
-;; at least 1 data/size pair, but we do not need to specify this in the guard,
-;; and leaving it out of the guard simplifies the guard proof.
+(local
+ (defrule binary-cat-as-radix-cat
+   (equal (binary-cat x m y n)
+          (radix-cat 2 x m y n))
+   :enable (binary-cat radix-cat)))
 
-(defun formal-+ (x y)
-  (declare (xargs :guard t))
-  (if (and (acl2-numberp x) (acl2-numberp y))
-      (+ x y)
-    (list '+ x y)))
-
-(defun cat-size (x)
-  (declare (xargs :guard (and (true-listp x) (evenp (length x)))))
-  (if (endp (cddr x))
-      (cadr x)
-    (formal-+ (cadr x)
-	      (cat-size (cddr x)))))
-
-(defmacro cat (&rest x)
-  (declare (xargs :guard (and x (true-listp x) (evenp (length x)))))
-  (cond ((endp (cddr x))
-         `(bits ,(car x) ,(formal-+ -1 (cadr x)) 0))
-        ((endp (cddddr x))
-         `(binary-cat ,@x))
-        (t
-         `(binary-cat ,(car x)
-                      ,(cadr x)
-                      (cat ,@(cddr x))
-                      ,(cat-size (cddr x))))))
-
-(defthm cat-nonnegative-integer-type
-  (and (integerp (cat x m y n))
-       (<= 0 (cat x m y n)))
-  :rule-classes (:type-prescription))
-
-(in-theory (disable (:type-prescription binary-cat)))
-
-(defthm cat-bvecp
+(defrule cat-bvecp
   (implies (and (<= (+ m n) k)
 		(case-split (integerp k)))
 	   (bvecp (cat x m y n) k)))
 
-(defthm cat-with-n-0
+(defrule cat-with-n-0
   (equal (binary-cat x m y 0)
 	 (bits x (1- m) 0)))
 
-(defthm cat-with-m-0
+(defrule cat-with-m-0
   (equal (binary-cat x 0 y n)
 	 (bits y (1- n) 0)))
 
-(defthmd cat-0
+(defruled cat-0
   (implies (and (case-split (bvecp y n))
 		(case-split (integerp n))
 		(case-split (integerp m))
 		(case-split (<= 0 m)))
-	   (equal (cat 0 m y n) y)))
+	   (equal (cat 0 m y n) y))
+  :enable cat-r-0)
 
-(defthmd cat-bits-1
+(defruled cat-bits-1
     (equal (cat (bits x (1- m) 0) m y n)
-	   (cat x m y n)))
+	   (cat x m y n))
+    :use (:instance cat-r-digits-1 (b 2)))
 
-(defthmd cat-bits-2
+(defruled cat-bits-2
     (equal (cat x m (bits y (1- n) 0) n)
-	   (cat x m y n)))
+	   (cat x m y n))
+    :use (:instance cat-r-digits-2 (b 2)))
 
-(defthm cat-associative
+(defrule cat-associative
   (implies (and (case-split (<= (+ m n) p))
 		(case-split (<= 0 m))
 		(case-split (<= 0 n))
@@ -787,7 +2300,7 @@
 	   (equal (cat (cat x m y n) p z q)
 		  (cat x m (cat y n z q) (+ n q)))))
 
-(defthmd cat-equal-constant
+(defruled cat-equal-constant
   (implies (and (syntaxp (and (quotep k)
 			      (quotep m)
 			      (quotep n)))
@@ -802,9 +2315,10 @@
 		(case-split (<= 0 n)))
 	   (equal (equal k (cat x m y n))
 		  (and (equal y (bits k (1- n) 0))
-		       (equal x (bits k (+ -1 m n) n))))))
+		       (equal x (bits k (+ -1 m n) n)))))
+  :use (:instance cat-r-equal-constant (b 2)))
 
-(defthmd cat-equal-rewrite
+(defruled cat-equal-rewrite
   (implies (and (case-split (bvecp x1 m))
 		(case-split (bvecp y1 n))
 		(case-split (bvecp x2 m))
@@ -816,9 +2330,10 @@
 	   (equal (equal (cat x1 m y1 n)
 			 (cat x2 m y2 n))
 		  (and (equal x1 x2)
-		       (equal y1 y2)))))
+		       (equal y1 y2))))
+  :enable cat-r-equal-rewrite)
 
-(defthm cat-bits-bits
+(defrule cat-bits-bits
   (implies (and (equal j (1+ k))
 		(equal n (+ 1 (- l) k))
 		(case-split (<= (+ 1 (- j) i) m))
@@ -831,7 +2346,7 @@
 	   (equal (cat (bits x i j) m (bits x k l) n)
 		  (bits x i l))))
 
-(defthm cat-bitn-bits
+(defrule cat-bitn-bits
     (implies (and (equal j (1+ k))
 		  (equal n (+ 1 (- l) k))
 		  (case-split (<= 1 m))
@@ -843,9 +2358,9 @@
 	     (equal (cat (bitn x j) m (bits x k l) n)
 		    (bits x j l))))
 
-(defthm cat-bits-bitn
+(defrule cat-bits-bitn
   (implies (and (equal j (1+ k))
-		(case-split (<= (+ 1 (- j) i) m))
+	(case-split (<= (+ 1 (- j) i) m))
 		(case-split (<= j i))
 		(case-split (integerp i))
 		(case-split (integerp j))
@@ -854,14 +2369,14 @@
 	   (equal (cat (bits x i j) m (bitn x k) 1)
 		  (bits x i k))))
 
-(defthm cat-bitn-bitn
+(defrule cat-bitn-bitn
   (implies (and (equal i (1+ j))
 		(case-split (integerp i))
 		(case-split (integerp j)))
 	   (equal (cat (bitn x i) 1 (bitn x j) 1)
 		  (bits x i j))))
 
-(defthmd bits-cat
+(defruled bits-cat
   (implies (and (case-split (natp n))
 		(case-split (natp m))
 		(case-split (natp i))
@@ -879,9 +2394,10 @@
 				      (1- m)) 0)
 			    (1+ (- i n))
 			    (bits y (1- n) j)
-			    (- n j)))))))
+			    (- n j))))))
+  :enable digits-cat-r)
 
-(defthm bits-cat-constants
+(defrule bits-cat-constants
   (implies (and (syntaxp (quotep n))
 		(syntaxp (quotep m))
 		(syntaxp (quotep i))
@@ -903,9 +2419,10 @@
 				     (1- m)) 0)
 			   (1+ (- i n))
 			   (bits y (1- n) j)
-			   (- n j)))))))
+			   (- n j))))))
+  :use bits-cat)
 
-(defthmd bitn-cat
+(defruled bitn-cat
   (implies (and (case-split (natp n))
 		(case-split (natp m))
 		(case-split (natp i)))
@@ -914,9 +2431,10 @@
 		      (bitn y i)
 		    (if (< i (+ m n))
 		      (bitn x (- i n))
-		    0)))))
+                      0))))
+  :enable digitn-cat-r)
 
-(defthm bitn-cat-constants
+(defrule bitn-cat-constants
   (implies (and (syntaxp (quotep n))
 		(syntaxp (quotep m))
 		(syntaxp (quotep i))
@@ -928,7 +2446,8 @@
 		      (bitn y i)
 		    (if (< i (+ m n))
 		      (bitn x (- i n))
-		    0)))))
+                      0))))
+  :use bitn-cat)
 
 ;; We introduce mbe for MULCAT not because we want particularly fast execution,
 ;; but because the existing logic definition does not satisfy the guard of cat,
@@ -951,39 +2470,39 @@
                           l))
                     (t 0))))
 
-(defthm mulcat-nonnegative-integer-type
-  (and (integerp (mulcat l n x))
-       (<= 0 (mulcat l n x)))
-  :rule-classes (:type-prescription))
+(local
+ (defrule mulcat-as-mulcat-r
+   (equal (mulcat l n x)
+          (mulcat-r l n x 2))
+   :enable (mulcat mulcat-r)))
 
-(in-theory (disable (:type-prescription mulcat)))
-
-(defthmd mulcat-bits
+(defruled mulcat-bits
     (implies (and (integerp l)
 		  (integerp x))
 	     (equal (mulcat l n (bits x (1- l) 0))
-		    (mulcat l n x))))
+		    (mulcat l n x)))
+    :enable mulcat-r-digits)
 
-(defthm mulcat-bvecp
+(defrule mulcat-bvecp
   (implies (and (>= p (* l n))
 		(case-split (integerp p))
 		(case-split (natp l)))
 	   (bvecp (mulcat l n x) p)))
 
-(defthm mulcat-1
+(defrule mulcat-1
     (implies (natp l)
 	     (equal (mulcat l 1 x)
 		    (bits x (1- l) 0))))
 
-(defthm mulcat-0
+(defrule mulcat-0
   (equal (mulcat l n 0) 0))
 
-(defthm mulcat-n-1
+(defrule mulcat-n-1
   (implies (case-split (<= 0 n))
 	   (equal (mulcat 1 n 1)
 		  (1- (expt 2 n)))))
 
-(defthm bitn-mulcat-1
+(defrule bitn-mulcat-1
   (implies (and (< m n)
 		(case-split (bvecp x 1))
 		(case-split (natp m))
@@ -991,77 +2510,171 @@
 	   (equal (bitn (mulcat 1 n x) m)
 		  x)))
 
+;;;**********************************************************************
+;;;		      Signed Integer Encodings with Radix
+;;;**********************************************************************
+
+(defund si-r (r n b)
+  (declare (xargs :guard (and (real/rationalp r)
+                              (integerp n)
+                              (radixp b))))
+  (let ((r (mod (realfix r) (expt b n))))
+    (if (>= r (/ (expt b n) 2))
+        (- r (expt b n))
+      r)))
+
+(defrule si-r-range
+  (implies (radixp b)
+           (and (< (si-r r n b) (/ (expt b n) 2))
+                (>= (si-r r n b) (- (/ (expt b n) 2)))))
+  :enable si-r
+  :rule-classes :linear)
+
+(acl2::with-arith5-nonlinear-help
+ (defruled si-r-even-b
+  (implies (and (radixp b)
+                (evenp b))
+           (equal (si-r r n b)
+                  (let ((r (realfix r))
+                        (b^n (expt b n)))
+                    (if (>= (digitn r (1- (ifix n)) b) (/ b 2))
+                        (- (mod r b^n) b^n)
+                    (mod r b^n)))))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help
+     (defrule lemma
+       (implies (and (real/rationalp r)
+                     (integerp n)
+                     (integerp d)
+                     (radixp b))
+                (equal (< (digitn r (1- n) b) d)
+                       (< (mod r (expt b n)) (* d (expt b (1- n))))))
+       :enable (digitn digits)
+       :use (:instance fl-def
+                       (x (* (mod r (expt b n)) (expt b (- 1 n)))))
+       :rule-classes ())))
+  :enable si-r
+  :use (:instance lemma
+         (r (realfix r))
+         (n (ifix n))
+         (d (/ b 2)))))
+
+(defrule si-r-digits
+  (implies (and (integerp x)
+                (< x (/ (expt b n) 2))
+                (>= x (- (/ (expt b n) 2)))
+                (radixp b))
+           (= (si-r (digits x (1- n) 0 b) n b)
+              x))
+  :enable si-r
+  :use (:instance digits-tail-gen (i (1- n)))
+  :rule-classes ())
+
+(defruled digits-si-r
+  (implies (and (integerp n)
+                (< i n)
+                (radixp b))
+           (equal (digits (si-r r n b) i j b)
+                  (digits r i j b)))
+  :enable si-r
+  :cases ((and (integerp i) (integerp j)))
+  :hints (("subgoal 1" :in-theory (enable mod-digits-equal-cor)
+          :use (:instance digits-plus-mult-2-rewrite
+                          (x (mod r (expt b n)))
+                          (c (- (expt b n)))
+                          (n i)
+                          (m j)))))
+
+(defund sextend-r (m n r b)
+  (declare (xargs :guard (and (real/rationalp r)
+                              (integerp m)
+                              (integerp n)
+                              (radixp b))))
+  (digits (si-r r n b) (1- m) 0 b))
+
+(defruled si-r-sextend-r
+  (implies (and (integerp r)
+                (integerp n)
+                (integerp m)
+                (<= n m)
+                (radixp b))
+           (equal (si-r (sextend-r m n r b) m b)
+                  (si-r r n b)))
+  :enable (sextend-r)
+  :use (:instance si-r-digits
+                  (x (si-r r n b))
+                  (n m)))
 
 ;;;**********************************************************************
 ;;;		      Signed Integer Encodings
 ;;;**********************************************************************
-
-(defun intval (w x)
-  (if (= (bitn x (1- w)) 1)
-      (- x (expt 2 w))
-    x))
-
-(defthm intval-bits
-    (implies (and (integerp x)
-		  (natp w)
-		  (< x (expt 2 (1- w)))
-		  (>= x (- (expt 2 (1- w)))))
-	     (= (intval w (bits x (1- w) 0))
-                x))
-    :rule-classes nil)
-
-(defun sign-extend (n m x)
-  (bits (intval m x) (1- n) 0))
-
-(defthmd intval-sign-extend
-    (implies (and (natp n)
-		  (natp m)
-		  (<= m n)
-		  (bvecp x m))
-	     (equal (intval n (sign-extend n m x))
-		    (intval m x))))
 
 (defund si (r n)
   (if (= (bitn r (1- n)) 1)
       (- r (expt 2 n))
     r))
 
-(local-defthm si-rewrite
-  (equal (si r n) (intval n r))
-  :hints (("Goal" :in-theory (enable si))))
+(local
+ (defrule si-as-si-r
+   (implies (bvecp r n)
+            (equal (si r n)
+                   (si-r r n 2)))
+   :enable (si si-r-even-b)
+   :disable digits-n-n-rewrite
+   :cases ((integerp n))
+   :hints (("subgoal 2" :in-theory (enable digitn digits dvecp)))))
 
-(defthm si-bits
+(defrule si-bits
     (implies (and (integerp x)
 		  (natp n)
 		  (< x (expt 2 (1- n)))
 		  (>= x (- (expt 2 (1- n)))))
 	     (= (si (bits x (1- n) 0) n)
                 x))
-    :rule-classes ()
-  :hints (("Goal" :use ((:instance intval-bits (w n))))))
+    :disable bvecp-as-dvecp
+    :cases ((bvecp (bits x (1- n) 0) n))
+    :hints (
+      ("subgoal 2" :in-theory (enable bvecp-as-dvecp))
+      ("subgoal 1" :use (:instance si-r-digits (b 2))))
+    :rule-classes ())
 
-(defthmd bits-si
+(defruled bits-si
   (implies (and (integerp n)
                 (< i n))
            (equal (bits (si r n) i j)
                   (bits r i j)))
-  :hints (("Goal" :in-theory (enable si)
-                  :use (:instance bits-plus-mult-2 (n i) (k n) (y -1) (x r) (m j)))))
+  :enable si
+  :cases ((and (real/rationalp r) (integerp i)))
+  :hints (
+    ("subgoal 2" :in-theory (enable digits fl))
+    ("subgoal 1" :use (:instance digits-plus-mult-2-rewrite
+                          (x r)
+                          (c (- (expt 2 n)))
+                          (n i)
+                          (m j)
+                          (b 2)))))
 
 (defund sextend (m n r)
   (bits (si r n) (1- m) 0))
 
-(in-theory (disable intval))
+(local
+ (defrule sextend-as-sextend-r
+   (implies (and (natp n)
+                 (<= n m)
+                 (bvecp r n))
+            (equal (sextend m n r)
+                   (sextend-r m n r 2)))
+   :enable (sextend-r sextend)
+   :disable bvecp-as-dvecp))
 
-(local-defthm sextend-rewrite
-  (equal (sextend m n r) (sign-extend m n r))
-  :hints (("Goal" :in-theory (enable sextend))))
-
-(defthmd si-sextend
-    (implies (and (natp n)
-		  (natp m)
-		  (<= n m)
-		  (bvecp r n))
-	     (equal (si (sextend m n r) m)
-		    (si r n)))
-  :hints (("Goal" :use ((:instance intval-sign-extend (x r) (n m) (m n))))))
+(defruled si-sextend
+  (implies (and (natp n)
+                (natp m)
+                (<= n m)
+                (bvecp r n))
+           (equal (si (sextend m n r) m)
+                  (si r n)))
+  :enable si-r-sextend-r
+  :disable bvecp-as-dvecp
+  :cases ((bvecp (sextend m n r) m))
+  :hints (("subgoal 2" :in-theory (enable bvecp-as-dvecp sextend-r))))

--- a/books/rtl/rel11/support/float.lisp
+++ b/books/rtl/rel11/support/float.lisp
@@ -1,226 +1,474 @@
 (in-package "RTL")
 
-(local (include-book "../rel9-rtl-pkg/lib/top"))
+(include-book "tools/with-arith5-help" :dir :system)
+(local (acl2::allow-arith5-help))
+(local (in-theory (acl2::enable-arith5)))
 
-(include-book "../rel9-rtl-pkg/lib/util")
+(local (include-book "basic"))
+(include-book "definitions")
+(include-book "projects/quadratic-reciprocity/euclid" :dir :system)
 
-(local (include-book "arithmetic-5/top" :dir :system))
+(defrule abs-type
+  (implies (real/rationalp x)
+           (real/rationalp (abs x)))
+  :rule-classes :type-prescription)
 
-;; The following lemmas from arithmetic-5 have given me trouble:
+;;;**********************************************************************
+;;;                 Sign, Significand, and Exponent with Radix
+;;;**********************************************************************
 
-(local-in-theory #!acl2(disable |(mod (+ x y) z) where (<= 0 z)| |(mod (+ x (- (mod a b))) y)| |(mod (mod x y) z)| |(mod (+ x (mod a b)) y)|
-                    simplify-products-gather-exponents-equal mod-cancel-*-const cancel-mod-+ reduce-additive-constant-<
-                    |(floor x 2)| |(equal x (if a b c))| |(equal (if a b c) x)|))
+(defrule signum-minus
+  (equal (signum (- x)) (- (signum (fix x)))))
 
-;; From basic.lisp:
-
-(defund fl (x)
-  (declare (xargs :guard (real/rationalp x)))
-  (floor x 1))
-
-;; From bits.lisp:
-
-(defund bvecp (x k)
-  (declare (xargs :guard (integerp k)))
-  (and (integerp x)
-       (<= 0 x)
-       (< x (expt 2 k))))
-
-(defund bits (x i j)
-  (declare (xargs :guard (and (integerp x)
-                              (integerp i)
-                              (integerp j))))
-  (mbe :logic (if (or (not (integerp i))
-                      (not (integerp j)))
-                  0
-                (fl (/ (mod x (expt 2 (1+ i))) (expt 2 j))))
-       :exec  (if (< i j)
-                  0
-                (logand (ash x (- j)) (1- (ash 1 (1+ (- i j))))))))
-
-(defund bitn (x n)
-  (declare (xargs :guard (and (integerp x)
-                              (integerp n))))
-  (mbe :logic (bits x n n)
-       :exec  (if (evenp (ash x (- n))) 0 1)))
-
-
-;;---------------------------------------------------------------------------
-
-#|
-Lemma(exactp-factors): Assume that x and y are k-exact for some k.  If xy is non-zero and p-exact, then so are x and y.
-
-Proof: Let m and n be the smallest integers such that x' = 2^n*x and y' = 2^m*y are integers.  Thus, x' and y' are odd.
-Since x, y, or x*y, respectively, is p-exact iff x', y', or x'*y' is p-exact, we may replace x and y with
-x' and y'.  That is, we may assume without loss of generality that x and y are odd integers.
-
-An odd integer z is p-exact iff |z| < 2^p.  Thus, since xy is p-exact, xy < 2^p, which implies x < 2^p and
-y < 2^p, and hence x and y are p-exact.
-|#
-
-(local-defun pow2 (n)
-  (if (or (zp n) (oddp n))
-      0
-    (1+ (pow2 (/ n 2)))))
-
-(local-defthmd pow2-oddp-1
-  (implies (integerp n)
-           (equal (expt 2 (1- n))
-                  (* 1/2 (expt 2 n))))
-  :hints (("Goal" :use ((:instance expt (r 2) (i n))
-                        (:instance expt (r 2) (i (1- n)))))))
-
-(local-defthm pow2-oddp
-  (implies (not (zp n))
-           (and (integerp (/ n (expt 2 (pow2 n))))
-                (oddp (/ n (expt 2 (pow2 n))))))
-  :rule-classes ()
-  :hints (("Subgoal *1/3" :use ((:instance pow2-oddp-1 (n (- (pow2 (/ n 2)))))))
-          ("Subgoal *1/2" :use ((:instance pow2-oddp-1 (n (- (pow2 (/ n 2)))))))))
-
-(local-defthm exactp-factors-1
-  (implies (and (integerp x) (integerp y))
-           (integerp (* x y)))
+(defrule signum-mult
+  (implies (real/rationalp r)
+           (equal (signum (* x r))
+             (cond ((> r 0) (signum (fix x)))
+                   ((< r 0) (- (signum (fix x))))
+                   (t 0))))
   :rule-classes ())
 
-(local-defthm exactp-factors-2
-  (implies (and (integerp n)
-                (oddp n)
-                (not (zp k)))
-           (not (integerp (/ n (expt 2 k)))))
-  :rule-classes ()
-  :hints (("Goal" :use ((:instance pow2-oddp-1 (n k))
-                        (:instance exactp-factors-1 (x (/ n (expt 2 k))) (y (expt 2 (1- k))))))))
+(in-theory (disable signum))
 
-(local-defthm exactp-factors-3
-  (implies (and (integerp n)
-                (integerp k)
-                (oddp n))
-           (iff (integerp (* (expt 2 k) n))
-                (>= k 0)))
-  :rule-classes ()
-  :hints (("Goal" :use ((:instance exactp-factors-2 (k (- k)))))))
+(local (defrule e0-oridnalp-expo-measure
+  (e0-ordinalp (expo-measure x))))
 
-(local-defthm exactp-factors-4
-  (implies (and (integerp n)
-                (integerp k)
-                (oddp n))
-           (iff (exactp n k)
-                (> k (expo n))))
-  :rule-classes ()
-  :hints (("Goal" :use ((:instance exactp-factors-3 (k (- (1- k) (expo n)))))
-                  :in-theory (enable exactp2))))
+(defrule e0-ord-<-expo-measure
+  (implies (and (real/rationalp x)
+                (radixp b))
+           (and (implies (< x 0)
+                         (e0-ord-< (expo-measure (- x))
+                                   (expo-measure x)))
+                (implies (and (< 0 x) (< x 1))
+                         (e0-ord-< (expo-measure (* b x))
+                                   (expo-measure x)))
+                (implies (<= b x)
+                         (e0-ord-< (expo-measure (* (/ b) x))
+                                   (expo-measure x)))))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help (defrule lemma
+      (implies (and (real/rationalp x) (>= x 1) (radixp b))
+               (< (fl (* (/ b) x)) (fl x)))))))
 
-(local-defthm exactp-factors-5
-  (implies (and (integerp x)
-                (integerp y)
-                (oddp x)
-                (oddp y))
-           (>= (expo (* x y)) (expo x)))
-  :rule-classes ()
-  :hints (("Goal" :use ((:instance expo-monotone (y (* x y)))))))
+; e from IEEE 754-2008
+(defund expe (x b)
+  (declare (xargs :guard (and (real/rationalp x) (radixp b))
+                  :hints (("goal" :in-theory (disable expo-measure)))
+                  :well-founded-relation e0-ord-<
+                  :measure (expo-measure (realfix x))))
+  (cond ((not (mbt (real/rationalp x))) 0)
+        ((not (mbt (radixp b))) 0)
+        ((equal x 0) 0)
+        ((< x 0) (expe (- x) b))
+        ((< x 1) (1- (expe (* b x) b)))
+        ((< x b) 0)
+        (t (1+ (expe (/ x b) b)))))
 
-(local-defthm exactp-factors-6
-  (implies (integerp x)
-           (iff (oddp x) (= (mod x 2) 1)))
-  :rule-classes ()
-  :hints (("Goal" :use ((:instance fl-integerp (x (/ x 2)))
-                        (:instance mod-def (y 2))
-                        (:instance mod012 (m x)))
-                  :in-theory (disable fl-integerp))))
+(local (defrule expe-x=0
+  (equal (expe 0 b) 0)
+  :enable expe))
 
-(local-defthm exactp-factors-7
-  (implies (and (integerp x)
-                (integerp y)
-                (oddp x)
-                (oddp y))
-           (oddp (* x y)))
-  :hints (("Goal" :use (exactp-factors-6
-                        (:instance exactp-factors-6 (x y))
-                        (:instance exactp-factors-6 (x (* x y)))
-                        (:instance mod-mod-times (n 2) (a x) (b y))))))
+(local (defrule expe-x-default
+  (implies (not (real/rationalp x))
+           (equal (expe x b) 0))
+  :enable expe))
 
-(local-defthm exactp-factors-8
-  (implies (and (integerp x)
-                (integerp y)
-                (oddp x)
-                (oddp y)
-                (integerp k)
-                (exactp (* x y) k))
-           (exactp x k))
-  :rule-classes ()
-  :hints (("Goal" :use (exactp-factors-5
-                        exactp-factors-7
-                        (:instance exactp-factors-4 (n (* x y)))
-                        (:instance exactp-factors-4 (n x))))))
+(local (defrule expe-b-default
+  (implies (not (radixp b))
+           (equal (expe x b) 0))
+  :enable expe))
 
-(local-defthm exactp-factors-9
-  (implies (and (rationalp x)
-                (rationalp y)
-                (integerp k)
+; m from IEEE 754-2008
+(defund sigm (x b)
+  (declare (xargs :guard (and (real/rationalp x) (radixp b))))
+  (cond ((not (mbt (real/rationalp x))) 0)
+        ((not (mbt (radixp b))) 0)
+        (t (* (abs x) (expt b (- (expe x b)))))))
+
+(defrule sigm-type
+  (implies (radixp b)
+           (and (real/rationalp (sigm x b))
+                (>= (sigm x b) 0)))
+  :enable sigm
+  :rule-classes :type-prescription)
+
+(local (defrule sigm-x=0
+  (equal (sigm 0 b) 0)
+  :enable sigm))
+
+(local (defrule sigm-x-default
+  (implies (not (real/rationalp x))
+           (equal (sigm x b) 0))
+  :enable sigm))
+
+(local (defrule sigm-b-default
+  (implies (not (radixp b))
+           (equal (sigm x b) 0))
+  :enable sigm))
+
+(defrule expe-minus
+  (equal (expe (- x) b) (expe x b))
+  :expand ((expe (- x) b) (expe x b)))
+
+(defrule sigm-minus
+  (equal (sigm (- x) b) (sigm x b))
+  :enable sigm)
+
+(defruled expe-lower-bound
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (radixp b))
+           (<= (expt b (expe x b)) (abs x)))
+  :enable expe
+  :induct (expe x b)
+  :rule-classes :linear)
+
+(defruled expe-upper-bound
+    (implies (and (real/rationalp x) (radixp b))
+	     (< (abs x) (expt b (1+ (expe x b)))))
+  :enable expe
+  :induct (expe x b)
+  :rule-classes :linear)
+
+(defrule expe-unique
+  (implies (and (<= (expt b n) (abs x))
+                (< (abs x) (expt b (1+ n)))
+                (real/rationalp x)
                 (integerp n)
-                (not (zerop x))
-                (not (zerop y))
-                (exactp x k)
-                (exactp y k))
-           (let ((xp (/ (abs (* (expt 2 (- (1- k) (expo x))) x))
-                        (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x))))))
-                 (yp (/ (abs (* (expt 2 (- (1- k) (expo y))) y))
-                        (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y)))))))
-             (and (integerp xp)
-                  (oddp xp)
-                  (iff (exactp x n) (exactp xp n))
-                  (integerp yp)
-                  (oddp yp)
-                  (iff (exactp x n) (exactp xp n))
-                  (iff (exactp y n) (exactp yp n))
-                  (iff (exactp (* x y) n) (exactp (* xp yp) n)))))
-  :rule-classes ()
-  :hints (("Goal" :in-theory (enable exactp2)
-                  :use (exactp-minus
-                        (:instance exactp-minus (x y))
-                        (:instance exactp-minus (x (* x y)))
-                        (:instance exactp-shift (x (abs x)) (k (- (1- k) (+ (expo x) (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x)))))))
-                        (:instance exactp-shift (x (abs y)) (k (- (1- k) (+ (expo y) (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y)))))))
-                        (:instance exactp-shift (x (abs (* x y)))
-                                                (k (+ (- (1- k) (+ (expo x) (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x)))))
-                                                   (- (1- k) (+ (expo y) (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y))))))))
-                        (:instance pow2-oddp (n (abs (* (expt 2 (- (1- k) (expo x))) x))))
-                        (:instance pow2-oddp (n (abs (* (expt 2 (- (1- k) (expo y))) y))))))))
+                (radixp b))
+           (equal n (expe x b)))
+  :enable (expe-lower-bound expe-upper-bound)
+  :cases ((<= (1+ n) (expe x b))
+          (>= n (1+ (expe x b))))
+  :rule-classes ())
 
-(local-defthm exactp-factors
-  (implies (and (rationalp x)
-                (rationalp y)
-                (integerp k)
+(defrule fp-rep-em
+  (implies (radixp b)
+           (equal (realfix x) (* (signum x) (sigm x b) (expt b (expe x b)))))
+  :enable (signum sigm)
+  :rule-classes ())
+
+(defrule fp-abs-em
+  (implies (radixp b)
+           (equal (abs (realfix x)) (* (sigm x b) (expt b (expe x b)))))
+  :enable signum
+  :use fp-rep-em
+  :rule-classes ())
+
+(defruled expe>=
+    (implies (and (<= (expt b n) x)
+                  (real/rationalp x)
+		  (integerp n)
+                  (radixp b))
+	     (<= n (expe x b)))
+  :use expe-upper-bound
+  :cases ((>= n (1+ (expe x b))))
+  :rule-classes :linear)
+
+(defruled expe<=
+    (implies (and (< x (* b (expt b n)))
+                  (< 0 x)
+                  (real/rationalp x)
+		  (integerp n)
+                  (radixp b))
+	     (<= (expe x b) n))
+  :enable expe-lower-bound
+  :cases ((<= (1+ n) (expe x b)))
+  :rule-classes :linear)
+
+(defrule expe-b**n
+    (implies (and (integerp n)
+                  (radixp b))
+	     (equal (expe (expt b n) b)
+		    n))
+  :cases ((< (expe (expt b n) b) n)
+          (> (expe (expt b n) b) n))
+  :hints (
+    ("subgoal 2" :use (:instance expe>=
+                        (x (expt b n))))
+    ("subgoal 1" :use (:instance expe<=
+                        (x (expt b n))))))
+
+(defruled expe-monotone
+  (implies (and (<= (abs x) (abs y))
+                (case-split (real/rationalp x))
+                (case-split (not (equal x 0)))
+                (case-split (real/rationalp y))
+                (radixp b))
+           (<= (expe x b) (expe y b)))
+  :enable expe-lower-bound
+  :use (:instance expe>=
+         (x (abs y))
+         (n (expe x b)))
+  :rule-classes :linear)
+
+(defruled dvecp-expe
+    (implies (and (case-split (natp x))
+                  (case-split (radixp b)))
+	     (dvecp x (1+ (expe x b)) b))
+  :enable (dvecp expe-upper-bound)
+  :cases ((real/rationalp x)))
+
+(defruled mod-expe-2
+  (implies (and (< 0 x)
+                (real/rationalp x))
+           (equal (mod x (expt 2 (expe x 2)))
+                  (- x (expt 2 (expe x 2)))))
+  :enable (expe-lower-bound expe-upper-bound)
+  :use (:instance mod-force
+         (m x)
+         (n (expt 2 (expe x 2)))
+         (a 1)))
+
+(defruled sigm-lower-bound
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (radixp b))
+           (<= 1 (sigm x b)))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help (defrule lemma
+      (implies (and (radixp b) (<= (expt b (- n)) x))
+               (<= 1 (* x (expt b n)))))))
+  :enable sigm
+  :disable abs
+  :use expe-lower-bound
+  :rule-classes (:rewrite :linear))
+
+(defrule sigm-type-x-nonzero
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (radixp b))
+           (and (real/rationalp (sigm x b))
+                (> (sigm x b) 0)))
+  :enable sigm-lower-bound
+  :rule-classes :type-prescription)
+
+(defruled sigm-upper-bound
+  (implies (radixp b)
+           (< (sigm x b) b))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help (defrule lemma
+      (implies (and (radixp b) (< x (expt b (- n))))
+               (< (* x (expt b n)) 1)))))
+  :enable sigm
+  :disable abs
+  :use expe-upper-bound
+  :rule-classes (:rewrite :linear))
+
+(defrule expe-sigm
+  (equal (expe (sigm x b) b) 0)
+  :enable (sigm-lower-bound sigm-upper-bound)
+  :cases ((and (real/rationalp x) (not (= x 0)) (radixp b)))
+  :hints (
+    ("subgoal 2" :in-theory (enable sigm expe))
+    ("subgoal 1" :use (:instance  expe-unique
+                        (x (sigm x b))
+                        (n 0)))))
+
+(defruled sigm-self
+  (implies (and (real/rationalp x)
+                (<= 1 x)
+                (< x b)
+                (radixp b))
+           (equal (sigm x b) x))
+  :enable sigm
+  :use (:instance expe-unique
+         (n 0)))
+
+(defrule sigm-sigm
+  (equal (sigm (sigm x b) b)
+         (sigm x b))
+  :enable (sigm-lower-bound sigm-upper-bound)
+  :use (:instance sigm-self
+         (x (sigm x b)))
+  :cases ((and (real/rationalp x) (not (= x 0)) (radixp b)))
+  :hints (("subgoal 2" :in-theory (enable sigm))))
+
+(defrule fp-rep-em-unique
+  (implies (and (real/rationalp m)
+                (<= 1 m)
+                (< m b)
+                (integerp e)
+                (radixp b)
+                (= (abs x) (* m (expt b e))))
+           (and (= m (sigm x b))
+                (= e (expe x b))))
+  :enable sigm
+  :disable abs
+  :use (:instance expe-unique
+         (n e))
+  :cases ((real/rationalp x))
+  :hints (("subgoal 2" :in-theory (enable abs)))
+  :rule-classes ())
+
+(defruled signum-shift
+  (implies (and (real/rationalp x)
+                (radixp b))
+           (equal (signum (* x (expt b k)))
+                  (signum x)))
+  :use (:instance signum-mult
+         (r (expt b k))))
+
+(defruled expe-shift
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
                 (integerp n)
-                (not (zerop x))
-                (not (zerop y))
-                (exactp x k)
-                (exactp y k)
-                (exactp (* x y) n))
-           (exactp x n))
-  :rule-classes ()
-  :hints (("Goal" :use (exactp-factors-9
-                        (:instance exactp-factors-8 (k n)
-                                                    (x (/ (abs (* (expt 2 (- (1- k) (expo x))) x))
-                                                          (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x))))))
-                                                    (y (/ (abs (* (expt 2 (- (1- k) (expo y))) y))
-                                                          (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y)))))))))))
+                (radixp b))
+           (equal (expe (* (expt b n) x) b)
+                  (+ n (expe x b))))
+  :enable (expe-lower-bound)
+  :use ((:instance expe-unique
+          (x (* (expt b n) x))
+          (n (+ n (expe x b))))
+        expe-upper-bound))
 
-(local-defthmd expo-fp-
-  (implies (and (rationalp x)
-                (> x 0)
-                (not (= x (expt 2 (expo x))))
-                (integerp n)
-                (> n 0)
-                (exactp x n))
-           (equal (expo (fp- x n)) (expo x)))
-  :hints (("Goal" :use (expo-lower-bound expo-upper-bound
-                        (:instance fp-2 (y (expt 2 (expo x))))
-                        (:instance exactp-2**n (n (expo x)) (m n))
-                        (:instance expo<= (x (fp- x n)) (n (expo x)))
-                        (:instance expo>= (x (fp- x n)) (n (expo x)))))))
+(defruled sigm-shift
+  (equal (sigm (* x (expt b n)) b)
+         (sigm x b))
+  :enable (sigm)
+  :cases ((and (real/rationalp x) (not (= x 0)) (integerp n)))
+  :hints (
+    ("subgoal 2" :in-theory (enable expe expt))
+    ("subgoal 1" :use expe-shift)))
 
+(defruled signum-prod
+  (implies (and (case-split (real/rationalp x))
+                (case-split (real/rationalp y)))
+           (equal (signum (* x y))
+                  (* (signum x) (signum y))))
+  :enable signum)
+
+(defruled expe-prod
+    (implies (and (real/rationalp x)
+		  (not (= x 0))
+		  (real/rationalp y)
+		  (not (= y 0))
+                  (radixp b))
+	     (equal (expe (* x y) b)
+		    (if (< (* (sigm x b) (sigm y b)) b)
+			(+ (expe x b) (expe y b))
+		      (+ 1 (expe x b) (expe y b)))))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help (defrule lemma1
+      (implies (and (real/rationalp mx) (<= 1 mx) (< mx b) (integerp ex)
+                    (real/rationalp my) (<= 1 my) (< my b) (integerp ey)
+                    (radixp b))
+               (equal (expe (* (* mx (expt b ex)) (* my (expt b ey))) b)
+                      (if (< (* mx my) b) (+ ex ey) (+ 1 ex ey))))
+      :use (:instance expe-unique
+             (x (* (* mx (expt b ex)) (* my (expt b ey))))
+             (n (if (< (* mx my) b) (+ ex ey) (+ 1 ex ey))))))
+    (defrule lemma2
+      (implies (and (real/rationalp x) (> x 0)
+                    (real/rationalp y) (> y 0)
+                    (radixp b))
+	     (equal (expe (* x y) b)
+		    (if (< (* (sigm x b) (sigm y b)) b)
+			(+ (expe x b) (expe y b))
+		      (+ 1 (expe x b) (expe y b)))))
+      :enable (signum sigm-lower-bound sigm-upper-bound)
+      :use (
+        (:instance fp-rep-em
+          (x x))
+        (:instance fp-rep-em
+          (x y))
+        (:instance lemma1
+          (mx (sigm (abs x) b))
+          (ex (expe (abs x) b))
+          (my (sigm (abs y) b))
+          (ey (expe (abs y) b))))))
+  :use (:instance lemma2
+         (x (abs x))
+         (y (abs y))))
+
+(defruled expe-prod-lower
+    (implies (and (real/rationalp x)
+		  (not (= x 0))
+		  (real/rationalp y)
+		  (not (= y 0)))
+	     (<= (+ (expe x b) (expe y b)) (expe (* x y) b)))
+  :use expe-prod
+  :rule-classes :linear)
+
+(defruled expe-prod-upper
+    (implies (and (real/rationalp x)
+		  (not (= x 0))
+		  (real/rationalp y)
+		  (not (= y 0)))
+	     (>= (+ (expe x b) (expe y b) 1) (expe (* x y) b)))
+  :use expe-prod
+  :rule-classes :linear)
+
+(defruled sigm-prod
+    (implies (and (real/rationalp x)
+		  (not (= x 0))
+		  (real/rationalp y)
+		  (not (= y 0)))
+	     (equal (sigm (* x y) b)
+		    (if (< (* (sigm x b) (sigm y b)) b)
+			(* (sigm x b) (sigm y b))
+		      (* (/ b) (sigm x b) (sigm y b)))))
+  :enable (sigm expe-prod)
+  :disable abs
+  :cases ((equal (abs (* x y)) (* (abs x) (abs y))))
+  :hints (("subgoal 2" :in-theory(enable abs))))
+
+(defruled compare-abs-em
+  (implies (and (real/rationalp x)
+                (real/rationalp y)
+                (radixp b))
+           (equal (signum (- (abs x) (abs y)))
+                  (cond ((and (= x 0) (= y 0)) 0)
+                        ((= x 0) -1)
+                        ((= y 0) 1)
+                        ((< (expe x b) (expe y b)) -1)
+                        ((> (expe x b) (expe y b)) 1)
+                        ((< (sigm x b) (sigm y b)) -1)
+                        ((> (sigm x b) (sigm y b)) 1)
+                        (t 0))))
+  :prep-lemmas (
+    (defrule lemma1
+      (implies (and (real/rationalp mx) (<= 1 mx) (< mx b) (integerp ex)
+                    (real/rationalp my) (<= 1 my) (< my b) (integerp ey)
+                    (< ex ey)
+                    (radixp b))
+               (< (* mx (expt b ex)) (* my (expt b ey))))
+      :cases ((not (< (* mx (expt b ex)) (expt b (1+ ex))))
+              (not (>= (* my (expt b ey)) (expt b ey)))
+              (not (<= (expt b (1+ ex)) (expt b ey))))
+      :rule-classes ())
+    (defruled lemma2
+      (implies (and (real/rationalp mx) (<= 1 mx) (< mx b) (integerp ex)
+                    (real/rationalp my) (<= 1 my) (< my b) (integerp ey)
+                    (radixp b))
+               (equal (signum (- (* mx (expt b ex)) (* my (expt b ey))))
+                              (cond ((< ex ey) -1)
+                                    ((> ex ey) 1)
+                                    ((< mx my) -1)
+                                    ((> mx my) 1)
+                                    (t 0))))
+      :enable (acl2::scatter-exponents-theory signum)
+      :disable (acl2::gather-exponents-theory)
+      :cases ((= ex ey)
+              (< ex ey)
+              (> ex ey))
+      :hints (
+        ("subgoal 2" :use (:instance lemma1 (ex ex) (ey ey) (mx mx) (my my)))
+        ("subgoal 1" :use (:instance lemma1 (ex ey) (ey ex) (mx my) (my mx))))))
+  :enable (signum sigm-upper-bound)
+  :cases ((= x 0)
+          (= y 0))
+  :hints (
+    ("subgoal 3" :in-theory (disable abs) :use (
+      (:instance fp-abs-em
+        (x x))
+      (:instance fp-abs-em
+        (x y))
+      (:instance lemma2
+                        (ex (expe x b))
+                        (ey (expe y b))
+                        (mx (sigm x b))
+                        (my (sigm y b)))))))
 
 ;;;**********************************************************************
 ;;;                 Sign, Significand, and Exponent
@@ -249,48 +497,78 @@ y < 2^p, and hence x and y are p-exact.
         (* x (expt 2 (- (expo x)))))
     0))
 
-(defthmd expo-lower-bound
+(local (defrule sgn-as-signum
+  (equal (sgn x)
+         (if (rationalp x) (signum x) 0))
+  :enable (sgn signum)))
+
+(local (defrule expo-as-expe
+  (equal (expo x)
+         (if (rationalp x) (expe x 2) 0))
+  :enable (expo expe)))
+
+(local (defrule sig-as-sigm
+  (equal (sig x)
+         (if (rationalp x) (sigm x 2) 0))
+  :enable (sig sigm)))
+
+(defthm expo-minus
+  (implies (rationalp x)
+           (equal (expo (- x)) (expo x))))
+
+(defthm sig-minus
+  (implies (rationalp x)
+           (equal (sig (- x)) (sig x))))
+
+(defruled expo-lower-bound
     (implies (and (rationalp x)
 		  (not (equal x 0)))
 	     (<= (expt 2 (expo x)) (abs x)))
+  :enable expe-lower-bound
   :rule-classes :linear)
 
-(defthmd expo-upper-bound
+(defruled expo-upper-bound
     (implies (and (rationalp x))
 	     (< (abs x) (expt 2 (1+ (expo x)))))
+  :enable expe-upper-bound
   :rule-classes :linear)
 
-(defthm expo-unique
+(defrule expo-unique
   (implies (and (<= (expt 2 n) (abs x))
                 (< (abs x) (expt 2 (1+ n)))
                 (rationalp x)
                 (integerp n))
            (equal n (expo x)))
+  :use (:instance expe-unique (b 2))
   :rule-classes ())
 
-(defthm fp-rep
+(defrule fp-rep
     (implies (rationalp x)
 	     (equal x (* (sgn x) (sig x) (expt 2 (expo x)))))
+  :use (:instance fp-rep-em (b 2))
   :rule-classes ())
 
-(defthm fp-abs
+(defrule fp-abs
     (implies (rationalp x)
 	     (equal (abs x) (* (sig x) (expt 2 (expo x)))))
+  :use (:instance fp-abs-em (b 2))
   :rule-classes ())
 
-(defthmd expo>=
+(defruled expo>=
     (implies (and (<= (expt 2 n) x)
                   (rationalp x)
 		  (integerp n))
 	     (<= n (expo x)))
+  :enable expe>=
   :rule-classes :linear)
 
-(defthmd expo<=
+(defruled expo<=
     (implies (and (< x (* 2 (expt 2 n)))
                   (< 0 x)
                   (rationalp x)
 		  (integerp n))
 	     (<= (expo x) n))
+  :use (:instance expe<= (b 2))
   :rule-classes :linear)
 
 (defthm expo-2**n
@@ -298,61 +576,58 @@ y < 2^p, and hence x and y are p-exact.
 	     (equal (expo (expt 2 n))
 		    n)))
 
-(defthmd expo-monotone
+(defruled expo-monotone
   (implies (and (<= (abs x) (abs y))
                 (case-split (rationalp x))
                 (case-split (not (equal x 0)))
                 (case-split (rationalp y)))
            (<= (expo x) (expo y)))
+  :use (:instance expe-monotone (b 2))
   :rule-classes :linear)
 
-(defthmd bvecp-expo
+(defruled bvecp-expo
     (implies (case-split (natp x))
-	     (bvecp x (1+ (expo x)))))
+	     (bvecp x (1+ (expo x))))
+  :enable (bvecp dvecp)
+  :use (:instance dvecp-expe (b 2)))
 
-(defthmd mod-expo
+(defruled mod-expo
   (implies (and (< 0 x)
                 (rationalp x))
            (equal (mod x (expt 2 (expo x)))
-                  (- x (expt 2 (expo x))))))
+                  (- x (expt 2 (expo x)))))
+  :enable mod-expe-2)
 
-(defthmd sig-lower-bound
+(defruled sig-lower-bound
   (implies (and (rationalp x)
                 (not (equal x 0)))
            (<= 1 (sig x)))
+  :enable sigm-lower-bound
   :rule-classes (:rewrite :linear))
 
-(defthmd sig-upper-bound
+(defruled sig-upper-bound
   (< (sig x) 2)
+  :enable sigm-upper-bound
   :rule-classes (:rewrite :linear))
-
-(defthmd sig-self
-  (implies (and (rationalp x)
-                (<= 1 x)
-                (< x 2))
-           (equal (sig x) x)))
-
-(defthm sig-sig
-    (equal (sig (sig x))
-	   (sig x)))
-
-(defthm expo-minus
-  (implies (rationalp x)
-           (equal (expo (- x)) (expo x)))
-  :hints (("Goal" :in-theory (enable expo))))
-
-(defthm sig-minus
-  (implies (rationalp x)
-           (equal (sig (- x)) (sig x)))
-  :hints (("Goal" :in-theory (enable sig))))
 
 (defthm expo-sig
   (implies (rationalp x)
-           (equal (expo (sig x)) 0))
-  :hints (("Goal" :in-theory (enable expo)
-                  :use (sig-upper-bound sig-lower-bound))))
+           (equal (expo (sig x)) 0)))
 
-(defthm fp-rep-unique
+(defruled sig-self
+  (implies (and (rationalp x)
+                (<= 1 x)
+                (< x 2))
+           (equal (sig x) x))
+  :enable sigm-self)
+
+(defrule sig-sig
+    (equal (sig (sig x))
+	   (sig x))
+  :cases ((rationalp (sig x)))
+  :use (:instance sigm-sigm (b 2)))
+
+(defrule fp-rep-unique
     (implies (and (rationalp x)
 		  (rationalp m)
 		  (<= 1 m)
@@ -361,30 +636,35 @@ y < 2^p, and hence x and y are p-exact.
 		  (= (abs x) (* m (expt 2 e))))
 	     (and (= m (sig x))
 		  (= e (expo x))))
+  :use (:instance fp-rep-em-unique (b 2))
   :rule-classes ())
 
-(defthmd sgn-shift
+(defruled sgn-shift
   (equal (sgn (* x (expt 2 k)))
-         (sgn x)))
+         (sgn x))
+  :enable signum-shift)
 
-(defthmd expo-shift
+(defruled expo-shift
   (implies (and (rationalp x)
                 (not (equal x 0))
                 (integerp n))
            (equal (expo (* (expt 2 n) x))
-                  (+ n (expo x)))))
+                  (+ n (expo x))))
+  :use (:instance expe-shift (b 2)))
 
-(defthmd sig-shift
+(defruled sig-shift
   (equal (sig (* (expt 2 n) x))
-         (sig x)))
+         (sig x))
+  :use (:instance sigm-shift (b 2)))
 
-(defthmd sgn-prod
+(defruled sgn-prod
   (implies (and (case-split (rationalp x))
                 (case-split (rationalp y)))
            (equal (sgn (* x y))
-                  (* (sgn x) (sgn y)))))
+                  (* (sgn x) (sgn y))))
+  :enable signum-prod)
 
-(defthmd expo-prod
+(defruled expo-prod
     (implies (and (rationalp x)
 		  (not (= x 0))
 		  (rationalp y)
@@ -392,25 +672,28 @@ y < 2^p, and hence x and y are p-exact.
 	     (equal (expo (* x y))
 		    (if (< (* (sig x) (sig y)) 2)
 			(+ (expo x) (expo y))
-		      (+ 1 (expo x) (expo y))))))
+		      (+ 1 (expo x) (expo y)))))
+  :enable expe-prod)
 
-(defthmd expo-prod-lower
+(defruled expo-prod-lower
     (implies (and (rationalp x)
 		  (not (= x 0))
 		  (rationalp y)
 		  (not (= y 0)))
 	     (<= (+ (expo x) (expo y)) (expo (* x y))))
+  :enable expe-prod-lower
   :rule-classes :linear)
 
-(defthmd expo-prod-upper
+(defruled expo-prod-upper
     (implies (and (rationalp x)
 		  (not (= x 0))
 		  (rationalp y)
 		  (not (= y 0)))
 	     (>= (+ (expo x) (expo y) 1) (expo (* x y))))
+  :enable expe-prod-upper
   :rule-classes :linear)
 
-(defthmd sig-prod
+(defruled sig-prod
     (implies (and (rationalp x)
 		  (not (= x 0))
 		  (rationalp y)
@@ -418,8 +701,1125 @@ y < 2^p, and hence x and y are p-exact.
 	     (equal (sig (* x y))
 		    (if (< (* (sig x) (sig y)) 2)
 			(* (sig x) (sig y))
-		      (* 1/2 (sig x) (sig y))))))
+		      (* 1/2 (sig x) (sig y)))))
+  :enable sigm-prod)
 
+;;;**********************************************************************
+;;;                 Integer Significand with its corresponding Exponent
+;;;**********************************************************************
+
+; q from IEEE 754-2008
+(defund expq (x p b)
+  (declare (xargs :guard (and (real/rationalp x) (integerp p) (radixp b))))
+  (- (expe x b) (1- p)))
+
+(defrule expq-type
+  (implies
+    (integerp p)
+    (integerp (expq x p b)))
+  :enable expq
+  :rule-classes :type-prescription)
+
+(local (defrule expq-x=0
+  (equal (expq 0 p b) (- 1 p))
+  :enable expq))
+
+(local (defrule expq-x-default
+  (implies (not (real/rationalp x))
+           (equal (expq x p b) (- 1 p)))
+  :enable expq))
+
+(local (defrule expq-b-default
+  (implies (not (radixp b))
+           (equal (expq x p b) (- 1 p)))
+  :enable expq))
+
+; c from IEEE 754-2008
+(defund sigc (x p b)
+  (declare (xargs :guard (and (real/rationalp x) (integerp p) (radixp b))))
+  (* (sigm x b) (expt b (1- p))))
+
+(local (defrule sigc-x=0
+  (equal (sigc 0 p b) 0)
+  :enable sigc))
+
+(local (defrule sigc-x-default
+  (implies (not (real/rationalp x))
+           (equal (sigc x p b) 0))
+  :enable sigc))
+
+(local (defrule sigc-p-default
+  (implies
+    (not (integerp p))
+    (equal (sigc x p b)
+           (if (acl2-numberp p)
+               (sigm x b)
+               (/ (sigm x b) b))))
+  :enable sigc))
+
+(local (defrule sigc-b-default
+  (implies (not (radixp b))
+           (equal (sigc x p b) 0))
+  :enable sigc))
+
+(defrule expq-minus
+  (equal (expq (- x) p b) (expq x p b))
+  :enable expq)
+
+(defrule sigc-minus
+  (equal (sigc (- x) p b) (sigc x p b))
+  :enable sigc)
+
+(defruled expq-lower-bound
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (radixp b))
+           (<= (expt b (+ -1 p (expq x p b))) (abs x)))
+  :enable (expq expe-lower-bound)
+  :disable abs
+  :rule-classes :linear)
+
+(defruled expq-upper-bound
+    (implies (and (real/rationalp x)
+                  (radixp b))
+	     (< (abs x) (expt b (+ p (expq x p b)))))
+  :enable (expq expe-upper-bound)
+  :rule-classes :linear)
+
+(defrule expq-unique
+  (implies (and (<= (expt b (+ -1 n p)) (abs x))
+                (< (abs x) (expt b (+ n p)))
+                (integerp n)
+                (real/rationalp x)
+                (radixp b))
+           (equal n (expq x p b)))
+  :enable expq
+  :use (:instance expe-unique
+         (n (+ -1 n p)))
+  :rule-classes ())
+
+(defrule fp-rep-qc
+  (implies (and (real/rationalp x)
+                (integerp p)
+                (radixp b))
+           (equal x (* (signum x) (sigc x p b) (expt b (expq x p b)))))
+  :enable (sigc expq)
+  :use fp-rep-em
+  :rule-classes ())
+
+(defrule fp-abs-qc
+  (implies (and (real/rationalp x)
+                (integerp p)
+                (radixp b))
+           (equal (abs x) (* (sigc x p b) (expt b (expq x p b)))))
+  :enable (sigc expq)
+  :use fp-abs-em
+  :rule-classes ())
+
+(defruled expq>=
+    (implies (and (<= (expt b (+ -1 n p)) x)
+                  (real/rationalp x)
+		  (integerp n)
+                  (integerp p)
+                  (radixp b))
+	     (<= n (expq x p b)))
+  :enable (expq expe>=)
+  :rule-classes :linear)
+
+(defruled expq<=
+    (implies (and (< x (expt b (+ n p)))
+                  (< 0 x)
+                  (real/rationalp x)
+		  (integerp n)
+                  (integerp p)
+                  (radixp b))
+	     (<= (expq x p b) n))
+  :enable (expq)
+  :use (:instance expe<=
+         (n (+ -1 n p)))
+  :rule-classes :linear)
+
+(defrule expq-b**n
+    (implies (and (integerp n)
+                  (radixp b))
+	     (equal (expq (expt b n) p b)
+		    (+ 1 n (- p))))
+  :enable expq)
+
+(defruled expq-monotone
+  (implies (and (<= (abs x) (abs y))
+                (case-split (real/rationalp x))
+                (case-split (not (equal x 0)))
+                (case-split (real/rationalp y))
+                (radixp b))
+           (<= (expq x p b) (expq y p b)))
+  :enable (expq expe-monotone)
+  :disable abs)
+
+(defruled dvecp-expq
+    (implies (and (case-split (natp x))
+                  (case-split (radixp b)))
+	     (dvecp x (+ p (expq x p b)) b))
+  :enable (expq dvecp-expe))
+
+(defruled mod-expq-2
+  (implies (and (< 0 x)
+                (real/rationalp x))
+           (equal (mod x (expt 2 (+ -1 p (expq x p 2))))
+                  (- x (expt 2 (+ -1 p (expq x p 2))))))
+  :enable (expq mod-expe-2))
+
+(defruled sigc-lower-bound
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (radixp b))
+           (<= (expt b (1- p)) (sigc x p b)))
+  :enable sigc
+  :rule-classes (:rewrite (:linear :trigger-terms ((sigc x p b)))))
+
+(defrule sigc-type-x-nonzero
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (radixp b))
+           (and (real/rationalp (sigc x p b))
+                (> (sigc x p b) 0)))
+  :enable sigc
+  :rule-classes :type-prescription)
+
+(defruled sigc-upper-bound
+  (implies (and (integerp p)
+                (radixp b))
+           (< (sigc x p b) (expt b p)))
+  :enable (sigc sigm-upper-bound)
+  :rule-classes (:rewrite (:linear :trigger-terms ((sigc x p b)))))
+
+(defrule expq-sigc
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (integerp p)
+                (radixp b))
+           (equal (expq (sigc x p b) p b) 0))
+  :enable (sigc expq sigm)
+  :cases ((and (real/rationalp x) (> x 0))
+          (and (real/rationalp x) (< x 0)))
+  :hints (
+    ("subgoal 2" :use (:instance expe-shift
+                       (n (- (expq x p b)))))
+    ("subgoal 1" :use (:instance expe-shift
+                        (n (- (expq x p b)))))))
+
+(defruled sigc-self
+  (implies (and (real/rationalp x)
+                (integerp p)
+                (radixp b)
+                (<= (expt b (1- p)) x)
+                (< x (expt b p)))
+           (equal (sigc x p b) x))
+  :enable signum
+  :cases ((equal (expq x p b) 0))
+  :hints (
+    ("subgoal 2" :use (:instance expq-unique
+                        (n 0)))
+    ("subgoal 1" :use fp-rep-qc)))
+
+(defrule sigm-sigc
+  (implies (radixp b)
+           (equal (sigm (sigc x p b) b)
+                  (sigm x b)))
+  :enable sigc
+  :cases ((not (acl2-numberp p))
+          (integerp p))
+  :hints (
+    ("subgoal 2" :use (:instance sigm-shift
+                        (x (sigm x b))
+                        (n -1)))
+    ("subgoal 1" :use (:instance sigm-shift
+                        (x (sigm x b))
+                        (n (1- p))))))
+
+(defrule sigc-sigm
+  (implies (radixp b)
+           (equal (sigc (sigm x b) p b)
+                  (sigc x p b)))
+  :enable sigc)
+
+(defrule sigc-sigc
+ (implies (radixp b)
+          (equal (sigc (sigc x s b) p b)
+                 (sigc x p b)))
+  :disable sigm-sigc
+  :cases ((equal (sigm (sigc x s b) b) (sigm x b)))
+  :hints (
+    ("subgoal 2" :in-theory (enable sigm-sigc))
+    ("subgoal 1" :in-theory (enable sigc))))
+
+(defrule fp-rep-qc-unique
+  (implies (and (real/rationalp c)
+                (<= (expt b (1- p)) c)
+                (< c (expt b p))
+                (integerp q)
+                (= (abs x) (* c (expt b q)))
+                (integerp p)
+                (radixp b))
+           (and (= c (sigc x p b))
+                (= q (expq x p b))))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help (defrule lemma1
+      (implies
+        (and
+          (<= (expt b (- n)) c)
+          (posp b))
+        (>= (* c (expt b n)) 1))
+      :rule-classes :linear))
+    (acl2::with-arith5-nonlinear-help (defrule lemma2
+      (implies
+        (and
+          (< c (expt b (- n)))
+          (posp b))
+        (<  (* c (expt b n)) 1))
+      :rule-classes :linear)))
+  :enable (sigc expq)
+  :disable abs
+  :use (:instance fp-rep-em-unique
+         (m (/ c (expt b (- p 1))))
+         (e (+ q (1- p))))
+  :rule-classes ())
+
+(defruled expq-shift
+  (implies (and (real/rationalp x)
+                (not (equal x 0))
+                (integerp n)
+                (integerp p)
+                (radixp b))
+           (equal (expq (* (expt b n) x) p b)
+                  (+ n (expq x p b))))
+  :enable (expq-lower-bound)
+  :use ((:instance expq-unique
+          (x (* (expt b n) x))
+          (n (+ n (expq x p b))))
+        expq-upper-bound))
+
+(defruled sigc-shift
+  (implies (and (integerp p)
+                (radixp b))
+           (equal (sigc (* x (expt b n)) p b)
+                  (sigc x p b)))
+  :enable (sigc expq sigm-shift))
+
+(defruled expq-prod
+  (implies (and (real/rationalp x)
+                (not (= x 0))
+                (real/rationalp y)
+                (not (= y 0))
+                (integerp p)
+                (radixp b))
+           (equal (expq (* x y) p b)
+                  (if (< (* (sigc x p b) (sigc y p b))
+                         (expt b (+ -1 (* 2 p))))
+                      (+ -1 p (expq x p b) (expq y p b))
+                    (+ p (expq x p b) (expq y p b)))))
+  :enable (sigc expq expe-prod))
+
+(defruled expq-prod-lower
+    (implies (and (real/rationalp x)
+		  (not (= x 0))
+		  (real/rationalp y)
+		  (not (= y 0))
+                  (integerp p)
+                  (radixp b))
+	     (<= (+ -1 p (expq x p b) (expq y p b)) (expq (* x y) p b)))
+  :use expq-prod
+  :rule-classes :linear)
+
+(defruled expq-prod-upper
+    (implies (and (real/rationalp x)
+		  (not (= x 0))
+		  (real/rationalp y)
+		  (not (= y 0))
+                  (integerp p)
+                  (radixp b))
+	     (>= (+ p (expq x p b) (expq y p b) 1) (expq (* x y) p b)))
+  :use expq-prod
+  :rule-classes :linear)
+
+(defruled sigc-prod
+  (implies (and (real/rationalp x)
+                (not (= x 0))
+                (real/rationalp y)
+                (not (= y 0))
+                (integerp p)
+                (radixp b))
+           (equal (sigc (* x y) p b)
+                  (* (expt b
+                           (if (< (* (sigc x p b) (sigc y p b))
+                                  (expt b (+ -1 (* 2 p))))
+                               (- 1 p)
+                             (- p)))
+                     (sigc x p b)
+                     (sigc y p b))))
+  :enable (sigc expq sigm-prod))
+
+(defruled compare-abs-qc
+  (implies (and (real/rationalp x) (> x 0)
+                (real/rationalp y) (> y 0)
+                (integerp p)
+                (radixp b))
+           (equal (signum (- (abs x) (abs y)))
+                  (cond ((and (= x 0) (= y 0)) 0)
+                        ((= x 0) -1)
+                        ((= y 0) 1)
+                        ((< (expq x p b) (expq y p b)) -1)
+                        ((> (expq x p b) (expq y p b)) 1)
+                        ((< (sigc x p b) (sigc y p b)) -1)
+                        ((> (sigc x p b) (sigc y p b)) 1)
+                        (t 0))))
+  :enable (expq sigc)
+  :use compare-abs-em)
+
+;;;**********************************************************************
+;;;                          Exactness with Radix
+;;;**********************************************************************
+
+(defnd exactrp (x p b)
+  (and (real/rationalp x)
+       (integerp p)
+       (radixp b)
+       (integerp (sigc x p b))))
+
+(defrule exactrp-forward
+  (implies (exactrp x p b)
+           (and (rationalp x)
+                (integerp p)
+                (radixp b)))
+  :enable (exactrp sigc sigm)
+  :rule-classes :forward-chaining)
+
+(defruled exactrp-forward-p<1
+  (implies (and (exactrp x p b)
+                (< p 1))
+           (= x 0))
+  :enable (exactrp sigc-upper-bound)
+  :cases ((< (sigc x p b) 1))
+  :rule-classes :forward-chaining)
+
+(defruled exactrp-forward-p<1-2
+  (implies (exactrp x p b)
+           (implies (< p 1) (= x 0)))
+  :enable (exactrp sigc-upper-bound)
+  :cases ((< (sigc x p b) 1))
+  :rule-classes :forward-chaining)
+
+(local (defrule exactrp-x=0
+  (equal (exactrp 0 p b)
+         (and (integerp p)
+              (radixp b)))
+  :enable exactrp))
+
+(defrule exactrp-sigm
+  (equal (exactrp (sigm x b) p b)
+         (if (real/rationalp x)
+             (exactrp x p b)
+             (and (integerp p) (radixp b))))
+  :enable exactrp)
+
+(defrule exactrp-sigc
+  (equal (exactrp (sigc x s b) p b)
+         (if (real/rationalp x)
+             (exactrp x p b)
+             (and (integerp p) (radixp b))))
+  :enable (exactrp sigc)
+  :use (:instance sigm-shift
+         (x (sigm x b))
+         (n (1- (ifix s)))))
+
+(defrule minus-exactrp
+  (equal (exactrp (- x) p b)
+         (exactrp (fix x) p b))
+  :enable (exactrp))
+
+(defthm exactrp-abs
+  (equal (exactrp (abs x) p b)
+         (exactrp x p b)))
+
+(defruled exactrp-shift
+  (implies (integerp p)
+           (equal (exactrp (* (expt b k) x) p b)
+                  (exactrp (fix x) p b)))
+  :enable (exactrp sigc expq sigm-shift))
+
+(defruled exactrp-<=
+  (implies (and (exactrp x s b)
+                (<= s p)
+                (integerp p))
+           (exactrp x p b))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (integerp m)
+                    (natp n)
+                    (radixp b)
+                    (integerp (* x (expt b m))))
+               (integerp (* x (expt b (+ n m)))))
+      :enable (acl2::scatter-exponents-theory)
+      :disable (acl2::gather-exponents-theory)
+      :rule-classes ()))
+  :enable (exactrp sigc)
+  :use (:instance lemma
+         (x (sigm x b))
+         (m (1- s))
+         (n (- p s))))
+
+(defruled exactrp-b**n
+  (equal (exactrp (expt b n) p b)
+         (and (posp p)
+              (radixp b)))
+  :enable (exactrp sigc sigm expe))
+
+(defrule dvecp-exactrp
+  (implies (and (dvecp x p b)
+                (integerp p)
+                (radixp b))
+           (exactrp x p b))
+  :prep-lemmas (
+    (defrule lemma1
+      (implies (and (natp x)
+                    (radixp b))
+               (exactrp x (1+ (expe x b)) b))
+      :enable (exactrp sigc sigm))
+    (defrule lemma2
+      (implies (and (< x (expt b p))
+                    (natp x)
+                    (posp p)
+                    (radixp b))
+               (<= (1+ (expe x b)) p))
+      :use (:instance expe<=
+             (n (1- p)))
+      :rule-classes :linear))
+  :enable dvecp
+  :cases ((posp p))
+  :hints (("subgoal 1" :use (:instance exactrp-<=
+                              (s (1+ (expe x b)))))))
+
+(defrule exactrp-prod
+  (implies (and (exactrp x px b)
+                (integerp px)
+                (exactrp y py b)
+                (integerp py))
+          (exactrp (* x y) (+ px py) b))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and
+                 (integerp p)
+                 (integerp n)
+                 (radixp b))
+               (equal (sigc x (+ p n) b)
+                      (* (sigc x p b) (expt b n))))
+      :enable sigc
+      :rule-classes ()))
+  :enable (exactrp sigc-prod)
+  :use ((:instance lemma
+          (x x)
+          (p px)
+          (n py))
+        (:instance lemma
+          (x y)
+          (p py)
+          (n px)))
+  :cases ((= x 0)
+          (= y 0))
+  :rule-classes ())
+
+(defrule sigc-rationalp
+  (implies (and (rationalp x)
+                (radixp b))
+           (rationalp (sigc x p b)))
+  :enable (sigc sigm)
+  :rule-classes :type-prescription)
+
+(defrule exactrp-x2
+    (implies (and (rationalp x)
+                  (integerp p)
+		  (primep b)
+		  (exactrp (* x x) (* 2 p) b))
+	     (exactrp x p b))
+  :prep-lemmas (
+    (defrule lemma-p<=0
+      (implies (and (rationalp x)
+                    (<= p 0)
+                    (exactrp (* x x) p b))
+               (equal x 0))
+      :enable exactrp-forward-p<1
+      :rule-classes ())
+    (defrule lemma-sigc
+      (implies (and (real/rationalp x)
+                    (integerp p)
+                    (exactrp (* x x) (* 2 p) b))
+               (or (integerp (* b (sigc x p b) (sigc x p b)))
+                   (integerp (* (sigc x p b) (sigc x p b)))))
+      :enable (exactrp sigc)
+      :use (:instance sigm-prod (x x) (y x))
+      :rule-classes ())
+    (defrule divides-p-when-divides-p*p
+      (implies (and (posp p) (divides (* p p) x))
+               (divides p x))
+      :enable (divides acl2::intp-*)
+      :use (:instance acl2::intp-1
+             (x (/ x (* p p)))
+             (y p)))
+    (defrule divides-p-n*n
+      (implies (and (integerp n)
+                    (primep p)
+                    (divides (* p p) (* b n n))
+                    (or (primep b) (= b 1)))
+               (divides p (* n n)))
+      :cases ((divides p (* b n n)))
+      :hints (
+        ("subgoal 1" :cases ((= p b)))
+        ("subgoal 1.2" :cases ((divides p b)))
+        ("subgoal 1.2.2" :use (:instance euclid
+                               (a b)
+                               (b (* n n))))
+        ("subgoal 1.2.1" :use (:instance primep-no-divisor
+                                (p b)
+                                (d p)))
+        ("subgoal 1.1" :in-theory (enable divides)))
+      :rule-classes ())
+    (defrule divides-p-n
+      (implies (and (integerp n)
+                    (primep p)
+                    (divides (* p p) (* b n n))
+                    (or (primep b) (= b 1)))
+               (divides p n))
+      :use (divides-p-n*n
+            (:instance euclid (a n) (b n)))
+      :rule-classes ())
+    (defrule kkkk
+      (implies (and (posp p)
+                    (posp d)
+                    (divides p d)
+                    (integerp (* b (/ n d) (/ n d))))
+        (divides (* p p) (* b n n)))
+     :enable (divides acl2::intp-*)
+     :use ((:instance acl2::intp-1
+             (x (/ d p))
+             (y (/ d p)))
+           (:instance acl2::intp-1
+             (x (* (/ d p) (/ d p)))
+             (y (* b (/ n d) (/ n d))))))
+    (defrule ttt
+      (implies (and (integerp n)
+                    (posp d)
+                    (primep p)
+                    (divides p d)
+                    (integerp (* b (/ n d) (/ n d)))
+                    (or (primep b) (= b 1)))
+               (divides p n))
+      :use (divides-p-n kkkk))
+    (defrule least-divisor-denominator
+      (implies (and (rationalp c)
+                    (not (integerp c)))
+               (and (primep (least-divisor 2 (denominator c)))
+                    (divides (least-divisor 2 (denominator c))
+                             (denominator c))
+                    (not (divides (least-divisor 2 (denominator c))
+                                  (numerator c)))))
+      :enable divides
+      :use ((:instance primep-least-divisor
+              (n (denominator c)))
+            (:instance least-divisor-divides
+              (k 2)
+              (n (denominator c)))
+            (:instance lowest-terms
+             (x c)
+             (n (least-divisor 2 (denominator c)))
+             (r (/ (numerator c) (least-divisor 2 (denominator c))))
+             (q (/ (denominator c) (least-divisor 2 (denominator c)))))))
+    (defrule lemma2
+      (implies (and (rationalp c)
+                    (integerp (* b c c))
+                    (or (primep b) (= b 1)))
+               (integerp c))
+      :use (least-divisor-denominator
+            (:instance ttt
+              (n (numerator c))
+              (d (denominator c))
+              (p (least-divisor 2 (denominator c))))))
+    (defrule lemma3
+      (implies (and (rationalp x)
+                    (integerp p)
+                    (primep b)
+                    (exactrp (* x x) (* 2 p) b))
+               (integerp (sigc x p b)))
+      :use (lemma-sigc
+            (:instance lemma2
+              (c (sigc x p b))
+              (b 1))
+            (:instance lemma2
+              (c (sigc x p b))
+              (b b)))))
+  :cases ((= x 0) (not (posp p)))
+  :hints (
+     ("subgoal 3" :in-theory (enable exactrp)
+                  :use lemma3)
+     ("subgoal 1" :use (:instance lemma-p<=0 (p (* 2 p)))))
+  :rule-classes ())
+#|
+(defthm exactp-factors
+  (implies (and (real/rationalp x)
+                (real/rationalp y)
+                (integerp k)
+                (integerp n)
+                (not (zerop x))
+                (not (zerop y))
+                (exactrp x k 2)
+                (exactrp y k 2)
+                (exactrp (* x y) n 2))
+           (exactrp x n 2))
+  :rule-classes ())
+|#
+(defrule exact-digits-1
+  (implies (and (acl2-numberp x)
+                (integerp k)
+                (radixp b))
+           (equal (integerp (/ x (expt b k)))
+                  (exactrp x (+ 1 (- k) (expe x b)) b)))
+  :enable (exactrp sigc sigm)
+  :rule-classes ())
+
+(defrule exact-digits-2
+  (implies (and (<= 0 x)
+                (integerp k)
+                (radixp b))
+           (equal (integerp (/ x (expt b k)))
+		  (equal (digits x (expe x b) k b)
+                         (/ x (expt b k)))))
+  :enable (digits expe-upper-bound)
+  :rule-classes ())
+
+(defrule exact-digits-3
+  (implies (and (integerp x)
+                (radixp b))
+           (equal (integerp (/ x (expt b k)))
+		  (equal (digits x (1- k) 0 b)
+                         0)))
+  :enable digits
+  :cases ((integerp (/ x (expt b k))))
+  :hints (("subgoal 2" :cases ((posp k))))
+  :rule-classes ())
+
+(defrule exact-digit-k+1
+    (implies (and (integerp k)
+                  (radixp b)
+		  (exactrp x (+ 1 (- k) (expe x b)) b))
+	     (equal (exactrp x (+ (- k) (expe x b)) b)
+                    (= (digitn x k b) 0)))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (integerp (* x (expt b (- k))))
+                    (integerp k)
+                    (radixp b))
+               (equal (integerp (* x (expt b (+ -1 (- k)))))
+                      (= (digitn x k b) 0)))
+      :enable (digitn digits)))
+  :enable (digitn digits)
+  :use ((:instance exact-digits-1 (k k))
+        (:instance exact-digits-1 (k (1+ k))))
+  :rule-classes ())
+
+(defrule exactrp-diff
+    (implies (and (integerp k)
+		  (> p k)
+		  (exactrp x p b)
+		  (exactrp y p b)
+		  (<= (+ k (expe (- x y) b)) (expe x b))
+		  (<= (+ k (expe (- x y) b)) (expe y b)))
+	     (exactrp (- x y) (- p k) b))
+  :prep-lemmas (
+    (defrule lemma1
+      (implies
+         (and
+           (integerp x)
+           (natp n)
+           (radixp b))
+         (integerp (* x (expt b n))))
+      :rule-classes ())
+    (defrule lemma2
+      (implies
+         (and
+           (integerp (* x (expt b m)))
+           (<= m n)
+           (integerp m)
+           (integerp n)
+           (radixp b))
+         (integerp (* x (expt b n))))
+      :use (:instance lemma1
+             (x (* x (expt b m)))
+             (n (- n m)))))
+  :use (
+    (:instance exact-digits-1
+      (x (- x y))
+      (k (+ 1 (expe (- x y) b) (- k p))))
+    (:instance exact-digits-1
+      (x x)
+      (k (+ 1 (expe x b) (- p))))
+    (:instance exact-digits-1
+      (x y)
+      (k (+ 1 (expe y b) (- p)))))
+  :rule-classes ())
+
+(defrule exactrp-diff-cor
+  (implies (and (exactrp x p b)
+                (exactrp y p b)
+                (<= (abs (- x y)) (abs x))
+                (<= (abs (- x y)) (abs y)))
+           (exactrp (- x y) p b))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (real/rationalp x)
+                    (real/rationalp y)
+                    (radixp b)
+                    (not (equal (- x y) 0))
+                    (<= (abs (- x y)) (abs x))
+                    (<= (abs (- x y)) (abs y)))
+               (and
+                 (<= (expe (- x y) b) (expe x b))
+                 (<= (expe (- x y) b) (expe y b))))
+      :use ((:instance expe-monotone
+              (x (- x y))
+              (y x))
+            (:instance expe-monotone
+              (x (- x y))
+              (y y)))
+      :disable abs
+      :rule-classes :linear))
+  :enable exactrp-forward-p<1
+  :disable abs
+  :use (:instance exactrp-diff
+         (k 0))
+  :cases ((= x y))
+  :rule-classes ())
+
+(defun fpr+ (x p b)
+  (declare (xargs :guard (and (exactrp x p b) (> x 0))))
+  (+ x (expt b (expq x p b))))
+
+(defrule fpr+-positive
+  (implies (and (<= 0 x)
+                (radixp b))
+           (< 0 (fpr+ x p b)))
+  :rule-classes :type-prescription)
+
+(defrule fpr+-real/rationalp
+  (implies (and (real/rationalp x)
+                (radixp b))
+           (real/rationalp (fpr+ x p b)))
+  :rule-classes :type-prescription)
+
+(defrule fpr+-rationalp
+  (implies (and (rationalp x)
+                (radixp b))
+           (rationalp (fpr+ x p b)))
+  :rule-classes :type-prescription)
+
+(local (defruled fpr+-rep-qc
+  (implies (and (real/rationalp x)
+                (> x 0)
+                (posp p)
+                (radixp b)
+                (< (sigc x p b) (1- (expt b p))))
+           (and
+             (equal (expq (fpr+ x p b) p b) (expq x p b))
+             (equal (sigc (fpr+ x p b) p b) (1+ (sigc x p b)))))
+  :enable (signum sigc-lower-bound)
+  :use (fp-rep-qc
+        (:instance fp-rep-qc-unique
+          (x (fpr+ x p b))
+          (q (expq x p b))
+          (c (1+ (sigc x p b)))))))
+
+(local (defruled fpr+1-rep-qc
+  (implies (and (real/rationalp x)
+                (> x 0)
+                (posp p)
+                (radixp b)
+                (= (sigc x p b) (1- (expt b p))))
+           (and
+             (equal (expq (fpr+ x p b) p b) (1+ (expq x p b)))
+             (equal (sigc (fpr+ x p b) p b) (expt b (1- p)))))
+  :enable signum
+  :use (fp-rep-qc
+        (:instance fp-rep-qc-unique
+          (x (fpr+ x p b))
+          (q (1+ (expq x p b)))
+          (c (expt b (1- p)))))))
+
+(defrule fpr+1
+    (implies (and (> x 0)
+                  (exactrp x p b))
+             (exactrp (fpr+ x p b) p b))
+  :enable (exactrp-forward-p<1 sigc-upper-bound
+           fpr+-rep-qc fpr+1-rep-qc)
+  :disable fpr+
+  :cases ((and (rationalp x) (posp p)))
+  :hints (("subgoal 1" :in-theory (enable exactrp)
+                       :cases ((< (sigc x p b) (1- (expt b p)))
+                               (= (sigc x p b) (1- (expt b p))))))
+  :rule-classes())
+
+(defrule fpr+2
+    (implies (and (> x 0)
+		  (> y x)
+		  (exactrp x p b)
+		  (exactrp y p b))
+	     (>= y (fpr+ x p b)))
+  :enable (exactrp-forward-p<1
+           sigc-lower-bound sigc-upper-bound
+           fpr+-rep-qc fpr+1-rep-qc)
+  :disable fpr+
+  :cases ((and (rationalp x) (posp p)))
+  :hints (
+    ("subgoal 1" :in-theory (enable exactrp radixp signum)
+                 :use ((:instance compare-abs-qc (x x))
+                       (:instance compare-abs-qc (x (fpr+ x p b))))
+                 :cases ((< (sigc x p b) (1- (expt b p)))
+                         (= (sigc x p b) (1- (expt b p))))))
+  :rule-classes ())
+
+(defrule fpr+expe
+    (implies (and (> x 0)
+                  (exactrp x p b)
+                  (not (= (expe (fpr+ x p b) b) (expe x b))))
+	     (equal (fpr+ x p b) (expt b (1+ (expe x b)))))
+  :enable (exactrp-forward-p<1 sigc-upper-bound
+           fpr+-rep-qc fpr+1-rep-qc)
+  :disable fpr+
+  :cases ((and (rationalp x) (posp p)))
+  :hints (
+    ("subgoal 1" :cases ((< (sigc x p b) (1- (expt b p)))
+                         (= (sigc x p b) (1- (expt b p)))))
+    ("subgoal 1.3" :in-theory(enable exactrp))
+    ("subgoal 1.2" :cases ((equal (expq (fpr+ x p b) p b) (expq x p b))))
+    ("subgoal 1.2.1" :in-theory (enable expq))
+    ("subgoal 1.1" :cases ((equal (expq (fpr+ x p b) p b) (1+ (expq x p b))))
+                   :use (:instance fp-rep-qc
+                          (x (fpr+ x p b))))
+    ("subgoal 1.1.1" :in-theory (enable signum expq)))
+  :rule-classes ())
+
+(defrule fpr+expq
+    (implies (and (> x 0)
+                  (exactrp x p b)
+                  (not (= (expq (fpr+ x p b) p b) (expq x p b))))
+	     (equal (fpr+ x p b) (expt b (+ p (expq x p b)))))
+  :enable expq
+  :disable fpr+
+  :use fpr+expe
+  :rule-classes ())
+
+(defrule expe-diff-min
+    (implies (and (exactrp x p b)
+		  (exactrp y p b)
+		  (not (= y x)))
+	     (>= (expe (- y x) b)
+                 (- (1+ (min (expe x b) (expe y b))) p)))
+  :prep-lemmas (
+    (defrule lemma0
+      (implies (and (integerp x)
+                    (integerp y)
+                    (not (= y x))
+                    (real/rationalp r)
+                    (> r 0))
+               (>= (abs (* r (- y x))) r))
+      :cases ((>= y (1+ x))
+              (<= y (1- x)))
+      :rule-classes ())
+    (defrule lemma
+      (implies (and (real/rationalp x)
+                    (real/rationalp y)
+                    (integerp (/ x (expt b n)))
+                    (integerp (/ y (expt b n)))
+                    (not (= y x))
+                    (integerp n)
+                    (radixp b))
+               (>= (expe (- y x) b) n))
+      :use ((:instance lemma0
+              (x (/ x (expt b n)))
+              (y (/ y (expt b n)))
+              (r (expt b n)))
+            (:instance expe-monotone
+              (x (expt b n))
+              (y (- y x))))
+      :rule-classes ()))
+  :enable (exactrp-forward-p<1 expq exactrp-<=)
+  :use (
+    (:instance lemma (n (min (expq x p b) (expq y p b))))
+    (:instance exact-digits-1 (x x) (k (min (expq x p b) (expq y p b))))
+    (:instance exact-digits-1 (x y) (k (min (expq x p b) (expq y p b)))))
+  :rule-classes ())
+
+(defun fpr- (x p b)
+  (declare (xargs :guard (and (exactrp x p b) (> x 0))))
+  (if (= x (expt b (expe x b)))
+      (- x (expt b (expq x (1+ p) b)))
+    (- x (expt b (expq x p b)))))
+
+(defrule fpr--non-negative
+   (implies (and (rationalp x)
+                 (> x 0)
+                 (posp p)
+                 (radixp b))
+            (and (rationalp (fpr- x p b))
+                 (< 0 (fpr- x p b))))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (posp p)
+                    (integerp n)
+                    (radixp b))
+               (<= (expt b (+ 1 (- p) n)) (expt b n)))
+      :rule-classes :linear))
+  :enable (sigc expq sigm expe-lower-bound)
+  :rule-classes :type-prescription)
+
+(local (defruled fpr--rep-qc
+  (implies (and (real/rationalp x)
+                (> x 0)
+                (posp p)
+                (radixp b)
+                (>= (sigc x p b) (1+ (expt b (1- p)))))
+           (and
+             (equal (expq (fpr- x p b) p b) (expq x p b))
+             (equal (sigc (fpr- x p b) p b) (1- (sigc x p b)))))
+  :prep-lemmas (
+    (defrule lemma
+      (implies (and (>= (sigc x p b) (1+ (expt b (1- p))))
+                    (integerp p)
+                    (radixp b))
+               (not (equal x (expt b (expe x b)))))
+      :enable (sigc sigm)))
+  :enable (signum sigc-upper-bound)
+  :use (fp-rep-qc
+        (:instance fp-rep-qc-unique
+          (x (fpr- x p b))
+          (q (expq x p b))
+          (c (1- (sigc x p b)))))))
+
+(local (defruled fpr-1-rep-qc
+  (implies (and (real/rationalp x)
+                (> x 0)
+                (posp p)
+                (radixp b)
+                (= (sigc x p b) (expt b (1- p))))
+           (and
+             (equal (expq (fpr- x p b) p b) (1- (expq x p b)))
+             (equal (sigc (fpr- x p b) p b) (1- (expt b p)))))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear-help (defrule lemma
+      (implies (and (posp p)
+                    (radixp b))
+               (<= (1+ (expt b (1- p))) (expt b p))))))
+  :enable signum
+  :use (fp-rep-qc
+        (:instance fp-rep-qc-unique
+          (x (fpr- x p b))
+          (q (1- (expq x p b)))
+          (c (1- (expt b p)))))))
+
+(defrule exactrp-fpr-
+    (implies (and (> x 0)
+                  (exactrp x p b))
+             (exactrp (fpr- x p b) p b))
+  :enable (exactrp-forward-p<1 sigc-lower-bound
+           fpr--rep-qc fpr-1-rep-qc)
+  :disable fpr-
+  :cases ((and (rationalp x) (posp p)))
+  :hints (("subgoal 1" :in-theory (enable exactrp)
+                       :cases ((>= (sigc x p b) (1+ (expt b (1- p))))
+                               (= (sigc x p b) (expt b (1- p))))))
+  :rule-classes())
+
+(defrule fpr+-
+  (implies (and (> x 0)
+                (exactrp x p b))
+           (equal (fpr+ (fpr- x p b) p b)
+                  x))
+  :enable (signum exactrp-forward-p<1
+           sigc-lower-bound sigc-upper-bound
+           fpr--rep-qc fpr-1-rep-qc
+           fpr+-rep-qc fpr+1-rep-qc)
+  :disable (fpr+ fpr-)
+  :use ((:instance fp-rep-qc (x x))
+        (:instance fp-rep-qc (x (fpr+ (fpr- x p b) p b))))
+  :cases ((posp p))
+  :hints (
+    ("subgoal 1" :cases ((>= (sigc x p b) (1+ (expt b (1- p))))
+                         (= (sigc x p b) (expt b (1- p)))))
+    ("subgoal 1.3" :in-theory (enable exactrp))))
+
+(defrule fpr-+
+  (implies (and (> x 0)
+                (exactrp x p b))
+           (equal (fpr- (fpr+ x p b) p b)
+                  x))
+  :enable (signum exactrp-forward-p<1
+           sigc-lower-bound sigc-upper-bound
+           fpr--rep-qc fpr-1-rep-qc
+           fpr+-rep-qc fpr+1-rep-qc
+           acl2::scatter-exponents-theory)
+  :disable (fpr+ fpr- acl2::gather-exponents-theory)
+  :use ((:instance fp-rep-qc (x x))
+        (:instance fp-rep-qc (x (fpr- (fpr+ x p b) p b))))
+  :cases ((posp p))
+  :hints (
+    ("subgoal 1" :cases ((< (sigc x p b) (1- (expt b p)))
+                         (= (sigc x p b) (1- (expt b p)))))
+    ("subgoal 1.3" :in-theory (enable exactrp))))
+
+(defrule fpr-2
+  (implies (and (> y 0)
+                (> x y)
+                (exactrp x p b)
+                (exactrp y p b))
+           (<= y (fpr- x p b)))
+  :enable (exactrp-forward-p<1
+           sigc-lower-bound sigc-upper-bound
+           fpr--rep-qc fpr-1-rep-qc)
+  :disable fpr-
+  :cases ((and (rationalp x) (posp p)))
+  :hints (
+    ("subgoal 1" :in-theory (enable exactrp signum)
+                 :use ((:instance compare-abs-qc (x x))
+                       (:instance compare-abs-qc (x (fpr- x p b))))
+                 :cases ((>= (sigc x p b) (1+ (expt b (1- p))))
+                         (= (sigc x p b) (expt b (1- p))))))
+  :rule-classes ())
+
+(defruled expq-fpr-
+   (implies (and (> x 0)
+                 (not (= x (expt b (expe x b))))
+                 (exactrp x p b))
+            (equal (expq (fpr- x p b) p b) (expq x p b)))
+  :prep-lemmas (
+    (acl2::with-arith5-nonlinear++-help (defrule lemma
+      (implies (and (equal (* x (expt b (- n))) 1)
+                    (integerp n)
+                    (radixp b))
+               (equal (expt b n) x)))))
+  :enable (exactrp exactrp-forward-p<1 sigc-lower-bound
+           fpr--rep-qc fpr-1-rep-qc)
+  :disable fpr-
+  :cases ((posp p))
+  :hints (
+    ("subgoal 1" :cases ((>= (sigc x p b) (1+ (expt b (1- p))))
+                         (= (sigc x p b) (expt b (1- p)))))
+    ("subgoal 1.1" :in-theory (enable sigc sigm))))
+
+(defruled expe-fpr-
+   (implies (and (> x 0)
+                 (not (= x (expt b (expe x b))))
+                 (exactrp x p b))
+            (equal (expe (fpr- x p b) b) (expe x b)))
+  :enable expq
+  :disable fpr-
+  :use expq-fpr-)
 
 ;;;**********************************************************************
 ;;;                          Exactness
@@ -428,54 +1828,64 @@ y < 2^p, and hence x and y are p-exact.
 (defund exactp (x n)
   (integerp (* (sig x) (expt 2 (1- n)))))
 
-(defthmd exactp2
+(local (defrule exactp-as-exactrp
+  (implies (integerp p)
+           (equal (exactp x p)
+                  (or (not (rationalp x)) (exactrp x p 2))))
+  :enable (exactp exactrp sigc)))
+
+(defruled exactp2
     (implies (and (rationalp x)
 		  (integerp n))
 	     (equal (exactp x n)
-		    (integerp (* x (expt 2 (- (1- n) (expo x))))))))
+		    (integerp (* x (expt 2 (- (1- n) (expo x)))))))
+  :enable (exactrp sigc sigm))
 
-(defthm exactp-sig
+(defrule exactp-sig
   (equal (exactp (sig x) n)
-         (exactp x n)))
+         (exactp x n))
+  :enable exactp)
 
-(defthm exactp-minus
-  (equal (exactp (* -1 x) n)
-         (exactp x n)))
-
-(defthm minus-exactp
+(defrule minus-exactp
   (equal (exactp (- x) n)
          (exactp x n))
-  :hints (("Goal" :use (exactp-minus))))
+  :enable exactp)
 
 (defthm exactp-abs
   (equal (exactp (abs x) n)
          (exactp x n)))
 
-(defthmd exactp-shift
+(defruled exactp-shift
   (implies (and (rationalp x)
                 (integerp k)
                 (integerp n))
            (equal (exactp (* (expt 2 k) x) n)
-                  (exactp x n))))
+                  (exactp x n)))
+  :use (:instance exactrp-shift (p n) (b 2)))
 
-(defthmd exactp-<=
+(defruled exactp-<=
     (implies (and (exactp x m)
                   (<= m n)
                   (rationalp x)
 		  (integerp n)
 		  (integerp m))
-	     (exactp x n)))
+	     (exactp x n))
+  :enable exactrp-<=)
 
-(defthmd exactp-2**n
+(defruled exactp-2**n
   (implies  (and (case-split (integerp m))
                  (case-split (> m 0)))
-            (exactp (expt 2 n) m)))
+            (exactp (expt 2 n) m))
+  :use (:instance exactrp-b**n (n (ifix n)) (p m) (b 2)))
 
-(defthm bvecp-exactp
+(defrule bvecp-exactp
   (implies (bvecp x n)
-           (exactp x n)))
+           (exactp x n))
+  :enable (bvecp dvecp)
+  :cases ((integerp n))
+  :hints (("subgoal 2" :in-theory (enable exactp))))
 
-(defthm exactp-prod
+(defrule exactp-prod
     (implies (and (rationalp x)
 		  (rationalp y)
 		  (integerp m)
@@ -483,16 +1893,28 @@ y < 2^p, and hence x and y are p-exact.
 		  (exactp x m)
 		  (exactp y n))
 	     (exactp (* x y) (+ m n)))
+  :use (:instance exactrp-prod (px m) (py n) (b 2))
   :rule-classes ())
 
-(defthm exactp-x2
+(defrule exactp-x2
     (implies (and (rationalp x)
 		  (integerp n)
 		  (exactp (* x x) (* 2 n)))
 	     (exactp x n))
+  :use (:instance exactrp-x2 (p n) (b 2))
   :rule-classes ())
 
-(defthm exactp-factors
+#|
+Lemma(exactp-factors): Assume that x and y are k-exact for some k.  If xy is non-zero and p-exact, then so are x and y.
+
+Proof: Let m and n be the smallest integers such that x' = 2^n*x and y' = 2^m*y are integers.  Thus, x' and y' are odd.
+Since x, y, or x*y, respectively, is p-exact iff x', y', or x'*y' is p-exact, we may replace x and y with
+x' and y'.  That is, we may assume without loss of generality that x and y are odd integers.
+
+An odd integer z is p-exact iff |z| < 2^p.  Thus, since xy is p-exact, xy < 2^p, which implies x < 2^p and
+y < 2^p, and hence x and y are p-exact.
+|#
+(defrule exactp-factors
   (implies (and (rationalp x)
                 (rationalp y)
                 (integerp k)
@@ -503,17 +1925,155 @@ y < 2^p, and hence x and y are p-exact.
                 (exactp y k)
                 (exactp (* x y) n))
            (exactp x n))
+  :prep-lemmas (
+    (defun pow2 (n)
+      (if (or (zp n) (oddp n))
+          0
+        (1+ (pow2 (/ n 2)))))
+
+    (defruled pow2-oddp-1
+      (implies (integerp n)
+               (equal (expt 2 (1- n))
+                      (* 1/2 (expt 2 n))))
+      :use ((:instance expt (r 2) (i n))
+            (:instance expt (r 2) (i (1- n)))))
+
+    (defrule pow2-oddp
+      (implies (not (zp n))
+               (and (integerp (/ n (expt 2 (pow2 n))))
+                    (oddp (/ n (expt 2 (pow2 n))))))
+      :rule-classes ()
+      :hints (("Subgoal *1/3" :use ((:instance pow2-oddp-1 (n (- (pow2 (/ n 2)))))))
+              ("Subgoal *1/2" :use ((:instance pow2-oddp-1 (n (- (pow2 (/ n 2)))))))))
+
+    (defrule lemma-1
+      (implies (and (integerp x) (integerp y))
+               (integerp (* x y)))
+      :rule-classes ())
+
+    (defrule lemma-2
+      (implies (and (integerp n)
+                    (oddp n)
+                    (not (zp k)))
+               (not (integerp (/ n (expt 2 k)))))
+      :rule-classes ()
+      :use ((:instance pow2-oddp-1 (n k))
+            (:instance lemma-1 (x (/ n (expt 2 k))) (y (expt 2 (1- k))))))
+
+    (defrule lemma-3
+      (implies (and (integerp n)
+                    (integerp k)
+                    (oddp n))
+               (iff (integerp (* (expt 2 k) n))
+                    (>= k 0)))
+      :rule-classes ()
+      :use (:instance lemma-2 (k (- k))))
+
+    (defrule lemma-4
+      (implies (and (integerp n)
+                    (integerp k)
+                    (oddp n))
+               (iff (exactp n k)
+                    (> k (expo n))))
+      :rule-classes ()
+      :enable exactp2
+      :use (:instance lemma-3 (k (- (1- k) (expo n)))))
+
+    (defrule lemma-5
+      (implies (and (integerp x)
+                    (integerp y)
+                    (oddp x)
+                    (oddp y))
+               (>= (expo (* x y)) (expo x)))
+      :rule-classes ()
+      :use (:instance expo-monotone (y (* x y))))
+
+    (defrule lemma-6
+      (implies (integerp x)
+               (iff (oddp x) (= (mod x 2) 1)))
+      :rule-classes ()
+      :disable fl-integerp
+      :use ((:instance fl-integerp (x (/ x 2)))
+            (:instance mod-def (y 2))
+            (:instance mod012 (m x))))
+
+    (defrule lemma-7
+      (implies (and (integerp x)
+                    (integerp y)
+                    (oddp x)
+                    (oddp y))
+               (oddp (* x y)))
+      :use (lemma-6
+            (:instance lemma-6 (x y))
+            (:instance lemma-6 (x (* x y)))
+            (:instance mod-mod-times (n 2) (a x) (b y))))
+
+    (defrule lemma-8
+      (implies (and (integerp x)
+                    (integerp y)
+                    (oddp x)
+                    (oddp y)
+                    (integerp k)
+                    (exactp (* x y) k))
+               (exactp x k))
+      :rule-classes ()
+      :use (lemma-5
+            lemma-7
+            (:instance lemma-4 (n (* x y)))
+            (:instance lemma-4 (n x))))
+
+    (defrule lemma-9
+      (implies (and (rationalp x)
+                    (rationalp y)
+                    (integerp k)
+                    (integerp n)
+                    (not (zerop x))
+                    (not (zerop y))
+                    (exactp x k)
+                    (exactp y k))
+               (let ((xp (/ (abs (* (expt 2 (- (1- k) (expo x))) x))
+                            (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x))))))
+                     (yp (/ (abs (* (expt 2 (- (1- k) (expo y))) y))
+                            (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y)))))))
+                 (and (integerp xp)
+                      (oddp xp)
+                      (iff (exactp x n) (exactp xp n))
+                      (integerp yp)
+                      (oddp yp)
+                      (iff (exactp x n) (exactp xp n))
+                      (iff (exactp y n) (exactp yp n))
+                      (iff (exactp (* x y) n) (exactp (* xp yp) n)))))
+      :rule-classes ()
+      :enable exactp2
+      :use (minus-exactp
+            (:instance minus-exactp (x y))
+            (:instance minus-exactp (x (* x y)))
+            (:instance exactp-shift (x (abs x)) (k (- (1- k) (+ (expo x) (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x)))))))
+            (:instance exactp-shift (x (abs y)) (k (- (1- k) (+ (expo y) (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y)))))))
+            (:instance exactp-shift (x (abs (* x y)))
+                       (k (+ (- (1- k) (+ (expo x) (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x)))))
+                             (- (1- k) (+ (expo y) (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y))))))))
+            (:instance pow2-oddp (n (abs (* (expt 2 (- (1- k) (expo x))) x))))
+            (:instance pow2-oddp (n (abs (* (expt 2 (- (1- k) (expo y))) y))))))
+  )
+  :use (lemma-9
+        (:instance lemma-8 (k n)
+                   (x (/ (abs (* (expt 2 (- (1- k) (expo x))) x))
+                         (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo x))) x))))))
+                   (y (/ (abs (* (expt 2 (- (1- k) (expo y))) y))
+                         (expt 2 (pow2 (abs (* (expt 2 (- (1- k) (expo y))) y))))))))
   :rule-classes ())
 
-(defthm exact-bits-1
+(defrule exact-bits-1
   (implies (and (equal (expo x) (1- n))
                 (rationalp x)
                 (integerp k))
            (equal (integerp (/ x (expt 2 k)))
 		  (exactp x (- n k))))
+  :use (:instance exact-digits-1 (b 2))
   :rule-classes ())
 
-(defthm exact-bits-2
+(defrule exact-bits-2
   (implies (and (equal (expo x) (1- n))
                 (rationalp x)
                 (<= 0 x)
@@ -522,16 +2082,20 @@ y < 2^p, and hence x and y are p-exact.
            (equal (integerp (/ x (expt 2 k)))
 		  (equal (bits x (1- n) k)
                          (/ x (expt 2 k)))))
+  :enable (bits digits)
+  :use (:instance exact-digits-2 (b 2))
   :rule-classes ())
 
-(defthm exact-bits-3
+(defrule exact-bits-3
   (implies (integerp x)
            (equal (integerp (/ x (expt 2 k)))
 		  (equal (bits x (1- k) 0)
                          0)))
+  :enable (bits digits)
+  :use (:instance exact-digits-3 (b 2))
   :rule-classes ())
 
-(defthm exact-k+1
+(defrule exact-k+1
     (implies (and (natp n)
 		  (natp x)
 		  (= (expo x) (1- n))
@@ -540,9 +2104,11 @@ y < 2^p, and hence x and y are p-exact.
 		  (exactp x (- n k)))
 	     (iff (exactp x (1- (- n k)))
 		  (= (bitn x k) 0)))
+  :enable (bitn bits digitn digits)
+  :use (:instance exact-digit-k+1 (b 2))
   :rule-classes ())
 
-(defthm exactp-diff
+(defrule exactp-diff
     (implies (and (rationalp x)
 		  (rationalp y)
 		  (integerp k)
@@ -554,9 +2120,10 @@ y < 2^p, and hence x and y are p-exact.
 		  (<= (+ k (expo (- x y))) (expo x))
 		  (<= (+ k (expo (- x y))) (expo y)))
 	     (exactp (- x y) (- n k)))
+  :use (:instance exactrp-diff (p n) (b 2))
   :rule-classes ())
 
-(defthm exactp-diff-cor
+(defrule exactp-diff-cor
     (implies (and (rationalp x)
 		  (rationalp y)
 		  (integerp n)
@@ -566,6 +2133,7 @@ y < 2^p, and hence x and y are p-exact.
 		  (<= (abs (- x y)) (abs x))
 		  (<= (abs (- x y)) (abs y)))
 	     (exactp (- x y) n))
+  :use (:instance exactrp-diff-cor (p n) (b 2))
   :rule-classes ())
 
 (defun fp+ (x n)
@@ -576,16 +2144,23 @@ y < 2^p, and hence x and y are p-exact.
            (< 0 (fp+ x n)))
   :rule-classes :type-prescription)
 
-(defthm fp+1
+(local (defrule fp+-as-fpr+
+  (implies (and (rationalp x)
+                (integerp n))
+           (equal (fp+ x n) (fpr+ x n 2)))
+  :enable expq))
+
+(defrule fp+1
     (implies (and (rationalp x)
 		  (> x 0)
 		  (integerp n)
 		  (> n 0)
 		  (exactp x n))
 	     (exactp (fp+ x n) n))
+  :use (:instance fpr+1 (p n) (b 2))
   :rule-classes ())
 
-(defthm fp+2
+(defrule fp+2
     (implies (and (rationalp x)
 		  (> x 0)
 		  (rationalp y)
@@ -595,9 +2170,10 @@ y < 2^p, and hence x and y are p-exact.
 		  (exactp x n)
 		  (exactp y n))
 	     (>= y (fp+ x n)))
+  :use (:instance fpr+2 (p n) (b 2))
   :rule-classes ())
 
-(defthm fp+expo
+(defrule fp+expo
     (implies (and (rationalp x)
 		  (> x 0)
 		  (integerp n)
@@ -605,9 +2181,10 @@ y < 2^p, and hence x and y are p-exact.
 		  (exactp x n)
   		  (not (= (expo (fp+ x n)) (expo x))))
 	     (equal (fp+ x n) (expt 2 (1+ (expo x)))))
+  :use (:instance fpr+expe (p n) (b 2))
   :rule-classes ())
 
-(defthm expo-diff-min
+(defrule expo-diff-min
     (implies (and (rationalp x)
 		  (rationalp y)
 		  (integerp n)
@@ -616,6 +2193,7 @@ y < 2^p, and hence x and y are p-exact.
 		  (exactp y n)
 		  (not (= y x)))
 	     (>= (expo (- y x)) (- (1+ (min (expo x) (expo y))) n)))
+  :use (:instance expe-diff-min (p n) (b 2))
   :rule-classes ())
 
 (defun fp- (x n)
@@ -623,43 +2201,52 @@ y < 2^p, and hence x and y are p-exact.
       (- x (expt 2 (- (expo x) n)))
     (- x (expt 2 (- (1+ (expo x)) n)))))
 
-(defthm fp--non-negative
+(local (defrule fp--as-fpr-
+  (implies (and (rationalp x)
+                (integerp n))
+           (equal (fp- x n) (fpr- x n 2)))
+  :enable expq))
+
+(defrule fp--non-negative
    (implies (and (rationalp x)
                  (integerp n)
                  (> n 0)
                  (> x 0))
             (and (rationalp (fp- x n))
                  (< 0 (fp- x n))))
+   :use (:instance fpr--non-negative (p n) (b 2))
    :rule-classes :type-prescription)
 
-(defthm exactp-fp-
+(defrule exactp-fp-
   (implies (and (rationalp x)
                 (> x 0)
                 (integerp n)
                 (> n 0)
                 (exactp x n))
            (exactp (fp- x n) n))
-  :hints (("Goal" :use (fp-1))))
+  :use (:instance exactrp-fpr- (p n) (b 2)))
 
-(defthm fp+-
+(defrule fp+-
   (implies (and (rationalp x)
                 (> x 0)
                 (integerp n)
                 (> n 0)
                 (exactp x n))
            (equal (fp+ (fp- x n) n)
-                  x)))
+                  x))
+  :use (:instance fpr+- (p n) (b 2)))
 
-(defthm fp-+
+(defrule fp-+
   (implies (and (rationalp x)
                 (> x 0)
                 (integerp n)
                 (> n 0)
                 (exactp x n))
            (equal (fp- (fp+ x n) n)
-                  x)))
+                  x))
+  :use (:instance fpr-+ (p n) (b 2)))
 
-(defthm fp-2
+(defrule fp-2
   (implies (and (rationalp x)
                 (rationalp y)
                 (> y 0)
@@ -669,13 +2256,15 @@ y < 2^p, and hence x and y are p-exact.
                 (exactp x n)
                 (exactp y n))
            (<= y (fp- x n)))
+  :use (:instance fpr-2 (p n) (b 2))
   :rule-classes ())
 
- (defthmd expo-fp-
+(defruled expo-fp-
    (implies (and (rationalp x)
                  (> x 0)
                  (not (= x (expt 2 (expo x))))
                  (integerp n)
                  (> n 0)
                  (exactp x n))
-            (equal (expo (fp- x n)) (expo x))))
+            (equal (expo (fp- x n)) (expo x)))
+  :use (:instance expe-fpr- (p n) (b 2)))

--- a/books/rtl/rel11/support/harrison.lisp
+++ b/books/rtl/rel11/support/harrison.lisp
@@ -1,11 +1,13 @@
 (in-package "RTL")
 
+(include-book "tools/with-arith5-help" :dir :system)
+(local (acl2::allow-arith5-help))
+(local (in-theory (acl2::enable-arith5)))
+
 (include-book "markstein")
 (local (include-book "basic"))
 (local (include-book "float"))
 (local (include-book "round"))
-
-(local (include-book "arithmetic-5/top" :dir :system))
 
 ;; The following lemmas from arithmetic-5 have given me trouble:
 
@@ -458,7 +460,7 @@
            (<= 0 (* (expt 2 (* 2 p)) ep)))
   :rule-classes ())
 
-(local-defthm h-41
+(local (acl2::with-arith5-nonlinear-help (defthm h-41
   (let ((d (cg (* (expt 2 (* 2 p)) ep))))
     (implies (and (rationalp b)
                   (rationalp yp)
@@ -475,7 +477,9 @@
                   (<= d (expt 2 (1- p))))))
   :rule-classes ()
   :hints (("Goal" :use (h-39 h-40
-                        (:instance n>=cg-linear (n (expt 2 (1- p))) (x (* (expt 2 (* 2 p)) ep)))))))
+                        (:instance n>=cg-linear (n (expt 2 (1- p))) (x (* (expt
+                                                                           2 (* 2 p)) ep)))))))))
+
 
 (local-defthm h-42
   (let ((y (rne yp p))

--- a/books/rtl/rel11/support/log.lisp
+++ b/books/rtl/rel11/support/log.lisp
@@ -1,12 +1,14 @@
 (in-package "RTL")
 
-(include-book "../rel9-rtl-pkg/lib/util")
+(local (include-book "arithmetic-5/top" :dir :system))
+
+(local (include-book "basic"))
+(local (include-book "bits"))
+(include-book "definitions")
 
 (local (encapsulate ()
 
-(local (include-book "../rel9-rtl-pkg/lib/top"))
-
-(local (include-book "arithmetic-5/top" :dir :system))
+(local (include-book "../rel9-rtl-pkg/lib/log"))
 
 ;; The following lemmas from arithmetic-5 have given me trouble:
 
@@ -198,8 +200,6 @@
            (equal (fl (* (expt 2 (- n)) (logxor x y)))
                   (logxor (fl (* (expt 2 (- n)) x)) (fl (* (expt 2 (- n)) y)))))
   :hints (("Goal" :use ((:instance fl-logxor (k n) (n 0))))))
-
-(local (include-book "bits"))
 
 (local-defthmd logand-cat-1
   (implies (and (case-split (integerp x1))

--- a/books/rtl/rel11/support/markstein.lisp
+++ b/books/rtl/rel11/support/markstein.lisp
@@ -1,10 +1,10 @@
 (in-package "RTL")
 
+(local (include-book "arithmetic-5/top" :dir :system))
 (include-book "util")
 (local (include-book "basic"))
 (include-book "float")
 (include-book "round")
-(local (include-book "arithmetic-5/top" :dir :system))
 
 ;; The following lemmas from arithmetic-5 have given me trouble:
 #|
@@ -3490,7 +3490,7 @@
            (exactp (* (expt 2 (- p (1+ (expo q)))) (- (* b q) a)) p))
   :rule-classes ()
   :hints (("Goal" :use (r-exactp-75
-                        (:instance exactp-minus (x (- (* b q) a)) (n p))
+                        (:instance minus-exactp (x (- (* b q) a)) (n p))
                         (:instance exactp-shift (n p) (x (- (* b q) a)) (k (- p (1+ (expo q)))))))))
 
 (local-defthm r-neg-18
@@ -4068,7 +4068,7 @@
            (exactp (* (expt 2 (- p (expo q))) (- (* b q) a)) p))
   :rule-classes ()
   :hints (("Goal" :use (r-exactp-75
-                        (:instance exactp-minus (x (- (* b q) a)) (n p))
+                        (:instance minus-exactp (x (- (* b q) a)) (n p))
                         (:instance exactp-shift (n p) (x (- (* b q) a)) (k (- p (expo q))))))))
 
 (local-defthm r-neg-rne-20
@@ -4498,7 +4498,7 @@
            (exactp (* (expt 2 (- p (expo q))) (- (* b q) a)) p))
   :rule-classes ()
   :hints (("Goal" :use (r-exactp-75
-                        (:instance exactp-minus (x (- (* b q) a)) (n p))
+                        (:instance minus-exactp (x (- (* b q) a)) (n p))
                         (:instance exactp-shift (n p) (x (- (* b q) a)) (k (- p (expo q))))))))
 
 (local-defthm r-neg-rne-up-20

--- a/books/rtl/rel11/support/old-round.lisp
+++ b/books/rtl/rel11/support/old-round.lisp
@@ -3450,7 +3450,7 @@ ACL2::SIMPLIFY-SUMS-< ACL2::REDUCE-ADDITIVE-CONSTANT-<)
              (= y (rne x n)))
   :rule-classes ()
   :hints (("Goal" :use (rne-minus
-                       (:instance exactp-minus (x y))
+                       (:instance minus-exactp (x y))
                        (:instance rf-16 (x (- x)) (y (- y)))))))
 
 (defthm rne-force

--- a/books/rtl/rel11/support/reps.lisp
+++ b/books/rtl/rel11/support/reps.lisp
@@ -75,8 +75,9 @@
   (declare (xargs :guard (formatp f)))
   (and (formatp f) (bvecp x (+ 1 (expw f) (sigw f)))))
 
-(defrule encodinp-forward
-  (implies (encodingp x f) (formatp f))
+(defrule encodingp-forward
+  (implies (encodingp x f)
+           (formatp f))
   :enable encodingp
   :rule-classes :forward-chaining)
 
@@ -481,7 +482,6 @@
   :rule-classes ((:rewrite :match-free :once))
   :hints (("Goal" :in-theory (enable nrepp) :use (largest-lpn-1 positive-lpn))))
 
-
 ;;;***************************************************************
 ;;;               Denormals and Zeroes
 ;;;***************************************************************
@@ -819,7 +819,7 @@
   :prep-lemmas (
     (defrule lemma
       (implies (and (posp p)
-                    (real/rationalp x)
+                    (rationalp x)
                     (> x 0))
                (iff (and
                       (<= 0 (expo x))


### PR DESCRIPTION
… float.lisp

Radix-aware version of almost each function in
rtl/rel11/support/bits.lisp and rtl/rel11/support/float.lisp .
These versions have an additional argument b. It is radix b >= 2.

One of new theorems is valid for prime radix now. A book euclid.lisp
is imported. Import in this book was patched to avoid circular dependency.

New functions and methods are not mirrored in rtl/rel11/lib .
Also they are not documented yet.

ACL2(r) certifies bits.lisp and float.lisp now. It also attemts to
certify books in curve25519. A trivial fix was necessary in one of these
books to avoid ACL2(r) certifcation failure.