### PR TITLE
Math XDOC topic.

### DIFF
--- a/books/centaur/bitops/top.lisp
+++ b/books/centaur/bitops/top.lisp
@@ -51,7 +51,7 @@
 (include-book "signed-byte-p")
 
 (defxdoc bitops
-  :parents (acl2::arithmetic)
+  :parents (acl2::bit-vectors)
   :short "Bitops is <a href='http://www.centtech.com/'>Centaur Technology</a>'s
 library for reasoning about bit-vector arithmetic.  It grew out of an extension
 to the venerable @(see acl2::ihs) library, and is now fairly comprehensive."

--- a/books/cowles/acl2-agp.lisp
+++ b/books/cowles/acl2-agp.lisp
@@ -16,9 +16,9 @@
 (include-book "acl2-asg")
 
 (defsection abelian-groups
-  :parents (cowles)
+  :parents (algebra)
   :short "Axiomatization of an associative and commutative binary operation
-with an identity and an unary inverse operation."
+with an identity and an unary inverse operation, developed by John Cowles."
 
   :long "<h3>Theory of Abelian Groups</h3>
 

--- a/books/cowles/acl2-asg.lisp
+++ b/books/cowles/acl2-asg.lisp
@@ -15,14 +15,9 @@
 (in-package "ACL2-ASG")
 (include-book "xdoc/top" :dir :system)
 
-(defsection cowles
-  :parents (acl2::arithmetic)
-  :short "Fundamental notions of groups and rings, developed by John Cowles,
-typically used in other @(see acl2::arithmetic) libraries.")
-
 (defsection abelian-semigroups
-  :parents (cowles)
-  :short "Axiomatization of an associative and commutative binary operation."
+  :parents (algebra)
+  :short "Axiomatization of an associative and commutative binary operation, developed by John Cowles."
   :autodoc nil
   :long "<h3>Theory of Abelian SemiGroups</h3>
 

--- a/books/cowles/acl2-crg.lisp
+++ b/books/cowles/acl2-crg.lisp
@@ -15,10 +15,10 @@
 (include-book "acl2-agp")
 
 (defsection commutative-rings
-  :parents (cowles)
+  :parents (algebra)
   :short "Axiomatization of two associative and commutative operations, one
 distributes over the other, while the other has an identity and an unary
-inverse operation."
+inverse operation, developed by John Cowles."
 
   :long "<h3>Theory of Commutative Rings</h3>
 

--- a/books/cowles/package.lsp
+++ b/books/cowles/package.lsp
@@ -12,8 +12,7 @@
 ; information about that, see:
 ; http://code.google.com/p/acl2-books/issues/detail?id=4
 
-             '(arithmetic
-               cowles
+             '(algebra
                abelian-semigroups
                abelian-groups
                commutative-rings

--- a/books/doc/more-topics.lisp
+++ b/books/doc/more-topics.lisp
@@ -32,10 +32,22 @@
 (include-book "xdoc/top" :dir :system)
 
 
-(defsection arithmetic
+(defsection math
   :parents (top)
+  :short "Math-related libraries: arithmetic, algebra, bit-vectors.")
+
+(defsection algebra
+  :parents (math)
+  :short "Libraries to reason about algebraic structures, e.g. groups, rings, fields, polynomials.")
+
+(defsection arithmetic
+  :parents (math)
   :short "Libraries for reasoning about basic arithmetic, bit-vector
 arithmetic, modular arithmetic, etc.")
+
+(defsection bit-vectors
+  :parents (math)
+  :short "Libraries for reasoning about bit vectors.")
 
 (defsection boolean-reasoning
   :parents (top)

--- a/books/ihs/ihs-doc-topic.lisp
+++ b/books/ihs/ihs-doc-topic.lisp
@@ -10,7 +10,7 @@
 (include-book "xdoc/top" :dir :system)
 
 (defxdoc ihs
-  :parents (arithmetic)
+  :parents (bit-vectors)
   :short "The Integer Hardware Specification (IHS) library is a collection of
 arithmetic books, mainly geared toward bit-vector arithmetic."
 

--- a/books/rtl/rel11/lib/doc.lisp
+++ b/books/rtl/rel11/lib/doc.lisp
@@ -214,7 +214,7 @@
                           ,(rtl-node-name-lst children)))
 
 (defxdoc rtl
-  :parents (acl2::arithmetic acl2::hardware-verification)
+  :parents (acl2::bit-vectors acl2::hardware-verification)
   :short "A library of register-transfer logic and computer arithmetic"
   :long "<p>This @(see documentation) for @(see community-books) residing under
   @('rtl/rel11') contains links to David Russinoff's online rtl manual, <i><a


### PR DESCRIPTION
There were a discussion in #585 a few months ago about adding a new MATH topic directly under TOP, moving the existing ARITHMETIC topic to be a child of MATH. 

Sorry for a long delay. This pull request tries to implement that discussion

Organize some of math XDOC stuff in such a hierarchy:
```
Math
  Algebra
    Abelian-groups
    Abelian-semigroups
    Commutative-rings
  Arithmetic
    Arith-equivs
    Arithmetic-1
    Lispfloat
    Proof-by-arith
  Bit-vectors
    Bitops
    Ihs
    Rtl
```