### PR TITLE
More congruences in Cowles algebra books.

### DIFF
--- a/books/arithmetic/equalities.lisp
+++ b/books/arithmetic/equalities.lisp
@@ -122,59 +122,50 @@ experiment with using @(see force).</p>
   (defthm commutativity-2-of-*
     (equal (* x (* y z))
            (* y (* x z)))
-    :hints (("Goal" :use (:instance
-                          (:functional-instance acl2-asg::commutativity-2-of-op
-                                                (acl2-asg::equiv equal)
-                                                (acl2-asg::pred (lambda (x) t))
-                                                (acl2-asg::op binary-*))
-                          (acl2-asg::x x)
-                          (acl2-asg::y y)
-                          (acl2-asg::z z)))))
+    :hints (("Goal" :use (:functional-instance acl2-asg::commutativity-2-of-op
+                                               (acl2-asg::equiv equal)
+                                               (acl2-asg::pred (lambda (x) t))
+                                               (acl2-asg::op binary-*)))))
 
   (defthm functional-self-inversion-of-/
     (equal (/ (/ x)) (fix x))
-    :hints (("Goal" :use ((:instance (:functional-instance
-                                      acl2-agp::Involution-of-inv
-                                      (acl2-agp::equiv equal)
-                                      (acl2-agp::pred (lambda (x)
-                                                        (and (acl2-numberp x)
-                                                             (not (equal x 0)))))
-                                      (acl2-agp::op binary-*)
-                                      (acl2-agp::id (lambda () 1))
-                                      (acl2-agp::inv unary-/))
-                                     (acl2-agp::x x))))))
+    :hints (("Goal" :use (:functional-instance
+                          acl2-agp::Involution-of-inv
+                          (acl2-agp::equiv equal)
+                          (acl2-agp::pred (lambda (x)
+                                            (and (acl2-numberp x)
+                                                 (not (equal x 0)))))
+                          (acl2-agp::op binary-*)
+                          (acl2-agp::id (lambda () 1))
+                          (acl2-agp::inv unary-/)))))
 
   (defthm distributivity-of-/-over-*
     (equal (/ (* x y))
            (* (/ x) (/ y)))
-    :hints (("Goal" :use ((:instance (:functional-instance
-                                      acl2-agp::Distributivity-of-inv-over-op
-                                      (acl2-agp::equiv equal)
-                                      (acl2-agp::pred (lambda (x)
-                                                        (and (acl2-numberp x)
-                                                             (not (equal x 0)))))
-                                      (acl2-agp::op binary-*)
-                                      (acl2-agp::id (lambda () 1))
-                                      (acl2-agp::inv unary-/))
-                                     (acl2-agp::x x)
-                                     (acl2-agp::y y))))))
+    :hints (("Goal" :use (:functional-instance
+                          acl2-agp::Distributivity-of-inv-over-op
+                          (acl2-agp::equiv equal)
+                          (acl2-agp::pred (lambda (x)
+                                            (and (acl2-numberp x)
+                                                 (not (equal x 0)))))
+                          (acl2-agp::op binary-*)
+                          (acl2-agp::id (lambda () 1))
+                          (acl2-agp::inv unary-/)))))
 
   (defthm /-cancellation-on-right
     (implies (and (fc (acl2-numberp x))
                   (fc (not (equal x 0))))
              (equal (* x y (/ x))
                     (fix y)))
-    :hints (("Goal" :use ((:instance (:functional-instance
-                                      acl2-agp::inv-cancellation-on-right
-                                      (acl2-agp::equiv equal)
-                                      (acl2-agp::pred (lambda (x)
-                                                        (and (acl2-numberp x)
-                                                             (not (equal x 0)))))
-                                      (acl2-agp::op binary-*)
-                                      (acl2-agp::id (lambda () 1))
-                                      (acl2-agp::inv unary-/))
-                                     (acl2-agp::x x)
-                                     (acl2-agp::y y))))))
+    :hints (("Goal" :use (:functional-instance
+                          acl2-agp::inv-cancellation-on-right
+                          (acl2-agp::equiv equal)
+                          (acl2-agp::pred (lambda (x)
+                                            (and (acl2-numberp x)
+                                                 (not (equal x 0)))))
+                          (acl2-agp::op binary-*)
+                          (acl2-agp::id (lambda () 1))
+                          (acl2-agp::inv unary-/)))))
 
   (defthm /-cancellation-on-left
     (implies (and (fc (acl2-numberp x))
@@ -191,18 +182,15 @@ experiment with using @(see force).</p>
                    (acl2-numberp x)
                    (acl2-numberp y))
               (equal (equal x y) t))
-     :hints (("Goal" :use ((:instance (:functional-instance
-                                       acl2-agp::Right-cancellation-for-op
-                                       (acl2-agp::equiv equal)
-                                       (acl2-agp::pred (lambda (x)
-                                                         (and (acl2-numberp x)
-                                                              (not (equal x 0)))))
-                                       (acl2-agp::op binary-*)
-                                       (acl2-agp::id (lambda () 1))
-                                       (acl2-agp::inv unary-/))
-                                      (acl2-agp::x x)
-                                      (acl2-agp::y y)
-                                      (acl2-agp::z z)))))))
+     :hints (("Goal" :use (:functional-instance
+                           acl2-agp::Right-cancellation-for-op
+                           (acl2-agp::equiv equal)
+                           (acl2-agp::pred (lambda (x)
+                                             (and (acl2-numberp x)
+                                                  (not (equal x 0)))))
+                           (acl2-agp::op binary-*)
+                           (acl2-agp::id (lambda () 1))
+                           (acl2-agp::inv unary-/))))))
 
   (defthm right-cancellation-for-*
     (equal (equal (* x z) (* y z))
@@ -245,17 +233,15 @@ experiment with using @(see force).</p>
                          (equal (* x y) 1))
                     (equal y (/ x)))
            :rule-classes nil
-           :hints (("Goal" :use (:instance (:functional-instance
-                                            acl2-agp::Uniqueness-of-op-inverses
-                                            (acl2-agp::equiv equal)
-                                            (acl2-agp::pred (lambda (x)
-                                                              (and (acl2-numberp x)
-                                                                   (not (equal x 0)))))
-                                            (acl2-agp::op binary-*)
-                                            (acl2-agp::id (lambda () 1))
-                                            (acl2-agp::inv unary-/))
-                                           (acl2-agp::x x)
-                                           (acl2-agp::y y))))))
+           :hints (("Goal" :use (:functional-instance
+                                 acl2-agp::Uniqueness-of-op-inverses
+                                 (acl2-agp::equiv equal)
+                                 (acl2-agp::pred (lambda (x)
+                                                   (and (acl2-numberp x)
+                                                        (not (equal x 0)))))
+                                 (acl2-agp::op binary-*)
+                                 (acl2-agp::id (lambda () 1))
+                                 (acl2-agp::inv unary-/))))))
 
   (defthm equal-/
     (implies (and (fc (acl2-numberp x))
@@ -364,16 +350,14 @@ of negations."
                          (fc (acl2-numberp y)))
                     (equal (* x (- y))
                            (- (* x y))))
-           :hints (("Goal" :use ((:instance (:functional-instance
-                                             acl2-crg::functional-commutativity-of-minus-times-right
-                                             (acl2-crg::equiv equal)
-                                             (acl2-crg::pred acl2-numberp)
-                                             (acl2-crg::plus binary-+)
-                                             (acl2-crg::times binary-*)
-                                             (acl2-crg::zero (lambda () 0))
-                                             (acl2-crg::minus unary--))
-                                            (acl2-crg::x x)
-                                            (acl2-crg::y y)))))
+           :hints (("Goal" :use (:functional-instance
+                                 acl2-crg::functional-commutativity-of-minus-times-right
+                                 (acl2-crg::equiv equal)
+                                 (acl2-crg::pred acl2-numberp)
+                                 (acl2-crg::plus binary-+)
+                                 (acl2-crg::times binary-*)
+                                 (acl2-crg::zero (lambda () 0))
+                                 (acl2-crg::minus unary--))))
            :rule-classes nil))
 
   (defthm functional-commutativity-of-minus-*-right

--- a/books/centaur/fty/tests/terms.lisp
+++ b/books/centaur/fty/tests/terms.lisp
@@ -193,7 +193,7 @@
      :ctor-body (list 'lambda formals body))
     :xvar z)
 
-  (deflist ptermlist :elt-type pterm-p :xvar acl2-asg::x))
+  (deflist ptermlist :elt-type pterm-p))
 
 (deflist fnsymlist :elt-type fnsym)
 
@@ -272,7 +272,7 @@
       :xvar z
       :count nil)
 
-    (deflist pterm1list :elt-type pterm1-p :xvar acl2-asg::x)))
+    (deflist pterm1list :elt-type pterm1-p)))
 
 (with-output :off (prove event observation)
   :summary (acl2::form)
@@ -323,7 +323,7 @@
        :ctor-body (list 'lambda formals body))
       :xvar z)
 
-    (deflist pterm2list :elt-type pterm2-p :xvar acl2-asg::x :count nil)))
+    (deflist pterm2list :elt-type pterm2-p :count nil)))
 
 
 ;; non-recursive SOP
@@ -890,7 +890,7 @@
   ;;    :ctor-body (list 'lambda formals body))
   ;;   :xvar z)
 
-  (deflist pterm3list :elt-type pterm3-p :xvar acl2-asg::x
+  (deflist pterm3list :elt-type pterm3-p
     :elementp-of-nil t
     :true-listp t))
 
@@ -988,10 +988,10 @@
   ;;    :ctor-body (list 'lambda formals body))
   ;;   :xvar z)
 
-  (deflist pterm4list :elt-type pterm4-p :xvar acl2-asg::x
+  (deflist pterm4list :elt-type pterm4-p
     :true-listp t
     :elementp-of-nil nil
-    :measure (two-nats-measure (acl2-count acl2-asg::x) 0) )
+    :measure (two-nats-measure (acl2-count x) 0) )
 
 
 
@@ -1102,10 +1102,10 @@
   ;;    :ctor-body (list 'lambda formals body))
   ;;   :xvar z)
 
-  (deflist pterm5list :elt-type pterm5-p :xvar acl2-asg::x
+  (deflist pterm5list :elt-type pterm5-p
     :true-listp t
     :elementp-of-nil nil
-    :measure (two-nats-measure (acl2-count acl2-asg::x) 0) )
+    :measure (two-nats-measure (acl2-count x) 0) )
 
 
 

--- a/books/cowles/acl2-agp.lisp
+++ b/books/cowles/acl2-agp.lisp
@@ -61,8 +61,10 @@ acts as an @('ACL2-AGP::op-inverse') for @('ACL2-AGP:: id').</p>
 <p>with the following, constraining axioms:</p>
 
 @(def Equiv-is-an-equivalence)
-@(def Equiv-1-implies-equiv-op)
-@(def Equiv-2-implies-equiv-op)
+@(def Equiv-implies-iff-pred-1)
+@(def Equiv-implies-equiv-op-1)
+@(def Equiv-implies-equiv-op-2)
+@(def Equiv-implies-equiv-inv-1)
 @(def Closure-of-op-for-pred)
 @(def Closure-of-id-for-pred)
 @(def Closure-of-inv-for-pred)
@@ -103,31 +105,20 @@ acts as an @('ACL2-AGP::op-inverse') for @('ACL2-AGP:: id').</p>
              (declare (xargs :guard (pred x)))
              x))
 
-    (defthm Equiv-is-an-equivalence
-      (and (booleanp (equiv x y))
-           (equiv x x)
-           (implies (equiv x y)
-                    (equiv y x))
-           (implies (and (equiv x y)
-                         (equiv y z))
-                    (equiv x z)))
+    (defequiv equiv
       :rule-classes (:equivalence
                      (:type-prescription
                       :corollary
                       (or (equal (equiv x y) t)
                           (equal (equiv x y) nil)))))
 
-    (defthm Equiv-1-implies-equiv-op
-      (implies (equiv x1 x2)
-               (equiv (op x1 y)
-                      (op x2 y)))
-      :rule-classes :congruence)
+    (defcong equiv iff (pred x) 1)
 
-    (defthm Equiv-2-implies-equiv-op
-      (implies (equiv y1 y2)
-               (equiv (op x y1)
-                      (op x y2)))
-      :rule-classes :congruence)
+    (defcong equiv equiv (op x y) 1)
+
+    (defcong equiv equiv (op x y) 2)
+
+    (defcong equiv equiv (inv x) 1)
 
     (defthm Closure-of-op-for-pred
       (implies (and (pred x)
@@ -192,10 +183,10 @@ acts as an @('ACL2-AGP::op-inverse') for @('ACL2-AGP:: id').</p>
                          (equiv x y)))
            :rule-classes nil
            :hints (("Subgoal 1"
-                    :in-theory (disable Equiv-1-implies-equiv-op)
-                    :use (:instance Equiv-1-implies-equiv-op
-                                    (x1 (op x z))
-                                    (x2 (op y z))
+                    :in-theory (disable Equiv-implies-equiv-op-1)
+                    :use (:instance Equiv-implies-equiv-op-1
+                                    (x (op x z))
+                                    (x-equiv (op y z))
                                     (y  (inv z)))))))
 
   (defthm Right-cancellation-for-op

--- a/books/cowles/acl2-asg.lisp
+++ b/books/cowles/acl2-asg.lisp
@@ -55,7 +55,9 @@ both Associative and Commutative :@(see rewrite) rules. The macro
 <p>with the following, constraining axioms:</p>
 
 @(def Equiv-is-an-equivalence)
-@(def Equiv-2-implies-equiv-op)
+@(def Equiv-implies-iff-pred-1)
+@(def Equiv-implies-equiv-op-1)
+@(def Equiv-implies-equiv-op-2)
 @(def Closure-of-op-for-pred)
 @(def Associativity-of-op)
 @(def Commutativity-of-op)
@@ -85,21 +87,13 @@ both Associative and Commutative :@(see rewrite) rules. The macro
              (and (or x y)
                   (not (and x y)))))
 
-    (defthm Equiv-is-an-equivalence
-      (and (acl2::booleanp (equiv x y))
-           (equiv x x)
-           (implies (equiv x y)
-                    (equiv y x))
-           (implies (and (equiv x y)
-                         (equiv y z))
-                    (equiv x z)))
-      :rule-classes :equivalence)
+    (defequiv equiv)
 
-    (defthm Equiv-2-implies-equiv-op
-      (implies (equiv y1 y2)
-               (equiv (op x y1)
-                      (op x y2)))
-      :rule-classes :congruence)
+    (defcong equiv iff (pred x) 1)
+
+    (defcong equiv equiv (op x y) 1)
+
+    (defcong equiv equiv (op x y) 2)
 
     (defthm Closure-of-op-for-pred
       (implies (and (pred x)

--- a/books/cowles/acl2-crg.lisp
+++ b/books/cowles/acl2-crg.lisp
@@ -238,7 +238,7 @@ acl2-agp::abelian-groups).</p>"
                      (acl2-agp::op plus)
                      (acl2-agp::id zero)
                      (acl2-agp::inv minus))
-                    (acl2-agp::x (times (zero) x)))
+                    (x (times (zero) x)))
                    (:instance Left-distributivity-of-times-over-plus
                               (y (zero))
                               (z (zero)))))))
@@ -262,8 +262,8 @@ acl2-agp::abelian-groups).</p>"
                      (acl2-agp::op plus)
                      (acl2-agp::id zero)
                      (acl2-agp::inv minus))
-                    (acl2-agp::x (times x y))
-                    (acl2-agp::y (times x (minus y))))
+                    (x (times x y))
+                    (y (times x (minus y))))
                    (:instance
                     Left-distributivity-of-times-over-plus
                     (z (minus y)))))))

--- a/books/cowles/acl2-crg.lisp
+++ b/books/cowles/acl2-crg.lisp
@@ -64,10 +64,12 @@ RG which acts as an @('ACL2-CRG::plus-inverse') for @('ACL2-CRG::zero').</p>
 <p>with the following, constraining axioms:</p>
 
 @(def Equiv-is-an-equivalence)
-@(def Equiv-1-implies-equiv-plus)
-@(def Equiv-2-implies-equiv-plus)
-@(def Equiv-2-implies-equiv-times)
-@(def Equiv-1-implies-equiv-minus)
+@(def Equiv-implies-iff-pred-1)
+@(def Equiv-implies-equiv-plus-1)
+@(def Equiv-implies-equiv-plus-2)
+@(def Equiv-implies-equiv-times-1)
+@(def Equiv-implies-equiv-times-2)
+@(def Equiv-implies-equiv-minus-1)
 
 @(def Closure-of-plus-for-pred)
 @(def Closure-of-times-for-pred)
@@ -132,43 +134,24 @@ acl2-agp::abelian-groups).</p>"
              (declare (xargs :guard (pred x)))
              x))
 
-    (defthm Equiv-is-an-equivalence
-      (and (booleanp (equiv x y))
-           (equiv x x)
-           (implies (equiv x y)
-                    (equiv y x))
-           (implies (and (equiv x y)
-                         (equiv y z))
-                    (equiv x z)))
+    (defequiv equiv
       :rule-classes (:equivalence
                      (:type-prescription
                       :corollary
                       (or (equal (equiv x y) t)
                           (equal (equiv x y) nil)))))
 
-    (defthm Equiv-1-implies-equiv-plus
-      (implies (equiv x1 x2)
-               (equiv (plus x1 y)
-                      (plus x2 y)))
-      :rule-classes :congruence)
+    (defcong equiv iff (pred x) 1)
 
-    (defthm Equiv-2-implies-equiv-plus
-      (implies (equiv y1 y2)
-               (equiv (plus x y1)
-                      (plus x y2)))
-      :rule-classes :congruence)
+    (defcong equiv equiv (plus x y) 1)
 
-    (defthm Equiv-2-implies-equiv-times
-      (implies (equiv y1 y2)
-               (equiv (times x y1)
-                      (times x y2)))
-      :rule-classes :congruence)
+    (defcong equiv equiv (plus x y) 2)
 
-    (defthm Equiv-1-implies-equiv-minus
-      (implies (equiv x1 x2)
-               (equiv (minus x1)
-                      (minus x2)))
-      :rule-classes :congruence)
+    (defcong equiv equiv (times x y) 1)
+
+    (defcong equiv equiv (times x y) 2)
+
+    (defcong equiv equiv (minus x) 1)
 
     (defthm Closure-of-plus-for-pred
       (implies (and (pred x)

--- a/books/cowles/package.lsp
+++ b/books/cowles/package.lsp
@@ -20,6 +20,7 @@
                defxdoc
                defsection
                rewrite
+               x y z
                ))
    '(zero)))
 

--- a/books/workshops/1999/knuth-91/aof.lisp
+++ b/books/workshops/1999/knuth-91/aof.lisp
@@ -372,24 +372,16 @@ To certify this book, first, create a world with the following packages:
 		(equal (*_a x y z)
 		       (*_a y x z))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-asg::commutativity-2-of-op
-		   (acl2-asg::equiv equal)
-		   (acl2-asg::pred aofp)
-		   (acl2-asg::op binary-+_a))
-		  (acl2-asg::x x)
-		  (acl2-asg::y y)
-		  (acl2-asg::z z))
-		 (:instance
-		  (:functional-instance
-		   acl2-asg::commutativity-2-of-op
-		   (acl2-asg::equiv equal)
-		   (acl2-asg::pred aofp)
-		   (acl2-asg::op binary-*_a))
-		  (acl2-asg::x x)
-		  (acl2-asg::y y)
-		  (acl2-asg::z z))))))
+	   :use ((:functional-instance
+                  acl2-asg::commutativity-2-of-op
+                  (acl2-asg::equiv equal)
+                  (acl2-asg::pred aofp)
+                  (acl2-asg::op binary-+_a))
+		 (:functional-instance
+                  acl2-asg::commutativity-2-of-op
+                  (acl2-asg::equiv equal)
+                  (acl2-asg::pred aofp)
+                  (acl2-asg::op binary-*_a))))))
 
 (defthm
   Reverse-Extension-Laws
@@ -442,16 +434,14 @@ To certify this book, first, create a world with the following packages:
 		(equal (*_a x 0)
 		       0)))
   :hints (("Goal"
-	   :use (:instance
-		 (:functional-instance
-		  acl2-crg::Left-nullity-of-zero-for-times
-		  (acl2-crg::equiv equal)
-		  (acl2-crg::pred aofp)
-		  (acl2-crg::plus binary-+_a)
-		  (acl2-crg::times binary-*_a)
-		  (acl2-crg::minus unary--_a)
-		  (acl2-crg::zero (lambda () 0)))
-		 (acl2-crg::x x)))))
+	   :use (:functional-instance
+                 acl2-crg::Left-nullity-of-zero-for-times
+                 (acl2-crg::equiv equal)
+                 (acl2-crg::pred aofp)
+                 (acl2-crg::plus binary-+_a)
+                 (acl2-crg::times binary-*_a)
+                 (acl2-crg::minus unary--_a)
+                 (acl2-crg::zero (lambda () 0))))))
 
 (defthm
   Type-of-/_a
@@ -521,26 +511,22 @@ To certify this book, first, create a world with the following packages:
 			 (equal (/_a (/_a x))
 				x))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Involution-of-inv
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred aofp)
-		   (acl2-agp::op binary-+_a)
-		   (acl2-agp::id (lambda () 0))
-		   (acl2-agp::inv unary--_a))
-		  (acl2-agp::x x))
-		 (:instance
-		  (:functional-instance
-		   acl2-agp::Involution-of-inv
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred (lambda (x)
-				     (and (aofp x)
-					  (not (equal x 0)))))
-		   (acl2-agp::op binary-*_a)
-		   (acl2-agp::id (lambda () 1))
-		   (acl2-agp::inv unary-/_a))
-		  (acl2-agp::x x))))))
+	   :use ((:functional-instance
+                  acl2-agp::Involution-of-inv
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred aofp)
+                  (acl2-agp::op binary-+_a)
+                  (acl2-agp::id (lambda () 0))
+                  (acl2-agp::inv unary--_a))
+		 (:functional-instance
+                  acl2-agp::Involution-of-inv
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred (lambda (x)
+                                    (and (aofp x)
+                                         (not (equal x 0)))))
+                  (acl2-agp::op binary-*_a)
+                  (acl2-agp::id (lambda () 1))
+                  (acl2-agp::inv unary-/_a))))))
 
 (defthm
   Inverse-Distributive-Laws
@@ -553,28 +539,22 @@ To certify this book, first, create a world with the following packages:
 			 (equal (/_a (*_a x y))
 				(*_a (/_a x)(/_a y))))))
   :hints (("Goal"
-	   :use ((:instance
-                  (:functional-instance
-                   acl2-agp::Distributivity-of-inv-over-op
-                   (acl2-agp::equiv equal)
-                   (acl2-agp::pred aofp)
-                   (acl2-agp::op binary-+_a)
-                   (acl2-agp::id (lambda () 0))
-                   (acl2-agp::inv unary--_a))
-                  (acl2-agp::x x)
-                  (acl2-agp::y y))
-		 (:instance
-                  (:functional-instance
-                   acl2-agp::Distributivity-of-inv-over-op
-                   (acl2-agp::equiv equal)
-                   (acl2-agp::pred (lambda (x)
-                                     (and (aofp x)
-                                          (not (equal x 0)))))
-                   (acl2-agp::op binary-*_a)
-                   (acl2-agp::id (lambda () 1))
-                   (acl2-agp::inv unary-/_a))
-                  (acl2-agp::x x)
-                  (acl2-agp::y y))))))
+	   :use ((:functional-instance
+                  acl2-agp::Distributivity-of-inv-over-op
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred aofp)
+                  (acl2-agp::op binary-+_a)
+                  (acl2-agp::id (lambda () 0))
+                  (acl2-agp::inv unary--_a))
+		 (:functional-instance
+                  acl2-agp::Distributivity-of-inv-over-op
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred (lambda (x)
+                                    (and (aofp x)
+                                         (not (equal x 0)))))
+                  (acl2-agp::op binary-*_a)
+                  (acl2-agp::id (lambda () 1))
+                  (acl2-agp::inv unary-/_a))))))
 
 (defthm
   Inverse-Cancellation-Laws
@@ -590,28 +570,22 @@ To certify this book, first, create a world with the following packages:
 			      (equal (*_a x (/_a x) y)
 				     y)))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::inv-cancellation-on-right
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred aofp)
-		   (acl2-agp::op binary-+_a)
-		   (acl2-agp::id (lambda () 0))
-		   (acl2-agp::inv unary--_a))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y))
-		 (:instance
-		  (:functional-instance
-		   acl2-agp::inv-cancellation-on-right
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred (lambda (x)
-				     (and (aofp x)
-					  (not (equal x 0)))))
-		   (acl2-agp::op binary-*_a)
-		   (acl2-agp::id (lambda () 1))
-		   (acl2-agp::inv unary-/_a))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y))))))
+	   :use ((:functional-instance
+                  acl2-agp::inv-cancellation-on-right
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred aofp)
+                  (acl2-agp::op binary-+_a)
+                  (acl2-agp::id (lambda () 0))
+                  (acl2-agp::inv unary--_a))
+		 (:functional-instance
+                  acl2-agp::inv-cancellation-on-right
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred (lambda (x)
+                                    (and (aofp x)
+                                         (not (equal x 0)))))
+                  (acl2-agp::op binary-*_a)
+                  (acl2-agp::id (lambda () 1))
+                  (acl2-agp::inv unary-/_a))))))
 
 (defthm
   Cancellation-Laws
@@ -639,30 +613,22 @@ To certify this book, first, create a world with the following packages:
 		       (or (equal z 0)
 			   (equal x y)))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Right-cancellation-for-op
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred aofp)
-		   (acl2-agp::op binary-+_a)
-		   (acl2-agp::id (lambda () 0))
-		   (acl2-agp::inv unary--_a))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y)
-		  (acl2-agp::z z))
-		 (:instance
-		  (:functional-instance
-		   acl2-agp::Right-cancellation-for-op
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred (lambda (x)
-				     (and (aofp x)
-					  (not (equal x 0)))))
-		   (acl2-agp::op binary-*_a)
-		   (acl2-agp::id (lambda () 1))
-		   (acl2-agp::inv unary-/_a))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y)
-		  (acl2-agp::z z))))))
+	   :use ((:functional-instance
+                  acl2-agp::Right-cancellation-for-op
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred aofp)
+                  (acl2-agp::op binary-+_a)
+                  (acl2-agp::id (lambda () 0))
+                  (acl2-agp::inv unary--_a))
+		 (:functional-instance
+                  acl2-agp::Right-cancellation-for-op
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred (lambda (x)
+                                    (and (aofp x)
+                                         (not (equal x 0)))))
+                  (acl2-agp::op binary-*_a)
+                  (acl2-agp::id (lambda () 1))
+                  (acl2-agp::inv unary-/_a))))))
 
 (defthm
   Equal_-_a-zero
@@ -711,15 +677,13 @@ To certify this book, first, create a world with the following packages:
 	   (equal (equal (+_a x x) x)
 		  (equal x 0)))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Uniqueness-of-id-as-op-idempotent
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred aofp)
-		   (acl2-agp::op binary-+_a)
-		   (acl2-agp::id (lambda () 0))
-		   (acl2-agp::inv unary--_a))
-		  (acl2-agp::x x))))))
+	   :use ((:functional-instance
+                  acl2-agp::Uniqueness-of-id-as-op-idempotent
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred aofp)
+                  (acl2-agp::op binary-+_a)
+                  (acl2-agp::id (lambda () 0))
+                  (acl2-agp::inv unary--_a))))))
 
 (defthm
   Projection-Laws
@@ -745,18 +709,15 @@ To certify this book, first, create a world with the following packages:
 		  (and (not (equal x 0))
 		       (equal y (/_a x)))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Uniqueness-of-op-inverses
-		   (acl2-agp::equiv equal)
-		   (acl2-agp::pred (lambda (x)
-				     (and (aofp x)
-					  (not (equal x 0)))))
-		   (acl2-agp::op binary-*_a)
-		   (acl2-agp::id (lambda () 1))
-		   (acl2-agp::inv unary-/_a))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y))))))
+	   :use ((:functional-instance
+                  acl2-agp::Uniqueness-of-op-inverses
+                  (acl2-agp::equiv equal)
+                  (acl2-agp::pred (lambda (x)
+                                    (and (aofp x)
+                                         (not (equal x 0)))))
+                  (acl2-agp::op binary-*_a)
+                  (acl2-agp::id (lambda () 1))
+                  (acl2-agp::inv unary-/_a))))))
 
 (defthm
   Functional-Commutativity-Laws-1
@@ -767,17 +728,14 @@ To certify this book, first, create a world with the following packages:
 		(equal (*_a (-_a y) x)
 		       (-_a (*_a y x)))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-crg::functional-commutativity-of-minus-times-right
-		   (acl2-crg::equiv equal)
-		   (acl2-crg::pred aofp)
-		   (acl2-crg::plus binary-+_a)
-		   (acl2-crg::times binary-*_a)
-		   (acl2-crg::zero (lambda () 0))
-		   (acl2-crg::minus unary--_a))
-		  (acl2-crg::x x)
-		  (acl2-crg::y y))))))
+	   :use ((:functional-instance
+                  acl2-crg::functional-commutativity-of-minus-times-right
+                  (acl2-crg::equiv equal)
+                  (acl2-crg::pred aofp)
+                  (acl2-crg::plus binary-+_a)
+                  (acl2-crg::times binary-*_a)
+                  (acl2-crg::zero (lambda () 0))
+                  (acl2-crg::minus unary--_a))))))
 
 (local
  (defthm

--- a/books/workshops/2006/cowles-gamboa-euclid/Euclid/ed1.lisp
+++ b/books/workshops/2006/cowles-gamboa-euclid/Euclid/ed1.lisp
@@ -811,24 +811,16 @@ To certify this book, first, create a world with the following package:
 		(==_e (**_e x (**_e y z))
 		      (**_e y (**_e x z)))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-asg::commutativity-2-of-op
-		   (acl2-asg::equiv ==_e)
-		   (acl2-asg::pred edp)
-		   (acl2-asg::op ++_e))
-		  (acl2-asg::x x)
-		  (acl2-asg::y y)
-		  (acl2-asg::z z))
-		 (:instance
-		  (:functional-instance
-		   acl2-asg::commutativity-2-of-op
-		   (acl2-asg::equiv ==_e)
-		   (acl2-asg::pred edp)
-		   (acl2-asg::op **_e))
-		  (acl2-asg::x x)
-		  (acl2-asg::y y)
-		  (acl2-asg::z z))))))
+	   :use ((:functional-instance
+                  acl2-asg::commutativity-2-of-op
+                  (acl2-asg::equiv ==_e)
+                  (acl2-asg::pred edp)
+                  (acl2-asg::op ++_e))
+		 (:functional-instance
+                  acl2-asg::commutativity-2-of-op
+                  (acl2-asg::equiv ==_e)
+                  (acl2-asg::pred edp)
+                  (acl2-asg::op **_e))))))
 
 (defthm
   Nullity-Laws

--- a/books/workshops/2006/cowles-gamboa-euclid/Euclid/ed3.lisp
+++ b/books/workshops/2006/cowles-gamboa-euclid/Euclid/ed3.lisp
@@ -1999,7 +1999,7 @@ To certify this book, first, create a world with the following packages:
 		 (acl2-agp::inv (lambda (x)(divides-pp-witness x (1_e)))))
 		(acl2-agp::x x)
 		(acl2-agp::y y)))
-	  ("Subgoal 3"
+	  ("Subgoal 5"
 ; Changed after v4-3 by Kaufmann/Moore, for tau system --
 ; tau on {"Subgoal 3"} tau off: {"Subgoal 8"}
 	   :use (:instance

--- a/books/workshops/2006/cowles-gamboa-euclid/Euclid/ed3.lisp
+++ b/books/workshops/2006/cowles-gamboa-euclid/Euclid/ed3.lisp
@@ -864,24 +864,16 @@ To certify this book, first, create a world with the following packages:
 		(==_e (**_e x y z)
 		      (**_e y x z))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-asg::commutativity-2-of-op
-		   (acl2-asg::equiv ==_e)
-		   (acl2-asg::pred edp)
-		   (acl2-asg::op binary-++_e))
-		  (acl2-asg::x x)
-		  (acl2-asg::y y)
-		  (acl2-asg::z z))
-		 (:instance
-		  (:functional-instance
-		   acl2-asg::commutativity-2-of-op
-		   (acl2-asg::equiv ==_e)
-		   (acl2-asg::pred edp)
-		   (acl2-asg::op binary-**_e))
-		  (acl2-asg::x x)
-		  (acl2-asg::y y)
-		  (acl2-asg::z z))))))
+	   :use ((:functional-instance
+                  acl2-asg::commutativity-2-of-op
+                  (acl2-asg::equiv ==_e)
+                  (acl2-asg::pred edp)
+                  (acl2-asg::op binary-++_e))
+		 (:functional-instance
+                  acl2-asg::commutativity-2-of-op
+                  (acl2-asg::equiv ==_e)
+                  (acl2-asg::pred edp)
+                  (acl2-asg::op binary-**_e))))))
 
 (defthm
   Nullity-Laws
@@ -897,15 +889,13 @@ To certify this book, first, create a world with the following packages:
 	   (==_e (-_e (-_e x))
 		 x))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Involution-of-inv
-		   (acl2-agp::equiv ==_e)
-		   (acl2-agp::pred edp)
-		   (acl2-agp::op binary-++_e)
-		   (acl2-agp::id 0_e)
-		   (acl2-agp::inv -_e))
-		  (acl2-agp::x x))))))
+	   :use (:functional-instance
+                 acl2-agp::Involution-of-inv
+                 (acl2-agp::equiv ==_e)
+                 (acl2-agp::pred edp)
+                 (acl2-agp::op binary-++_e)
+                 (acl2-agp::id 0_e)
+                 (acl2-agp::inv -_e)))))
 
 (defthm
   Inverse-Distributive-Law
@@ -914,16 +904,13 @@ To certify this book, first, create a world with the following packages:
 	   (==_e (-_e (++_e x y))
 		 (++_e (-_e x)(-_e y))))
   :hints (("Goal"
-	   :use ((:instance
-                  (:functional-instance
-                   acl2-agp::Distributivity-of-inv-over-op
-                   (acl2-agp::equiv ==_e)
-                   (acl2-agp::pred edp)
-                   (acl2-agp::op binary-++_e)
-                   (acl2-agp::id 0_e)
-                   (acl2-agp::inv -_e))
-                  (acl2-agp::x x)
-                  (acl2-agp::y y))))))
+	   :use (:functional-instance
+                 acl2-agp::Distributivity-of-inv-over-op
+                 (acl2-agp::equiv ==_e)
+                 (acl2-agp::pred edp)
+                 (acl2-agp::op binary-++_e)
+                 (acl2-agp::id 0_e)
+                 (acl2-agp::inv -_e)))))
 
 (defthm
   Inverse-Cancellation-Laws
@@ -934,16 +921,13 @@ To certify this book, first, create a world with the following packages:
 		(==_e (++_e x (-_e x) y)
 		      y)))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::inv-cancellation-on-right
-		   (acl2-agp::equiv ==_e)
-		   (acl2-agp::pred edp)
-		   (acl2-agp::op binary-++_e)
-		   (acl2-agp::id 0_e)
-		   (acl2-agp::inv -_e))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y))))))
+	   :use (:functional-instance
+                 acl2-agp::inv-cancellation-on-right
+                 (acl2-agp::equiv ==_e)
+                 (acl2-agp::pred edp)
+                 (acl2-agp::op binary-++_e)
+                 (acl2-agp::id 0_e)
+                 (acl2-agp::inv -_e)))))
 
 (defthm
   Cancellation-Laws-for-++_e
@@ -959,17 +943,13 @@ To certify this book, first, create a world with the following packages:
 		(equal (==_e (++_e x z)(++_e z y))
 		       (==_e x y))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Right-cancellation-for-op
-		   (acl2-agp::equiv ==_e)
-		   (acl2-agp::pred edp)
-		   (acl2-agp::op binary-++_e)
-		   (acl2-agp::id 0_e)
-		   (acl2-agp::inv -_e))
-		  (acl2-agp::x x)
-		  (acl2-agp::y y)
-		  (acl2-agp::z z))))))
+	   :use (:functional-instance
+                 acl2-agp::Right-cancellation-for-op
+                 (acl2-agp::equiv ==_e)
+                 (acl2-agp::pred edp)
+                 (acl2-agp::op binary-++_e)
+                 (acl2-agp::id 0_e)
+                 (acl2-agp::inv -_e)))))
 
 (defthm
   Functional-Commutativity-Laws-1
@@ -980,17 +960,14 @@ To certify this book, first, create a world with the following packages:
 		(==_e (**_e (-_e y) x)
 		      (-_e (**_e y x)))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-crg::functional-commutativity-of-minus-times-right
-		   (acl2-crg::equiv ==_e)
-		   (acl2-crg::pred edp)
-		   (acl2-crg::plus binary-++_e)
-		   (acl2-crg::times binary-**_e)
-		   (acl2-crg::zero 0_e)
-		   (acl2-crg::minus -_e))
-		  (acl2-crg::x x)
-		  (acl2-crg::y y))))))
+	   :use (:functional-instance
+                 acl2-crg::functional-commutativity-of-minus-times-right
+                 (acl2-crg::equiv ==_e)
+                 (acl2-crg::pred edp)
+                 (acl2-crg::plus binary-++_e)
+                 (acl2-crg::times binary-**_e)
+                 (acl2-crg::zero 0_e)
+                 (acl2-crg::minus -_e)))))
 
 (defthm
   -_e-0
@@ -1032,15 +1009,13 @@ To certify this book, first, create a world with the following packages:
 	   (equal (==_e (++_e x x) x)
 		  (==_e x (0_e))))
   :hints (("Goal"
-	   :use ((:instance
-		  (:functional-instance
-		   acl2-agp::Uniqueness-of-id-as-op-idempotent
-		   (acl2-agp::equiv ==_e)
-		   (acl2-agp::pred edp)
-		   (acl2-agp::op binary-++_e)
-		   (acl2-agp::id 0_e)
-		   (acl2-agp::inv -_e))
-		  (acl2-agp::x x))))))
+	   :use (:functional-instance
+                 acl2-agp::Uniqueness-of-id-as-op-idempotent
+                 (acl2-agp::equiv ==_e)
+                 (acl2-agp::pred edp)
+                 (acl2-agp::op binary-++_e)
+                 (acl2-agp::id 0_e)
+                 (acl2-agp::inv -_e)))))
 
 (defthm
   ==_e_-_e-0_e
@@ -1989,23 +1964,20 @@ To certify this book, first, create a world with the following packages:
 		 (**_e (divides-pp-witness x (1_e))
 		       (divides-pp-witness y (1_e)))))
   :hints (("Goal"
-	   :by (:instance
-		(:functional-instance
-		 acl2-agp::Distributivity-of-inv-over-op
-		 (acl2-agp::equiv ==_e)
-		 (acl2-agp::pred unit-pp)
-		 (acl2-agp::op binary-**_e)
-		 (acl2-agp::id 1_e)
-		 (acl2-agp::inv (lambda (x)(divides-pp-witness x (1_e)))))
-		(acl2-agp::x x)
-		(acl2-agp::y y)))
+	   :by (:functional-instance
+                acl2-agp::Distributivity-of-inv-over-op
+                (acl2-agp::equiv ==_e)
+                (acl2-agp::pred unit-pp)
+                (acl2-agp::op binary-**_e)
+                (acl2-agp::id 1_e)
+                (acl2-agp::inv (lambda (x)(divides-pp-witness x (1_e))))))
 	  ("Subgoal 5"
 ; Changed after v4-3 by Kaufmann/Moore, for tau system --
 ; tau on {"Subgoal 3"} tau off: {"Subgoal 8"}
 	   :use (:instance
-		 Unit-pp-closure-**_e
-		 (u acl2-agp::x)
-		 (v acl2-agp::y)))))
+                 Unit-pp-closure-**_e
+                 (u x)
+                 (v y)))))
 
 (defthm
   Divides-pp-witness-1_e


### PR DESCRIPTION
Books cowles/acl2-*.lisp define equivalence relation `equiv`.
It is desirable if other functions in these books
would respect this relation by full set of congruence rules.
This fix also uses macros `defequiv` and `defcong`
instead of boilerplate equivalence/congruence text.

Below is an example of concrete abelian semigroup functions.
They pass `defattach` before the change, but some congruences fail.
`defattach` fails after the change.

```lisp
(in-package "ACL2")
(include-book "misc/assert" :dir :system)
(include-book "cowles/acl2-asg" :dir :system)

(defn my-pred (x)
  (booleanp x))

(defn my-equiv (x y)
  (iff x y))

(defn my-op (x y)
  (if (equal x 0) (not y) (and x y)))

(defattach
  (acl2-asg::pred my-pred)
  (acl2-asg::equiv my-equiv)
  (acl2-asg::op my-op))

(assert! (acl2-asg::equiv
          0
          t))
(assert! (not (iff
               (acl2-asg::pred 0)
               (acl2-asg::pred t))))
(assert! (not (acl2-asg::equiv
               (acl2-asg::op 0 nil)
               (acl2-asg::op t nil))))

(defequiv my-equiv)

(defcong my-equiv my-equiv (my-op x y) 2)

;(defcong my-equiv my-equiv (my-op x y) 1)

;(defcong my-equiv iff (my-pred x) 1)
```