### PR TITLE
Heuristic tweak to choice of whether to clrhash or reallocate memo ta…

### DIFF
--- a/hons-raw.lisp
+++ b/hons-raw.lisp
@@ -1816,7 +1816,8 @@
     (when *hl-addr-limit-should-clear-memo-tables*
       (clear-memoize-tables))
 
-    (hl-hspace-hons-wash hs)
+    (time$ (hl-hspace-hons-wash hs)
+           :msg "; Hons-wash: ~st sec, ~sa bytes~%")
 
     (format note-stream "; Hons-Note: After ADDR-LIMIT actions, ~:D used of ~:D slots.~%"
             (hash-table-count (hl-hspace-addr-ht hs))


### PR DESCRIPTION
Matt -- another tweak to memoize heuristics.  When we are predicting how big a memo/pons table is likely to grow, we only care about how big it'll get if it gets written to at all.  This change makes it so we won't average zeros into that prediction when we clear a memoize table that doesn't have any entries.