### PR TITLE
Type of alists from symbols to symbols, nil-terminated.

### DIFF
--- a/books/kestrel/general/alists.lisp
+++ b/books/kestrel/general/alists.lisp
@@ -1,0 +1,32 @@
+; Alist Utilities
+;
+; Copyright (C) 2016 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Alessandro Coglio (coglio@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; This file provides some alist utilities.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "ACL2")
+
+(include-book "std/util/top" :dir :system)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defxdoc kestrel-alist-utilities
+  :parents (kestrel-general-utilities programming)
+  :short "Some alist utilities.")
+
+(std::defalist symbol-symbol-alistp (x)
+  :key (symbolp x)
+  :val (symbolp x)
+  :parents (kestrel-alist-utilities)
+  :short "Alists from symbols to symbols, @('nil')-terminated."
+  :keyp-of-nil t
+  :valp-of-nil t
+  :true-listp t)

--- a/books/kestrel/general/top.lisp
+++ b/books/kestrel/general/top.lisp
@@ -1,6 +1,6 @@
 ; General-Purpose Utilities
 ;
-; Copyright (C) 2015 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2015-2016 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
@@ -14,6 +14,7 @@
 
 (in-package "ACL2")
 
+(include-book "alists")
 (include-book "ensure")
 (include-book "testing")
 


### PR DESCRIPTION
I used 'programming' as additional xdoc parent for now, but perhaps 'std/alists' might be more appropriate?