### PR TITLE
Xdoc number theory

### DIFF
--- a/books/projects/doc.lisp
+++ b/books/projects/doc.lisp
@@ -9,6 +9,7 @@
 (include-book "milawa/doc")
 (include-book "regex/regex-ui")
 (include-book "leftist-trees/top")
+(include-book "quadratic-reciprocity/euler")
 (include-book "sidekick/server")
 (include-book "x86isa/top")
 

--- a/books/projects/quadratic-reciprocity/euclid.lisp
+++ b/books/projects/quadratic-reciprocity/euclid.lisp
@@ -3,6 +3,7 @@
 ;; http://www.russinoff.com
 
 (in-package "RTL")
+(include-book "xdoc/top" :dir :system)
 
 (include-book "support/euclid")
 
@@ -10,13 +11,32 @@
 (set-inhibit-warnings "theory") ; avoid warning in the next event
 (local (in-theory nil))
 
-;; This book contains proofs of two theorems of Euclid:
+(defsection number-theory
+  :parents (acl2::arithmetic)
+  :short "Quadratic Reciprocity Theorem and other facts from Number Theory")
 
-;;   (1) There exist infinitely many primes.
+(defsection euclid
+  :parents (number-theory)
+  :short "Definition of prime number and two theorems of Euclid"
+  :long "<h3>Overview</h3>
 
-;;   (2) If p is a prime divisor of a*b, then p divides either a or b.
+This book contains proofs of two theorems of Euclid:
+<ol>
+  <li>There exist infinitely many primes.</li>
+  <li>If @('p') is a prime divisor of @('a*b'), then @('p') divides either @('a') or @('b').</li>
+ </ol>"
 
-;; We first list some basic properties of divisibility.
+"We first list some basic properties of divisibility.
+ @(def divides)
+ @(thm divides-leq)
+ @(thm divides-minus)
+ @(thm divides-sum)
+ @(thm divides-product)
+ @(thm divides-transitive)
+ @(thm divides-self)
+ @(thm divides-0)
+ @(thm divides-mod-equal)
+ @(thm divides-mod-0)"
 
 (defn divides (x y)
   (and (acl2-numberp x)
@@ -84,10 +104,17 @@
 
 (in-theory (disable divides))
 
-;; Our definition of primality is based on the following function, which computes
-;; the least divisor of a natural number n that is greater than or equal to k.
-;; (In the book "mersenne", in which we are concerned with efficiency, we shall
-;; introduce an equivalent version that checks for divisors only up to sqrt(n).)
+"Our definition of primality is based on the following function, which computes
+ the least divisor of a natural number @('n') that is greater than or equal to @('k').
+ (In the book @(see mersenne), in which we are concerned with efficiency, we shall
+ introduce an equivalent version that checks for divisors only up to @('sqrt(n)').)
+ @(def least-divisor)
+ @(thm least-divisor-divides)
+ @(thm least-divisor-is-least)
+ @(def primep)
+ @(thm primep-gt-1)
+ @(thm primep-no-divisor)
+ @(thm primep-least-divisor)"
 
 (defn least-divisor (k n)
   (declare (xargs :measure (:? k n)))
@@ -149,8 +176,14 @@
 
 (in-theory (disable primep))
 
-;; Our formulation of the infinitude of the set of primes is based on a function that
-;; returns a prime that is greater than its argument:
+"Our formulation of the infinitude of the set of primes is based on a function that
+ returns a prime that is greater than its argument:
+ @(def fact)
+ @(def greater-prime)
+ @(thm greater-prime-divides)
+ @(thm divides-fact)
+ @(thm not-divides-fact-plus1)
+ @(thm infinitude-of-primes)"
 
 (defun fact (n)
   (declare (xargs :guard (natp n)))
@@ -187,8 +220,14 @@
 		  (> (greater-prime n) n)))
   :rule-classes ())
 
-;; Our main theorem of Euclid depends on the properties of the greatest common divisor,
-;; which we define according to Euclid's algorithm.
+"Our main theorem of Euclid depends on the properties of the greatest common divisor,
+ which we define according to Euclid's algorithm.
+ @(def g-c-d-nat)
+ @(def g-c-d)
+ @(thm g-c-d-nat-pos)
+ @(thm g-c-d-pos)
+ @(thm divides-g-c-d-nat)
+ @(thm g-c-d-divides)"
 
 (defun g-c-d-nat (x y)
   (declare (xargs :guard (and (natp x)
@@ -236,10 +275,18 @@
 		  (or (= y 0) (divides (g-c-d x y) y))))
   :rule-classes ())
 
-;; It remains to be shown that the gcd of x and y is divisible by any common
-;; divisor of x and y.  This depends on the observation that the gcd may be
-;; expressed as a linear combination r*x + s*y.  We construct the coefficients r
-;; and s explicitly.
+"It remains to be shown that the gcd of @('x') and @('y') is divisible by any common
+ divisor of @('x') and @('y').  This depends on the observation that the gcd may be
+ expressed as a linear combination @({r*x + s*y}).  We construct the coefficients @('r')
+ and @('s') explicitly.
+ @(def r-nat)
+ @(def s-nat)
+ @(thm r-s-nat)
+ @(def r-int)
+ @(def s-int)
+ @(thm g-c-d-linear-combination)
+ @(thm divides-g-c-d)
+ @(thm g-c-d-prime)"
 
 (mutual-recursion
 
@@ -328,7 +375,8 @@ ACL2 derives them from definitions.
 	     (= (g-c-d p a) 1))
   :rule-classes ())
 
-;; the main theorem:
+"The main theorem:
+ @(thm euclid)"
 
 (defthm euclid
     (implies (and (primep p)
@@ -339,3 +387,4 @@ ACL2 derives them from definitions.
 	     (not (divides p (* a b))))
   :rule-classes ())
 
+)

--- a/books/projects/quadratic-reciprocity/euclid.lisp
+++ b/books/projects/quadratic-reciprocity/euclid.lisp
@@ -277,37 +277,40 @@
 		(g-c-d-nat x y)))
   :rule-classes ())
 
-(defun r (x y)
+(defun r-int (x y)
   (declare (xargs :guard (and (integerp x)
                               (integerp y))))
   (if (< x 0)
       (- (r-nat (abs x) (abs y)))
     (r-nat (abs x) (abs y))))
 
-(defun s (x y)
+(defun s-int (x y)
   (declare (xargs :guard (and (integerp x)
                               (integerp y))))
   (if (< y 0)
       (- (s-nat (abs x) (abs y)))
     (s-nat (abs x) (abs y))))
+#|
+These type-prescription rules are redundant.
+ACL2 derives them from definitions.
 
-(defthm integerp-r
-    (integerp (r x y))
+(defthm integerp-r-int
+    (integerp (r-int x y))
   :rule-classes (:type-prescription))
 
-(defthm integerp-s
-    (integerp (s x y))
+(defthm integerp-s-int
+    (integerp (s-int x y))
   :rule-classes (:type-prescription))
-
+|#
 (defthm g-c-d-linear-combination
     (implies (and (integerp x)
 		  (integerp y))
-	     (= (+ (* (r x y) x)
-		   (* (s x y) y))
+	     (= (+ (* (r-int x y) x)
+		   (* (s-int x y) y))
 		(g-c-d x y)))
   :rule-classes ())
 
-(in-theory (disable g-c-d r s))
+(in-theory (disable g-c-d r-int s-int))
 
 (defthm divides-g-c-d
     (implies (and (integerp x)

--- a/books/projects/quadratic-reciprocity/euler.lisp
+++ b/books/projects/quadratic-reciprocity/euler.lisp
@@ -10,27 +10,40 @@
 (set-inhibit-warnings "theory") ; avoid warning in the next event
 (local (in-theory nil))
 
-;; This book contains a proof of Euler's Criterion for quadratic residues:
-;; If p is an odd prime and m is not divisible by p, then
-
-;;   mod(m^((p-1)/2),p) = 1 if m is a quadratic residue mod p
-;;                        p-1 if not.
-
-;; Along the way, we also prove Wilson's Theorem: If p is prime, then
-;; mod((p-1)!,p) = p-1.
-
-;; Finally, as a consequence of Euler's Criterion, we derive the First
-;; Supplement to the Law of Quadratic Reciprocity: -1 is a quadratic
-;; residue mod p iff mod(p,4) = 1.
-
-;; The proof depends on Fermat's Theorem:
-
 (include-book "fermat")
 
-;; Let p be a prime, let m be relatively prime to p, and let 0 < j < p.
-;; Then there exists a unique j' such that 0 < j' < p and
-;;         mod(j*j',p) = mod(m,p),
-;; called the associate of j w.r.t. a mod p.
+(defsection euler
+  :parents (number-theory)
+  :short "This book contains a proof of Euler's Criterion for quadratic residues"
+  :long "This book contains a proof of Euler's Criterion for quadratic residues:
+ If @('p') is an odd prime and @('m') is not divisible by @('p'), then
+@({
+   mod(m^((p-1)/2),p) = 1 if m is a quadratic residue mod p
+                        p-1 if not.
+})
+
+ Along the way, we also prove Wilson's Theorem: If @('p') is prime, then
+ @('mod((p-1)!,p) = p-1').
+
+ Finally, as a consequence of Euler's Criterion, we derive the First
+ Supplement to the Law of Quadratic Reciprocity: @('-1') is a quadratic
+ residue mod @('p') iff @('mod(p,4) = 1').
+
+ The proof depends on Fermat's Theorem:"
+
+"Let @('p') be a prime, let @('m') be relatively prime to @('p'), and let @('0 < j < p').
+ Then there exists a unique <tt>j'</tt> such that <tt>0 &lt; j' &lt; p</tt> and
+<code>
+         mod(j*j',p) = mod(m,p),
+</code>
+ called the associate of @('j') w.r.t. a mod @('p').
+@(def associate)
+@(thm associate-property)
+@(thm associate-bnds)
+@(thm associate-is-unique)
+@(thm associate-of-associate)
+@(thm associate-equal)
+@(thm associate-square)"
 
 (defund associate (j m p)
   (mod (* m (expt j (- p 2))) p))
@@ -97,8 +110,8 @@
 		  (= (mod (* j j) p) (mod m p))))
   :rule-classes ())
 
-;; If there exists x such that mod(x*x,p) = mod(m,p), then m is said to be
-;; m (quadratic) residue mod p.
+"If there exists @('x') such that @('mod(x*x,p) = mod(m,p)'), then @('m') is said to be
+@('m') (quadratic) residue mod @('p')."
 
 (defun find-root (n m p)
   (if (zp n)
@@ -137,8 +150,15 @@
 	     (not (equal (associate j m p) j)))
   :rule-classes ())
 
-;; If m is a residue mod p, then there are exactly 2 roots of
-;; mod(x*x,p) = mod(m,p) in the range 0 < x < p.
+"If @('m') is a residue mod @('p'), then there are exactly 2 roots of
+ @('mod(x*x,p) = mod(m,p)') in the range @('0 < x < p').
+@(def root1)
+@(thm res-root1)
+@(def root2)
+@(thm res-root2)
+@(thm associate-roots)
+@(thm only-2-roots)
+@(thm roots-distinct)"
 
 (defun root1 (m p)
   (find-root (1- p) m p))
@@ -197,10 +217,15 @@
 	     (not (= (root1 m p) (root2 m p))))
   :rule-classes ())
 
-;; For 0 <= n < p, we construct a list associates(n,m,p) of distinct integers 
-;; between 1 and p-1 with the following properties:
-;; (a) If 1 <= j <= n, then j is in associates(n,m,p).
-;; (b) If j is in associates(n,m,p), then so is associate(j,m,p).
+"For @('0 <= n < p'), we construct a list @('associates(n,m,p)') of distinct integers
+between @('1') and @('p-1') with the following properties:
+<ul>
+  <li>If @('1 <= j <= n'), then @('j') is in @('associates(n,m,p)').</li>
+  <li>If @('j') is in @('associates(n,m,p)'), then so is @('associate(j,m,p)').</li>
+</ul>
+@(def associates)
+@(thm member-associates)"
+
 
 (defun associates (n m p)
   (if (zp n)
@@ -224,7 +249,11 @@
 	     (iff (member (associate j m p) (associates n m p))
 		  (member j (associates n m p)))))
 
-;; We shall show that associates(p-1,m,p) is a permutation of positives(p-1).
+"We shall show that @('associates(p-1,m,p)') is a permutation of @('positives(p-1)').
+@(thm subset-positives-associates)
+@(thm member-self-associate)
+@(thm distinct-positives-associates-lemma)
+@(thm distinct-positives-associates)"
 
 (defthm subset-positives-associates
     (subsetp (positives n) (associates n m p)))
@@ -256,7 +285,9 @@
 	     (distinct-positives (associates (1- p) m p) (1- p)))
   :rule-classes ())
 
-;; We shall require a variation of the pigeonhole principle.
+"We shall require a variation of the pigeonhole principle.
+@(thm pigeonhole-principle-2)
+@(thm perm-associates-positives)"
 
 (defthm pigeonhole-principle-2
     (implies (and (natp n)
@@ -274,8 +305,13 @@
 		   (associates (1- p) m p)))
   :rule-classes ())
 
-;; It follows that the product of associates(p-1,m,p) is (p-1)! and its
-;; length is p-1.
+"It follows that the product of @('associates(p-1,m,p)') is @('(p-1)!') and its
+length is @('p-1').
+@(thm times-list-associates-fact)
+@(thm perm-len)
+@(thm len-positives)
+@(thm len-associates)
+@(thm len-associates-even)"
 
 (defthm times-list-associates-fact
     (implies (and (primep p)
@@ -313,8 +349,9 @@
 	     (integerp (* 1/2 (len (associates n m p)))))
   :rule-classes (:type-prescription))
 
-;; On the other hand, we can compute the product of associates(p-1,a,p) as
-;; follows.
+"On the other hand, we can compute the product of @('associates(p-1,a,p)') as
+follows.
+@(thm times-list-associates)"
 
 (defthm times-list-associates
     (implies (and (primep p)
@@ -328,7 +365,10 @@
 		      (mod (expt m (/ (len (associates n m p)) 2)) p))))
   :rule-classes ())
 
-;; Both Wilson's Theorem and Euler's Criterion now follow easily.
+"Both Wilson's Theorem and Euler's Criterion now follow easily.
+@(thm euler-lemma)
+@(thm wilson)
+@(thm euler-criterion)"
 
 (defthm euler-lemma
     (implies (and (primep p)
@@ -358,7 +398,8 @@
 		      (1- p))))
   :rule-classes ())
 
-;;  The "First Supplement" is the case a = 1:
+"The First Supplement is the case @('a = 1')
+@(thm first-supplement)"
 
 (defthm first-supplement
     (implies (and (primep p)
@@ -366,3 +407,5 @@
 	     (iff (residue -1 p)
 		  (= (mod p 4) 1)))
   :rule-classes ())
+
+)

--- a/books/projects/quadratic-reciprocity/fermat.lisp
+++ b/books/projects/quadratic-reciprocity/fermat.lisp
@@ -10,14 +10,18 @@
 (set-inhibit-warnings "theory") ; avoid warning in the next event
 (local (in-theory nil))
 
-;; This book contains a proof of Fermat's Theorem: if p is a prime and m
-;; is not divisible by p, then mod(m^(p-1),p) = 1.
-
 ;; The proof depends on Euclid's Theorem:
 
 (include-book "euclid")
 
-;; We shall construct two lists of integers, each of which is a permutation of the other.
+(defsection fermat
+  :parents (number-theory)
+  :short "This book contains a proof of Fermat's Theorem: if @('p') is a prime and @('m')
+ is not divisible by @('p'), then @('mod(m^(p-1),p) = 1')."
+  :long "The proof depends on Euclid's Theorem:"
+
+"We shall construct two lists of integers, each of which is a permutation of the other.
+ @(def perm)"
 
 (defun perm (a b)
   (if (consp a)
@@ -26,14 +30,16 @@
 	())
     (not (consp b))))
 
-;; The first list is positives(p-1) = (1, 2, ..., p-1):
+"The first list is @({positives(p-1) = (1, 2, ..., p-1)})
+ @(def positives)"
 
 (defun positives (n)
   (if (zp n)
       ()
     (cons n (positives (1- n)))))
 
-;;The second list is mod-prods(p-1,a,p) = (mod(a,p), mod(2*a,p), ..., mod((p-1)*a,p)):
+"The second list is @({mod-prods(p-1,a,p) = (mod(a,p), mod(2*a,p), ..., mod((p-1)*a,p))})
+ @(def mod-prods)"
 
 (defun mod-prods (n m p)
   (if (zp n)
@@ -41,7 +47,12 @@
     (cons (mod (* m n) p)
 	  (mod-prods (1- n) m p))))
 
-;; The proof is based on the pigeonhole principle, as stated below.
+"The proof is based on the pigeonhole principle, as stated below.
+ @(thm not-member-remove1)
+ @(thm perm-member)
+ @(def distinct-positives)
+ @(thm member-positives)
+ @(thm pigeonhole-principle)"
 
 (defthm not-member-remove1
     (implies (not (member x l))
@@ -72,8 +83,13 @@
 	     (perm (positives (len l)) l))
   :rule-classes ())
 
-;; We must show that mod-prods(p-1,m,p) is a list of length p-1 of distinct
-;; integers between 1 and p-1.
+"We must show that @('mod-prods(p-1,m,p)') is a list of length @('p-1') of distinct
+ integers between @('1') and @('p-1').
+ @(thm len-mod-prods)
+ @(thm mod-distinct)
+ @(thm mod-p-bnds)
+ @(thm mod-prods-distinct-positives)
+ @(thm perm-mod-prods)"
 
 (defthm len-mod-prods
     (implies (natp n)
@@ -117,7 +133,9 @@
 		   (mod-prods (1- p) m p)))
   :rule-classes ())
 
-;; The product of the members of a list is invariant under permutation:
+"The product of the members of a list is invariant under permutation:
+ @(def times-list)
+ @(thm perm-times-list)"
 
 (defun times-list (l)
   (if (consp l)
@@ -131,7 +149,10 @@
 		    (times-list l2)))
   :rule-classes ())
 
-;; It follows that the product of the members of mod-prods(p-1,m,p) is (p-1)!.
+"It follows that the product of the members of @('mod-prods(p-1,m,p)') is @('(p-1)!').
+ @(thm times-list-positives)
+ @(thm times-list-equal-fact)
+ @(thm times-list-mod-prods)"
 
 (defthm times-list-positives
   (equal (times-list (positives n))
@@ -148,7 +169,8 @@
 	     (equal (times-list (mod-prods (1- p) m p))
 		    (fact (1- p)))))
 
-;; On the other hand, the product modulo p may be computed as follows.
+"On the other hand, the product modulo @('p') may be computed as follows.
+ @(thm mod-mod-prods)"
 
 (defthm mod-mod-prods
     (implies (and (not (zp p))
@@ -158,7 +180,10 @@
 		    (mod (* (fact n) (expt m n)) p)))
   :rule-classes ())
 
-;; Fermat's theorem now follows easily.
+"Fermat's theorem now follows easily.
+ @(thm not-divides-p-fact)
+ @(thm mod-times-prime)
+ @(thm fermat)"
 
 (defthm not-divides-p-fact
     (implies (and (primep p)
@@ -185,4 +210,4 @@
 		    1))
   :rule-classes ())
 
-
+)

--- a/books/projects/quadratic-reciprocity/support/euclid.lisp
+++ b/books/projects/quadratic-reciprocity/support/euclid.lisp
@@ -321,38 +321,38 @@
 		(g-c-d-nat x y)))
   :rule-classes ())
 
-(defun r (x y)
+(defun r-int (x y)
   (declare (xargs :guard (and (integerp x)
                               (integerp y))))
   (if (< x 0)
       (- (r-nat (abs x) (abs y)))
     (r-nat (abs x) (abs y))))
 
-(defun s (x y)
+(defun s-int (x y)
   (declare (xargs :guard (and (integerp x)
                               (integerp y))))
   (if (< y 0)
       (- (s-nat (abs x) (abs y)))
     (s-nat (abs x) (abs y))))
-
-(defthm integerp-r
-    (integerp (r x y))
+#|
+(defthm integerp-r-int
+    (integerp (r-int x y))
   :rule-classes (:type-prescription))
 
-(defthm integerp-s
-    (integerp (s x y))
+(defthm integerp-s-int
+    (integerp (s-int x y))
   :rule-classes (:type-prescription))
-
+|#
 (defthm g-c-d-linear-combination
     (implies (and (integerp x)
 		  (integerp y))
-	     (= (+ (* (r x y) x)
-		   (* (s x y) y))
+	     (= (+ (* (r-int x y) x)
+		   (* (s-int x y) y))
 		(g-c-d x y)))
   :rule-classes ()
   :hints (("Goal" :use (:instance r-s-nat (x (abs x)) (y (abs y))))))
 
-(in-theory (disable g-c-d r s))
+(in-theory (disable g-c-d r-int s-int))
 
 (defthm divides-g-c-d
     (implies (and (integerp x)
@@ -363,9 +363,9 @@
 		  (divides d y))
 	     (divides d (g-c-d x y)))
   :hints (("Goal" :use (g-c-d-linear-combination
-			(:instance divides-sum (x d) (y (* (r x y) x)) (z (* (s x y) y)))
-			(:instance divides-product (x d) (y x) (z (r x y)))
-			(:instance divides-product (x d) (z (s x y)))))))
+			(:instance divides-sum (x d) (y (* (r-int x y) x)) (z (* (s-int x y) y)))
+			(:instance divides-product (x d) (y x) (z (r-int x y)))
+			(:instance divides-product (x d) (z (s-int x y)))))))
 
 (defthm g-c-d-prime
     (implies (and (primep p)
@@ -381,8 +381,8 @@
   (implies (and (primep p)
                 (integerp a)
                 (integerp b)
-                (= (+ (* a (s p a)) (* p (r p a))) 1))
-           (equal (+ (* a b (s p a)) (* b p (r p a)))
+                (= (+ (* a (s-int p a)) (* p (r-int p a))) 1))
+           (equal (+ (* a b (s-int p a)) (* b p (r-int p a)))
                   b)))
 
 ;; the main theorem:
@@ -396,9 +396,8 @@
 	     (not (divides p (* a b))))
   :rule-classes ()
   :hints (("Goal" :use (g-c-d-prime
-			;(:instance cancel-equal-* (a b) (r (+ (* (r p a) p) (* (s p a) a))) (s 1))
 			(:instance g-c-d-linear-combination (x p) (y a))
-			(:instance divides-sum (x p) (y (* (r p a) p b)) (z (* (s p a) a b)))
-			(:instance divides-product (x p) (y (* a b)) (z (s p a)))
-			(:instance divides-product (x p) (y p) (z (* b (r p a))))))))
+			(:instance divides-sum (x p) (y (* (r-int p a) p b)) (z (* (s-int p a) a b)))
+			(:instance divides-product (x p) (y (* a b)) (z (s-int p a)))
+			(:instance divides-product (x p) (y p) (z (* b (r-int p a))))))))
 


### PR DESCRIPTION
Avoid name conflict between `s` functions in `euclid.lisp` and `record.lisp`.

Create XDOC topic `number-theory`. It's parent is `arithmetic`.
Write markup for some books of @russinoff and attach them to the new topic.