### PR TITLE
Replace EXECUTABLEP system utility with NON-EXECUTABLEP.

### DIFF
--- a/books/kestrel/system/world-queries-tests.lisp
+++ b/books/kestrel/system/world-queries-tests.lisp
@@ -111,24 +111,32 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(assert-event (executablep 'cons (w state)))
+(assert-event (eq (non-executablep 'cons (w state)) nil))
 
-(assert-event (executablep 'not (w state)))
+(assert-event (eq (non-executablep 'not (w state)) nil))
 
-(assert-event (executablep 'len (w state)))
+(assert-event (eq (non-executablep 'len (w state)) nil))
 
 (must-succeed*
  (defun-nx f (x) x)
- (assert-event (not (executablep 'f (w state)))))
+ (assert-event (eq (non-executablep 'f (w state)) t)))
 
 (must-succeed*
  (defun-sk g (x) (forall (y z) (equal x (cons y z))))
- (assert-event (not (executablep 'g (w state)))))
+ (assert-event (eq (non-executablep 'g (w state)) t)))
 
 (must-succeed*
  (defun-sk h (x y) (exists z (equal z (cons x y)))
    :witness-dcls ((declare (xargs :non-executable nil))))
- (assert-event (executablep 'h (w state))))
+ (assert-event (eq (non-executablep 'h (w state)) nil)))
+
+(must-succeed*
+ (defstub s (*) => *)
+ (assert-event (eq (non-executablep 's (w state)) nil)))
+
+(must-succeed*
+ (defproxy p (* *) => *)
+ (assert-event (eq (non-executablep 'p (w state)) :program)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/system/world-queries.lisp
+++ b/books/kestrel/system/world-queries.lisp
@@ -63,11 +63,20 @@
   (defmacro guard-verifiedp (fun w)
     `(eq (symbol-class ,fun ,w) :common-lisp-compliant)))
 
-(define executablep ((fun (function-namep fun w)) (w plist-worldp))
-  :returns (yes/no booleanp)
-  :short
-  "True iff the function @('fun') is executable."
-  (not (getpropc fun 'non-executablep nil w)))
+(define non-executablep ((fun (function-namep fun w)) (w plist-worldp))
+  :returns (result (member result '(t nil :program)))
+  :short "Return the @(tsee non-executable) status of the function @('fun')."
+  :long
+  "<p>
+  Note that if @('nil') is returned,
+  it does not necessarily mean that @('fun') is executable.
+  For instance, @('nil') is returned
+  if @('fun') is a <see topic='@(url defstub)'>stub</see>.
+  A non-@('nil') return value
+  just means that @('name') has been explicitly marked as non-executable,
+  e.g. via @(tsee defun-nx).
+  </p>"
+  (getpropc fun 'non-executablep nil w))
 
 (define measure ((fun (and (function-namep fun w)
                            (logicalp fun w)


### PR DESCRIPTION
As pointed out by Matt Kaufmann, a NON-EXECUTABLEP property with value NIL is
not the same as the function being "executable" in an intuitive sense. It just
means that the function has not been explicitly marked as non-executable
(e.g. via a DEFUN-NX). So the new system utility just returns the value of that
property; its documentation clarifies the relationship between the result and
"executability".