### PR TITLE
Bitp updates

### DIFF
--- a/books/centaur/bitops/congruences.lisp
+++ b/books/centaur/bitops/congruences.lisp
@@ -354,6 +354,13 @@
                            (b-and (logcar a) (logcar c))
                            (b-and (logcar b) (logcar c))))))))
 
+   (local (defthm logxor-1
+            (implies (bitp x)
+                     (equal (logxor 1 x)
+                            (b-not x)))))
+
+   (local (set-default-hints nil))
+
 ; Reordering the rewrite-clause-type-alist: I added the uppercase text below to
 ; make this work.  See the comment in rewrite-clause-type-alist.
 ; JSM April 7, 2013.
@@ -370,7 +377,7 @@
               :do-not '(generalize fertilize)
               :expand ((:free (b) (loghead n b))
                        (:free (b) (loghead m b)))
-              :in-theory (e/d (nfix logcdr-of-bit b-and b-ior)
+              :in-theory (e/d (nfix logcdr-of-bit b-and b-ior b-not)
                               (loghead-identity
                                (:FORWARD-CHAINING LOGCAR-POSSIBILITIES)
                                ))

--- a/books/centaur/bitops/parity.lisp
+++ b/books/centaur/bitops/parity.lisp
@@ -59,7 +59,7 @@ reason about.  However, it isn't particularly efficient; see @(see fast-parity)
 for a more efficient, logically identical function.</p>"
 
   :measure (nfix n)
-  :returns (p bitp)
+  :returns (p bitp :rule-classes :type-prescription)
   (cond ((zp n) 0)
         (t (logxor (logand x 1) (parity (1- n) (ash x -1)))))
   ///
@@ -108,7 +108,7 @@ for a more efficient, logically identical function.</p>"
   :inline t
   :enabled t
   :verify-guards nil
-  :returns (p bitp :rule-classes (:rewrite :type-prescription))
+  :returns (p bitp :rule-classes :type-prescription)
   :long "<p>The basic idea is from Sean Anderson's <a
 href='http://graphics.stanford.edu/~seander/bithacks.html'>bit twiddling
 hacks</a> page.  The number @('#x6996') acts as a lookup table for the parity
@@ -169,7 +169,7 @@ parity4) for details about why we don't do that.</p>"
 
 
 (define fast-parity ((n natp) (x integerp))
-  :returns (p bitp :rule-classes (:rewrite :type-prescription))
+  :returns (p bitp :rule-classes :type-prescription)
   :short "Optimized alternative to @(see parity)."
   :enabled t
   :long "<p>This is faster than @(see parity) because it computes up to 32 bits

--- a/books/centaur/sv/svex/lattice.lisp
+++ b/books/centaur/sv/svex/lattice.lisp
@@ -140,7 +140,7 @@ acl2::4v-monotonicity).</p>"
                              BITOPS::LOGBITP-WHEN-BIT
                              2VEC-P$INLINE
                              (:t logbitp)
-                             acl2::bit-functions-type
+                             ;acl2::bit-functions-type
                              bitops::logbitp-of-mask
                              acl2::bfix-when-not-1
                              bitops::logand-with-bitmask

--- a/books/ihs/logops-definitions.lisp
+++ b/books/ihs/logops-definitions.lisp
@@ -124,12 +124,14 @@
 (defsection bitp-basics
   :parents (bitp)
 
-  (defthm bitp-forward
-    (implies (bitp i)
-             (and (integerp i)
-                  (>= i 0)
-                  (< i 2)))
-    :rule-classes :forward-chaining)
+  ;; [Jared] 2016-04-08: I think we shouldn't need this now that bitp is
+  ;; more deeply known to type-set.
+  ;; (defthm bitp-forward
+  ;;   (implies (bitp i)
+  ;;            (and (integerp i)
+  ;;                 (>= i 0)
+  ;;                 (< i 2)))
+  ;;   :rule-classes :forward-chaining)
 
   (defthm bitp-mod-2
     (implies (integerp i)

--- a/books/ihs/logops-lemmas.lisp
+++ b/books/ihs/logops-lemmas.lisp
@@ -644,6 +644,9 @@
 
   (defthm bitp-loghead-1
     (bitp (loghead 1 i))
+    ;; [Jared] 2016-04-08: changing this to a type-prescription now that bitp
+    ;; is a good type-prescription
+    :rule-classes :type-prescription
     :hints (("Goal" :in-theory (enable bitp loghead)))))
 
 
@@ -1694,7 +1697,7 @@ definitions of logical operations."
                (equal (logand x (logior y z))
                       (logior (logand x y) (logand x z))))
       :hints (("Goal" :induct (logcdr-induction-3 x y z)
-               :in-theory (enable ifix)))))
+               :in-theory (enable ifix bfix)))))
 
   (encapsulate ()
     (local (defthm logand-logxor-lemma
@@ -2262,7 +2265,7 @@ definitions of logical operations."
              (equal (equal (logext size (+ i j)) (logext size (+ i k)))
                     (equal (logext size j) (logext size k))))
     :hints (("Goal"
-             :in-theory (e/d (bitp logext*)
+             :in-theory (e/d (bitp b-and b-xor logext*)
 ; Modified April 2016 by Matt K. with addition of type-set bit for {1}.
                              ((:t b-not$inline)))
              :restrict ((logext-+ ((size size) (i i) (j j))

--- a/books/models/jvm/m5/demo.lisp
+++ b/books/models/jvm/m5/demo.lisp
@@ -627,6 +627,14 @@ T
                      (run (fact-sched th n) s))))
                   (int-fix (factorial n)))))
 
+;; sswords (2016-04-27) -- needed this lemma presumably due to new rules taking
+;; advantage of new bitp typeset stuff
+(local (defthm integerp-of-+-1-forward
+         (implies (and (integerp (+ 1 k))
+                       (acl2-numberp k))
+                  (integerp k))
+         :rule-classes :forward-chaining))
+
 ; Symbolic Computation and Use of fact as a Subroutine
 
 (defthm symbolic-computation

--- a/books/projects/symbolic/m5/demo.lisp
+++ b/books/projects/symbolic/m5/demo.lisp
@@ -627,6 +627,14 @@ T
                      (run (fact-sched th n) s))))
                   (int-fix (factorial n)))))
 
+;; sswords (2016-04-27) -- needed this lemma presumably due to new rules taking
+;; advantage of new bitp typeset stuff
+(local (defthm integerp-of-+-1-forward
+         (implies (and (integerp (+ 1 k))
+                       (acl2-numberp k))
+                  (integerp k))
+         :rule-classes :forward-chaining))
+
 ; Symbolic Computation and Use of fact as a Subroutine
 
 (defthm symbolic-computation

--- a/books/projects/x86isa/machine/instructions/fp/fp-cvt-base.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/fp-cvt-base.lisp
@@ -9,6 +9,9 @@
 (local (include-book "arithmetic/top-with-meta" :dir :system))
 (local (in-theory (e/d (bitops::ash-1-removal) ())))
 
+;; sswords: fix breakage due to bitp typeset rule changes
+(local (in-theory (disable bitops::loghead-1-of-logtail)))
+
 ;; ======================================================================
 
 (defsection floating-point-converts

--- a/books/projects/x86isa/machine/instructions/rotates.lisp
+++ b/books/projects/x86isa/machine/instructions/rotates.lisp
@@ -140,6 +140,14 @@
 	 :gen-linear t))
     ))
 
+;; sswords: need this because of new rules taking advantage of bitp typeset
+(local (defthm unsigned-byte-p-when-bitp
+         (implies (and (bitp x)
+                       (posp n))
+                  (unsigned-byte-p n x))
+         :hints(("Goal" :in-theory (enable bitp expt)))
+         :rule-classes ((:rewrite :backchain-limit-lst 0))))
+
 (make-event (rcl-spec-gen  8))
 (make-event (rcl-spec-gen 16))
 (make-event (rcl-spec-gen 32))

--- a/books/projects/x86isa/machine/x86-register-readers-and-writers.lisp
+++ b/books/projects/x86isa/machine/x86-register-readers-and-writers.lisp
@@ -1155,27 +1155,29 @@ using the @(see undef-read) function.</p>"
 
 (local (include-book "centaur/gl/gl" :dir :system))
 
+;; sswords: trivially changed the form of the LHS to match what is produced
+;; below since bitp typeset rule changes
 (local
  (def-gl-thm write-user-rflags-mbe-proof
    :hyp (and (n32p user-flags-vector)
              (n32p rflags))
    :concl (equal (logior
-                  (ash (loghead 1 (bool->bit (logbitp 11 user-flags-vector))) 11)
+                  (ash (bool->bit (logbitp 11 user-flags-vector)) 11)
                   (logand
                    4294965247
                    (logior
-                    (ash (loghead 1 (bool->bit (logbitp 7 user-flags-vector))) 7)
+                    (ash (bool->bit (logbitp 7 user-flags-vector)) 7)
                     (logand
                      4294967167
                      (logior
-                      (ash (loghead 1 (bool->bit (logbitp 6 user-flags-vector))) 6)
+                      (ash (bool->bit (logbitp 6 user-flags-vector)) 6)
                       (logand
                        4294967231
                        (logior
-                        (ash (loghead 1 (bool->bit (logbitp 4 user-flags-vector))) 4)
+                        (ash (bool->bit (logbitp 4 user-flags-vector)) 4)
                         (logand
                          4294967279
-                         (logior (ash (loghead 1 (bool->bit (logbitp 2 user-flags-vector))) 2)
+                         (logior (ash (bool->bit (logbitp 2 user-flags-vector)) 2)
                                  (logand 4294967291
                                          (logior (loghead 1 user-flags-vector)
                                                  (logand 4294967294 rflags))))))))))))
@@ -1185,6 +1187,20 @@ using the @(see undef-read) function.</p>"
    :g-bindings (gl::auto-bindings
                 (:nat user-flags-vector 32)
                 (:nat rflags 32))))
+
+
+;; sswords: need this because of new rules taking advantage of bitp typeset
+(local (defthm unsigned-byte-p-when-bitp
+         (implies (and (bitp x)
+                       (posp n))
+                  (unsigned-byte-p n x))
+         :hints(("Goal" :in-theory (enable bitp expt)))
+         :rule-classes ((:rewrite :backchain-limit-lst 0))))
+
+;; (local (defthm loghead-1-is-logbit
+;;          (equal (loghead 1 x)
+;;                 (logbit 0 x))
+;;          :hints(("Goal" :in-theory (enable loghead** logbitp**)))))
 
 (define write-user-rflags
   ((user-flags-vector :type (unsigned-byte 32))

--- a/books/std/basic/arith-equivs.lisp
+++ b/books/std/basic/arith-equivs.lisp
@@ -646,7 +646,6 @@
 (defcong nat-equiv equal (logmask n) 1)
 
 
-
 (encapsulate
   ()
 
@@ -682,12 +681,19 @@
 
   (defcong iff equal (bool->bit x) 1)
 
+  ;; [Jared] 2016-04-08 BOZO.  I think we shouldn't need this rule because we
+  ;; have a bitp type-prescription for bool->bit and, given
+  ;; bitp-compound-recognizer, shouldn't we know that it's a bit?  But having
+  ;; this as a rewrite seems to be necessary for a proof in
+  ;; gl/always-equal-prep.lisp.  So, for now, I'll leave this in place, even
+  ;; though I think we shouldn't need this???
+
   (defthm bitp-of-bool->bit
     (bitp (bool->bit x)))
 
-  (defthm bool->bit-bound
-    (< (bool->bit x) 2)
-    :rule-classes :linear)
+  ;; (defthm bool->bit-bound
+  ;;   (< (bool->bit x) 2)
+  ;;   :rule-classes :linear)
 
   (defthm bfix-when-bit->bool
     (implies (bit->bool x)

--- a/books/std/basic/defs.lisp
+++ b/books/std/basic/defs.lisp
@@ -79,7 +79,7 @@ satisfies @('maybe-bitp'), then either it is a @(see bitp) or nothing.</p>"
   (defthm maybe-bitp-compound-recognizer
     (implies (maybe-bitp x)
              (or (not x)
-                 (natp x)))
+                 (bitp x)))
     :rule-classes :compound-recognizer))
 
 (defsection lnfix

--- a/books/std/strings/binary.lisp
+++ b/books/std/strings/binary.lisp
@@ -149,21 +149,31 @@
 (define bit-digit-val
   :short "Coerces a @(see bit-digitp) character into a number, 0 or 1."
   ((x bit-digitp :type character))
+  :returns (bit bitp :rule-classes :type-prescription)
   :split-types t
-  :returns (val natp :rule-classes :type-prescription)
   :inline t
   (if (eql x #\1)
       1
     0)
   ///
   (local (in-theory (enable bit-digitp)))
+
   (defcong ichareqv equal (bit-digit-val x) 1
     :hints(("Goal" :in-theory (enable ichareqv downcase-char char-fix))))
-  (defthm bit-digit-val-upper-bound
-    (< (bit-digit-val x) 2)
-    :rule-classes ((:rewrite) (:linear)))
-  (defthm bitp-of-bit-digit-val
-    (acl2::bitp (bit-digit-val x)))
+
+  ;; [Jared] 2016-04-08: shouldn't be needed now that we have a bitp type-prescription
+  ;; :returns specifier.
+  ;;
+  ;; (defthm bit-digit-val-upper-bound
+  ;;   (< (bit-digit-val x) 2)
+  ;;   :rule-classes ((:rewrite) (:linear)))
+  ;;
+  ;; (defthm bitp-of-bit-digit-val
+  ;;   (acl2::bitp (bit-digit-val x))
+  ;;   :rule-classes :type-prescription)
+
+  ;; [Jared] this is kind of ugly, might be better to just have a global rule
+  ;; that bitp means unsigned-byte-p 1.
   (defthm unsigned-byte-p-of-bit-digit-val
     (unsigned-byte-p 1 (bit-digit-val x)))
   (defthm equal-of-bit-digit-val-and-bit-digit-val
@@ -172,8 +182,7 @@
              (equal (equal (bit-digit-val x) (bit-digit-val y))
                     (equal x y))))
   (defthm bit-digit-val-of-digit-to-char
-    (implies (and (natp n)
-                  (< n 2))
+    (implies (bitp n)
              (equal (bit-digit-val (digit-to-char n))
                     n))))
 

--- a/books/workshops/2003/moore_vcg/support/demo.lisp
+++ b/books/workshops/2003/moore_vcg/support/demo.lisp
@@ -628,6 +628,14 @@ T
                      (run (fact-sched th n) s))))
                   (int-fix (factorial n)))))
 
+;; sswords (2016-04-27) -- needed this lemma presumably due to new rules taking
+;; advantage of new bitp typeset stuff
+(local (defthm integerp-of-+-1-forward
+         (implies (and (integerp (+ 1 k))
+                       (acl2-numberp k))
+                  (integerp k))
+         :rule-classes :forward-chaining))
+
 ; Symbolic Computation and Use of fact as a Subroutine
 
 (defthm symbolic-computation

--- a/books/workshops/2006/pike-shields-matthews/core_verifier/Fibonacci/proof-fibs.lisp
+++ b/books/workshops/2006/pike-shields-matthews/core_verifier/Fibonacci/proof-fibs.lisp
@@ -17,7 +17,9 @@
 ;; --------------------------------------------------------
 
 ; Matt K. mod April 2016 for the addition of a type-set bit for the set {1}.
-(local (in-theory (disable (:t b-not))))
+(local (in-theory (disable (:t b-not)
+                           ;; Jared
+                           bitp-of-b-not)))
 
 (make-thm :name |inv-fibs-thm|
           :thm-type invariant

--- a/books/workshops/2006/pike-shields-matthews/core_verifier/RC6/proof-RC6.lisp
+++ b/books/workshops/2006/pike-shields-matthews/core_verifier/RC6/proof-RC6.lisp
@@ -17,7 +17,9 @@
 ;; --------------------------------------------------------
 
 ; Matt K. mod April 2016 for the addition of a type-set bit for the set {1}.
-(local (in-theory (disable (:t b-not))))
+(local (in-theory (disable (:t b-not)
+                           ;; Jared
+                           bitp-of-b-not)))
 
 (make-thm :name |inv-consts|
           :thm-type invariant


### PR DESCRIPTION
These commits update some bit-level reasoning libraries (primarily ihs and centaur/bitops) to take advantage of ACL2's new ability to regard `bitp` as a typeset.  This is fairly disruptive to some libraries.  I have fixed the breakage this causes within the community books but I decided to make a pull request rather than just pushing because it might also cause breakage in non-public books.
Especially, @shigoel -- this affects proofs in the x86 model in a few places.  That said, I think this is an improvement in reasoning power and should eventually be incorporated.