### PR TITLE
Avoid perl warnings during certification.

### DIFF
--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -70,6 +70,9 @@ use File::Path qw(make_path);
 use FindBin qw($RealBin);
 use POSIX qw(strftime);
 use Cwd;
+use utf8;
+
+binmode(STDOUT,':utf8');
 
 (do "$RealBin/paths.pl") or die ("Error loading $RealBin/paths.pl:\n!: $!\n\@: $@\n");
 


### PR DESCRIPTION
Perl gives me a warning on every output of month during certification on my Locale.
It looks like:

    Wide character in print at /export/home/dn146861/dist/acl2/acl2-devel.defprod/books//build/make_cert_help.pl line 526.
    Making /export/home/dn146861/t/ole72a/fgu/acl2/models/concrete/ma/xmontmul-proof.cert on 13-сен-2016 15:09:53

`сен` is Septemeber in Russian.

The line 526 of make_cert_help.pl is:

    print "Making $printgoal on " . strftime('%d-%b-%Y %H:%M:%S',localtime) . "\n";

So `srtftime` gives UTF8 month on my locale and this causes warnings.

To avoid warnings I suggest to allow perl to output UTF8 month by:

    use utf8;
    binmode(STDOUT,':utf8');