### PR TITLE
rel-notes: Add more rtl/rel11/support books certifiable by ACL2(r)

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -397,8 +397,10 @@ books work only for ACL2 built on CCL or SBCL.</p>
  @('n') as inputs.</p>
 
  <p>The books @('rtl/rel11/support/basic.lisp'),
- @('rtl/rel11/support/bits.lisp'), and
- @('rtl/rel11/support/float.lisp') are now certifiable by ACL2(r).</p>
+ @('rtl/rel11/support/bits.lisp'),
+ @('rtl/rel11/support/float.lisp'),
+ @('rtl/rel11/support/reps.lisp'), and
+ @('rtl/rel11/support/masc.lisp') are now certifiable by ACL2(r).</p>
 
  <p>Some books from @('rtl/rel11/rel9-rtl-pkg/lib'), like
  @('reps.lisp'), @('rom-helpers.lisp'), and


### PR DESCRIPTION
I thank @shigoel  for her patience in combining huge rtl/rel11 commit logs in #572
and add a pair of books to the list of rtl/rel11/support books certifiable by ACL2(r)