### PR TITLE
Added support for checking alignment of memory operands of the form m<x>:<y>

### DIFF
--- a/books/projects/x86isa/machine/guard-helpers.lisp
+++ b/books/projects/x86isa/machine/guard-helpers.lisp
@@ -51,6 +51,55 @@
    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)))
   :rule-classes :linear)
 
+(def-gl-export rm48-guard-proof-helper
+  :hyp (and (n08p a) (n08p b) (n32p c))
+  :concl (equal (logior a (ash b 8) (ash c 16))
+                (logior a (ash (logior b (ash c 8)) 8)))
+  :g-bindings
+  (gl::auto-bindings
+   (:mix (:nat a 32) (:nat b 32) (:nat c 32)))
+  :rule-classes :linear)
+
+(def-gl-export rb-and-rm48-helper-1
+  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
+            (n08p e) (n08p f))
+  :concl (equal (logior
+                 a
+                 (ash (logior
+                       b
+                       (ash (logior
+                             c
+                             (ash (logior
+                                   d (ash (logior e (ash f 8)) 8)) 8)) 8)) 8))
+                (logior
+                 a
+                 (ash b 8)
+                 (ash (logior
+                       c
+                       (ash (logior d (ash (logior e (ash f 8)) 8))
+                            8)) 16)))
+  :g-bindings
+  (gl::auto-bindings
+   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
+         (:nat e 8) (:nat f 8))))
+
+(def-gl-export rb-and-rm48-helper-2
+  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
+            (n08p e) (n08p f))
+  :concl (<
+          (logior
+           a
+           (ash b 8)
+           (ash (logior
+                 c
+                 (ash (logior d (ash (logior e (ash f 8)) 8))
+                      8)) 16))
+          #.*2^48*)
+  :g-bindings
+  (gl::auto-bindings
+   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
+         (:nat e 8) (:nat f 8))))
+
 (def-gl-export rb-and-rvm64-helper
   :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
             (n08p e) (n08p f) (n08p g) (n08p h))
@@ -83,12 +132,61 @@
    (:mix (:nat a 32) (:nat b 32)))
   :rule-classes :linear)
 
-(in-theory (e/d ()                
+(def-gl-export rm80-guard-proof-helper
+  :hyp (and (n08p a) (n08p b) (n64p c))
+  :concl (equal (logior a (ash b 8) (ash c 16))
+                (logior a (ash (logior b (ash c 8)) 8)))
+  :g-bindings
+  (gl::auto-bindings
+   (:mix (:nat a 64) (:nat b 64) (:nat c 64)))
+  :rule-classes :linear)
+
+(def-gl-export rm80-in-system-level-mode-guard-proof-helper
+  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d) (n08p e)
+            (n08p f) (n08p g) (n08p h) (n08p i) (n08p j))
+  :concl (<
+          (logior a
+                  (ash b 8)
+                  (ash (logior
+                        c
+                        (ash
+                         (logior
+                          d
+                          (ash
+                           (logior
+                            e
+                            (ash
+                             (logior
+                              f
+                              (ash
+                               (logior g
+                                       (ash (logior
+                                             h (ash
+                                                (logior i (ash j 8))
+                                                8)) 8)) 8)) 8)) 8)) 8)) 16))
+          *2^80*)
+  :g-bindings (gl::auto-bindings
+               (:mix (:nat a 8)
+                     (:nat b 8)
+                     (:nat c 8)
+                     (:nat d 8)
+                     (:nat e 8)
+                     (:nat f 8)
+                     (:nat g 8)
+                     (:nat h 8)
+                     (:nat i 8)
+                     (:nat j 8))))
+
+(in-theory (e/d ()
                 (rm16-guard-proof-helper
-                 rb-and-rvm32-helper                
+                 rm48-guard-proof-helper
+                 rb-and-rm48-helper-1
+                 rb-and-rm48-helper-2
+                 rb-and-rvm32-helper
                  rm32-guard-proof-helper
                  rb-and-rvm64-helper
-                 rm64-guard-proof-helper)))
+                 rm64-guard-proof-helper
+                 rm80-in-system-level-mode-guard-proof-helper)))
 
 (def-gl-export rm32-rb-system-level-mode-proof-helper
   :hyp (and (n08p a)

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-arithmetic-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-arithmetic-instructions.lisp
@@ -69,7 +69,9 @@
         t)
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -198,7 +200,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -363,7 +367,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -507,7 +513,9 @@
         t)
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -598,7 +606,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -732,7 +742,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-bitscan-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-bitscan-instructions.lisp
@@ -104,7 +104,9 @@
             (the (signed-byte 64) ?v-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* operand-size inst-acc? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* operand-size inst-acc?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-convert-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-convert-instructions.lisp
@@ -72,7 +72,9 @@
         t)
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* xmm/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* xmm/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -201,7 +203,9 @@
         t)
        ((mv flg0 reg/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -316,7 +320,9 @@
         t)
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* xmm/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* xmm/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -412,7 +418,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 8 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 8 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -521,7 +529,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-logical-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-logical-instructions.lisp
@@ -80,7 +80,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -219,7 +221,9 @@
 
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          1 ;; One-byte immediate operand
          x86))
 
@@ -326,7 +330,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          1 ;; One-byte immediate operand
          x86))
 
@@ -491,7 +497,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          1 ;; One-byte immediate operand
          x86))
 
@@ -636,7 +644,9 @@
 
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-mov-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-mov-instructions.lisp
@@ -53,7 +53,9 @@
 
        ((mv flg0 xmm/mem (the (integer 0 4) increment-RIP-by) (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -229,7 +231,9 @@
             (the (signed-byte 64) ?v-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -400,7 +404,9 @@
             (the (signed-byte 64) ?v-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -577,7 +583,9 @@
             (the (signed-byte 64) ?v-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 8 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 8 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -738,7 +746,9 @@
             (the (signed-byte 64) ?v-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 8 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 8 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-mxcsr-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-mxcsr-instructions.lisp
@@ -49,7 +49,9 @@
             (the (signed-byte 64) v-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* 4 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* 4 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -87,7 +89,9 @@
            (b* ((mxcsr (the (unsigned-byte 32) (mxcsr x86)))
                 ((mv flg1 x86)
                  (x86-operand-to-reg/mem
-                  4 inst-ac? mxcsr v-addr rex-byte r/m mod x86))
+                  4 inst-ac?
+                  nil ;; Not a memory pointer operand
+                  mxcsr v-addr rex-byte r/m mod x86))
                 ;; Note: If flg1 is non-nil, we bail out without changing the
                 ;; x86 state.
                 ((when flg1)

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-shuffle-and-unpack-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-shuffle-and-unpack-instructions.lisp
@@ -91,7 +91,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib 
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          1 ;; One-byte immediate operand
          x86))
        ((when flg0)
@@ -203,7 +205,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib 
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          1 ;; One-byte immediate operand
          x86))
 
@@ -326,7 +330,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib 
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -461,7 +467,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib 
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/x86-fp-simd-integer-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/x86-fp-simd-integer-instructions.lisp
@@ -110,7 +110,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 
@@ -270,7 +272,9 @@
             (the (integer 0 4) increment-RIP-by)
             (the (signed-byte 64) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*xmm-access* 16 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*xmm-access* 16 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
 

--- a/books/projects/x86isa/machine/instructions/x86-arith-and-logic-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-arith-and-logic-instructions.lisp
@@ -180,7 +180,9 @@
             (the (signed-byte #.*max-linear-address-size*) E-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -222,7 +224,9 @@
             ;; CMP and TEST modify just the flags.
             (mv nil x86)
           (x86-operand-to-reg/mem
-           operand-size inst-ac? result
+           operand-size inst-ac?
+           nil ;; Not a memory pointer operand
+           result
            (the (signed-byte #.*max-linear-address-size*) E-addr)
            rex-byte r/m mod x86)))
        ((when flg1)
@@ -372,7 +376,9 @@
             (the (signed-byte #.*max-linear-address-size*) E-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -583,7 +589,9 @@
             (the (signed-byte #.*max-linear-address-size*) E-addr)
             x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* E-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* E-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          imm-size ;; imm-size bytes of immediate data
          x86))
        ((when flg0)
@@ -660,7 +668,9 @@
             ;; CMP and TEST modify just the flags.
             (mv nil x86)
           (x86-operand-to-reg/mem
-           E-size inst-ac? result
+           E-size inst-ac?
+           nil ;; Not a memory pointer operand
+           result
            (the (signed-byte #.*max-linear-address-size*) E-addr)
            rex-byte r/m mod x86)))
        ;; Note: If flg1 is non-nil, we bail out without changing the
@@ -871,7 +881,9 @@
        ((mv flg0 r/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* r/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* r/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -918,7 +930,9 @@
 
        ((mv flg1 x86)
         (x86-operand-to-reg/mem
-         r/mem-size inst-ac? result
+         r/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         result
          (the (signed-byte #.*max-linear-address-size*) v-addr)
          rex-byte r/m mod x86))
        ((when flg1)
@@ -970,7 +984,9 @@
        ((mv flg0 r/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* r/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* r/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -1021,7 +1037,9 @@
           x86))
        ((mv flg1 x86)
         (x86-operand-to-reg/mem
-         r/mem-size inst-ac? result (the (signed-byte #.*max-linear-address-size*) v-addr)
+         r/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         result (the (signed-byte #.*max-linear-address-size*) v-addr)
          rex-byte r/m mod x86))
        ((when flg1)
         (!!ms-fresh :x86-operand-to-reg/mem flg1))

--- a/books/projects/x86isa/machine/instructions/x86-bit-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-bit-instructions.lisp
@@ -52,7 +52,9 @@
        ((mv flg0 bitBase (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          1 ;; One-byte immediate data
          x86))
        ((when flg0)

--- a/books/projects/x86isa/machine/instructions/x86-conditional-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-conditional-instructions.lisp
@@ -458,7 +458,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -631,8 +633,8 @@
        (val (if branch-cond 1 0))
        ((mv flg2 x86)
         (x86-operand-to-reg/mem
-         1 inst-ac? val
-         (the (signed-byte #.*max-linear-address-size+1*) v-addr)
+         1 inst-ac? nil ;; Not a memory pointer operand
+         val (the (signed-byte #.*max-linear-address-size+1*) v-addr)
          rex-byte r/m mod x86))
        ;; Note: If flg1 is non-nil, we bail out without changing the x86 state.
        ((when flg2)

--- a/books/projects/x86isa/machine/instructions/x86-divide-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-divide-instructions.lisp
@@ -79,7 +79,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -213,7 +215,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)

--- a/books/projects/x86isa/machine/instructions/x86-exchange-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-exchange-instructions.lisp
@@ -86,7 +86,9 @@
         (if (equal (ash opcode -4) 9) ;; #x90+rw/rd
             (mv nil (rgfi-size reg/mem-size *rax* rex-byte x86) 0 0 x86)
           (x86-operand-from-modr/m-and-sib-bytes
-           #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+           #.*rgf-access* reg/mem-size inst-ac?
+           nil ;; Not a memory pointer operand
+           p2 p4? temp-rip rex-byte r/m mod sib
            0 ;; No immediate operand
            x86)))
        ((when flg0)
@@ -130,8 +132,9 @@
                                    x86)))
               (mv nil x86))
           (x86-operand-to-reg/mem
-           reg/mem-size inst-ac? val2
-           (the (signed-byte #.*max-linear-address-size*) v-addr)
+           reg/mem-size inst-ac?
+           nil ;; Not a memory pointer operand
+           val2 (the (signed-byte #.*max-linear-address-size*) v-addr)
            rex-byte r/m mod x86)))
        ;; Note: If flg2 is non-nil, we bail out without changing the x86 state.
        ((when flg2)
@@ -197,7 +200,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -229,8 +234,9 @@
                                        (reg-index reg rex-byte #.*r*) rex-byte
                                        x86)))
               (x86-operand-to-reg/mem
-               reg/mem-size inst-ac? register
-               (the (signed-byte #.*max-linear-address-size*) v-addr)
+               reg/mem-size inst-ac?
+               nil ;; Not a memory pointer operand
+               register (the (signed-byte #.*max-linear-address-size*) v-addr)
                rex-byte r/m mod x86))
           ;; rAX != reg/mem or ZF == 0
           ;; Put the destination operand into the accumulator.

--- a/books/projects/x86isa/machine/instructions/x86-jump-and-loop-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-jump-and-loop-instructions.lisp
@@ -48,6 +48,7 @@
   ;;                sign-extended to 64-bits
 
   :parents (one-byte-opcodes)
+  :guard-debug t
   :guard-hints (("Goal" :in-theory (e/d (rim08 rim32) ())))
   :returns (x86 x86p :hyp (and (x86p x86)
                                (canonical-address-p temp-rip)))
@@ -80,18 +81,18 @@
              (case offset-size
                (1
                 (mv-let (flag val x86)
-                        (rm08 temp-rip :x x86)
-                        (mv flag
-                            (n08-to-i08 val)
-                            x86)))
+                  (rm08 temp-rip :x x86)
+                  (mv flag
+                      (n08-to-i08 val)
+                      x86)))
                (4
                 (mv-let (flag val x86)
-                        (rm32 temp-rip :x x86)
-                        (mv flag
-                            (n32-to-i32 val)
-                            x86)))
+                  (rm32 temp-rip :x x86)
+                  (mv flag
+                      (n32-to-i32 val)
+                      x86)))
                (otherwise
-                (mv 'UNSUPPORTED-NBYTES 0 x86)))))
+                (mv 'rim-size 0 x86)))))
 
        ((when flg)
         (!!ms-fresh :rim-size-error flg))
@@ -113,7 +114,7 @@
         (!!ms-fresh :virtual-memory-error temp-rip))
        ;; Update the x86 state:
        (x86 (!rip temp-rip x86)))
-      x86))
+    x86))
 
 (def-inst x86-near-jmp-Op/En-M
 

--- a/books/projects/x86isa/machine/instructions/x86-jump-and-loop-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-jump-and-loop-instructions.lisp
@@ -152,7 +152,9 @@
        ((mv flg jmp-addr (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* 8 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* 8 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg)
@@ -274,7 +276,7 @@ indirectly with a memory location \(m16:16 or m16:32 or m16:64\).</p>"
          ;; offset-size is the number of bytes of the
          ;; offset.  We need two more bytes for the selector.
          (the (integer 2 10) (+ 2 offset-size))
-         inst-ac?
+         inst-ac? t ;; A memory pointer operand
          p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))

--- a/books/projects/x86isa/machine/instructions/x86-move-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-move-instructions.lisp
@@ -123,7 +123,9 @@
        (inst-ac? t)
        ((mv flg2 x86)
         (x86-operand-to-reg/mem
-         operand-size inst-ac? register v-addr rex-byte r/m mod x86))
+         operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         register v-addr rex-byte r/m mod x86))
        ;; Note: If flg1 is non-nil, we bail out without changing the x86 state.
        ((when flg2)
         (!!ms-fresh :x86-operand-to-reg/mem flg2))
@@ -181,7 +183,9 @@
        (inst-ac? t)
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by) ?v-addr x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* operand-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -582,7 +586,9 @@
        (inst-ac? t)
        ((mv flg3 x86)
         (x86-operand-to-reg/mem
-         reg/mem-size inst-ac? imm v-addr rex-byte r/m mod x86))
+         reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         imm v-addr rex-byte r/m mod x86))
        ;; Note: If flg2 is non-nil, we bail out without changing the x86 state.
        ((when flg3)
         (!!ms-fresh :x86-operand-to-reg/mem flg3))
@@ -737,7 +743,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -820,7 +828,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -913,7 +923,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)

--- a/books/projects/x86isa/machine/instructions/x86-multiply-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-multiply-instructions.lisp
@@ -64,7 +64,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -185,7 +187,9 @@
        (inst-ac? t)
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by) ?v-addr x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -280,7 +284,9 @@
        ((mv flg0 reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -384,7 +390,9 @@
             (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          imm-size ;; imm-size bytes of immediate data
          x86))
        ((when flg0)

--- a/books/projects/x86isa/machine/instructions/x86-push-and-pop-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-push-and-pop-instructions.lisp
@@ -149,9 +149,12 @@ extension (ModR/m.reg = 6).</p>"
        ((mv flg0 E (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) ?E-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
+         #.*rgf-access* operand-size 
          ;; inst-ac? is nil here because we only need increment-RIP-by
          ;; from this function.
-         #.*rgf-access* operand-size nil p2 p4? temp-rip rex-byte r/m mod sib
+         nil
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -541,7 +544,9 @@ extension (ModR/m.reg = 0).</p>"
 
        ((mv flg3 x86)
         (x86-operand-to-reg/mem
-         operand-size inst-ac? val v-addr rex-byte r/m mod x86))
+         operand-size inst-ac?
+         nil ;; Not a memory pointer operand
+         val v-addr rex-byte r/m mod x86))
        ((when flg3)
         (!!ms-fresh :x86-operand-to-reg/mem flg2))
 
@@ -571,7 +576,7 @@ extension (ModR/m.reg = 0).</p>"
        (x86 (!rgfi *rsp* new-rsp x86))
        (x86 (!rip temp-rip x86)))
 
-      x86))
+    x86))
 
 ;; (def-inst x86-pop-segment-register
 ;;   :parents (one-byte-opcodes)

--- a/books/projects/x86isa/machine/instructions/x86-rotate-and-shift-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-rotate-and-shift-instructions.lisp
@@ -197,7 +197,9 @@
        ((mv flg0 ?reg/mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* reg/mem-size inst-ac? p2 p4 temp-rip rex-byte r/m mod sib
+         #.*rgf-access* reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4 temp-rip rex-byte r/m mod sib
          ;; Bytes of immediate data (only relevant when RIP-relative
          ;; addressing is done to get ?reg/mem operand)
          (if (or (equal opcode #xC0)
@@ -296,6 +298,7 @@
        ((mv flg2 x86)
         (x86-operand-to-reg/mem
          reg/mem-size inst-ac?
+         nil ;; Not a memory pointer operand
          ;; TO-DO@Shilpi: Remove this trunc.
          (trunc reg/mem-size result)
          (the (signed-byte #.*max-linear-address-size*) v-addr)

--- a/books/projects/x86isa/machine/instructions/x86-segmentation-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-segmentation-instructions.lisp
@@ -69,7 +69,9 @@
        ((mv flg0 mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         0 10 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         0 10 inst-ac?
+         t ;; Memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -156,7 +158,9 @@
        ((mv flg0 mem (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         0 10 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         0 10 inst-ac?
+         t ;; Memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)
@@ -248,7 +252,9 @@ a non-canonical form, raise the SS exception.</p>"
        ((mv flg0 selector (the (unsigned-byte 3) increment-RIP-by)
             (the (signed-byte #.*max-linear-address-size*) v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         0 2 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         0 2 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)

--- a/books/projects/x86isa/machine/instructions/x86-subroutine-instructions.lisp
+++ b/books/projects/x86isa/machine/instructions/x86-subroutine-instructions.lisp
@@ -151,7 +151,9 @@
        ((mv flg0 (the (unsigned-byte 64) call-rip) (the (unsigned-byte 3) increment-rip-by)
             (the (signed-byte #.*max-linear-address-size*) ?v-addr) x86)
         (x86-operand-from-modr/m-and-sib-bytes
-         #.*rgf-access* 8 inst-ac? p2 p4? temp-rip rex-byte r/m mod sib
+         #.*rgf-access* 8 inst-ac?
+         nil ;; Not a memory pointer operand
+         p2 p4? temp-rip rex-byte r/m mod sib
          0 ;; No immediate operand
          x86))
        ((when flg0)

--- a/books/projects/x86isa/machine/x86-top-level-memory.lisp
+++ b/books/projects/x86isa/machine/x86-top-level-memory.lisp
@@ -665,6 +665,12 @@ memory.</li>
                (part-select val :low 8  :width 8)
                (part-select val :low 16 :width 8)
                (part-select val :low 24 :width 8)))
+      (6 (list (part-select val :low 0  :width 8)
+               (part-select val :low 8  :width 8)
+               (part-select val :low 16 :width 8)
+               (part-select val :low 24 :width 8)
+               (part-select val :low 32 :width 8)
+               (part-select val :low 40 :width 8)))
       (8 (list (part-select val :low 0  :width 8)
                (part-select val :low 8  :width 8)
                (part-select val :low 16 :width 8)
@@ -673,6 +679,16 @@ memory.</li>
                (part-select val :low 40 :width 8)
                (part-select val :low 48 :width 8)
                (part-select val :low 56 :width 8)))
+      (10 (list (part-select val :low 0   :width 8)
+                (part-select val :low 8   :width 8)
+                (part-select val :low 16  :width 8)
+                (part-select val :low 24  :width 8)
+                (part-select val :low 32  :width 8)
+                (part-select val :low 40  :width 8)
+                (part-select val :low 48  :width 8)
+                (part-select val :low 56  :width 8)
+                (part-select val :low 64  :width 8)
+                (part-select val :low 72  :width 8)))
       (16 (list (part-select val :low 0   :width 8)
                 (part-select val :low 8   :width 8)
                 (part-select val :low 16  :width 8)
@@ -1064,7 +1080,7 @@ memory.</li>
                          ()
                        (revappend p-addrs p-addrs-new)))
               (equal x86-alt x86-new)))
-       :hints (("goal" :induct (las-to-pas-tailrec
+       :hints (("Goal" :induct (las-to-pas-tailrec
                                 l-addrs p-addrs r-w-x cpl x86)))))
 
     (local
@@ -1091,7 +1107,7 @@ memory.</li>
     (defthmd las-to-pas-as-las-to-pas-tailrec
       (equal (las-to-pas l-addrs r-w-x cpl x86)
              (las-to-pas-tailrec l-addrs () r-w-x cpl x86))
-      :hints (("goal" :use
+      :hints (("Goal" :use
                (las-to-pas-as-list
                 (:instance las-to-pas-tailrec-as-list (p-addrs ()))
                 (:instance las-to-pas-tailrec-as-las-to-pas-lemma (p-addrs ())))))))
@@ -2104,8 +2120,8 @@ memory.</li>
 
 ;; ======================================================================
 
-;; Defining the 8, 16, 32, and 64, and 128 bit memory read/write
-;; functions:
+;; Defining the 8, 16, 32, 48, and 64, 80, and 128 bit memory
+;; read/write functions:
 
 ;; I haven't used physical memory functions like rm-low-* and wm-low-*
 ;; in the system-level mode below because the *-low-* functions take
@@ -2116,6 +2132,16 @@ memory.</li>
 ;; addresses (though, IRL, that's likely the case). That's why there
 ;; are long and ugly sequences of memi and !memi below instead of nice
 ;; and pretty wrappers.
+
+(local
+ (defthm signed-byte-p-48-to-<-rule
+   (implies (and (signed-byte-p 48 lin-addr)
+                 (syntaxp (quotep n))
+                 (natp n))
+            (equal (signed-byte-p 48 (+ n lin-addr))
+                   (< (+ n lin-addr) #.*2^47*)))))
+
+(local (in-theory (e/d () (signed-byte-p))))
 
 (define rm08
   ((lin-addr :type (signed-byte #.*max-linear-address-size*))
@@ -2661,7 +2687,7 @@ memory.</li>
                                  r-w-x x86 nil)))
                 x86)
                (rvm32 lin-addr x86)))
-     :hints (("Goal" :expand (create-canonical-address-list 4 lin-addr)
+     :hints (("Goal"
               :in-theory (e/d (rm08 rvm08 rvm32) (force (force)))))))
 
   (if (mbt (canonical-address-p lin-addr))
@@ -2917,6 +2943,322 @@ memory.</li>
   (defthm x86p-wim32
     (implies (force (x86p x86))
              (x86p (mv-nth 1 (wim32 lin-addr val x86))))
+    :rule-classes (:rewrite :type-prescription)))
+
+(define rm48
+  ((lin-addr :type (signed-byte #.*max-linear-address-size*))
+   (r-w-x    :type (member  :r :w :x))
+   (x86))
+
+  :parents (x86-top-level-memory)
+  :guard (canonical-address-p lin-addr)
+  :guard-hints (("Goal"
+                 :expand ((create-canonical-address-list 6 lin-addr)
+                          (create-canonical-address-list 5 (+ 1 lin-addr)))
+                 :in-theory (e/d (rb-and-rvm48
+                                  rm08
+                                  rb-and-rm48-helper-1
+                                  rb-and-rm48-helper-2)
+                                 (not
+                                  member-equal
+                                  ash-monotone-2
+                                  (:rewrite acl2::ash-0)
+                                  (:rewrite acl2::zip-open)
+                                  (:linear ash-monotone-2)
+                                  (:linear bitops::logior-<-0-linear-2)
+                                  (:rewrite xr-and-ia32e-la-to-pa-in-non-marking-mode)
+                                  (:rewrite bitops::logior-equal-0)
+                                  (:linear memi-is-n08p)))))
+
+  :prepwork
+  ((local
+    (defthmd rb-and-rvm48-helper
+      (implies (and (programmer-level-mode x86)
+                    (x86p x86)
+                    (canonical-address-p lin-addr)
+                    (canonical-address-p (+ 5 lin-addr)))
+               (equal (rvm48 lin-addr x86)
+                      (list nil
+                            (logior (combine-bytes
+                                     (mv-nth 1 (rb-1 (create-canonical-address-list 2 lin-addr)
+                                                     r-w-x x86 nil)))
+                                    (ash (combine-bytes
+                                          (mv-nth 1
+                                                  (rb-1 (create-canonical-address-list 4 (+ 2 lin-addr))
+                                                        r-w-x x86 nil)))
+                                         16))
+                            x86)))
+      :hints (("Goal" :use ((:instance rb-and-rvm16)
+                            (:instance rb-and-rvm32 (lin-addr (+ 2 lin-addr))))
+               :in-theory (e/d (rvm48)
+                               (force (force)))))))
+
+   (defthmd rb-and-rvm48
+     (implies (and (programmer-level-mode x86)
+                   (x86p x86)
+                   (canonical-address-p lin-addr)
+                   (canonical-address-p (+ 5 lin-addr)))
+              (equal (rvm48 lin-addr x86)
+                     (b* (((mv flg bytes x86)
+                           (rb-1 (create-canonical-address-list 6 lin-addr)
+                                 r-w-x x86 nil))
+                          (result (combine-bytes bytes)))
+                       (mv flg result x86))))
+     :hints (("Goal"
+              :in-theory (e/d (rb-and-rvm48-helper
+                               rm48-guard-proof-helper)
+                              (rb-and-rvm32-helper
+                               logior-expt-to-plus-quotep
+                               signed-byte-p
+                               force (force)))))))
+
+  (if (mbt (canonical-address-p lin-addr))
+
+      (let* ((5+lin-addr (the (signed-byte #.*max-linear-address-size+1*)
+                           (+ 5 (the (signed-byte #.*max-linear-address-size*)
+                                  lin-addr)))))
+
+
+        (if (mbe :logic (canonical-address-p 5+lin-addr)
+                 :exec (< (the (signed-byte #.*max-linear-address-size+1*)
+                            5+lin-addr)
+                          #.*2^47*))
+
+            (mbe :logic
+                 (b* (((mv flg bytes x86)
+                       (rb (create-canonical-address-list 6 lin-addr)
+                           r-w-x x86))
+                      (result (combine-bytes bytes)))
+                   (mv flg result x86))
+
+                 :exec
+                 (if (programmer-level-mode x86)
+
+                     (rvm48 lin-addr x86)
+
+                   (let* ((cpl (cpl x86)))
+
+                     (b* (((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr0) x86)
+                           (la-to-pa lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+1*) 1+lin-addr)
+                           (+ 1 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr1) x86)
+                           (la-to-pa 1+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+2*) 2+lin-addr)
+                           (+ 2 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr2) x86)
+                           (la-to-pa 2+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+3*) 3+lin-addr)
+                           (+ 3 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr3) x86)
+                           (la-to-pa 3+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+4*) 4+lin-addr)
+                           (+ 4 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr4) x86)
+                           (la-to-pa 4+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+5*) 5+lin-addr)
+                           (+ 5 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr5) x86)
+                           (la-to-pa 5+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+
+                          (byte0 (memi p-addr0 x86))
+                          (byte1 (memi p-addr1 x86))
+                          (byte2 (memi p-addr2 x86))
+                          (byte3 (memi p-addr3 x86))
+                          (byte4 (memi p-addr4 x86))
+                          (byte5 (memi p-addr5 x86))
+
+                          (word0 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte1 8))
+                                           byte0)))
+                          (word1 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte3 8))
+                                           byte2)))
+                          (word2 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte5 8))
+                                           byte4)))
+                          (dword1 (the (unsigned-byte 32)
+                                    (logior (the (unsigned-byte 32) (ash word2 16))
+                                            word1)))
+                          (value (the (unsigned-byte 48)
+                                   (logior (the (unsigned-byte 48) (ash dword1 16))
+                                           word0))))
+
+                       (mv nil value x86)))))
+
+          (mv 'rm48 0 x86)))
+
+    (mv 'rm48 0 x86))
+
+  ///
+
+  (defthm-usb n48p-mv-nth-1-rm48
+    :hyp (and (signed-byte-p *max-linear-address-size* lin-addr)
+              (x86p x86))
+    :bound 48
+    :concl (mv-nth 1 (rm48 lin-addr r-w-x x86))
+    :hints (("Goal" :in-theory (e/d () (signed-byte-p ash-monotone-2))))
+    :otf-flg t
+    :gen-linear t
+    :hints-l (("Goal" :in-theory (e/d (signed-byte-p) (ash-monotone-2 rb))))
+    :hyp-t (forced-and (integerp lin-addr)
+                       (x86p x86))
+    :gen-type t)
+
+  (defthm x86p-rm48
+    (implies (force (x86p x86))
+             (x86p (mv-nth 2 (rm48 lin-addr r-w-x x86))))
+    :hints (("Goal" :in-theory (e/d () ((force) unsigned-byte-p signed-byte-p))))
+    :rule-classes (:rewrite :type-prescription)))
+
+(define wm48
+  ((lin-addr :type (signed-byte   #.*max-linear-address-size*))
+   (val      :type (unsigned-byte 48))
+   (x86))
+
+  :parents (x86-top-level-memory)
+  :guard (canonical-address-p lin-addr)
+
+  :guard-hints (("Goal"
+                 :expand ((create-canonical-address-list 6 lin-addr)
+                          (create-canonical-address-list 5 (+ 1 lin-addr)))
+                 :in-theory (e/d (wb-and-wvm48 byte-ify)
+                                 ((:rewrite acl2::ash-0)
+                                  (:rewrite acl2::zip-open)
+                                  (:linear ash-monotone-2)
+                                  (:linear bitops::logior-<-0-linear-2)
+                                  (:rewrite bitops::logior-equal-0)
+                                  (:linear memi-is-n08p)))))
+
+  :prepwork
+
+  ((defthmd wb-and-wvm48
+     (implies (and (programmer-level-mode x86)
+                   (canonical-address-p lin-addr)
+                   (canonical-address-p (+ 5 lin-addr)))
+              (equal (wvm48 lin-addr val x86)
+                     (wb (create-addr-bytes-alist
+                          (create-canonical-address-list 6 lin-addr)
+                          (byte-ify 6 val))
+                         x86)))
+     :hints (("Goal" :in-theory (e/d (wm08 wvm08 wvm16 wvm32 wvm48 byte-ify)
+                                     (append-and-create-addr-bytes-alist
+                                      cons-and-create-addr-bytes-alist
+                                      append-and-addr-byte-alistp
+                                      force (force)))))))
+
+  (if (mbt (canonical-address-p lin-addr))
+
+      (let* ((5+lin-addr (the (signed-byte #.*max-linear-address-size+1*)
+                           (+ 5 (the (signed-byte #.*max-linear-address-size*)
+                                  lin-addr)))))
+
+
+        (if (mbe :logic (canonical-address-p 5+lin-addr)
+                 :exec (< (the (signed-byte #.*max-linear-address-size+1*)
+                            5+lin-addr)
+                          #.*2^47*))
+
+            (mbe
+             :logic
+             (wb (create-addr-bytes-alist
+                  (create-canonical-address-list 6 lin-addr)
+                  (byte-ify 6 val))
+                 x86)
+             :exec
+
+             (if (programmer-level-mode x86)
+
+                 (wvm48 lin-addr val x86)
+
+               (let* ((cpl (cpl x86)))
+
+                 (b* (((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr0) x86)
+                       (la-to-pa lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      ((the (signed-byte #.*max-linear-address-size+1*) 1+lin-addr)
+                       (+ 1 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr1) x86)
+                       (la-to-pa 1+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      (2+lin-addr (the (signed-byte #.*max-linear-address-size+2*)
+                                    (+ 2 (the (signed-byte #.*max-linear-address-size*)
+                                           lin-addr))))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr2) x86)
+                       (la-to-pa 2+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      (3+lin-addr (the (signed-byte #.*max-linear-address-size+3*)
+                                    (+ 3 (the (signed-byte #.*max-linear-address-size*)
+                                           lin-addr))))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr3) x86)
+                       (la-to-pa 3+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      (4+lin-addr (the (signed-byte #.*max-linear-address-size+4*)
+                                    (+ 4 (the (signed-byte #.*max-linear-address-size*)
+                                           lin-addr))))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr4) x86)
+                       (la-to-pa 4+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      (5+lin-addr (the (signed-byte #.*max-linear-address-size+5*)
+                                    (+ 5 (the (signed-byte #.*max-linear-address-size*)
+                                           lin-addr))))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr5) x86)
+                       (la-to-pa 5+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      (byte0 (mbe
+                              :logic (part-select val :low 0 :width 8)
+                              :exec  (the (unsigned-byte 8) (logand #xff val))))
+                      (byte1 (mbe
+                              :logic (part-select val :low 8 :width 8)
+                              :exec  (the (unsigned-byte 8)
+                                       (logand #xff (ash val -8)))))
+                      (byte2 (mbe
+                              :logic (part-select val :low 16 :width 8)
+                              :exec (the (unsigned-byte 8)
+                                      (logand #xff (ash val -16)))))
+                      (byte3 (mbe
+                              :logic (part-select val :low 24 :width 8)
+                              :exec (the (unsigned-byte 8)
+                                      (logand #xff (ash val -24)))))
+                      (byte4 (mbe
+                              :logic (part-select val :low 32 :width 8)
+                              :exec (the (unsigned-byte 8)
+                                      (logand #xff (ash val -32)))))
+                      (byte5 (mbe
+                              :logic (part-select val :low 40 :width 8)
+                              :exec (the (unsigned-byte 8)
+                                      (logand #xff (ash val -40)))))
+
+                      (x86 (!memi p-addr0 byte0 x86))
+                      (x86 (!memi p-addr1 byte1 x86))
+                      (x86 (!memi p-addr2 byte2 x86))
+                      (x86 (!memi p-addr3 byte3 x86))
+                      (x86 (!memi p-addr4 byte4 x86))
+                      (x86 (!memi p-addr5 byte5 x86)))
+                   (mv nil x86)))))
+
+          (mv 'wm48 x86)))
+
+    (mv 'wm48 x86))
+
+  ///
+
+  (defthm x86p-wm48
+    (implies (force (x86p x86))
+             (x86p (mv-nth 1 (wm48 lin-addr val x86))))
+    :hints (("Goal" :in-theory (e/d () (force (force)))))
     :rule-classes (:rewrite :type-prescription)))
 
 (define rm64
@@ -3338,6 +3680,367 @@ memory.</li>
              (x86p (mv-nth 1 (wim64 lin-addr val x86))))
     :rule-classes (:rewrite :type-prescription)))
 
+(define rm80
+  ((lin-addr :type (signed-byte #.*max-linear-address-size*))
+   (r-w-x    :type (member  :r :w :x))
+   (x86))
+
+  :parents (x86-top-level-memory)
+  :guard (canonical-address-p lin-addr)
+  :guard-hints (("Goal"
+                 :expand ((create-canonical-address-list 10 lin-addr)
+                          (create-canonical-address-list  9 (+ 1 lin-addr))
+                          (create-canonical-address-list  8 (+ 2 lin-addr))
+                          (create-canonical-address-list  7 (+ 3 lin-addr)))
+                 :in-theory (e/d (rb-and-rvm80
+                                  rm80-in-system-level-mode-guard-proof-helper
+                                  rm08)
+                                 (not
+                                  member-equal
+                                  ash-monotone-2
+                                  (:rewrite acl2::ash-0)
+                                  (:rewrite acl2::zip-open)
+                                  (:linear ash-monotone-2)
+                                  (:linear bitops::logior-<-0-linear-2)
+                                  (:rewrite xr-and-ia32e-la-to-pa-in-non-marking-mode)
+                                  (:rewrite bitops::logior-equal-0)))))
+
+  :prepwork
+  ((defthmd rb-and-rvm80
+     (implies (and (programmer-level-mode x86)
+                   (x86p x86)
+                   (canonical-address-p lin-addr)
+                   (canonical-address-p (+ 9 lin-addr)))
+              (equal (rvm80 lin-addr x86)
+                     (b* (((mv flg bytes x86)
+                           (rb (create-canonical-address-list 10 lin-addr)
+                               r-w-x x86))
+                          (result (combine-bytes bytes)))
+                       (mv flg result x86))))
+     :hints (("Goal"
+
+              :in-theory (e/d (rvm80 rb-and-rvm16 rb-and-rvm64 rm80-guard-proof-helper)
+                              (force (force))))))
+
+   (defthm combine-bytes-size-for-rm80
+     (implies (and (signed-byte-p 48 lin-addr)
+                   (x86p x86)
+                   (signed-byte-p 48 (+ 9 lin-addr)))
+              (< (combine-bytes (mv-nth 1
+                                        (rb (create-canonical-address-list 10 lin-addr)
+                                            r-w-x x86)))
+                 *2^80*))
+     :rule-classes :linear))
+
+  (if (mbt (canonical-address-p lin-addr))
+
+      (let* ((9+lin-addr (the (signed-byte #.*max-linear-address-size+1*)
+                           (+ 9 (the (signed-byte #.*max-linear-address-size*)
+                                  lin-addr)))))
+
+        (if (mbe :logic (canonical-address-p 9+lin-addr)
+                 :exec (< (the (signed-byte #.*max-linear-address-size+1*)
+                            9+lin-addr)
+                          #.*2^47*))
+
+            (mbe :logic
+                 (b* (((mv flg bytes x86)
+                       (rb (create-canonical-address-list 10 lin-addr)
+                           r-w-x x86))
+                      (result (combine-bytes bytes)))
+                   (mv flg result x86))
+
+                 :exec
+                 (if (programmer-level-mode x86)
+
+                     (rvm80 lin-addr x86)
+
+                   (let* ((cpl (cpl x86)))
+
+                     (b* (((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr0) x86)
+                           (la-to-pa lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+1*) 1+lin-addr)
+                           (+ 1 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr1) x86)
+                           (la-to-pa 1+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+2*) 2+lin-addr)
+                           (+ 2 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr2) x86)
+                           (la-to-pa 2+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+3*) 3+lin-addr)
+                           (+ 3 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr3) x86)
+                           (la-to-pa 3+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+4*) 4+lin-addr)
+                           (+ 4 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr4) x86)
+                           (la-to-pa 4+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+5*) 5+lin-addr)
+                           (+ 5 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr5) x86)
+                           (la-to-pa 5+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+6*) 6+lin-addr)
+                           (+ 6 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr6) x86)
+                           (la-to-pa 6+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+7*) 7+lin-addr)
+                           (+ 7 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr7) x86)
+                           (la-to-pa 7+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+8*) 8+lin-addr)
+                           (+ 8 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr8) x86)
+                           (la-to-pa 8+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+                          ((the (signed-byte #.*max-linear-address-size+9*) 9+lin-addr)
+                           (+ 9 lin-addr))
+                          ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr9) x86)
+                           (la-to-pa 9+lin-addr r-w-x cpl x86))
+                          ((when flag) (mv flag 0 x86))
+
+                          (byte0  (memi p-addr0  x86))
+                          (byte1  (memi p-addr1  x86))
+                          (byte2  (memi p-addr2  x86))
+                          (byte3  (memi p-addr3  x86))
+                          (byte4  (memi p-addr4  x86))
+                          (byte5  (memi p-addr5  x86))
+                          (byte6  (memi p-addr6  x86))
+                          (byte7  (memi p-addr7  x86))
+                          (byte8  (memi p-addr8  x86))
+                          (byte9  (memi p-addr9  x86))
+
+                          (word0 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte1 8))
+                                           byte0)))
+                          (word1 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte3 8))
+                                           byte2)))
+                          (word2 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte5 8))
+                                           byte4)))
+                          (dword0 (the (unsigned-byte 32)
+                                    (logior (the (unsigned-byte 32) (ash word2 16))
+                                            word1)))
+                          (word3 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte7 8))
+                                           byte6)))
+                          (word4 (the (unsigned-byte 16)
+                                   (logior (the (unsigned-byte 16) (ash byte9 8))
+                                           byte8)))
+                          (dword1 (the (unsigned-byte 32)
+                                    (logior (the (unsigned-byte 32) (ash word4 16))
+                                            word3)))
+                          (qword (the (unsigned-byte 64)
+                                   (logior (the (unsigned-byte 64) (ash dword1 32))
+                                           dword0)))
+                          (value
+                           (the (unsigned-byte 80)
+                             (logior (the (unsigned-byte 80) (ash qword 16))
+                                     word0))))
+
+                       (mv nil value x86)))))
+
+          (mv 'rm80 0 x86)))
+
+    (mv 'rm80 0 x86))
+
+  ///
+
+  (defthm-usb n80p-mv-nth-1-rm80
+    :hyp (and (signed-byte-p *max-linear-address-size* lin-addr)
+              (x86p x86))
+    :bound 80
+    :concl (mv-nth 1 (rm80 lin-addr r-w-x x86))
+    :hints (("Goal" :in-theory (e/d () (signed-byte-p ash-monotone-2 rb))))
+    :otf-flg t
+    :gen-linear t
+    :hints-l (("Goal" :in-theory (e/d (signed-byte-p) (ash-monotone-2 rb))))
+    :hyp-t (forced-and (integerp lin-addr)
+                       (x86p x86))
+    :gen-type t)
+
+  (defthm x86p-rm80
+    (implies (force (x86p x86))
+             (x86p (mv-nth 2 (rm80 lin-addr r-w-x x86))))
+    :hints (("Goal" :in-theory (e/d () (rb unsigned-byte-p signed-byte-p (force)))))
+    :rule-classes (:rewrite :type-prescription)))
+
+(define wm80
+  ((lin-addr :type (signed-byte #.*max-linear-address-size*))
+   (val      :type (unsigned-byte 80))
+   (x86))
+
+  :parents (x86-top-level-memory)
+  :guard (canonical-address-p lin-addr)
+  :guard-hints (("Goal"
+                 :expand ((create-canonical-address-list 10 lin-addr)
+                          (create-canonical-address-list 9 (+ 1 lin-addr))
+                          (create-canonical-address-list 8 (+ 2 lin-addr))
+                          (create-canonical-address-list 7 (+ 3 lin-addr)))
+                 :in-theory (e/d (wb-and-wvm80 byte-ify)
+                                 ((:rewrite acl2::ash-0)
+                                  (:rewrite acl2::zip-open)
+                                  (:linear ash-monotone-2)
+                                  (:linear bitops::logior-<-0-linear-2)
+                                  (:rewrite xr-and-ia32e-la-to-pa-in-non-marking-mode)
+                                  (:rewrite bitops::logior-equal-0)))))
+
+  :prepwork
+
+  ((defthmd wb-and-wvm80
+     (implies (and (programmer-level-mode x86)
+                   (canonical-address-p lin-addr)
+                   (canonical-address-p (+ 9 lin-addr)))
+              (equal (wvm80 lin-addr val x86)
+                     (wb (create-addr-bytes-alist
+                          (create-canonical-address-list 10 lin-addr)
+                          (byte-ify 10 val))
+                         x86)))
+     :hints (("Goal" :in-theory (e/d (wm08 wvm08 wvm16 wvm32 wvm64 wvm80 byte-ify)
+                                     (append-and-create-addr-bytes-alist
+                                      cons-and-create-addr-bytes-alist
+                                      append-and-addr-byte-alistp
+                                      force (force) nthcdr-byte-listp))))))
+
+  (if (mbt (canonical-address-p lin-addr))
+
+      (let* ((9+lin-addr (the (signed-byte #.*max-linear-address-size+1*)
+                           (+ 9 (the (signed-byte #.*max-linear-address-size*)
+                                  lin-addr)))))
+
+
+        (if (mbe :logic (canonical-address-p 9+lin-addr)
+                 :exec (< (the (signed-byte #.*max-linear-address-size+1*)
+                            9+lin-addr)
+                          #.*2^47*))
+
+            (mbe
+             :logic
+             (wb (create-addr-bytes-alist
+                  (create-canonical-address-list 10 lin-addr)
+                  (byte-ify 10 val))
+                 x86)
+
+             :exec
+             (if (programmer-level-mode x86)
+
+                 (wvm80 lin-addr val x86)
+
+               (let* ((cpl (cpl x86)))
+
+                 (b* (((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr0) x86)
+                       (la-to-pa lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+1*) 1+lin-addr)
+                       (+ 1 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr1) x86)
+                       (la-to-pa 1+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+2*) 2+lin-addr)
+                       (+ 2 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr2) x86)
+                       (la-to-pa 2+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+3*) 3+lin-addr)
+                       (+ 3 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr3) x86)
+                       (la-to-pa 3+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+4*) 4+lin-addr)
+                       (+ 4 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr4) x86)
+                       (la-to-pa 4+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+5*) 5+lin-addr)
+                       (+ 5 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr5) x86)
+                       (la-to-pa 5+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+6*) 6+lin-addr)
+                       (+ 6 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr6) x86)
+                       (la-to-pa 6+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+7*) 7+lin-addr)
+                       (+ 7 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr7) x86)
+                       (la-to-pa 7+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+8*) 8+lin-addr)
+                       (+ 8 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr8) x86)
+                       (la-to-pa 8+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+                      ((the (signed-byte #.*max-linear-address-size+9*) 9+lin-addr)
+                       (+ 9 lin-addr))
+                      ((mv flag (the (unsigned-byte #.*physical-address-size*) p-addr9) x86)
+                       (la-to-pa 9+lin-addr :w cpl x86))
+                      ((when flag) (mv flag x86))
+
+                      (byte0 (mbe :logic (part-select val :low 0 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff val))))
+                      (byte1 (mbe :logic (part-select val :low 8 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -8)))))
+                      (byte2 (mbe :logic (part-select val :low 16 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -16)))))
+                      (byte3 (mbe :logic (part-select val :low 24 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -24)))))
+                      (byte4 (mbe :logic (part-select val :low 32 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -32)))))
+                      (byte5 (mbe :logic (part-select val :low 40 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -40)))))
+                      (byte6 (mbe :logic (part-select val :low 48 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -48)))))
+                      (byte7 (mbe :logic (part-select val :low 56 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -56)))))
+                      (byte8 (mbe :logic (part-select val :low 64 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -64)))))
+                      (byte9 (mbe :logic (part-select val :low 72 :width 8)
+                                  :exec (the (unsigned-byte 8)
+                                          (logand #xff (ash val -72)))))
+
+                      (x86 (!memi p-addr0 byte0 x86))
+                      (x86 (!memi p-addr1 byte1 x86))
+                      (x86 (!memi p-addr2 byte2 x86))
+                      (x86 (!memi p-addr3 byte3 x86))
+                      (x86 (!memi p-addr4 byte4 x86))
+                      (x86 (!memi p-addr5 byte5 x86))
+                      (x86 (!memi p-addr6 byte6 x86))
+                      (x86 (!memi p-addr7 byte7 x86))
+                      (x86 (!memi p-addr8 byte8 x86))
+                      (x86 (!memi p-addr9 byte9 x86)))
+
+                   (mv nil x86)))))
+
+          (mv 'wm80 x86)))
+
+    (mv 'wm80 x86))
+
+  ///
+
+  (defthm x86p-wm80
+    (implies (force (x86p x86))
+             (x86p (mv-nth 1 (wm80 lin-addr val x86))))
+    :hints (("Goal" :in-theory (e/d () (rb force (force) unsigned-byte-p signed-byte-p))))
+    :rule-classes (:rewrite :type-prescription)))
+
 (define rm128
   ((lin-addr :type (signed-byte #.*max-linear-address-size*))
    (r-w-x    :type (member  :r :w :x))
@@ -3345,18 +4048,29 @@ memory.</li>
 
   :parents (x86-top-level-memory)
   :guard (canonical-address-p lin-addr)
-  :guard-hints (("Goal" :in-theory (e/d (rb-and-rvm128
-                                         las-to-pas-as-las-to-pas-tailrec
-                                         las-to-pas-tailrec-opener
-                                         las-to-pas-tailrec-nil
-                                         combine-bytes-as-merge-16-u8s
-                                         natp-memi memi<256)
-                                        (rvm128
-                                         las-to-pas
-                                         memi
-                                         combine-bytes
-                                         not member-equal
-                                         ash-monotone-2))))
+  :guard-hints
+  (("Goal"
+    :in-theory
+    (e/d (rb-and-rvm128
+          las-to-pas-as-las-to-pas-tailrec
+          las-to-pas-tailrec-opener
+          las-to-pas-tailrec-nil
+          combine-bytes-as-merge-16-u8s)
+         (rvm128
+          page-structure-marking-mode$inline
+          xr-and-ia32e-la-to-pa-in-non-marking-mode
+          mv-nth-2-ia32e-la-to-pa-system-level-non-marking-mode
+          acl2::loghead-identity
+          loghead-zero-smaller
+          (:meta acl2::mv-nth-cons-meta)
+          las-to-pas
+          combine-bytes
+          not
+          member-equal
+          ash-monotone-2
+          default-+-2
+          default-+-1
+          unsigned-byte-p))))
 
   :prepwork
   ((local
@@ -3366,20 +4080,23 @@ memory.</li>
                     (canonical-address-p lin-addr)
                     (canonical-address-p (+ 15 lin-addr)))
                (equal (rvm128 lin-addr x86)
-                      (list nil
-                            (logior (combine-bytes
-                                     (mv-nth 1 (rb-1 (create-canonical-address-list 8 lin-addr)
-                                                     r-w-x x86 nil)))
-                                    (ash (combine-bytes
-                                          (mv-nth 1
-                                                  (rb-1 (create-canonical-address-list 8 (+ 8 lin-addr))
-                                                        r-w-x x86 nil)))
-                                         64))
-                            x86)))
+                      (list
+                       nil
+                       (logior (combine-bytes
+                                (mv-nth
+                                 1
+                                 (rb-1 (create-canonical-address-list 8 lin-addr)
+                                       r-w-x x86 nil)))
+                               (ash (combine-bytes
+                                     (mv-nth
+                                      1
+                                      (rb-1 (create-canonical-address-list 8 (+ 8 lin-addr))
+                                            r-w-x x86 nil)))
+                                    64))
+                       x86)))
       :hints (("Goal"
                :in-theory (e/d (rvm128 rb-and-rvm64)
                                (force (force)))))))
-
 
    (local
     (defthmd rb-and-rvm128-helper-2
@@ -3401,13 +4118,20 @@ memory.</li>
                                        (rb-1 (create-canonical-address-list 16 lin-addr)
                                              r-w-x x86 nil)))))
       :hints (("Goal"
-               :use ((:instance split-rb-and-create-canonical-address-list-in-programmer-level-mode
-                                (n 16)
-                                (m 8))
-                     (:instance combine-bytes-of-append-of-byte-lists
-                                (xs (mv-nth 1 (rb-1 (create-canonical-address-list 8 lin-addr) r-w-x x86 nil)))
-                                (ys (mv-nth 1 (rb-1 (create-canonical-address-list 8 (+ 8 lin-addr)) r-w-x x86 nil)))))
-               :in-theory (e/d () (force (force)))))))
+               :in-theory (e/d () (force (force)))
+               :use
+               ((:instance split-rb-and-create-canonical-address-list-in-programmer-level-mode
+                           (n 16)
+                           (m 8))
+                (:instance combine-bytes-of-append-of-byte-lists
+                           (xs (mv-nth
+                                1
+                                (rb-1 (create-canonical-address-list 8 lin-addr)
+                                      r-w-x x86 nil)))
+                           (ys (mv-nth
+                                1
+                                (rb-1 (create-canonical-address-list 8 (+ 8 lin-addr))
+                                      r-w-x x86 nil)))))))))
 
    (defthmd rb-and-rvm128
      (implies (and (programmer-level-mode x86)
@@ -3430,27 +4154,12 @@ memory.</li>
      (implies (and (signed-byte-p 48 lin-addr)
                    (x86p x86)
                    (signed-byte-p 48 (+ 15 lin-addr)))
-              (< (combine-bytes (mv-nth 1
-                                        (rb (create-canonical-address-list 16 lin-addr)
-                                            r-w-x x86)))
+              (< (combine-bytes
+                  (mv-nth 1
+                          (rb (create-canonical-address-list 16 lin-addr)
+                              r-w-x x86)))
                  *2^128*))
      :rule-classes :linear)
-
-   (defthm-usb logior-limit-lemma
-     :hyp (and (n64p x)
-               (n64p y))
-     :bound 128
-     :concl (logior x (ash y 64))
-     :hints (("Goal" :in-theory (e/d* (ihsext-inductions
-                                       ihsext-recursive-redefs
-                                       zip)
-                                      (unsigned-byte-p))))
-     :hints-l (("Goal" :in-theory (e/d (unsigned-byte-p)
-                                       (bitops::unsigned-byte-p-when-unsigned-byte-p-less
-                                        unsigned-byte-p-of-ash
-                                        unsigned-byte-p-of-logior))))
-     :gen-type nil
-     :gen-linear t)
 
    (defthm-usb unsigned-byte-p-128-of-merge-16-u8s-linear
      :hyp (and (unsigned-byte-p 8 h7)
@@ -3476,37 +4185,6 @@ memory.</li>
                 :use ((:instance bitops::unsigned-byte-p-128-of-merge-16-u8s))))
      :gen-linear t)
 
-   (local
-    (defthm floor-1
-      (implies (integerp x)
-               (equal (floor x 1) x))
-      :hints (("goal" :in-theory (enable floor)))))
-
-   (local
-    (defthm 2*ash
-      (implies (posp n)
-               (equal (* 2 (ash x (1- n)))
-                      (ash x n)))
-      :hints (("goal" :in-theory (enable ash)
-               :use (:instance acl2::exponents-add-unrestricted
-                               (r 2) (i 1) (j (1- n)))))))
-
-   (local
-    (defthmd ash-logior
-      (implies (natp n)
-               (equal (ash (logior x y) n)
-                      (logior (ash x n)
-                              (ash y n))))
-      :hints (("goal" :in-theory (enable logcons) :induct (acl2::dec-induct n))
-              ("subgoal *1/2" :use ((:instance logior** (i (ash x n)) (j (ash y n))))))))
-
-   (local
-    (defthmd ash-logior-8
-      (equal (ash (logior x y) 8)
-             (logior (ash x 8)
-                     (ash y 8)))
-      :hints (("goal" :in-theory (enable ash-logior)))))
-
    (defthmd combine-bytes-as-merge-16-u8s
      (implies
       (and (natp b0)  (natp b1)  (natp b2)  (natp b3)
@@ -3519,15 +4197,7 @@ memory.</li>
          b0 b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15))
        (bitops::merge-16-u8s
         b15 b14 b13 b12 b11 b10 b9 b8 b7 b6 b5 b4 b3 b2 b1 b0)))
-     :hints (("goal" :in-theory (enable ash-logior-8 merge-16-u8s))))
-
-   (defthmd natp-memi
-     (implies (and (x86p x86))
-              (natp (memi p-addr x86))))
-
-   (defthmd memi<256
-     (implies (and (x86p x86))
-              (< (memi p-addr x86) 256))))
+     :hints (("Goal" :in-theory (enable push-ash-inside-logior merge-16-u8s)))))
 
   (if (mbt (canonical-address-p lin-addr))
 
@@ -3693,17 +4363,18 @@ memory.</li>
   :parents (x86-top-level-memory)
   :guard (canonical-address-p lin-addr)
 
-  :guard-hints (("Goal" :in-theory (e/d (wb-and-wvm128
-                                         byte-ify
-                                         las-to-pas-as-las-to-pas-tailrec
-                                         las-to-pas-tailrec-opener
-                                         las-to-pas-tailrec-nil
-                                         create-addr-bytes-alist-opener)
-                                        (wvm128
-                                         las-to-pas))))
+  :guard-hints
+  (("Goal"
+    :in-theory (e/d (wb-and-wvm128
+                     byte-ify
+                     las-to-pas-as-las-to-pas-tailrec
+                     las-to-pas-tailrec-opener
+                     las-to-pas-tailrec-nil
+                     create-addr-bytes-alist-opener)
+                    (wvm128
+                     las-to-pas))))
 
   :prepwork
-
   ((defthmd wb-and-wvm128
      (implies (and (programmer-level-mode x86)
                    (canonical-address-p lin-addr)
@@ -3915,6 +4586,12 @@ memory.</li>
 
 ;; ======================================================================
 
+;; (i-am-here)
+;; TODO: Now that I've got proofs about the equivalence of rm/wm-size
+;; to rb/wb, I should think about two things: one, should rm/wm-size
+;; have mbes inside that define :logic as rb/wb? and two, should I
+;; disable these functions after proving bound rules about them?
+
 (defsection Parametric-Memory-Reads-and-Writes
 
   :parents (x86-top-level-memory)
@@ -3926,6 +4603,7 @@ memory.</li>
      (addr   :type (signed-byte #.*max-linear-address-size*))
      (r-w-x  :type (member :r :w :x))
      (x86))
+    :guard (natp nbytes)
     :inline t
     :enabled t
     (case nbytes
@@ -3935,60 +4613,42 @@ memory.</li>
       (6
        ;; Use case: To fetch operands of the form m16:32 (see far jmp
        ;; instruction).
-       (b* (((when (mbe :logic (not (canonical-address-p (+ 5 addr)))
-                        :exec (<= #.*2^47*
-                                  (the (signed-byte #.*max-linear-address-size+1*)
-                                    (+ 5 addr)))))
-             (mv 'rm48 0 x86))
-            ((mv flg0 (the (unsigned-byte 16) val15-0) x86)
-             (rm16 addr r-w-x x86))
-            ((when flg0) (mv flg0 0 x86))
-            ((mv flg1 (the (unsigned-byte 32) val47-16) x86)
-             (rm32 (+ 2 addr) r-w-x x86))
-            ((when flg1) (mv flg1 0 x86))
-            (val (mbe :logic (part-install
-                              val15-0
-                              (ash val47-16 16)
-                              :low 0 :width 16)
-                      :exec
-                      (logior (the (unsigned-byte 16) val15-0)
-                              (the (unsigned-byte 48)
-                                (ash (the (unsigned-byte 64) val47-16) 16))))))
-         (mv nil val x86)))
+       (rm48 addr r-w-x x86))
       (8 (rm64 addr r-w-x x86))
       (10
        ;; Use case: The instructions LGDT and LIDT need to read 10
        ;; bytes at once.
-       (b* (((when (mbe :logic (not (canonical-address-p (+ 9 addr)))
-                        :exec (<= #.*2^47*
-                                  (the (signed-byte #.*max-linear-address-size+1*)
-                                    (+ 9 addr)))))
-             (mv 'rm80 (+ 2 addr) x86))
-            ((mv flg0 (the (unsigned-byte 16) val15-0) x86)
-             (rm16 addr r-w-x x86))
-            ((when flg0) (mv flg0 0 x86))
-            ((mv flg1 (the (unsigned-byte 64) val79-16) x86)
-             (rm64 (+ 2 addr) r-w-x x86))
-            ((when flg1) (mv flg1 0 x86))
-            (val (mbe :logic (part-install
-                              val15-0
-                              (ash val79-16 16)
-                              :low 0 :width 16)
-                      :exec
-                      (logior (the (unsigned-byte 16) val15-0)
-                              (the (unsigned-byte 80)
-                                (ash (the (unsigned-byte 64) val79-16) 16))))))
-         (mv nil val x86)))
+       (rm80 addr r-w-x x86))
       (16 (rm128 addr r-w-x x86))
       (otherwise
-       (mv 'unsupported-nbytes nbytes x86)))
+       (if (mbe :logic (canonical-address-p (+ -1 nbytes addr))
+                :exec (< (+ nbytes addr) #.*2^47-1*))
+           (b* (((mv flg bytes x86)
+                 (rb (create-canonical-address-list nbytes addr) r-w-x x86))
+                ((when flg)
+                 (mv flg 0 x86)))
+             (mv nil (combine-bytes bytes) x86))
+         (mv 'rm-size 0 x86))))
 
     ///
 
     (defthm x86p-of-mv-nth-2-of-rm-size
       (implies (and (signed-byte-p *max-linear-address-size* lin-addr)
                     (x86p x86))
-               (x86p (mv-nth 2 (rm-size bytes lin-addr r-w-x x86))))))
+               (x86p (mv-nth 2 (rm-size bytes lin-addr r-w-x x86)))))
+
+    (defthmd rm-size-to-rb
+      (implies (and (canonical-address-p (+ -1 nbytes lin-addr))
+                    (canonical-address-p lin-addr))
+               (b* (((mv flg1 val x86-1)
+                     (rm-size nbytes lin-addr r-x x86))
+                    ((mv flg2 bytes x86-2)
+                     (rb (create-canonical-address-list nbytes lin-addr) r-x x86)))
+                 (and (iff flg1 flg2)
+                      (equal val (if flg1 0 (combine-bytes bytes)))
+                      (equal x86-1 x86-2))))
+      :hints (("Goal" :in-theory (e/d* (signed-byte-p rm08 rm128 rm32 rm48 rm64 rm80 rm16)
+                                       (create-canonical-address-list-1))))))
 
   (define rim-size
     ((nbytes :type (member 1 2 4 8))
@@ -4003,7 +4663,7 @@ memory.</li>
       (4 (rim32 addr r-w-x x86))
       (8 (rim64 addr r-w-x x86))
       (otherwise
-       (mv 'unsupported-nbytes nbytes x86))))
+       (mv 'rim-size nbytes x86))))
 
   (define wm-size
     ((nbytes :type (member 1 2 4 6 8 10 16))
@@ -4026,66 +4686,55 @@ memory.</li>
       (4 (wm32 addr val x86))
       (6
        ;; Use case: To store operands of the form m16:32.
-       (b* (((when (mbe :logic (not (canonical-address-p (+ 5 addr)))
-                        :exec (<= #.*2^47*
-                                  (the (signed-byte #.*max-linear-address-size+1*)
-                                    (+ 5 addr)))))
-             (mv 'wm48 x86))
-            (val15-0 (mbe :logic (part-select
-                                  val :low 0 :width 16)
-                          :exec
-                          (logand #xFFFF
-                                  (the (unsigned-byte 48) val))))
-            (val47-16 (mbe :logic (part-select
-                                   val :low 16 :width 32)
-                           :exec
-                           (the (unsigned-byte 32)
-                             (ash (the (unsigned-byte 48) val)
-                                  -16))))
-            ((mv flg0 x86)
-             (wm16 addr val15-0 x86))
-            ((when flg0) (mv flg0 x86))
-            ((mv flg1 x86)
-             (wm32 (+ 2 addr) (the (unsigned-byte 32) val47-16) x86))
-            ((when flg1) (mv flg1 x86)))
-         (mv nil x86)))
+       (wm48 addr val x86))
       (8 (wm64 addr val x86))
       (10
        ;; Use case: Instructions like SGDT and SIDT write 10 bytes to
        ;; the memory.
-       (b* (((when (mbe :logic (not (canonical-address-p (+ 9 addr)))
-                        :exec (<= #.*2^47*
-                                  (the (signed-byte #.*max-linear-address-size+1*)
-                                    (+ 9 addr)))))
-             (mv 'wm80 x86))
-            (val15-0 (mbe :logic (part-select
-                                  val
-                                  :low 0 :width 16)
-                          :exec
-                          (logand #xFFFF
-                                  (the (unsigned-byte 80) val))))
-            (val79-16 (mbe :logic (part-select
-                                   val
-                                   :low 16 :width 64)
-                           :exec
-                           (the (unsigned-byte 64)
-                             (ash (the (unsigned-byte 80) val)
-                                  -16))))
-            ((mv flg0 x86)
-             (wm16 addr val15-0 x86))
-            ((when flg0) (mv flg0 x86))
-            ((mv flg1 x86)
-             (wm64 (+ 2 addr) (the (unsigned-byte 64) val79-16) x86))
-            ((when flg1) (mv flg1 x86)))
-         (mv nil x86)))
+       (wm80 addr val x86))
       (16 (wm128 addr val x86))
       (otherwise
-       (mv 'unsupported-nbytes x86))))
+       (if (mbe :logic (canonical-address-p (+ -1 nbytes addr))
+                :exec (< (+ nbytes addr) #.*2^47-1*))
+           (b* (((mv flg x86)
+                 (wb (create-addr-bytes-alist
+                      (create-canonical-address-list nbytes addr)
+                      (byte-ify nbytes val))
+                     x86))
+                ((when flg)
+                 (mv flg x86)))
+             (mv nil x86))
+         (mv 'wm-size x86))))
+
+    ///
+
+    (defthm x86p-wm-size
+      (implies (force (x86p x86))
+               (x86p (mv-nth 1 (wm-size nbytes lin-addr val x86))))
+      :hints (("Goal" :in-theory (e/d () (rb force (force) unsigned-byte-p signed-byte-p)))))
+
+    (defthmd wm-size-to-wb
+      (implies (and (canonical-address-p (+ -1 nbytes lin-addr))
+                    (canonical-address-p lin-addr))
+               (b* (((mv flg1 x86-1)
+                     (wm-size nbytes lin-addr val x86))
+                    ((mv flg2 x86-2)
+                     (wb (create-addr-bytes-alist
+                          (create-canonical-address-list nbytes lin-addr)
+                          (byte-ify nbytes val))
+                         x86)))
+                 (and (iff flg1 flg2)
+                      (equal x86-1 x86-2))))
+      :hints (("Goal" :in-theory (e/d* (signed-byte-p
+                                        las-to-pas
+                                        byte-ify
+                                        wm08 wm128 wm32 wm48 wm64 wm80 wm16)
+                                       ())))))
 
   (define wim-size
     ((nbytes :type (member 1 2 4 8))
      (addr   :type (signed-byte #.*max-linear-address-size*))
-     (val    :type (integer 0 *))
+     (val    :type integer)
      (x86))
     :guard (case nbytes
              (1 (i08p val))
@@ -4100,7 +4749,7 @@ memory.</li>
       (4 (wim32 addr val x86))
       (8 (wim64 addr val x86))
       (otherwise
-       (mv 'unsupported-nbytes x86)))))
+       (mv 'wim-size x86)))))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-init.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-init.lisp
@@ -607,10 +607,6 @@
 
 ;; ======================================================================
 
-;; ======================================================================
-
-;; Begin: Effects theorems:
-
 ;; Assumptions for the effects theorems:
 
 (defun-nx x86-state-okp (x86)
@@ -626,7 +622,7 @@
    ;; CR3's reserved bits must be zero (MBZ).
    (equal (logtail 40 (ctri *cr3* x86)) 0)))
 
-(defun-nx program-ok-p (x86)
+ (defun-nx program-ok-p (x86)
   (and
    ;; Program addresses are canonical.
    (canonical-address-p (+ *rewire_dst_to_src-len* (xr :rip 0 x86)))

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy.lisp
@@ -1663,7 +1663,6 @@
                  (all-translation-governing-addresses
                   (create-canonical-address-list *2^30* (xr :rgf *rdi* x86))
                   x86)))
-
            (equal
             (mv-nth 1
                     (las-to-pas
@@ -6465,6 +6464,23 @@
                              force (force)))
            :use ((:instance program-at-alt-in-final-state-==-program-at-in-initial-state)
                  (:instance program-at-alt-in-final-state-==-program-at-in-final-state)))))
+
+;; 5. Final value in rax == 1, which signals that the 1G-aligned
+;; physical address of the destination at the end of execution of the
+;; program is equal to the 1G-aligned physical address of the source.
+
+(defthmd rax-==-1-rewire_dst_to_src-effects
+  (implies
+   (rewire_dst_to_src-effects-preconditions x86)
+   (equal
+    (xr :rgf *rax* (x86-run (rewire_dst_to_src-clk) x86))
+    1))
+  :hints (("Goal"
+           :use ((:instance rewire_dst_to_src-effects))
+           :in-theory (union-theories
+                       '(xr-xw-intra-array-field
+                         member-equal)
+                       (theory 'minimal-theory)))))
 
 ;; !! TODO: How much stack was used?
 


### PR DESCRIPTION
- Added functions to read/write 6 and 10 bytes of memory.  Thanks to @nadezhin for this suggestion that comes in useful to read memory operands of the form m16:32 and m16:64. 

- Added alignment checking support that is cognizant of whether a 32-bit memory operand is of the form m16:16 or simply m32 --- the natural boundary in the former case is any even address and in the latter case is an address divisible by 4.

- Proved that rm-size and wm-size are equal to rb and wb, respectively. Unlike other rm*/wm* functions, rm-size and wm-size are not defined in terms of rb and wb. That may happen in the future.

- Fixed some conflicts.