### PR TITLE
x86isa: Renamed all functions with the prefix "translation-governing-addresses"

### DIFF
--- a/books/projects/x86isa/proofs/utilities/system-level-mode/marking-mode-top.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/marking-mode-top.lisp
@@ -105,7 +105,7 @@
    @('rb-alt-and-wb-to-paging-structures-disjoint') <br/>
    @('rb-wb-disjoint-in-system-level-mode') <br/>
    @('rb-wb-equal-in-system-level-mode') <br/>
-   @('all-translation-governing-addresses-and-mv-nth-1-wb-disjoint') <br/>
+   @('all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint') <br/>
    @('la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs').<br/>
    <br/>
    Note that @(see rb) is rewritten to @(see rb-alt) when the read is
@@ -177,7 +177,7 @@
  @(def rb-alt-and-wb-to-paging-structures-disjoint)
  @(def rb-wb-disjoint-in-system-level-mode)
  @(def rb-wb-equal-in-system-level-mode)
- @(def all-translation-governing-addresses-and-mv-nth-1-wb-disjoint)
+ @(def all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint)
  @(def la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs).
  "
   )
@@ -195,7 +195,7 @@
 ;; (acl2::why rb-alt-wb-disjoint-in-system-level-mode)
 ;; (acl2::why rb-alt-wb-equal-in-system-level-mode)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-rb-alt)
-;; (acl2::why all-translation-governing-addresses-and-mv-nth-1-wb-disjoint)
+;; (acl2::why all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint)
 ;; (acl2::why la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-get-prefixes-alt-no-prefix-byte)
 ;; (acl2::why mv-nth-2-get-prefixes-alt-no-prefix-byte)
@@ -265,7 +265,7 @@
    (and (equal cpl (cpl x86))
         (disjoint-p
          (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-         (all-translation-governing-addresses (create-canonical-address-list count addr) (double-rewrite x86))))
+         (all-xlation-governing-entries-paddrs (create-canonical-address-list count addr) (double-rewrite x86))))
    (equal (direct-map-p count addr r-w-x cpl (mv-nth 1 (wb addr-lst x86)))
           (direct-map-p count addr r-w-x cpl (double-rewrite x86))))
   :hints (("Goal" :in-theory (e/d* () (force (force))))))
@@ -905,7 +905,7 @@
     (defthm mv-nth-0-rb-and-xw-mem-in-system-level-mode
       (implies (and (disjoint-p
                      (list index)
-                     (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                     (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                     (canonical-address-listp l-addrs)
                     (physical-address-p index)
                     (unsigned-byte-p 8 value)
@@ -929,13 +929,13 @@
       (implies (and
                 (disjoint-p
                  (list index)
-                 (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                 (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (disjoint-p
                  (list index)
                  (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86))))
                 (disjoint-p
                  (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86)))
-                 (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                 (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (canonical-address-listp l-addrs)
                 (physical-address-p index)
                 (unsigned-byte-p 8 value)
@@ -959,14 +959,14 @@
                                          signed-byte-p)
                                         ())))))
     (local
-     (defthmd disjoint-p-all-translation-governing-addresses-and-las-to-pas-subset-p
+     (defthmd disjoint-p-all-xlation-governing-entries-paddrs-and-las-to-pas-subset-p
        ;; Very similar to
        ;; MV-NTH-1-LAS-TO-PAS-SUBSET-P-DISJOINT-FROM-OTHER-P-ADDRS,
-       ;; DISJOINTNESS-OF-ALL-TRANSLATION-GOVERNING-ADDRESSES-FROM-ALL-TRANSLATION-GOVERNING-ADDRESSES-SUBSET-P.
+       ;; DISJOINTNESS-OF-ALL-XLATION-GOVERNING-ENTRIES-PADDRS-FROM-ALL-XLATION-GOVERNING-ENTRIES-PADDRS-SUBSET-P.
 
        ;; This rule is tailored to rewrite terms of the form
 
-       ;; (disjoint-p (all-translation-governing-addresses l-addrs-subset x86)
+       ;; (disjoint-p (all-xlation-governing-entries-paddrs l-addrs-subset x86)
        ;;             (mv-nth 1 (las-to-pas l-addrs-subset r-w-x cpl x86)))
 
        ;; where l-addrs-subset is a subset of l-addrs, and l-addrs is of
@@ -975,19 +975,19 @@
        (implies
         (and
          (bind-free (find-l-addrs-like-create-canonical-address-list-from-fn
-                     'all-translation-governing-addresses 'l-addrs mfc state)
+                     'all-xlation-governing-entries-paddrs 'l-addrs mfc state)
                     (l-addrs))
          ;; (syntaxp (not (cw "~% l-addrs: ~x0~%" l-addrs))) ; ;
          (disjoint-p
-          (all-translation-governing-addresses l-addrs (double-rewrite x86))
+          (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))
           (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (double-rewrite x86))))
          (subset-p l-addrs-subset l-addrs)
          (not (mv-nth 0 (las-to-pas l-addrs r-w-x cpl (double-rewrite x86)))))
-        (disjoint-p (all-translation-governing-addresses l-addrs-subset x86)
+        (disjoint-p (all-xlation-governing-entries-paddrs l-addrs-subset x86)
                     (mv-nth 1 (las-to-pas l-addrs-subset r-w-x cpl x86))))
        :hints
        (("Goal"
-         :use ((:instance disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+         :use ((:instance disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                           (l-addrs l-addrs)
                           (l-addrs-subset l-addrs-subset)
                           (other-p-addrs (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86)))
@@ -1124,7 +1124,7 @@
                        (:rewrite loghead-ash-0)
                        (:rewrite acl2::expt-with-violated-guards)
                        (:type-prescription bitops::lognot-negp)
-                       (:type-prescription all-translation-governing-addresses)
+                       (:type-prescription all-xlation-governing-entries-paddrs)
                        (:rewrite acl2::unsigned-byte-p-loghead)
                        (:rewrite bitops::loghead-of-ash-same)
                        (:type-prescription n44p$inline)
@@ -1155,7 +1155,7 @@
          (mv-nth 1 (las-to-pas
                     (create-canonical-address-list cnt start-rip)
                     :x (cpl x86) (double-rewrite x86)))
-         (all-translation-governing-addresses
+         (all-xlation-governing-entries-paddrs
           (create-canonical-address-list cnt start-rip) (double-rewrite x86)))
         (disjoint-p
          (list index)
@@ -1163,7 +1163,7 @@
                                :x (cpl x86) (double-rewrite x86))))
         (disjoint-p
          (list index)
-         (all-translation-governing-addresses
+         (all-xlation-governing-entries-paddrs
           (create-canonical-address-list cnt start-rip) (double-rewrite x86)))
         (not (mv-nth 0 (las-to-pas
                         (create-canonical-address-list cnt start-rip)
@@ -1192,9 +1192,9 @@
                  (get-prefixes start-rip prefixes cnt x86))
         :in-theory (e/d* (get-prefixes
                           disjoint-p$
-                          disjoint-p-all-translation-governing-addresses-and-las-to-pas-subset-p
+                          disjoint-p-all-xlation-governing-entries-paddrs-and-las-to-pas-subset-p
                           subset-p)
-                         (disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                         (disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                           get-prefixes-alt-opener-lemma-zero-cnt
                           member-p-strip-cars-of-remove-duplicate-keys
                           open-qword-paddr-list-and-member-p
@@ -1202,15 +1202,15 @@
                           xlate-equiv-memory-and-xr-mem-from-rest-of-memory
                           mv-nth-0-ia32e-la-to-pa-member-of-mv-nth-1-las-to-pas-if-lin-addr-member-p
                           mv-nth-1-ia32e-la-to-pa-member-of-mv-nth-1-las-to-pas-if-lin-addr-member-p
-                          infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses
+                          infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses
                           r-w-x-is-irrelevant-for-mv-nth-1-ia32e-la-to-pa-when-no-errors
                           mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
                           xlate-equiv-memory-with-mv-nth-2-las-to-pas
                           las-to-pas-values-and-xw-mem-not-member
-                          all-translation-governing-addresses-and-xw-mem-not-member
+                          all-xlation-governing-entries-paddrs-and-xw-mem-not-member
                           r/x-is-irrelevant-for-mv-nth-2-las-to-pas-when-no-errors
                           xr-programmer-level-mode-mv-nth-2-las-to-pas
-                          all-translation-governing-addresses-and-xw-not-mem
+                          all-xlation-governing-entries-paddrs-and-xw-not-mem
                           xr-seg-visible-mv-nth-2-las-to-pas
                           xr-page-structure-marking-mode-mv-nth-2-las-to-pas
                           disjoint-p
@@ -1235,7 +1235,7 @@
          (mv-nth 1
                  (las-to-pas (create-canonical-address-list cnt start-rip)
                              :x (cpl x86) (double-rewrite x86)))
-         (all-translation-governing-addresses
+         (all-xlation-governing-entries-paddrs
           (create-canonical-address-list cnt start-rip) (double-rewrite x86)))
         (disjoint-p
          p-addrs
@@ -1245,7 +1245,7 @@
                       :x (cpl x86) (double-rewrite x86))))
         (disjoint-p
          p-addrs
-         (all-translation-governing-addresses
+         (all-xlation-governing-entries-paddrs
           (create-canonical-address-list cnt start-rip) (double-rewrite x86)))
         (not (mv-nth 0 (las-to-pas (create-canonical-address-list cnt start-rip)
                                    :x (cpl x86) x86)))
@@ -1319,7 +1319,7 @@
       (("Goal"
         :do-not-induct t
         :use ((:instance get-prefixes-and-write-to-physical-memory)
-              (:instance all-translation-governing-addresses-subset-of-paging-structures
+              (:instance all-xlation-governing-entries-paddrs-subset-of-paging-structures
                          (l-addrs (create-canonical-address-list cnt start-rip))))
         :in-theory
         (e/d*
@@ -1332,7 +1332,7 @@
           get-prefixes-and-write-to-physical-memory
           xlate-equiv-memory-and-two-get-prefixes-values
           mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
-          all-translation-governing-addresses-subset-of-paging-structures
+          all-xlation-governing-entries-paddrs-subset-of-paging-structures
           force (force))))))
 
     (defthm get-prefixes-alt-and-wb-in-system-level-marking-mode-disjoint-from-paging-structures
@@ -1365,7 +1365,7 @@
                                  disjoint-p$
                                  wb
                                  disjoint-p-commutative
-                                 infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses
+                                 infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses
                                  xlate-equiv-memory-with-mv-nth-2-las-to-pas)
                                 (rewrite-get-prefixes-to-get-prefixes-alt
                                  xlate-equiv-memory-and-two-get-prefixes-values
@@ -1425,7 +1425,7 @@
                              :x (cpl x86) (double-rewrite x86))))
         (disjoint-p$
          p-addrs
-         (all-translation-governing-addresses
+         (all-xlation-governing-entries-paddrs
           (create-canonical-address-list cnt start-rip)
           (double-rewrite x86)))
         (equal (page-size (combine-bytes bytes)) 1)
@@ -1452,7 +1452,7 @@
       (("Goal"
         :do-not-induct t
         :use ((:instance get-prefixes-and-write-to-physical-memory)
-              (:instance all-translation-governing-addresses-subset-of-paging-structures
+              (:instance all-xlation-governing-entries-paddrs-subset-of-paging-structures
                          (l-addrs (create-canonical-address-list cnt start-rip)))
               (:instance disjointness-of-las-to-pas-from-write-to-physical-memory-subset-of-paging-structures
                          (index index)
@@ -1471,7 +1471,7 @@
           get-prefixes-and-write-to-physical-memory
           xlate-equiv-memory-and-two-get-prefixes-values
           mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
-          all-translation-governing-addresses-subset-of-paging-structures
+          all-xlation-governing-entries-paddrs-subset-of-paging-structures
           force (force))))))
 
     (defthm get-prefixes-alt-and-wb-to-paging-structures
@@ -1488,7 +1488,7 @@
         (disjoint-p
          (mv-nth 1 (las-to-pas (create-canonical-address-list 8 lin-addr)
                                :w (cpl x86) (double-rewrite x86)))
-         (all-translation-governing-addresses
+         (all-xlation-governing-entries-paddrs
           (create-canonical-address-list cnt start-rip) (double-rewrite x86)))
         (disjoint-p
          (mv-nth 1 (las-to-pas (create-canonical-address-list 8 lin-addr)
@@ -1537,7 +1537,7 @@
                                  acl2::fold-consts-in-+
                                  disjoint-p$
                                  wb
-                                 infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses
+                                 infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses
                                  xlate-equiv-memory-with-mv-nth-2-las-to-pas)
                                 (rewrite-get-prefixes-to-get-prefixes-alt
                                  mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs-alt
@@ -1625,7 +1625,7 @@
        (rewrite-program-at-to-program-at-alt
         program-at-wb-disjoint-in-system-level-mode
         rb-wb-disjoint-in-system-level-mode
-        disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+        disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
         mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs
         rb wb)))))
 
@@ -1683,7 +1683,7 @@
              (not (programmer-level-mode x86))
              (canonical-address-listp l-addrs)
              (not (mv-nth 0 (las-to-pas l-addrs r-w-x (cpl x86) x86)))
-             ;; (disjoint-p (all-translation-governing-addresses l-addrs x86)
+             ;; (disjoint-p (all-xlation-governing-entries-paddrs l-addrs x86)
              ;;             (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) x86)))
              (disjoint-p (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) x86))
                          (open-qword-paddr-list
@@ -1922,7 +1922,7 @@
                              (acl2::mv-nth-cons-meta
                               rb-in-terms-of-nth-and-pos-in-system-level-mode
                               rewrite-rb-to-rb-alt
-                              disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p))
+                              disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p))
              :use ((:instance rewrite-rb-to-rb-alt
                               (l-addrs (list lin-addr))
                               (r-w-x :x))
@@ -1967,7 +1967,7 @@
                              (rb-in-terms-of-rb-subset-p-in-system-level-mode
                               rewrite-rb-to-rb-alt
                               acl2::mv-nth-cons-meta
-                              disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p))
+                              disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p))
              :use ((:instance rb-in-terms-of-rb-subset-p-in-system-level-mode)
                    (:instance rewrite-rb-to-rb-alt
                               (r-w-x :x))
@@ -1988,7 +1988,7 @@
                   ;; of disjoint-p.
                   (disjoint-p$
                    ;; The physical addresses pertaining to the write are
-                   ;; disjoint from the translation-governing-addresses
+                   ;; disjoint from the xlation-governing-entries-paddrs
                    ;; pertaining to the read.
                    (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
                    (open-qword-paddr-list (gather-all-paging-structure-qword-addresses
@@ -2009,7 +2009,7 @@
                                disjoint-p$
                                disjoint-p-commutative)
                               (rewrite-rb-to-rb-alt
-                               disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                               disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                                mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs
                                force (force)))
              :use ((:instance rewrite-rb-to-rb-alt
@@ -2064,7 +2064,7 @@
                                disjoint-p$)
                               (rewrite-rb-to-rb-alt
                                rb-wb-disjoint-in-system-level-mode
-                               disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                               disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                                mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)))))
 
   (defthm disjointness-of-las-to-pas-from-wb-to-subset-of-paging-structures
@@ -2245,7 +2245,7 @@
                (mv-nth 1 (las-to-pas
                           (create-canonical-address-list 8 lin-addr)
                           :w (cpl x86) (double-rewrite x86)))
-               (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+               (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
               (disjoint-p
                (mv-nth 1 (las-to-pas (create-canonical-address-list 8 lin-addr)
                                      :w (cpl x86) (double-rewrite x86)))

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/marking-mode-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/marking-mode-utils.lisp
@@ -260,20 +260,20 @@
 (local
  (defthmd rm08-in-terms-of-nth-pos-and-rb-helper
    (implies (and (disjoint-p (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86))
-                             (all-translation-governing-addresses l-addrs x86))
+                             (all-xlation-governing-entries-paddrs l-addrs x86))
                  (not (mv-nth 0 (las-to-pas l-addrs r-w-x cpl x86)))
                  (member-p addr l-addrs))
             (equal (member-p
                     (mv-nth 1 (ia32e-la-to-pa addr r-w-x cpl x86))
-                    (translation-governing-addresses addr x86))
+                    (xlation-governing-entries-paddrs addr x86))
                    nil))
    :hints (("Goal"
             :do-not-induct t
             :use ((:instance not-member-p-when-disjoint-p
                              (e (mv-nth 1 (ia32e-la-to-pa addr r-w-x cpl x86)))
                              (x (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86)))
-                             (y (translation-governing-addresses addr x86))))
-            :in-theory (e/d* (all-translation-governing-addresses
+                             (y (xlation-governing-entries-paddrs addr x86))))
+            :in-theory (e/d* (all-xlation-governing-entries-paddrs
                               member-p
                               disjoint-p
                               subset-p
@@ -301,7 +301,7 @@
 (defthmd rm08-in-terms-of-nth-pos-and-rb-in-system-level-mode
   (implies (and
             (disjoint-p (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86)))
-                        (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                        (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (not (mv-nth 0 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86))))
             (member-p addr l-addrs)
             (canonical-address-listp l-addrs)
@@ -318,7 +318,7 @@
                             member-p disjoint-p
                             rm08-in-terms-of-nth-pos-and-rb-helper)
                            (member-p-canonical-address-p
-                            all-translation-governing-addresses
+                            all-xlation-governing-entries-paddrs
                             signed-byte-p
                             (:meta acl2::mv-nth-cons-meta))))))
 
@@ -341,7 +341,7 @@
                  (mv-nth 1 (las-to-pas
                             (create-canonical-address-list n prog-addr)
                             :x (cpl x86) (double-rewrite x86)))
-                 (all-translation-governing-addresses
+                 (all-xlation-governing-entries-paddrs
                   (create-canonical-address-list n prog-addr) (double-rewrite x86)))
                 (syntaxp (quotep n))
                 (not (programmer-level-mode x86))
@@ -366,7 +366,7 @@
   (implies (and (consp l-addrs)
                 (not (mv-nth 0 (rb l-addrs r-w-x x86)))
                 (disjoint-p (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86)))
-                            (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                            (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (canonical-address-listp l-addrs)
                 (not (programmer-level-mode x86)))
            (equal (mv-nth 1 (rb l-addrs r-w-x x86))
@@ -390,10 +390,10 @@
  (defthmd rb-in-terms-of-rb-subset-p-helper
    (implies (and (subset-p l-addrs-subset l-addrs)
                  (disjoint-p (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86))
-                             (all-translation-governing-addresses l-addrs x86))
+                             (all-xlation-governing-entries-paddrs l-addrs x86))
                  (not (mv-nth 0 (las-to-pas l-addrs r-w-x cpl x86))))
             (disjoint-p (mv-nth 1 (las-to-pas l-addrs-subset r-w-x cpl x86))
-                        (all-translation-governing-addresses l-addrs-subset x86)))))
+                        (all-xlation-governing-entries-paddrs l-addrs-subset x86)))))
 
 (defthm rb-in-terms-of-rb-subset-p-in-system-level-mode
   (implies
@@ -407,7 +407,7 @@
         (disjoint-p (mv-nth 1 (las-to-pas
                                (create-canonical-address-list n prog-addr)
                                :x (cpl x86) (double-rewrite x86)))
-                    (all-translation-governing-addresses
+                    (all-xlation-governing-entries-paddrs
                      (create-canonical-address-list n prog-addr)
                      (double-rewrite x86)))
         (syntaxp (quotep n))
@@ -433,7 +433,7 @@
                             canonical-address-p
                             acl2::mv-nth-cons-meta
                             rb-in-terms-of-nth-and-pos-in-system-level-mode
-                            all-translation-governing-addresses
+                            all-xlation-governing-entries-paddrs
                             las-to-pas))
            :use ((:instance rb-in-terms-of-nth-and-pos-in-system-level-mode
                             (lin-addr (car l-addrs)))
@@ -451,7 +451,7 @@
   (implies (and (disjoint-p (list index)
                             (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86))))
                 (disjoint-p (list index)
-                            (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+                            (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
                 (addr-byte-alistp addr-lst)
                 (not (programmer-level-mode x86)))
            (equal (xr :mem index (mv-nth 1 (wb addr-lst x86)))
@@ -467,7 +467,7 @@
   (implies (and (disjoint-p (addr-range 4 index)
                             (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86))))
                 (disjoint-p (addr-range 4 index)
-                            (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+                            (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
                 (addr-byte-alistp addr-lst))
            (equal (rm-low-32 index (mv-nth 1 (wb addr-lst x86)))
                   (rm-low-32 index x86)))
@@ -483,7 +483,7 @@
             (disjoint-p (addr-range 8 index)
                         (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86))))
             (disjoint-p (addr-range 8 index)
-                        (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+                        (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
             (addr-byte-alistp addr-lst)
             (integerp index))
            (equal (rm-low-64 index (mv-nth 1 (wb addr-lst x86)))
@@ -501,13 +501,13 @@
                             (n 8)
                             (m 4)
                             (index index)
-                            (xs (all-translation-governing-addresses (strip-cars addr-lst) x86)))
+                            (xs (all-xlation-governing-entries-paddrs (strip-cars addr-lst) x86)))
                  (:instance disjoint-p-and-addr-range-second-part-n=8
                             (index index)
                             (xs (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86))))
                  (:instance disjoint-p-and-addr-range-second-part-n=8
                             (index index)
-                            (xs (all-translation-governing-addresses (strip-cars addr-lst) x86)))
+                            (xs (all-xlation-governing-entries-paddrs (strip-cars addr-lst) x86)))
                  (:instance rm-low-32-wb-in-system-level-mode-disjoint
                             (index (+ 4 index))))
            :in-theory (e/d* (rm-low-64)
@@ -519,7 +519,7 @@
   ;; Generalization of
   ;; ia32e-la-to-pa-values-and-write-to-physical-memory-disjoint.
   (implies (and (disjoint-p p-addrs
-                            (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                            (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (physical-address-listp p-addrs)
                 (byte-listp bytes)
                 (equal (len bytes) (len p-addrs))
@@ -534,14 +534,14 @@
                        (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86)))))
   :hints (("Goal" :induct (las-to-pas l-addrs r-w-x cpl x86)
            :in-theory (e/d* (disjoint-p disjoint-p-commutative)
-                            (translation-governing-addresses)))))
+                            (xlation-governing-entries-paddrs)))))
 
 (defthm ia32e-la-to-pa-page-table-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs
   (implies (and (equal cpl (cpl x86))
                 (disjoint-p
                  (mv-nth 1 (las-to-pas
                             (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-                 (translation-governing-addresses-for-page-table
+                 (xlation-governing-entries-paddrs-for-page-table
                   lin-addr base-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-p base-addr)
@@ -569,7 +569,7 @@
                              disjoint-p-commutative
                              member-p
                              ia32e-la-to-pa-page-table
-                             translation-governing-addresses-for-page-table
+                             xlation-governing-entries-paddrs-for-page-table
                              wb)
                             (bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
@@ -583,7 +583,7 @@
         (disjoint-p
          (mv-nth 1 (las-to-pas
                     (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-         (translation-governing-addresses-for-page-directory
+         (xlation-governing-entries-paddrs-for-page-directory
           lin-addr base-addr (double-rewrite x86))))
    (xlate-equiv-entries
     (rm-low-64 (page-directory-entry-addr lin-addr base-addr)
@@ -592,7 +592,7 @@
                x86)))
   :hints (("Goal"
            :do-not-induct t
-           :in-theory (e/d* (translation-governing-addresses-for-page-directory
+           :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-directory
                              disjoint-p-commutative)
                             ()))))
 
@@ -601,7 +601,7 @@
                 (disjoint-p
                  (mv-nth 1 (las-to-pas
                             (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-                 (translation-governing-addresses-for-page-directory
+                 (xlation-governing-entries-paddrs-for-page-directory
                   lin-addr base-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-p base-addr)
@@ -651,7 +651,7 @@
                              disjoint-p-commutative
                              member-p
                              ia32e-la-to-pa-page-directory
-                             translation-governing-addresses-for-page-directory)
+                             xlation-governing-entries-paddrs-for-page-directory)
                             (wb
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
@@ -665,7 +665,7 @@
         (disjoint-p
          (mv-nth 1 (las-to-pas
                     (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-         (translation-governing-addresses-for-page-dir-ptr-table
+         (xlation-governing-entries-paddrs-for-page-dir-ptr-table
           lin-addr base-addr (double-rewrite x86))))
    (xlate-equiv-entries
     (rm-low-64 (page-dir-ptr-table-entry-addr lin-addr base-addr)
@@ -674,7 +674,7 @@
                x86)))
   :hints (("Goal"
            :do-not-induct t
-           :in-theory (e/d* (translation-governing-addresses-for-page-dir-ptr-table
+           :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                              disjoint-p-commutative)
                             ()))))
 
@@ -683,7 +683,7 @@
             (equal cpl (cpl x86))
             (disjoint-p
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-             (translation-governing-addresses-for-page-dir-ptr-table
+             (xlation-governing-entries-paddrs-for-page-dir-ptr-table
               lin-addr base-addr (double-rewrite x86)))
             (canonical-address-p lin-addr)
             (physical-address-p base-addr)
@@ -734,7 +734,7 @@
                              disjoint-p-commutative
                              member-p
                              ia32e-la-to-pa-page-dir-ptr-table
-                             translation-governing-addresses-for-page-dir-ptr-table)
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                             (wb
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
@@ -748,7 +748,7 @@
         (disjoint-p
          (mv-nth 1 (las-to-pas
                     (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-         (translation-governing-addresses-for-pml4-table
+         (xlation-governing-entries-paddrs-for-pml4-table
           lin-addr base-addr (double-rewrite x86))))
    (xlate-equiv-entries
     (rm-low-64 (pml4-table-entry-addr lin-addr base-addr)
@@ -757,7 +757,7 @@
                x86)))
   :hints (("Goal"
            :do-not-induct t
-           :in-theory (e/d* (translation-governing-addresses-for-pml4-table
+           :in-theory (e/d* (xlation-governing-entries-paddrs-for-pml4-table
                              disjoint-p-commutative)
                             (force (force))))))
 
@@ -766,7 +766,7 @@
             (equal cpl (cpl x86))
             (disjoint-p
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-             (translation-governing-addresses-for-pml4-table
+             (xlation-governing-entries-paddrs-for-pml4-table
               lin-addr base-addr (double-rewrite x86)))
             (canonical-address-p lin-addr)
             (physical-address-p base-addr)
@@ -803,7 +803,7 @@
                              disjoint-p-commutative
                              member-p
                              ia32e-la-to-pa-pml4-table
-                             translation-governing-addresses-for-pml4-table)
+                             xlation-governing-entries-paddrs-for-pml4-table)
                             (wb
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
@@ -813,7 +813,7 @@
   (implies (and (equal cpl (cpl x86))
                 (disjoint-p
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-                 (translation-governing-addresses lin-addr (double-rewrite x86)))
+                 (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr))
            (and
             (equal (mv-nth 0 (ia32e-la-to-pa lin-addr r-w-x cpl (mv-nth 1 (wb addr-lst x86))))
@@ -826,7 +826,7 @@
                              disjoint-p-commutative
                              member-p
                              ia32e-la-to-pa
-                             translation-governing-addresses)
+                             xlation-governing-entries-paddrs)
                             (wb
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
@@ -836,7 +836,7 @@
   (implies (and (equal cpl (cpl x86))
                 (disjoint-p
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl (double-rewrite x86)))
-                 (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                 (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (canonical-address-listp l-addrs))
            (and
             (equal (mv-nth 0 (las-to-pas l-addrs r-w-x cpl (mv-nth 1 (wb addr-lst x86))))
@@ -844,12 +844,12 @@
             (equal (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (mv-nth 1 (wb addr-lst x86))))
                    (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (double-rewrite x86))))))
   :hints (("Goal"
-           :induct (all-translation-governing-addresses l-addrs x86)
+           :induct (all-xlation-governing-entries-paddrs l-addrs x86)
            :in-theory (e/d* ()
-                            (disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                            (disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                              mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs
                              wb
-                             translation-governing-addresses
+                             xlation-governing-entries-paddrs
                              (:meta acl2::mv-nth-cons-meta)
                              force (force))))))
 
@@ -863,7 +863,7 @@
                  p-addrs
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86))))
                 (disjoint-p p-addrs
-                            (all-translation-governing-addresses
+                            (all-xlation-governing-entries-paddrs
                              (strip-cars addr-lst) (double-rewrite x86)))
                 (addr-byte-alistp addr-lst)
                 (not (programmer-level-mode x86))
@@ -882,22 +882,22 @@
              (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86))))
             (disjoint-p
              ;; The physical addresses corresponding to the read are
-             ;; disjoint from the translation-governing-addresses
+             ;; disjoint from the xlation-governing-entries-paddrs
              ;; pertaining to the write.
              (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
             (disjoint-p
              ;; The physical addresses pertaining to the read are
-             ;; disjoint from the translation-governing-addresses
+             ;; disjoint from the xlation-governing-entries-paddrs
              ;; pertaining to the read.
              (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (disjoint-p
              ;; The physical addresses pertaining to the write are
-             ;; disjoint from the translation-governing-addresses
+             ;; disjoint from the xlation-governing-entries-paddrs
              ;; pertaining to the read.
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (canonical-address-listp l-addrs)
             (addr-byte-alistp addr-lst)
             (not (programmer-level-mode x86))
@@ -915,7 +915,7 @@
                             (x86-2 x86)))
            :in-theory (e/d* (disjoint-p-commutative)
                             (wb
-                             disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                             disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                              mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)))))
 
 (defthmd rb-wb-equal-in-system-level-mode
@@ -927,10 +927,10 @@
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86))))
                 (disjoint-p
                  ;; The physical addresses pertaining to the write are
-                 ;; disjoint from the translation-governing-addresses
+                 ;; disjoint from the xlation-governing-entries-paddrs
                  ;; pertaining to the read.
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
-                 (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                 (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
 
                 (no-duplicates-p
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
@@ -963,22 +963,22 @@
              (mv-nth 1 (las-to-pas l-addrs :x (cpl x86) (double-rewrite x86))))
             (disjoint-p
              ;; The physical addresses corresponding to the read are
-             ;; disjoint from the translation-governing-addresses
+             ;; disjoint from the xlation-governing-entries-paddrs
              ;; pertaining to the write.
              (mv-nth 1 (las-to-pas l-addrs :x (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
             (disjoint-p
              ;; The physical addresses pertaining to the read are
-             ;; disjoint from the translation-governing-addresses
+             ;; disjoint from the xlation-governing-entries-paddrs
              ;; pertaining to the read.
              (mv-nth 1 (las-to-pas l-addrs :x (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (disjoint-p
              ;; The physical addresses pertaining to the write are
-             ;; disjoint from the translation-governing-addresses
+             ;; disjoint from the xlation-governing-entries-paddrs
              ;; pertaining to the read.
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (canonical-address-listp l-addrs)
             (addr-byte-alistp addr-lst)
             (not (programmer-level-mode x86))
@@ -991,7 +991,7 @@
                             (r-w-x :x)))
            :in-theory (e/d (program-at)
                            (rb-wb-disjoint-in-system-level-mode
-                            disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                            disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                             mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs
                             rb wb)))))
 
@@ -1002,7 +1002,7 @@
                     canonical-address-p
                     program-at
                     las-to-pas
-                    all-translation-governing-addresses
+                    all-xlation-governing-entries-paddrs
                     unsigned-byte-p
                     signed-byte-p))
 
@@ -1771,7 +1771,7 @@
                    (xlate-equiv-memory (double-rewrite x86-1) x86-2)
                    (disjoint-p
                     (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (double-rewrite x86-1)))
-                    (all-translation-governing-addresses l-addrs (double-rewrite x86-1)))
+                    (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86-1)))
                    (disjoint-p
                     (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (double-rewrite x86-1)))
                     (open-qword-paddr-list
@@ -1785,7 +1785,7 @@
                                 disjoint-p
                                 disjoint-p-commutative
                                 xlate-equiv-memory)
-                               (disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                               (disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                                 mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs))))))
 
   (defthm read-from-physical-memory-and-xlate-equiv-memory-disjoint-from-paging-structures
@@ -1807,7 +1807,7 @@
     :hints (("Goal"
              :use ((:instance read-from-physical-memory-and-xlate-equiv-memory-disjoint-from-paging-structures-helper))
              :in-theory (e/d* ()
-                              (disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                              (disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                                mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)))))
 
   (defthm mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
@@ -1865,10 +1865,10 @@
      (and
       (disjoint-p$
        (mv-nth 1 (las-to-pas l-addrs-1 r-w-x-1 (cpl x86) (double-rewrite x86)))
-       (all-translation-governing-addresses l-addrs-2 (double-rewrite x86)))
+       (all-xlation-governing-entries-paddrs l-addrs-2 (double-rewrite x86)))
       (disjoint-p$
        (mv-nth 1 (las-to-pas l-addrs-1 r-w-x-1 (cpl x86) (double-rewrite x86)))
-       (all-translation-governing-addresses l-addrs-1 (double-rewrite x86)))
+       (all-xlation-governing-entries-paddrs l-addrs-1 (double-rewrite x86)))
       (canonical-address-listp l-addrs-1)
       (canonical-address-listp l-addrs-2))
      (equal (mv-nth 1 (rb l-addrs-1 r-w-x-1 (mv-nth 2 (rb l-addrs-2 r-w-x-2 x86))))
@@ -1882,10 +1882,10 @@
      (and
       (disjoint-p
        (mv-nth 1 (las-to-pas l-addrs-1 r-w-x-1 (cpl x86) (double-rewrite x86)))
-       (all-translation-governing-addresses l-addrs-2 (double-rewrite x86)))
+       (all-xlation-governing-entries-paddrs l-addrs-2 (double-rewrite x86)))
       (disjoint-p
        (mv-nth 1 (las-to-pas l-addrs-1 r-w-x-1 (cpl x86) (double-rewrite x86)))
-       (all-translation-governing-addresses l-addrs-1 (double-rewrite x86)))
+       (all-xlation-governing-entries-paddrs l-addrs-1 (double-rewrite x86)))
       (not (xr :programmer-level-mode 0 x86))
       (canonical-address-listp l-addrs-1)
       (canonical-address-listp l-addrs-2))

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/non-marking-mode-top.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/non-marking-mode-top.lisp
@@ -98,7 +98,7 @@
    @('rb-wb-disjoint-in-system-level-non-marking-mode') <br/>
    @('rb-wb-equal-in-system-level-non-marking-mode') <br/>
    @('la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode') <br/>
-   @('all-translation-governing-addresses-and-mv-nth-1-wb-disjoint-in-non-marking-mode')
+   @('all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint-in-non-marking-mode')
    </li>
 
  </ul>
@@ -161,7 +161,7 @@
   @(def rb-wb-disjoint-in-system-level-non-marking-mode)
   @(def rb-wb-equal-in-system-level-non-marking-mode)
   @(def la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode)
-  @(def all-translation-governing-addresses-and-mv-nth-1-wb-disjoint-in-non-marking-mode)
+  @(def all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint-in-non-marking-mode)
 ")
 
 (local (xdoc::set-default-parents system-level-non-marking-mode-proof-utilities))
@@ -174,7 +174,7 @@
 ;; (acl2::why combine-bytes-rb-in-terms-of-rb-subset-p-in-system-level-non-marking-mode)
 ;; (acl2::why program-at-wb-disjoint-in-system-level-non-marking-mode)
 ;; (acl2::why rb-wb-disjoint-in-system-level-non-marking-mode)
-;; (acl2::why disjointness-of-translation-governing-addresses-from-all-translation-governing-addresses)
+;; (acl2::why disjointness-of-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs)
 ;; (acl2::why la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode)
 
 ;; ======================================================================
@@ -364,7 +364,7 @@
   :hints (("Goal" :in-theory (e/d* (member-p) ()))))
 
 (defthm las-to-pas-values-and-xw-mem-not-member-in-non-marking-mode
-  (implies (and (not (member-p index (all-translation-governing-addresses l-addrs x86)))
+  (implies (and (not (member-p index (all-xlation-governing-entries-paddrs l-addrs x86)))
                 (physical-address-p index)
                 (canonical-address-listp l-addrs)
                 (unsigned-byte-p 8 byte)
@@ -376,7 +376,7 @@
   :hints (("Goal"
            :in-theory (e/d* (disjoint-p
                              member-p)
-                            (translation-governing-addresses)))))
+                            (xlation-governing-entries-paddrs)))))
 
 (defun-nx wb-duplicate-writes-induct (addr-list x86)
   (if (endp addr-list)
@@ -410,14 +410,14 @@
   (implies (canonical-address-listp x)
            (canonical-address-listp (remove-duplicates-equal x))))
 
-(defthmd all-translation-governing-addresses-remove-duplicates-equal-and-subset-p
-  (subset-p (all-translation-governing-addresses (remove-duplicates-equal l-addrs) x86)
-            (all-translation-governing-addresses l-addrs x86))
-  :hints (("Goal" :in-theory (e/d* (subset-p) (translation-governing-addresses)))))
+(defthmd all-xlation-governing-entries-paddrs-remove-duplicates-equal-and-subset-p
+  (subset-p (all-xlation-governing-entries-paddrs (remove-duplicates-equal l-addrs) x86)
+            (all-xlation-governing-entries-paddrs l-addrs x86))
+  :hints (("Goal" :in-theory (e/d* (subset-p) (xlation-governing-entries-paddrs)))))
 
-(defthmd member-p-of-all-translation-governing-addresses-and-remove-duplicates-equal
-  (implies (not (member-p addr (all-translation-governing-addresses l-addrs x86)))
-           (not (member-p addr (all-translation-governing-addresses (remove-duplicates-equal l-addrs) x86)))))
+(defthmd member-p-of-all-xlation-governing-entries-paddrs-and-remove-duplicates-equal
+  (implies (not (member-p addr (all-xlation-governing-entries-paddrs l-addrs x86)))
+           (not (member-p addr (all-xlation-governing-entries-paddrs (remove-duplicates-equal l-addrs) x86)))))
 
 (defthmd wb-remove-duplicate-writes-in-system-level-non-marking-mode
   (implies (and (syntaxp (not (and (consp addr-lst)
@@ -426,7 +426,7 @@
                  ;; Physical addresses corresponding to (strip-cars
                  ;; addr-lst) are disjoint from the
                  ;; translation-governing addresses.
-                 (all-translation-governing-addresses (strip-cars addr-lst)  x86)
+                 (all-xlation-governing-entries-paddrs (strip-cars addr-lst)  x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (addr-byte-alistp addr-lst)
                 ;; (not (mv-nth 0 (wb addr-lst x86)))
@@ -443,13 +443,13 @@
            :in-theory (e/d (disjoint-p
                             member-p
                             subset-p
-                            member-p-of-all-translation-governing-addresses-and-remove-duplicates-equal
-                            all-translation-governing-addresses-remove-duplicates-equal-and-subset-p)
+                            member-p-of-all-xlation-governing-entries-paddrs-and-remove-duplicates-equal
+                            all-xlation-governing-entries-paddrs-remove-duplicates-equal-and-subset-p)
                            (acl2::mv-nth-cons-meta
                             disjoint-p-subset-p
                             member-p-and-remove-duplicates-equal
-                            disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
-                            translation-governing-addresses))
+                            disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
+                            xlation-governing-entries-paddrs))
            :induct (wb-duplicate-writes-induct addr-lst x86))))
 
 ;; ======================================================================
@@ -486,7 +486,7 @@
                              force (force))))))
 
 (defthm las-to-pas-values-in-non-marking-mode-and-write-to-physical-memory-disjoint
-  (implies (and (disjoint-p (all-translation-governing-addresses l-addrs x86) p-addrs)
+  (implies (and (disjoint-p (all-xlation-governing-entries-paddrs l-addrs x86) p-addrs)
                 (physical-address-listp p-addrs)
                 (canonical-address-listp l-addrs)
                 (not (page-structure-marking-mode x86)))
@@ -495,13 +495,13 @@
                 (equal (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (write-to-physical-memory p-addrs bytes x86)))
                        (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86)))))
   :hints (("Goal" :induct (las-to-pas l-addrs r-w-x cpl x86)
-           :in-theory (e/d* (disjoint-p disjoint-p-commutative) (translation-governing-addresses)))))
+           :in-theory (e/d* (disjoint-p disjoint-p-commutative) (xlation-governing-entries-paddrs)))))
 
 (defthm ia32e-la-to-pa-page-table-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode
   (implies (and (equal cpl (cpl x86))
                 (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (disjoint-p
-                 (translation-governing-addresses-for-page-table lin-addr base-addr x86)
+                 (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (not (page-structure-marking-mode x86))
                 (canonical-address-p lin-addr)
@@ -529,7 +529,7 @@
            :in-theory (e/d* (disjoint-p
                              member-p
                              ia32e-la-to-pa-page-table
-                             translation-governing-addresses-for-page-table)
+                             xlation-governing-entries-paddrs-for-page-table)
                             (wb
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
@@ -539,7 +539,7 @@
   (implies (and (equal cpl (cpl x86))
                 (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (disjoint-p
-                 (translation-governing-addresses-for-page-directory lin-addr base-addr x86)
+                 (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (not (page-structure-marking-mode x86))
                 (canonical-address-p lin-addr)
@@ -567,9 +567,9 @@
            :in-theory (e/d* (disjoint-p
                              member-p
                              ia32e-la-to-pa-page-directory
-                             translation-governing-addresses-for-page-directory)
+                             xlation-governing-entries-paddrs-for-page-directory)
                             (wb
-                             translation-governing-addresses-for-page-table
+                             xlation-governing-entries-paddrs-for-page-table
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
                              force (force))))))
@@ -578,7 +578,7 @@
   (implies (and (equal cpl (cpl x86))
                 (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (disjoint-p
-                 (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr x86)
+                 (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (not (page-structure-marking-mode x86))
                 (canonical-address-p lin-addr)
@@ -606,9 +606,9 @@
            :in-theory (e/d* (disjoint-p
                              member-p
                              ia32e-la-to-pa-page-dir-ptr-table
-                             translation-governing-addresses-for-page-dir-ptr-table)
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                             (wb
-                             translation-governing-addresses-for-page-directory
+                             xlation-governing-entries-paddrs-for-page-directory
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
                              force (force))))))
@@ -617,7 +617,7 @@
   (implies (and (equal cpl (cpl x86))
                 (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (disjoint-p
-                 (translation-governing-addresses-for-pml4-table lin-addr base-addr x86)
+                 (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (not (page-structure-marking-mode x86))
                 (canonical-address-p lin-addr)
@@ -643,9 +643,9 @@
            :in-theory (e/d* (disjoint-p
                              member-p
                              ia32e-la-to-pa-pml4-table
-                             translation-governing-addresses-for-pml4-table)
+                             xlation-governing-entries-paddrs-for-pml4-table)
                             (wb
-                             translation-governing-addresses-for-page-dir-ptr-table
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)
                              force (force))))))
@@ -653,7 +653,7 @@
 (defthm ia32e-la-to-pa-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode
   (implies (and (equal cpl (cpl x86))
                 (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
-                (disjoint-p (translation-governing-addresses lin-addr x86)
+                (disjoint-p (xlation-governing-entries-paddrs lin-addr x86)
                             (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (not (page-structure-marking-mode x86))
                 (canonical-address-p lin-addr))
@@ -667,16 +667,16 @@
            :in-theory (e/d* (disjoint-p
                              member-p
                              ia32e-la-to-pa
-                             translation-governing-addresses)
+                             xlation-governing-entries-paddrs)
                             (wb
-                             translation-governing-addresses-for-pml4-table
+                             xlation-governing-entries-paddrs-for-pml4-table
                              (:meta acl2::mv-nth-cons-meta)
                              force (force))))))
 
 (defthm la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode
   (implies (and (equal cpl (cpl x86))
                 (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
-                (disjoint-p (all-translation-governing-addresses l-addrs x86)
+                (disjoint-p (all-xlation-governing-entries-paddrs l-addrs x86)
                             (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w cpl x86)))
                 (not (page-structure-marking-mode x86))
                 (canonical-address-listp l-addrs))
@@ -686,10 +686,10 @@
             (equal (mv-nth 1 (las-to-pas l-addrs r-w-x cpl (mv-nth 1 (wb addr-lst x86))))
                    (mv-nth 1 (las-to-pas l-addrs r-w-x cpl x86)))))
   :hints (("Goal"
-           :induct (all-translation-governing-addresses l-addrs x86)
+           :induct (all-xlation-governing-entries-paddrs l-addrs x86)
            :in-theory (e/d* ()
                             (wb
-                             translation-governing-addresses
+                             xlation-governing-entries-paddrs
                              (:meta acl2::mv-nth-cons-meta)
                              force (force))))))
 
@@ -702,7 +702,7 @@
                  (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) x86))
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (disjoint-p
-                 (all-translation-governing-addresses l-addrs x86)
+                 (all-xlation-governing-entries-paddrs l-addrs x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (not (programmer-level-mode x86))
                 (not (page-structure-marking-mode x86))
@@ -736,7 +736,7 @@
                  (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) x86))
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (disjoint-p
-                 (all-translation-governing-addresses l-addrs x86)
+                 (all-xlation-governing-entries-paddrs l-addrs x86)
                  (mv-nth 1 (las-to-pas l-addrs r-w-x (cpl x86) x86)))
                 (no-duplicates-p
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
@@ -791,7 +791,7 @@
                  (mv-nth 1 (las-to-pas l-addrs :x (cpl x86) x86))
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (disjoint-p
-                 (all-translation-governing-addresses l-addrs x86)
+                 (all-xlation-governing-entries-paddrs l-addrs x86)
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (not (programmer-level-mode x86))
                 (not (page-structure-marking-mode x86))
@@ -826,49 +826,49 @@
                                    ()))))
 
 (local
- (defthm translation-governing-addresses-and-write-to-physical-memory
+ (defthm xlation-governing-entries-paddrs-and-write-to-physical-memory
    ;; This lemma already exists in paging/top.
-   (implies (and (disjoint-p p-addrs (all-translation-governing-addresses l-addrs x86))
+   (implies (and (disjoint-p p-addrs (all-xlation-governing-entries-paddrs l-addrs x86))
                  (physical-address-listp p-addrs))
             (equal
-             (all-translation-governing-addresses l-addrs (write-to-physical-memory p-addrs bytes x86))
-             (all-translation-governing-addresses l-addrs x86)))
+             (all-xlation-governing-entries-paddrs l-addrs (write-to-physical-memory p-addrs bytes x86))
+             (all-xlation-governing-entries-paddrs l-addrs x86)))
    :hints (("Goal" :in-theory (e/d* (disjoint-p-commutative) ())))))
 
-(defthm translation-governing-addresses-and-mv-nth-1-wb-disjoint-p-in-non-marking-mode
+(defthm xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint-p-in-non-marking-mode
   (implies (and (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
-                (disjoint-p (translation-governing-addresses lin-addr x86)
+                (disjoint-p (xlation-governing-entries-paddrs lin-addr x86)
                             (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
                 (not (programmer-level-mode x86))
                 (not (page-structure-marking-mode x86))
                 (x86p x86))
-           (equal (translation-governing-addresses lin-addr (mv-nth 1 (wb addr-lst x86)))
-                  (translation-governing-addresses lin-addr x86)))
+           (equal (xlation-governing-entries-paddrs lin-addr (mv-nth 1 (wb addr-lst x86)))
+                  (xlation-governing-entries-paddrs lin-addr x86)))
   :hints (("Goal"
            :do-not-induct t
            :in-theory (e/d* (disjoint-p wb) ()))))
 
-(defthm all-translation-governing-addresses-and-mv-nth-1-wb-disjoint-in-non-marking-mode
+(defthm all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint-in-non-marking-mode
   (implies (and
             (not (mv-nth 0 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
-            (disjoint-p (all-translation-governing-addresses l-addrs x86)
+            (disjoint-p (all-xlation-governing-entries-paddrs l-addrs x86)
                         (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
             (not (programmer-level-mode x86))
             (not (page-structure-marking-mode x86))
             (x86p x86))
-           (equal (all-translation-governing-addresses l-addrs (mv-nth 1 (wb addr-lst x86)))
-                  (all-translation-governing-addresses l-addrs x86)))
+           (equal (all-xlation-governing-entries-paddrs l-addrs (mv-nth 1 (wb addr-lst x86)))
+                  (all-xlation-governing-entries-paddrs l-addrs x86)))
   :hints (("Goal"
-           :in-theory (e/d* (all-translation-governing-addresses)
-                            (translation-governing-addresses
+           :in-theory (e/d* (all-xlation-governing-entries-paddrs)
+                            (xlation-governing-entries-paddrs
                              wb))
-           :induct (all-translation-governing-addresses l-addrs x86))))
+           :induct (all-xlation-governing-entries-paddrs l-addrs x86))))
 
 ;; ======================================================================
 
 (globally-disable '(rb wb canonical-address-p program-at
                        unsigned-byte-p signed-byte-p
-                       las-to-pas all-translation-governing-addresses))
+                       las-to-pas all-xlation-governing-entries-paddrs))
 
 (in-theory (e/d*
             ;; We enable all these functions so that reasoning about

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging/common-paging-lemmas.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging/common-paging-lemmas.lisp
@@ -15,7 +15,7 @@
 
 ;; ======================================================================
 
-;; Defining translation-governing-addresses of linear addresses:
+;; Defining xlation-governing-entries-paddrs of linear addresses:
 
 (defthm |(logand -4096 base-addr) = base-addr when low 12 bits are 0|
   (implies (and (equal (loghead 12 base-addr) 0)
@@ -55,10 +55,10 @@
                       page-fault-exception page-size)
                      ()))))
 
-;; ;; !!! Note that translation-governing-addresses-* do not talk about
+;; ;; !!! Note that xlation-governing-entries-paddrs-* do not talk about
 ;; ;; validity of paging entries.  Is that good or bad?
 
-(define translation-governing-addresses-for-page-table
+(define xlation-governing-entries-paddrs-for-page-table
   ((lin-addr             :type (signed-byte   #.*max-linear-address-size*))
    (page-table-base-addr :type (unsigned-byte #.*physical-address-size*))
    (x86))
@@ -68,30 +68,28 @@
   :ignore-ok t
 
   (b* ((page-table-entry-addr
-        (page-table-entry-addr lin-addr page-table-base-addr))
-       (page-table-entry
-        (rm-low-64 page-table-entry-addr x86)))
+        (page-table-entry-addr lin-addr page-table-base-addr)))
     ;; 4K pages
     (addr-range 8 page-table-entry-addr))
 
   ///
 
-  (defthm translation-governing-addresses-for-page-table-and-xw-not-mem
+  (defthm xlation-governing-entries-paddrs-for-page-table-and-xw-not-mem
     (implies (and (not (equal fld :mem))
                   (not (equal fld :programmer-level-mode)))
-             (equal (translation-governing-addresses-for-page-table lin-addr base-addr (xw fld index value x86))
-                    (translation-governing-addresses-for-page-table lin-addr base-addr (double-rewrite x86)))))
+             (equal (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr (xw fld index value x86))
+                    (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr (double-rewrite x86)))))
 
-  (defthm translation-governing-addresses-for-page-table-and-xw-mem-not-member
-    (implies (not (member-p index (translation-governing-addresses-for-page-table lin-addr base-addr (double-rewrite x86))))
-             (equal (translation-governing-addresses-for-page-table lin-addr base-addr (xw :mem index value x86))
-                    (translation-governing-addresses-for-page-table lin-addr base-addr (double-rewrite x86))))
+  (defthm xlation-governing-entries-paddrs-for-page-table-and-xw-mem-not-member
+    (implies (not (member-p index (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr (double-rewrite x86))))
+             (equal (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr (xw :mem index value x86))
+                    (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr (double-rewrite x86))))
     :hints (("Goal" :in-theory (e/d* (disjoint-p member-p)
                                      ()))))
 
   (defthm ia32e-la-to-pa-page-table-values-and-xw-mem-not-member
     (implies (and (not (member-p index
-                                 (translation-governing-addresses-for-page-table
+                                 (xlation-governing-entries-paddrs-for-page-table
                                   lin-addr base-addr (double-rewrite x86))))
                   (physical-address-p base-addr)
                   (equal (loghead 12 base-addr) 0)
@@ -116,7 +114,7 @@
                                      (bitops::logand-with-negated-bitmask
                                       negative-logand-to-positive-logand-with-integerp-x))))))
 
-(define translation-governing-addresses-for-page-directory
+(define xlation-governing-entries-paddrs-for-page-directory
   ((lin-addr                 :type (signed-byte   #.*max-linear-address-size*))
    (page-directory-base-addr :type (unsigned-byte #.*physical-address-size*))
    (x86))
@@ -124,7 +122,7 @@
               (canonical-address-p lin-addr)
               (equal (loghead 12 page-directory-base-addr) 0))
   :guard-hints (("Goal" :in-theory (e/d* (canonical-address-p)
-                                         (translation-governing-addresses-for-page-table
+                                         (xlation-governing-entries-paddrs-for-page-table
                                           unsigned-byte-p
                                           signed-byte-p
                                           acl2::commutativity-of-logior))))
@@ -143,7 +141,7 @@
        (page-table-base-addr
         (ash (ia32e-pde-pg-table-slice :pde-pt page-directory-entry) 12))
        (page-table-addresses
-        (translation-governing-addresses-for-page-table
+        (xlation-governing-entries-paddrs-for-page-table
          lin-addr page-table-base-addr x86)))
 
     (append
@@ -151,23 +149,23 @@
 
   ///
 
-  (defthm translation-governing-addresses-for-page-directory-and-xw-not-mem
+  (defthm xlation-governing-entries-paddrs-for-page-directory-and-xw-not-mem
     (implies (and (not (equal fld :mem))
                   (not (equal fld :programmer-level-mode)))
-             (equal (translation-governing-addresses-for-page-directory lin-addr base-addr (xw fld index value x86))
-                    (translation-governing-addresses-for-page-directory lin-addr base-addr (double-rewrite x86))))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses-for-page-table)))))
+             (equal (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr (xw fld index value x86))
+                    (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr (double-rewrite x86))))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs-for-page-table)))))
 
-  (defthm translation-governing-addresses-for-page-directory-and-xw-mem-not-member
-    (implies (not (member-p index (translation-governing-addresses-for-page-directory lin-addr base-addr (double-rewrite x86))))
-             (equal (translation-governing-addresses-for-page-directory lin-addr base-addr (xw :mem index value x86))
-                    (translation-governing-addresses-for-page-directory lin-addr base-addr (double-rewrite x86))))
+  (defthm xlation-governing-entries-paddrs-for-page-directory-and-xw-mem-not-member
+    (implies (not (member-p index (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr (double-rewrite x86))))
+             (equal (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr (xw :mem index value x86))
+                    (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr (double-rewrite x86))))
     :hints (("Goal" :in-theory (e/d* (disjoint-p member-p)
-                                     (translation-governing-addresses-for-page-table)))))
+                                     (xlation-governing-entries-paddrs-for-page-table)))))
 
   (defthm ia32e-la-to-pa-page-directory-values-and-xw-mem-not-member
     (implies (and (not (member-p index
-                                 (translation-governing-addresses-for-page-directory
+                                 (xlation-governing-entries-paddrs-for-page-directory
                                   lin-addr
                                   base-addr (double-rewrite x86))))
                   (physical-address-p base-addr)
@@ -194,7 +192,7 @@
                                       negative-logand-to-positive-logand-with-integerp-x
                                       force (force)))))))
 
-(define translation-governing-addresses-for-page-dir-ptr-table
+(define xlation-governing-entries-paddrs-for-page-dir-ptr-table
   ((lin-addr                 :type (signed-byte   #.*max-linear-address-size*))
    (ptr-table-base-addr :type (unsigned-byte #.*physical-address-size*))
    (x86))
@@ -202,7 +200,7 @@
               (canonical-address-p lin-addr)
               (equal (loghead 12 ptr-table-base-addr) 0))
   :guard-hints (("Goal" :in-theory (e/d* (canonical-address-p)
-                                         (translation-governing-addresses-for-page-directory
+                                         (xlation-governing-entries-paddrs-for-page-directory
                                           unsigned-byte-p
                                           signed-byte-p
                                           acl2::commutativity-of-logior))))
@@ -221,33 +219,33 @@
 
        (page-directory-base-addr (ash (ia32e-pdpte-pg-dir-slice :pdpte-pd page-dir-ptr-table-entry) 12))
        (page-directory-addresses
-        (translation-governing-addresses-for-page-directory
+        (xlation-governing-entries-paddrs-for-page-directory
          lin-addr page-directory-base-addr x86)))
 
     (append (addr-range 8 page-dir-ptr-table-entry-addr) page-directory-addresses))
 
   ///
 
-  (defthm translation-governing-addresses-for-page-dir-ptr-table-and-xw-not-mem
+  (defthm xlation-governing-entries-paddrs-for-page-dir-ptr-table-and-xw-not-mem
     (implies (and (not (equal fld :mem))
                   (not (equal fld :programmer-level-mode)))
-             (equal (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (xw fld index value x86))
-                    (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses-for-page-directory)))))
+             (equal (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (xw fld index value x86))
+                    (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs-for-page-directory)))))
 
-  (defthm translation-governing-addresses-for-page-dir-ptr-table-and-xw-mem-not-member
-    (implies (not (member-p index (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
-             (equal (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (xw :mem index value x86))
-                    (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
+  (defthm xlation-governing-entries-paddrs-for-page-dir-ptr-table-and-xw-mem-not-member
+    (implies (not (member-p index (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
+             (equal (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (xw :mem index value x86))
+                    (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
     :hints (("Goal" :in-theory (e/d* (disjoint-p member-p)
-                                     (translation-governing-addresses-for-page-directory)))))
+                                     (xlation-governing-entries-paddrs-for-page-directory)))))
 
   (defthm ia32e-la-to-pa-page-dir-ptr-table-values-and-xw-mem-not-member
     (implies (and
               (not
                (member-p
                 index
-                (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
+                (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86))))
               (physical-address-p base-addr)
               (equal (loghead 12 base-addr) 0)
               (canonical-address-p lin-addr))
@@ -273,7 +271,7 @@
                                       negative-logand-to-positive-logand-with-integerp-x
                                       force (force)))))))
 
-(define translation-governing-addresses-for-pml4-table
+(define xlation-governing-entries-paddrs-for-pml4-table
   ((lin-addr       :type (signed-byte   #.*max-linear-address-size*))
    (pml4-base-addr :type (unsigned-byte #.*physical-address-size*))
    (x86))
@@ -282,7 +280,7 @@
               (canonical-address-p lin-addr)
               (equal (loghead 12 pml4-base-addr) 0))
   :guard-hints (("Goal" :in-theory (e/d* (canonical-address-p)
-                                         (translation-governing-addresses-for-page-dir-ptr-table
+                                         (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                                           unsigned-byte-p
                                           signed-byte-p
                                           acl2::commutativity-of-logior))))
@@ -299,33 +297,33 @@
         (ash (ia32e-pml4e-slice :pml4e-pdpt pml4-entry) 12))
 
        (ptr-table-addresses
-        (translation-governing-addresses-for-page-dir-ptr-table
+        (xlation-governing-entries-paddrs-for-page-dir-ptr-table
          lin-addr ptr-table-base-addr x86)))
 
     (append (addr-range 8 pml4-entry-addr) ptr-table-addresses))
 
   ///
 
-  (defthm translation-governing-addresses-for-pml4-table-and-xw-not-mem
+  (defthm xlation-governing-entries-paddrs-for-pml4-table-and-xw-not-mem
     (implies (and (not (equal fld :mem))
                   (not (equal fld :programmer-level-mode)))
-             (equal (translation-governing-addresses-for-pml4-table lin-addr base-addr (xw fld index value x86))
-                    (translation-governing-addresses-for-pml4-table lin-addr base-addr (double-rewrite x86))))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses-for-page-table)))))
+             (equal (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (xw fld index value x86))
+                    (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (double-rewrite x86))))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs-for-page-table)))))
 
-  (defthm translation-governing-addresses-for-pml4-table-and-xw-mem-not-member
-    (implies (not (member-p index (translation-governing-addresses-for-pml4-table lin-addr base-addr (double-rewrite x86))))
-             (equal (translation-governing-addresses-for-pml4-table lin-addr base-addr (xw :mem index value x86))
-                    (translation-governing-addresses-for-pml4-table lin-addr base-addr (double-rewrite x86))))
+  (defthm xlation-governing-entries-paddrs-for-pml4-table-and-xw-mem-not-member
+    (implies (not (member-p index (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (double-rewrite x86))))
+             (equal (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (xw :mem index value x86))
+                    (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (double-rewrite x86))))
     :hints (("Goal" :in-theory (e/d* (disjoint-p member-p)
-                                     (translation-governing-addresses-for-page-dir-ptr-table)))))
+                                     (xlation-governing-entries-paddrs-for-page-dir-ptr-table)))))
 
   (defthm ia32e-la-to-pa-pml4-table-values-and-xw-mem-not-member
     (implies (and
               (not
                (member-p
                 index
-                (translation-governing-addresses-for-pml4-table lin-addr base-addr (double-rewrite x86))))
+                (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (double-rewrite x86))))
               (physical-address-p base-addr)
               (equal (loghead 12 base-addr) 0)
               (canonical-address-p lin-addr))
@@ -347,13 +345,13 @@
                                       negative-logand-to-positive-logand-with-integerp-x
                                       force (force)))))))
 
-(define translation-governing-addresses
+(define xlation-governing-entries-paddrs
   ((lin-addr :type (signed-byte   #.*max-linear-address-size*)
              "Canonical linear address to be mapped to a physical address")
    (x86 "x86 state"))
 
 
-  :long "<p>@('translation-governing-addresses') returns a
+  :long "<p>@('xlation-governing-entries-paddrs') returns a
   @('true-listp') of physical addresses that govern the translation of
   a linear address @('lin-addr') to its corresponding physical address
   @('p-addr').  Addresses that can be a part of the
@@ -373,7 +371,7 @@
 
   :guard (not (xr :programmer-level-mode 0 x86))
   :guard-hints (("Goal" :in-theory (e/d* (canonical-address-p)
-                                         (translation-governing-addresses-for-pml4-table
+                                         (xlation-governing-entries-paddrs-for-pml4-table
                                           unsigned-byte-p
                                           signed-byte-p
                                           acl2::commutativity-of-logior))))
@@ -383,156 +381,156 @@
            ;; PML4 Table:
            (pml4-base-addr (ash (cr3-slice :cr3-pdb cr3) 12)))
 
-        (translation-governing-addresses-for-pml4-table
+        (xlation-governing-entries-paddrs-for-pml4-table
          lin-addr pml4-base-addr x86))
     nil)
 
   ///
 
-  (defthm translation-governing-addresses-and-xw-not-mem
+  (defthm xlation-governing-entries-paddrs-and-xw-not-mem
     (implies (and (not (equal fld :mem))
                   (not (equal fld :ctr))
                   (not (equal fld :programmer-level-mode)))
-             (equal (translation-governing-addresses lin-addr (xw fld index value x86))
-                    (translation-governing-addresses lin-addr (double-rewrite x86))))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses-for-pml4-table)))))
+             (equal (xlation-governing-entries-paddrs lin-addr (xw fld index value x86))
+                    (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs-for-pml4-table)))))
 
-  (defthm translation-governing-addresses-and-xw-mem-not-member
-    (implies (not (member-p index (translation-governing-addresses lin-addr (double-rewrite x86))))
-             (equal (translation-governing-addresses lin-addr (xw :mem index value x86))
-                    (translation-governing-addresses lin-addr (double-rewrite x86))))
+  (defthm xlation-governing-entries-paddrs-and-xw-mem-not-member
+    (implies (not (member-p index (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
+             (equal (xlation-governing-entries-paddrs lin-addr (xw :mem index value x86))
+                    (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
     :hints (("Goal"
-             :in-theory (e/d* () (translation-governing-addresses-for-pml4-table)))))
+             :in-theory (e/d* () (xlation-governing-entries-paddrs-for-pml4-table)))))
 
   (defthm ia32e-la-to-pa-values-and-xw-mem-not-member
-    (implies (and (not (member-p index (translation-governing-addresses lin-addr (double-rewrite x86))))
+    (implies (and (not (member-p index (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
                   (canonical-address-p lin-addr))
              (and (equal (mv-nth 0 (ia32e-la-to-pa lin-addr r-w-x cpl (xw :mem index value x86)))
                          (mv-nth 0 (ia32e-la-to-pa lin-addr r-w-x cpl (double-rewrite x86))))
                   (equal (mv-nth 1 (ia32e-la-to-pa lin-addr r-w-x cpl (xw :mem index value x86)))
                          (mv-nth 1 (ia32e-la-to-pa lin-addr r-w-x cpl (double-rewrite x86))))))
-    :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa) (translation-governing-addresses-for-pml4-table)))))
+    :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa) (xlation-governing-entries-paddrs-for-pml4-table)))))
 
-  (defthm translation-governing-addresses-and-!flgi
-    (equal (translation-governing-addresses lin-addr (!flgi index value x86))
-           (translation-governing-addresses lin-addr (double-rewrite x86)))
-    :hints (("Goal" :in-theory (e/d* (!flgi) (translation-governing-addresses force (force))))))
+  (defthm xlation-governing-entries-paddrs-and-!flgi
+    (equal (xlation-governing-entries-paddrs lin-addr (!flgi index value x86))
+           (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
+    :hints (("Goal" :in-theory (e/d* (!flgi) (xlation-governing-entries-paddrs force (force))))))
 
-  (defthm translation-governing-addresses-and-!flgi-undefined
-    (equal (translation-governing-addresses lin-addr (!flgi-undefined index x86))
-           (translation-governing-addresses lin-addr (double-rewrite x86)))
-    :hints (("Goal" :in-theory (e/d* (!flgi-undefined) (translation-governing-addresses force (force))))))
+  (defthm xlation-governing-entries-paddrs-and-!flgi-undefined
+    (equal (xlation-governing-entries-paddrs lin-addr (!flgi-undefined index x86))
+           (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
+    :hints (("Goal" :in-theory (e/d* (!flgi-undefined) (xlation-governing-entries-paddrs force (force))))))
 
-  (defthm translation-governing-addresses-and-write-to-physical-memory-disjoint
-    (implies (and (disjoint-p (translation-governing-addresses lin-addr (double-rewrite x86)) p-addrs)
+  (defthm xlation-governing-entries-paddrs-and-write-to-physical-memory-disjoint
+    (implies (and (disjoint-p (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)) p-addrs)
                   (physical-address-listp p-addrs))
-             (equal (translation-governing-addresses lin-addr (write-to-physical-memory p-addrs bytes x86))
-                    (translation-governing-addresses lin-addr (double-rewrite x86))))
+             (equal (xlation-governing-entries-paddrs lin-addr (write-to-physical-memory p-addrs bytes x86))
+                    (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
     :hints (("Goal" :induct (write-to-physical-memory p-addrs bytes x86)
-             :in-theory (e/d* (disjoint-p disjoint-p-commutative) (translation-governing-addresses))))))
+             :in-theory (e/d* (disjoint-p disjoint-p-commutative) (xlation-governing-entries-paddrs))))))
 
-(define all-translation-governing-addresses
+(define all-xlation-governing-entries-paddrs
   ((l-addrs canonical-address-listp)
    x86)
   :guard (not (xr :programmer-level-mode 0 x86))
   :enabled t
   (if (endp l-addrs)
       nil
-    (append (translation-governing-addresses (car l-addrs) x86)
-            (all-translation-governing-addresses (cdr l-addrs)  x86)))
+    (append (xlation-governing-entries-paddrs (car l-addrs) x86)
+            (all-xlation-governing-entries-paddrs (cdr l-addrs)  x86)))
   ///
 
-  (defthm all-translation-governing-addresses-and-nil
-    (equal (all-translation-governing-addresses nil x86) nil))
+  (defthm all-xlation-governing-entries-paddrs-and-nil
+    (equal (all-xlation-governing-entries-paddrs nil x86) nil))
 
-  (defthm translation-governing-addresses-subset-p-all-translation-governing-addresses
+  (defthm xlation-governing-entries-paddrs-subset-p-all-xlation-governing-entries-paddrs
     (implies (member-p addr l-addrs)
-             (equal (subset-p (translation-governing-addresses addr x86)
-                              (all-translation-governing-addresses l-addrs x86))
+             (equal (subset-p (xlation-governing-entries-paddrs addr x86)
+                              (all-xlation-governing-entries-paddrs l-addrs x86))
                     t))
     :hints (("Goal" :in-theory (e/d* (subset-p) ()))))
 
-  (defthm all-translation-governing-addresses-subset-p-all-translation-governing-addresses
+  (defthm all-xlation-governing-entries-paddrs-subset-p-all-xlation-governing-entries-paddrs
     (implies (subset-p l-addrs-subset l-addrs)
              (equal
-              (subset-p (all-translation-governing-addresses l-addrs-subset x86)
-                        (all-translation-governing-addresses l-addrs x86))
+              (subset-p (all-xlation-governing-entries-paddrs l-addrs-subset x86)
+                        (all-xlation-governing-entries-paddrs l-addrs x86))
               t))
     :hints (("Goal" :in-theory (e/d* (subset-p member-p) ()))))
 
-  (defthm all-translation-governing-addresses-and-xw-not-mem
+  (defthm all-xlation-governing-entries-paddrs-and-xw-not-mem
     (implies (and (not (equal fld :mem))
                   (not (equal fld :ctr))
                   (not (equal fld :programmer-level-mode)))
-             (equal (all-translation-governing-addresses l-addrs (xw fld index value x86))
-                    (all-translation-governing-addresses l-addrs (double-rewrite x86))))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses)))))
+             (equal (all-xlation-governing-entries-paddrs l-addrs (xw fld index value x86))
+                    (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs)))))
 
-  (defthm all-translation-governing-addresses-and-xw-mem-not-member
-    (implies (and (not (member-p index (all-translation-governing-addresses l-addrs (double-rewrite x86))))
+  (defthm all-xlation-governing-entries-paddrs-and-xw-mem-not-member
+    (implies (and (not (member-p index (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))))
                   (integerp index))
-             (equal (all-translation-governing-addresses l-addrs (xw :mem index value x86))
-                    (all-translation-governing-addresses l-addrs (double-rewrite x86))))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses)))))
+             (equal (all-xlation-governing-entries-paddrs l-addrs (xw :mem index value x86))
+                    (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs)))))
 
-  (defthm all-translation-governing-addresses-and-!flgi
-    (equal (all-translation-governing-addresses l-addrs (!flgi index value x86))
-           (all-translation-governing-addresses l-addrs (double-rewrite x86)))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses force (force))))))
+  (defthm all-xlation-governing-entries-paddrs-and-!flgi
+    (equal (all-xlation-governing-entries-paddrs l-addrs (!flgi index value x86))
+           (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs force (force))))))
 
-  (defthm all-translation-governing-addresses-and-!flgi-undefined
-    (equal (all-translation-governing-addresses l-addrs (!flgi-undefined index x86))
-           (all-translation-governing-addresses l-addrs (double-rewrite x86)))
-    :hints (("Goal" :in-theory (e/d* () (translation-governing-addresses force (force)))))))
+  (defthm all-xlation-governing-entries-paddrs-and-!flgi-undefined
+    (equal (all-xlation-governing-entries-paddrs l-addrs (!flgi-undefined index x86))
+           (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
+    :hints (("Goal" :in-theory (e/d* () (xlation-governing-entries-paddrs force (force)))))))
 
 ;; ======================================================================
 
-(defthm disjointness-of-translation-governing-addresses-from-all-translation-governing-addresses
+(defthm disjointness-of-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs
   (implies (and (bind-free
-                 (find-l-addrs-from-fn 'all-translation-governing-addresses 'l-addrs mfc state)
+                 (find-l-addrs-from-fn 'all-xlation-governing-entries-paddrs 'l-addrs mfc state)
                  (l-addrs))
-                (disjoint-p (all-translation-governing-addresses l-addrs (double-rewrite x86)) other-p-addrs)
+                (disjoint-p (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)) other-p-addrs)
                 (member-p lin-addr l-addrs))
-           (disjoint-p (translation-governing-addresses lin-addr x86) other-p-addrs))
+           (disjoint-p (xlation-governing-entries-paddrs lin-addr x86) other-p-addrs))
   :hints (("Goal" :in-theory (e/d* (member-p) ()))))
 
-;; (defthm disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+;; (defthm disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
 ;;   (implies (and (bind-free
-;;               (find-l-addrs-from-fn 'all-translation-governing-addresses 'l-addrs mfc state)
+;;               (find-l-addrs-from-fn 'all-xlation-governing-entries-paddrs 'l-addrs mfc state)
 ;;               (l-addrs))
 ;;              (syntaxp (not (eq l-addrs-subset l-addrs)))
-;;              (disjoint-p (all-translation-governing-addresses l-addrs (double-rewrite x86)) other-p-addrs)
+;;              (disjoint-p (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)) other-p-addrs)
 ;;              (subset-p l-addrs-subset l-addrs))
-;;         (disjoint-p (all-translation-governing-addresses l-addrs-subset x86) other-p-addrs))
-;;   :hints (("Goal" :in-theory (e/d* (subset-p member-p) (translation-governing-addresses)))))
+;;         (disjoint-p (all-xlation-governing-entries-paddrs l-addrs-subset x86) other-p-addrs))
+;;   :hints (("Goal" :in-theory (e/d* (subset-p member-p) (xlation-governing-entries-paddrs)))))
 
-(defthm disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+(defthm disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
   (implies
    (and
     (bind-free
-     (find-l-addrs-from-fn 'all-translation-governing-addresses 'l-addrs mfc state)
+     (find-l-addrs-from-fn 'all-xlation-governing-entries-paddrs 'l-addrs mfc state)
      (l-addrs))
     (bind-free
      (find-arg-of-fn 'disjoint-p 2 'other-p-addrs mfc state)
      (other-p-addrs))
     (syntaxp (not (eq l-addrs-subset l-addrs)))
     ;; (syntaxp (not (eq other-p-addrs-subset other-p-addrs)))
-    (disjoint-p (all-translation-governing-addresses l-addrs (double-rewrite x86))
+    (disjoint-p (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))
                 other-p-addrs)
     (subset-p other-p-addrs-subset other-p-addrs)
     (subset-p l-addrs-subset l-addrs))
-   (disjoint-p (all-translation-governing-addresses l-addrs-subset x86)
+   (disjoint-p (all-xlation-governing-entries-paddrs l-addrs-subset x86)
                other-p-addrs-subset))
   :hints
   (("Goal" :in-theory (e/d* (subset-p member-p)
-                            (translation-governing-addresses)))))
+                            (xlation-governing-entries-paddrs)))))
 
 ;; ======================================================================
 
 ;; Other misc. events:
 
 (defthm ia32e-la-to-pa-values-and-write-to-physical-memory-disjoint
-  (implies (and (disjoint-p p-addrs (translation-governing-addresses lin-addr (double-rewrite x86)))
+  (implies (and (disjoint-p p-addrs (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                 (physical-address-listp p-addrs)
                 (canonical-address-p lin-addr))
            (and (equal (mv-nth 0 (ia32e-la-to-pa lin-addr r-w-x cpl (write-to-physical-memory p-addrs bytes x86)))
@@ -541,7 +539,7 @@
                        (mv-nth 1 (ia32e-la-to-pa lin-addr r-w-x cpl (double-rewrite x86))))))
   :hints (("Goal"
            :induct (write-to-physical-memory p-addrs bytes x86)
-           :in-theory (e/d* (disjoint-p) (translation-governing-addresses)))))
+           :in-theory (e/d* (disjoint-p) (xlation-governing-entries-paddrs)))))
 
 
 (local
@@ -549,7 +547,7 @@
    (equal (nth 0 xs) (car xs))))
 
 (defthm ia32e-la-to-pa-values-and-write-to-physical-memory-disjoint
-  (implies (and (disjoint-p p-addrs (translation-governing-addresses lin-addr (double-rewrite x86)))
+  (implies (and (disjoint-p p-addrs (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                 (physical-address-listp p-addrs)
                 (canonical-address-p lin-addr))
            (and (equal (mv-nth 0 (ia32e-la-to-pa lin-addr r-w-x cpl (write-to-physical-memory p-addrs bytes x86)))
@@ -558,7 +556,7 @@
                        (mv-nth 1 (ia32e-la-to-pa lin-addr r-w-x cpl (double-rewrite x86))))))
   :hints (("Goal"
            :induct (write-to-physical-memory p-addrs bytes x86)
-           :in-theory (e/d* (disjoint-p) (translation-governing-addresses)))))
+           :in-theory (e/d* (disjoint-p) (xlation-governing-entries-paddrs)))))
 
 (defthm rm-low-64-and-paging-entry-no-page-fault-p
   (equal (rm-low-64 index
@@ -658,7 +656,7 @@
 
 (defthm ia32e-la-to-pa-page-table-values-and-write-to-translation-governing-address
   ;; Similar lemmas can be found in proofs/zero-copy/zero-copy.lisp.
-  (b* ((p-addrs (translation-governing-addresses-for-page-table lin-addr base-addr x86))
+  (b* ((p-addrs (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr x86))
        (page-table-entry (rm-low-64 (page-table-entry-addr lin-addr base-addr) x86))
        (value (combine-bytes bytes)))
     (implies (and (not (mv-nth 0
@@ -701,7 +699,7 @@
                              member-p
                              ia32e-la-to-pa-page-table
                              page-table-entry-addr
-                             translation-governing-addresses-for-page-table)
+                             xlation-governing-entries-paddrs-for-page-table)
                             (wb
                              bitops::logand-with-negated-bitmask
                              (:meta acl2::mv-nth-cons-meta)

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging/page-walk-side-effects.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging/page-walk-side-effects.lisp
@@ -53,11 +53,11 @@
 
 ;; ======================================================================
 
-;; !! TODO: I should probably replace translation-governing-addresses*
+;; !! TODO: I should probably replace xlation-governing-entries-paddrs*
 ;; !! with xlate-governing-qword-addresses* eventually...
 
 ;; xlate-governing-qword-addresses are similar to
-;; translation-governing-addresses, except that they output quadword
+;; xlation-governing-entries-paddrs, except that they output quadword
 ;; addresses of the paging entries instead of byte addresses.
 
 (define xlate-governing-qword-addresses-for-page-table
@@ -82,9 +82,9 @@
     (equal (open-qword-paddr-list
             (xlate-governing-qword-addresses-for-page-table
              lin-addr base-addr x86))
-           (translation-governing-addresses-for-page-table
+           (xlation-governing-entries-paddrs-for-page-table
             lin-addr base-addr x86))
-    :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-table)
+    :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-table)
                                      ()))))
 
   (defthm xlate-governing-qword-addresses-for-page-table-and-xw-not-mem
@@ -143,9 +143,9 @@
     (equal (open-qword-paddr-list
             (xlate-governing-qword-addresses-for-page-directory
              lin-addr base-addr x86))
-           (translation-governing-addresses-for-page-directory
+           (xlation-governing-entries-paddrs-for-page-directory
             lin-addr base-addr x86))
-    :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-directory)
+    :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-directory)
                                      ()))))
 
   (defthm xlate-governing-qword-addresses-for-page-directory-and-xw-not-mem
@@ -205,9 +205,9 @@
     (equal (open-qword-paddr-list
             (xlate-governing-qword-addresses-for-page-dir-ptr-table
              lin-addr base-addr x86))
-           (translation-governing-addresses-for-page-dir-ptr-table
+           (xlation-governing-entries-paddrs-for-page-dir-ptr-table
             lin-addr base-addr x86))
-    :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-dir-ptr-table)
+    :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                                      ()))))
 
   (defthm xlate-governing-qword-addresses-for-page-dir-ptr-table-and-xw-not-mem
@@ -269,9 +269,9 @@
     (equal (open-qword-paddr-list
             (xlate-governing-qword-addresses-for-pml4-table
              lin-addr base-addr x86))
-           (translation-governing-addresses-for-pml4-table
+           (xlation-governing-entries-paddrs-for-pml4-table
             lin-addr base-addr x86))
-    :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-pml4-table)
+    :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-pml4-table)
                                      ()))))
 
   (defthm xlate-governing-qword-addresses-for-pml4-table-and-xw-not-mem
@@ -321,7 +321,7 @@
 </ol>
 
 <p>The following rule shows the relationship between @(see
-translation-governing-addresses) and
+xlation-governing-entries-paddrs) and
 @('xlate-governing-qword-addresses'):</p>
 
 @(def xlate-governing-qword-and-byte-addresses)"
@@ -347,8 +347,8 @@ translation-governing-addresses) and
   (defthm xlate-governing-qword-and-byte-addresses
     (equal (open-qword-paddr-list
             (xlate-governing-qword-addresses lin-addr x86))
-           (translation-governing-addresses lin-addr x86))
-    :hints (("Goal" :in-theory (e/d* (translation-governing-addresses)
+           (xlation-governing-entries-paddrs lin-addr x86))
+    :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs)
                                      ()))))
 
   (defthm xlate-governing-qword-addresses-and-xw-not-mem
@@ -381,8 +381,8 @@ translation-governing-addresses) and
   (defthm all-xlate-governing-qword-and-byte-addresses
     (equal (open-qword-paddr-list
             (all-xlate-governing-qword-addresses l-addrs x86))
-           (all-translation-governing-addresses l-addrs x86))
-    :hints (("Goal" :in-theory (e/d* (all-translation-governing-addresses)
+           (all-xlation-governing-entries-paddrs l-addrs x86))
+    :hints (("Goal" :in-theory (e/d* (all-xlation-governing-entries-paddrs)
                                      ()))))
 
   (defthm all-xlate-governing-qword-addresses-and-xw-not-mem

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/paging/top.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/paging/top.lisp
@@ -22,20 +22,20 @@
 
 ;; ======================================================================
 
-;; Some congruence rules about translation-governing-addresses:
+;; Some congruence rules about xlation-governing-entries-paddrs:
 
-(defthm translation-governing-addresses-for-page-table-and-xlate-equiv-memory-cong
+(defthm xlation-governing-entries-paddrs-for-page-table-and-xlate-equiv-memory-cong
   (implies (xlate-equiv-memory x86-1 x86-2)
-           (equal (translation-governing-addresses-for-page-table lin-addr base-addr x86-1)
-                  (translation-governing-addresses-for-page-table lin-addr base-addr x86-2)))
-  :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-table) ())))
+           (equal (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr x86-1)
+                  (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr x86-2)))
+  :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-table) ())))
   :rule-classes :congruence)
 
-(defthm translation-governing-addresses-for-page-directory-and-xlate-equiv-memory-cong
+(defthm xlation-governing-entries-paddrs-for-page-directory-and-xlate-equiv-memory-cong
   (implies (xlate-equiv-memory x86-1 x86-2)
-           (equal (translation-governing-addresses-for-page-directory lin-addr base-addr x86-1)
-                  (translation-governing-addresses-for-page-directory lin-addr base-addr x86-2)))
-  :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-directory)
+           (equal (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr x86-1)
+                  (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr x86-2)))
+  :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-directory)
                                    (xlate-equiv-memory-and-xlate-equiv-entries-rm-low-64-with-page-directory-entry-addr-cong))
            :use ((:instance xlate-equiv-memory-and-xlate-equiv-entries-rm-low-64-with-page-directory-entry-addr-cong)
                  (:instance xlate-equiv-entries-and-page-size
@@ -43,11 +43,11 @@
                             (e-2 (rm-low-64 (page-directory-entry-addr lin-addr base-addr) x86-2))))))
   :rule-classes :congruence)
 
-(defthm translation-governing-addresses-for-page-dir-ptr-table-and-xlate-equiv-memory-cong
+(defthm xlation-governing-entries-paddrs-for-page-dir-ptr-table-and-xlate-equiv-memory-cong
   (implies (xlate-equiv-memory x86-1 x86-2)
-           (equal (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr x86-1)
-                  (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr x86-2)))
-  :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-dir-ptr-table)
+           (equal (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr x86-1)
+                  (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr x86-2)))
+  :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                                    (xlate-equiv-memory-and-xlate-equiv-entries-rm-low-64-with-page-dir-ptr-table-entry-addr-cong))
            :use ((:instance xlate-equiv-memory-and-xlate-equiv-entries-rm-low-64-with-page-dir-ptr-table-entry-addr-cong)
                  (:instance xlate-equiv-entries-and-page-size
@@ -55,11 +55,11 @@
                             (e-2 (rm-low-64 (page-dir-ptr-table-entry-addr lin-addr base-addr) x86-2))))))
   :rule-classes :congruence)
 
-(defthm translation-governing-addresses-for-pml4-table-and-xlate-equiv-memory-cong
+(defthm xlation-governing-entries-paddrs-for-pml4-table-and-xlate-equiv-memory-cong
   (implies (xlate-equiv-memory x86-1 x86-2)
-           (equal (translation-governing-addresses-for-pml4-table lin-addr base-addr x86-1)
-                  (translation-governing-addresses-for-pml4-table lin-addr base-addr x86-2)))
-  :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-pml4-table)
+           (equal (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr x86-1)
+                  (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr x86-2)))
+  :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-pml4-table)
                                    (xlate-equiv-memory-and-xlate-equiv-entries-rm-low-64-with-pml4-table-entry-addr-cong))
            :use ((:instance xlate-equiv-memory-and-xlate-equiv-entries-rm-low-64-with-pml4-table-entry-addr-cong)
                  (:instance xlate-equiv-entries-and-page-size
@@ -67,19 +67,19 @@
                             (e-2 (rm-low-64 (pml4-table-entry-addr lin-addr base-addr) x86-2))))))
   :rule-classes :congruence)
 
-(defthm translation-governing-addresses-and-xlate-equiv-memory-cong
+(defthm xlation-governing-entries-paddrs-and-xlate-equiv-memory-cong
   (implies (xlate-equiv-memory x86-1 x86-2)
-           (equal (translation-governing-addresses lin-addr x86-1)
-                  (translation-governing-addresses lin-addr x86-2)))
+           (equal (xlation-governing-entries-paddrs lin-addr x86-1)
+                  (xlation-governing-entries-paddrs lin-addr x86-2)))
   :hints (("Goal"
-           :in-theory (e/d* (translation-governing-addresses) ())
+           :in-theory (e/d* (xlation-governing-entries-paddrs) ())
            :use ((:instance xlate-equiv-memory-and-cr3-cong))))
   :rule-classes :congruence)
 
-(defthm all-translation-governing-addresses-and-xlate-equiv-memory-cong
+(defthm all-xlation-governing-entries-paddrs-and-xlate-equiv-memory-cong
   (implies (xlate-equiv-memory x86-1 x86-2)
-           (equal (all-translation-governing-addresses lin-addr x86-1)
-                  (all-translation-governing-addresses lin-addr x86-2)))
+           (equal (all-xlation-governing-entries-paddrs lin-addr x86-1)
+                  (all-xlation-governing-entries-paddrs lin-addr x86-2)))
   :rule-classes :congruence)
 
 ;; ======================================================================
@@ -88,7 +88,7 @@
 
 (defthm xr-mem-disjoint-ia32e-la-to-pa-page-table
   (implies (and (disjoint-p (list index)
-                            (translation-governing-addresses-for-page-table
+                            (xlation-governing-entries-paddrs-for-page-table
                              lin-addr base-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-p base-addr)
@@ -99,13 +99,13 @@
                                             wp smep smap ac nxe r-w-x cpl x86)))
                   (xr :mem index x86)))
   :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-page-table
-                                    translation-governing-addresses-for-page-table)
+                                    xlation-governing-entries-paddrs-for-page-table)
                                    (negative-logand-to-positive-logand-with-integerp-x
                                     bitops::logand-with-negated-bitmask)))))
 
 (defthm xr-mem-disjoint-ia32e-la-to-pa-page-directory
   (implies (and (disjoint-p (list index)
-                            (translation-governing-addresses-for-page-directory
+                            (xlation-governing-entries-paddrs-for-page-directory
                              lin-addr base-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-p base-addr)
@@ -116,13 +116,13 @@
                                             wp smep smap ac nxe r-w-x cpl x86)))
                   (xr :mem index x86)))
   :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-page-directory
-                                    translation-governing-addresses-for-page-directory)
+                                    xlation-governing-entries-paddrs-for-page-directory)
                                    (negative-logand-to-positive-logand-with-integerp-x
                                     bitops::logand-with-negated-bitmask)))))
 
 (defthm xr-mem-disjoint-ia32e-la-to-pa-page-dir-ptr-table
   (implies (and (disjoint-p (list index)
-                            (translation-governing-addresses-for-page-dir-ptr-table
+                            (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                              lin-addr base-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-p base-addr)
@@ -133,13 +133,13 @@
                                             wp smep smap ac nxe r-w-x cpl x86)))
                   (xr :mem index x86)))
   :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-page-dir-ptr-table
-                                    translation-governing-addresses-for-page-dir-ptr-table)
+                                    xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                                    (negative-logand-to-positive-logand-with-integerp-x
                                     bitops::logand-with-negated-bitmask)))))
 
 (defthm xr-mem-disjoint-ia32e-la-to-pa-pml4-table
   (implies (and (disjoint-p (list index)
-                            (translation-governing-addresses-for-pml4-table
+                            (xlation-governing-entries-paddrs-for-pml4-table
                              lin-addr base-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-p base-addr)
@@ -149,32 +149,32 @@
                                             wp smep smap ac nxe r-w-x cpl x86)))
                   (xr :mem index x86)))
   :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa-pml4-table
-                                    translation-governing-addresses-for-pml4-table)
+                                    xlation-governing-entries-paddrs-for-pml4-table)
                                    (negative-logand-to-positive-logand-with-integerp-x
                                     bitops::logand-with-negated-bitmask)))))
 
 (defthm xr-mem-disjoint-ia32e-la-to-pa
   (implies (and (disjoint-p (list index)
-                            (translation-governing-addresses lin-addr (double-rewrite x86)))
+                            (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr))
            (equal (xr :mem index (mv-nth 2 (ia32e-la-to-pa lin-addr r-w-x cpl x86)))
                   (xr :mem index x86)))
   :hints (("Goal" :in-theory (e/d* (ia32e-la-to-pa
-                                    translation-governing-addresses)
+                                    xlation-governing-entries-paddrs)
                                    (negative-logand-to-positive-logand-with-integerp-x
                                     bitops::logand-with-negated-bitmask
                                     force (force))))))
 
 (defthm xr-mem-disjoint-las-to-pas
   (implies (and (disjoint-p (list index)
-                            (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                            (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (canonical-address-listp l-addrs))
            (equal (xr :mem index (mv-nth 2 (las-to-pas l-addrs r-w-x cpl x86)))
                   (xr :mem index x86)))
   :hints (("Goal"
            :induct (las-to-pas l-addrs r-w-x cpl x86)
            :in-theory (e/d* (las-to-pas
-                             all-translation-governing-addresses
+                             all-xlation-governing-entries-paddrs
                              disjoint-p
                              member-p)
                             (negative-logand-to-positive-logand-with-integerp-x
@@ -183,13 +183,13 @@
 
 (defthm read-from-physical-memory-and-mv-nth-2-ia32e-la-to-pa
   (implies (and (canonical-address-p lin-addr)
-                (disjoint-p p-addrs (translation-governing-addresses lin-addr (double-rewrite x86))))
+                (disjoint-p p-addrs (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
            (equal (read-from-physical-memory p-addrs (mv-nth 2 (ia32e-la-to-pa lin-addr r-w-x cpl x86)))
                   (read-from-physical-memory p-addrs x86)))
   :hints (("Goal" :in-theory (e/d* (disjoint-p) (force (force))))))
 
 (defthm read-from-physical-memory-and-mv-nth-2-las-to-pas
-  (implies (and (disjoint-p p-addrs (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+  (implies (and (disjoint-p p-addrs (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (canonical-address-listp l-addrs))
            (equal (read-from-physical-memory p-addrs (mv-nth 2 (las-to-pas l-addrs r-w-x cpl x86)))
                   (read-from-physical-memory p-addrs x86)))
@@ -197,19 +197,19 @@
 
 (defthm rm-low-64-disjoint-ia32e-la-to-pa
   (implies (and (disjoint-p (addr-range 8 index)
-                            (translation-governing-addresses lin-addr (double-rewrite x86)))
+                            (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr))
            (equal (rm-low-64 index (mv-nth 2 (ia32e-la-to-pa lin-addr r-w-x cpl x86)))
                   (rm-low-64 index x86)))
   :hints (("Goal" :in-theory (e/d* (rm-low-64 rm-low-32 disjoint-p)
-                                   (translation-governing-addresses
+                                   (xlation-governing-entries-paddrs
                                     negative-logand-to-positive-logand-with-integerp-x
                                     bitops::logand-with-negated-bitmask
                                     force (force))))))
 
 (defthm rm-low-64-disjoint-las-to-pas
   (implies (and (disjoint-p (addr-range 8 index)
-                            (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                            (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (canonical-address-listp l-addrs)
                 (x86p x86))
            (equal (rm-low-64 index (mv-nth 2 (las-to-pas l-addrs r-w-x cpl x86)))
@@ -217,18 +217,18 @@
   :hints (("Goal" :induct (las-to-pas l-addrs r-w-x cpl x86)
            :in-theory (e/d* (las-to-pas
                              disjoint-p)
-                            (translation-governing-addresses
+                            (xlation-governing-entries-paddrs
                              negative-logand-to-positive-logand-with-integerp-x
                              bitops::logand-with-negated-bitmask
                              force (force))))))
 
 ;; ======================================================================
 
-;; Proof that the translation-governing-addresses for every canonical
+;; Proof that the xlation-governing-entries-paddrs for every canonical
 ;; address are a subset of the addresses described by
 ;; gather-all-paging-structure-qword-addresses:
 
-(defthm translation-governing-addresses-for-page-table-subset-of-paging-structures
+(defthm xlation-governing-entries-paddrs-for-page-table-subset-of-paging-structures
   (implies
    (and (equal base-addr (page-table-base-addr lin-addr x86))
         ;; The following hyps are not needed when an
@@ -260,14 +260,14 @@
          0)
         (canonical-address-p lin-addr))
    (subset-p
-    (translation-governing-addresses-for-page-table
+    (xlation-governing-entries-paddrs-for-page-table
      lin-addr base-addr x86)
     (open-qword-paddr-list (gather-all-paging-structure-qword-addresses x86))))
   :hints (("Goal"
-           :in-theory (e/d* (translation-governing-addresses-for-page-table)
+           :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-table)
                             ()))))
 
-(defthm translation-governing-addresses-for-page-directory-subset-of-paging-structures
+(defthm xlation-governing-entries-paddrs-for-page-directory-subset-of-paging-structures
   (implies
    (and (equal base-addr (page-directory-base-addr lin-addr x86))
         ;; The following hyps are not needed when an
@@ -295,14 +295,14 @@
         ;;  1)
         (canonical-address-p lin-addr))
    (subset-p
-    (translation-governing-addresses-for-page-directory
+    (xlation-governing-entries-paddrs-for-page-directory
      lin-addr base-addr x86)
     (open-qword-paddr-list (gather-all-paging-structure-qword-addresses x86))))
   :hints (("Goal" :in-theory (e/d* (subset-p
-                                    translation-governing-addresses-for-page-directory)
-                                   (translation-governing-addresses-for-page-table)))))
+                                    xlation-governing-entries-paddrs-for-page-directory)
+                                   (xlation-governing-entries-paddrs-for-page-table)))))
 
-(defthm translation-governing-addresses-for-page-dir-ptr-table-subset-of-paging-structures
+(defthm xlation-governing-entries-paddrs-for-page-dir-ptr-table-subset-of-paging-structures
   (implies (and (equal base-addr (page-dir-ptr-table-base-addr lin-addr x86))
                 ;; The following hyps are not needed when an
                 ;; over-approximation of paging addresses is collected
@@ -321,7 +321,7 @@
                 ;;  1)
                 (canonical-address-p lin-addr))
            (subset-p
-            (translation-governing-addresses-for-page-dir-ptr-table
+            (xlation-governing-entries-paddrs-for-page-dir-ptr-table
              lin-addr base-addr x86)
             (open-qword-paddr-list (gather-all-paging-structure-qword-addresses x86))))
   :hints (("Goal"
@@ -330,92 +330,92 @@
                      (rm-low-64 (page-dir-ptr-table-entry-addr lin-addr (page-dir-ptr-table-base-addr lin-addr x86)) x86))
                     1))
            :in-theory (e/d* (subset-p
-                             translation-governing-addresses-for-page-dir-ptr-table)
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                             ()))))
 
-(defthm translation-governing-addresses-for-pml4-table-subset-of-paging-structures
+(defthm xlation-governing-entries-paddrs-for-pml4-table-subset-of-paging-structures
   (implies (and (equal base-addr (pml4-table-base-addr x86))
                 (canonical-address-p lin-addr))
            (subset-p
-            (translation-governing-addresses-for-pml4-table
+            (xlation-governing-entries-paddrs-for-pml4-table
              lin-addr base-addr x86)
             (open-qword-paddr-list (gather-all-paging-structure-qword-addresses x86))))
   :hints (("Goal" :in-theory (e/d* (subset-p
-                                    translation-governing-addresses-for-pml4-table)
+                                    xlation-governing-entries-paddrs-for-pml4-table)
                                    ()))))
 
-(defthm translation-governing-addresses-subset-of-paging-structures
+(defthm xlation-governing-entries-paddrs-subset-of-paging-structures
   (implies (canonical-address-p lin-addr)
            (subset-p
-            (translation-governing-addresses lin-addr x86)
+            (xlation-governing-entries-paddrs lin-addr x86)
             (open-qword-paddr-list
              (gather-all-paging-structure-qword-addresses x86))))
   :hints (("Goal"
-           :in-theory (e/d* (translation-governing-addresses
+           :in-theory (e/d* (xlation-governing-entries-paddrs
                              subset-p)
                             (canonical-address-p)))))
 
-(defthm all-translation-governing-addresses-subset-of-paging-structures
+(defthm all-xlation-governing-entries-paddrs-subset-of-paging-structures
   (implies (canonical-address-listp l-addrs)
            (subset-p
-            (all-translation-governing-addresses l-addrs x86)
+            (all-xlation-governing-entries-paddrs l-addrs x86)
             (open-qword-paddr-list
              (gather-all-paging-structure-qword-addresses x86))))
-  :hints (("Goal" :in-theory (e/d* (all-translation-governing-addresses
+  :hints (("Goal" :in-theory (e/d* (all-xlation-governing-entries-paddrs
                                     subset-p)
                                    (canonical-address-p)))))
 
 ;; ======================================================================
 
-;; Proof of translation-governing-addresses-and-mv-nth-1-wb-disjoint-p
-;; and all-translation-governing-addresses-and-mv-nth-1-wb-disjoint.
+;; Proof of xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint-p
+;; and all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint.
 
-(defthm translation-governing-addresses-for-page-table-and-write-to-physical-memory
-  (equal (translation-governing-addresses-for-page-table
+(defthm xlation-governing-entries-paddrs-for-page-table-and-write-to-physical-memory
+  (equal (xlation-governing-entries-paddrs-for-page-table
           lin-addr page-table-base-addr
           (write-to-physical-memory p-addrs bytes x86))
-         (translation-governing-addresses-for-page-table
+         (xlation-governing-entries-paddrs-for-page-table
           lin-addr page-table-base-addr (double-rewrite x86)))
-  :hints (("Goal" :in-theory (e/d* (translation-governing-addresses-for-page-table)
+  :hints (("Goal" :in-theory (e/d* (xlation-governing-entries-paddrs-for-page-table)
                                    ()))))
 
-(defthm translation-governing-addresses-for-page-table-and-mv-nth-1-wb
-  (equal (translation-governing-addresses-for-page-table
+(defthm xlation-governing-entries-paddrs-for-page-table-and-mv-nth-1-wb
+  (equal (xlation-governing-entries-paddrs-for-page-table
           lin-addr page-table-base-addr
           (mv-nth 1 (wb addr-lst x86)))
-         (translation-governing-addresses-for-page-table
+         (xlation-governing-entries-paddrs-for-page-table
           lin-addr page-table-base-addr (double-rewrite x86)))
   :hints (("Goal" :in-theory (e/d* (wb
-                                    translation-governing-addresses-for-page-table)
+                                    xlation-governing-entries-paddrs-for-page-table)
                                    ()))))
 
-(defthm translation-governing-addresses-for-page-directory-and-write-to-physical-memory-disjoint-p
+(defthm xlation-governing-entries-paddrs-for-page-directory-and-write-to-physical-memory-disjoint-p
   (implies (disjoint-p p-addrs
-                       (translation-governing-addresses-for-page-directory
+                       (xlation-governing-entries-paddrs-for-page-directory
                         lin-addr page-directory-base-addr (double-rewrite x86)))
-           (equal (translation-governing-addresses-for-page-directory
+           (equal (xlation-governing-entries-paddrs-for-page-directory
                    lin-addr page-directory-base-addr
                    (write-to-physical-memory p-addrs bytes x86))
-                  (translation-governing-addresses-for-page-directory
+                  (xlation-governing-entries-paddrs-for-page-directory
                    lin-addr page-directory-base-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
-                             translation-governing-addresses-for-page-directory)
+                             xlation-governing-entries-paddrs-for-page-directory)
                             ()))))
 
-(defthm translation-governing-addresses-for-page-directory-and-mv-nth-1-wb-disjoint-p
+(defthm xlation-governing-entries-paddrs-for-page-directory-and-mv-nth-1-wb-disjoint-p
   (implies (and
             (disjoint-p
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
-             (translation-governing-addresses-for-page-directory
+             (xlation-governing-entries-paddrs-for-page-directory
               lin-addr page-directory-base-addr (double-rewrite x86)))
             (not (programmer-level-mode x86)))
-           (equal (translation-governing-addresses-for-page-directory
+           (equal (xlation-governing-entries-paddrs-for-page-directory
                    lin-addr page-directory-base-addr
                    (mv-nth 1 (wb addr-lst x86)))
-                  (translation-governing-addresses-for-page-directory
+                  (xlation-governing-entries-paddrs-for-page-directory
                    lin-addr page-directory-base-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
@@ -427,36 +427,36 @@
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
                              wb
-                             translation-governing-addresses-for-page-directory)
+                             xlation-governing-entries-paddrs-for-page-directory)
                             ()))))
 
-(defthm translation-governing-addresses-for-page-dir-ptr-table-and-write-to-physical-memory-disjoint-p
+(defthm xlation-governing-entries-paddrs-for-page-dir-ptr-table-and-write-to-physical-memory-disjoint-p
   (implies (disjoint-p p-addrs
-                       (translation-governing-addresses-for-page-dir-ptr-table
+                       (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                         lin-addr page-dir-ptr-table-base-addr (double-rewrite x86)))
-           (equal (translation-governing-addresses-for-page-dir-ptr-table
+           (equal (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                    lin-addr page-dir-ptr-table-base-addr
                    (write-to-physical-memory p-addrs bytes x86))
-                  (translation-governing-addresses-for-page-dir-ptr-table
+                  (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                    lin-addr page-dir-ptr-table-base-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
-                             translation-governing-addresses-for-page-dir-ptr-table)
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                             ()))))
 
-(defthm translation-governing-addresses-for-page-dir-ptr-table-and-mv-nth-1-wb-disjoint-p
+(defthm xlation-governing-entries-paddrs-for-page-dir-ptr-table-and-mv-nth-1-wb-disjoint-p
   (implies (and (disjoint-p
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86)
                                        (double-rewrite x86)))
-                 (translation-governing-addresses-for-page-dir-ptr-table
+                 (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                   lin-addr page-dir-ptr-table-base-addr (double-rewrite x86)))
                 (not (programmer-level-mode x86)))
-           (equal (translation-governing-addresses-for-page-dir-ptr-table
+           (equal (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                    lin-addr page-dir-ptr-table-base-addr
                    (mv-nth 1 (wb addr-lst x86)))
-                  (translation-governing-addresses-for-page-dir-ptr-table
+                  (xlation-governing-entries-paddrs-for-page-dir-ptr-table
                    lin-addr page-dir-ptr-table-base-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
@@ -468,36 +468,36 @@
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
                              wb
-                             translation-governing-addresses-for-page-dir-ptr-table)
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table)
                             ()))))
 
-(defthm translation-governing-addresses-for-pml4-table-and-write-to-physical-memory-disjoint-p
+(defthm xlation-governing-entries-paddrs-for-pml4-table-and-write-to-physical-memory-disjoint-p
   (implies (disjoint-p p-addrs
-                       (translation-governing-addresses-for-pml4-table
+                       (xlation-governing-entries-paddrs-for-pml4-table
                         lin-addr pml4-table-base-addr (double-rewrite x86)))
-           (equal (translation-governing-addresses-for-pml4-table
+           (equal (xlation-governing-entries-paddrs-for-pml4-table
                    lin-addr pml4-table-base-addr
                    (write-to-physical-memory p-addrs bytes x86))
-                  (translation-governing-addresses-for-pml4-table
+                  (xlation-governing-entries-paddrs-for-pml4-table
                    lin-addr pml4-table-base-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
-                             translation-governing-addresses-for-pml4-table)
+                             xlation-governing-entries-paddrs-for-pml4-table)
                             ()))))
 
-(defthm translation-governing-addresses-for-pml4-table-and-mv-nth-1-wb-disjoint-p
+(defthm xlation-governing-entries-paddrs-for-pml4-table-and-mv-nth-1-wb-disjoint-p
   (implies (and (disjoint-p
                  (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86)
                                        (double-rewrite x86)))
-                 (translation-governing-addresses-for-pml4-table
+                 (xlation-governing-entries-paddrs-for-pml4-table
                   lin-addr pml4-table-base-addr (double-rewrite x86)))
                 (not (programmer-level-mode x86)))
-           (equal (translation-governing-addresses-for-pml4-table
+           (equal (xlation-governing-entries-paddrs-for-pml4-table
                    lin-addr pml4-table-base-addr
                    (mv-nth 1 (wb addr-lst x86)))
-                  (translation-governing-addresses-for-pml4-table
+                  (xlation-governing-entries-paddrs-for-pml4-table
                    lin-addr pml4-table-base-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
@@ -512,61 +512,61 @@
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
                              wb
-                             translation-governing-addresses-for-pml4-table)
+                             xlation-governing-entries-paddrs-for-pml4-table)
                             (force (force))))))
 
-(defthm translation-governing-addresses-and-write-to-physical-memory-disjoint-p
+(defthm xlation-governing-entries-paddrs-and-write-to-physical-memory-disjoint-p
   (implies (disjoint-p p-addrs
-                       (translation-governing-addresses lin-addr (double-rewrite x86)))
-           (equal (translation-governing-addresses
+                       (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
+           (equal (xlation-governing-entries-paddrs
                    lin-addr (write-to-physical-memory p-addrs bytes x86))
-                  (translation-governing-addresses lin-addr (double-rewrite x86))))
+                  (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
-           :in-theory (e/d* (disjoint-p translation-governing-addresses) ()))))
+           :in-theory (e/d* (disjoint-p xlation-governing-entries-paddrs) ()))))
 
-(defthm translation-governing-addresses-and-mv-nth-1-wb-disjoint-p
+(defthm xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint-p
   (implies (and
             (disjoint-p (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86)
                                               (double-rewrite x86)))
-                        (translation-governing-addresses lin-addr (double-rewrite x86)))
+                        (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
             (not (programmer-level-mode x86)))
-           (equal (translation-governing-addresses lin-addr (mv-nth 1 (wb addr-lst x86)))
-                  (translation-governing-addresses lin-addr (double-rewrite x86))))
+           (equal (xlation-governing-entries-paddrs lin-addr (mv-nth 1 (wb addr-lst x86)))
+                  (xlation-governing-entries-paddrs lin-addr (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
-                             translation-governing-addresses)
+                             xlation-governing-entries-paddrs)
                             (wb)))))
 
-(defthm all-translation-governing-addresses-and-write-to-physical-memory-disjoint-p
+(defthm all-xlation-governing-entries-paddrs-and-write-to-physical-memory-disjoint-p
   (implies (and
             (disjoint-p p-addrs
-                        (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                        (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (physical-address-listp p-addrs))
-           (equal (all-translation-governing-addresses
+           (equal (all-xlation-governing-entries-paddrs
                    l-addrs (write-to-physical-memory p-addrs bytes x86))
-                  (all-translation-governing-addresses l-addrs (double-rewrite x86))))
+                  (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))))
   :hints (("Goal"
            :in-theory (e/d* (disjoint-p
                              disjoint-p-commutative
-                             all-translation-governing-addresses)
+                             all-xlation-governing-entries-paddrs)
                             ()))))
 
-(defthm all-translation-governing-addresses-and-mv-nth-1-wb-disjoint
+(defthm all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint
   (implies (and
             (disjoint-p (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
-                        (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                        (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
             (not (programmer-level-mode x86)))
-           (equal (all-translation-governing-addresses l-addrs (mv-nth 1 (wb addr-lst x86)))
-                  (all-translation-governing-addresses l-addrs (double-rewrite x86))))
+           (equal (all-xlation-governing-entries-paddrs l-addrs (mv-nth 1 (wb addr-lst x86)))
+                  (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))))
   :hints (("Goal"
-           :in-theory (e/d* (all-translation-governing-addresses)
-                            (translation-governing-addresses
-                             disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+           :in-theory (e/d* (all-xlation-governing-entries-paddrs)
+                            (xlation-governing-entries-paddrs
+                             disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                              wb))
-           :induct (all-translation-governing-addresses l-addrs x86))))
+           :induct (all-xlation-governing-entries-paddrs l-addrs x86))))
 
 ;; ======================================================================
 
@@ -625,7 +625,7 @@
     (implies (and
               (disjoint-p
                (list index)
-               (translation-governing-addresses-for-page-table lin-addr base-addr (double-rewrite x86)))
+               (xlation-governing-entries-paddrs-for-page-table lin-addr base-addr (double-rewrite x86)))
               (canonical-address-p lin-addr)
               (physical-address-p base-addr)
               (equal (loghead 12 base-addr) 0)
@@ -647,7 +647,7 @@
     (implies (and
               (disjoint-p
                (list index)
-               (translation-governing-addresses-for-page-directory lin-addr base-addr (double-rewrite x86)))
+               (xlation-governing-entries-paddrs-for-page-directory lin-addr base-addr (double-rewrite x86)))
               (canonical-address-p lin-addr)
               (physical-address-p base-addr)
               (equal (loghead 12 base-addr) 0)
@@ -671,7 +671,7 @@
     (implies (and
               (disjoint-p
                (list index)
-               (translation-governing-addresses-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86)))
+               (xlation-governing-entries-paddrs-for-page-dir-ptr-table lin-addr base-addr (double-rewrite x86)))
               (canonical-address-p lin-addr)
               (physical-address-p base-addr)
               (equal (loghead 12 base-addr) 0)
@@ -693,7 +693,7 @@
     (implies (and
               (disjoint-p
                (list index)
-               (translation-governing-addresses-for-pml4-table lin-addr base-addr (double-rewrite x86)))
+               (xlation-governing-entries-paddrs-for-pml4-table lin-addr base-addr (double-rewrite x86)))
               (canonical-address-p lin-addr)
               (physical-address-p base-addr)
               (equal (loghead 12 base-addr) 0)
@@ -712,7 +712,7 @@
   (defthm xw-mem-and-ia32e-la-to-pa-commute
     (implies (and (disjoint-p
                    (list index)
-                   (translation-governing-addresses lin-addr (double-rewrite x86)))
+                   (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                   (canonical-address-p lin-addr)
                   (x86p x86) (integerp index) (unsigned-byte-p 8 value))
              (equal (xw :mem index value
@@ -723,7 +723,7 @@
   (defthm xw-mem-and-las-to-pas-commute
     (implies
      (and (disjoint-p (list index)
-                      (all-translation-governing-addresses
+                      (all-xlation-governing-entries-paddrs
                        l-addrs (double-rewrite x86)))
           (not (mv-nth 0 (las-to-pas l-addrs r-w-x cpl (double-rewrite x86))))
           (canonical-address-listp l-addrs)
@@ -736,7 +736,7 @@
       :in-theory (e/d* (disjoint-p
                         las-to-pas
                         member-p
-                        all-translation-governing-addresses)
+                        all-xlation-governing-entries-paddrs)
                        ()))))
 
   ) ;; End of encapsulate
@@ -744,7 +744,7 @@
 (defthm write-to-physical-memory-and-mv-nth-2-ia32e-la-to-pa-commute
   (implies (and (disjoint-p
                  p-addrs
-                 (translation-governing-addresses lin-addr (double-rewrite x86)))
+                 (xlation-governing-entries-paddrs lin-addr (double-rewrite x86)))
                 (canonical-address-p lin-addr)
                 (physical-address-listp p-addrs)
                 (byte-listp bytes)
@@ -762,7 +762,7 @@
 (defthm write-to-physical-memory-and-mv-nth-2-las-to-pas-commute
   (implies
    (and (disjoint-p p-addrs
-                    (all-translation-governing-addresses
+                    (all-xlation-governing-entries-paddrs
                      l-addrs (double-rewrite x86)))
         (canonical-address-listp l-addrs)
         (physical-address-listp p-addrs)
@@ -775,7 +775,7 @@
   :hints
   (("Goal" :induct (cons (las-to-pas l-addrs r-w-x cpl x86)
                          (write-to-physical-memory p-addrs bytes x86))
-    :in-theory (e/d* (disjoint-p las-to-pas all-translation-governing-addresses) ()))))
+    :in-theory (e/d* (disjoint-p las-to-pas all-xlation-governing-entries-paddrs) ()))))
 
 ;; ======================================================================
 
@@ -792,7 +792,7 @@
             (not
              (member-p
               index
-              (all-translation-governing-addresses l-addrs (double-rewrite x86))))
+              (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86))))
             (canonical-address-listp l-addrs)
             (x86p x86)
             (integerp index)
@@ -808,7 +808,7 @@
                              open-mv-nth-1-las-to-pas
                              disjoint-p
                              member-p)
-                            (translation-governing-addresses)))))
+                            (xlation-governing-entries-paddrs)))))
 
 (defthm mv-nth-1-las-to-pas-subset-p
   (implies (and (subset-p l-addrs-subset l-addrs)
@@ -830,10 +830,10 @@
   ;; (get-subterms-if-match
   ;;  1
   ;;  'create-canonical-address-list
-  ;;  '((all-translation-governing-addresses
+  ;;  '((all-xlation-governing-entries-paddrs
   ;;     (create-canonical-address-list cnt start-rip)
   ;;     p-addrs)
-  ;;    (all-translation-governing-addresses
+  ;;    (all-xlation-governing-entries-paddrs
   ;;     (cons 'start-rip nil)
   ;;     p-addrs)))
   (if (atom terms)
@@ -938,7 +938,7 @@
                      (lin-addr (car l-addrs-subset))
                      (l-addrs l-addrs))))))
 
-(defthm disjoint-p-las-to-pas-subset-p-and-all-translation-governing-addresses-subsets
+(defthm disjoint-p-las-to-pas-subset-p-and-all-xlation-governing-entries-paddrs-subsets
   ;; Very similar to
   ;; mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs (but
   ;; less general because it applies only during instruction fetches
@@ -947,19 +947,19 @@
    (and
     (syntaxp (not (eq l-addrs-1-subset l-addrs-2)))
     (bind-free (find-l-addrs-from-program-at-or-program-at-alt-term
-                'disjoint-p-las-to-pas-subset-p-and-all-translation-governing-addresses
+                'disjoint-p-las-to-pas-subset-p-and-all-xlation-governing-entries-paddrs
                 'l-addrs-1 mfc state)
                (l-addrs-1))
     (disjoint-p$
      (mv-nth 1 (las-to-pas l-addrs-1 :x cpl (double-rewrite x86)))
-     (all-translation-governing-addresses l-addrs-2 (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs l-addrs-2 (double-rewrite x86)))
     (subset-p l-addrs-1-subset l-addrs-1)
     (not (mv-nth 0 (las-to-pas l-addrs-1 :x cpl (double-rewrite x86)))))
    (disjoint-p (mv-nth 1 (las-to-pas l-addrs-1-subset :x cpl x86))
-               (all-translation-governing-addresses l-addrs-2 x86)))
+               (all-xlation-governing-entries-paddrs l-addrs-2 x86)))
   :hints (("Goal" :in-theory (e/d* () (mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs))
            :use ((:instance mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs
-                            (other-p-addrs (all-translation-governing-addresses l-addrs-2 x86))
+                            (other-p-addrs (all-xlation-governing-entries-paddrs l-addrs-2 x86))
                             (r-w-x :x)
                             (l-addrs l-addrs-1)
                             (l-addrs-subset l-addrs-1-subset))))))
@@ -990,10 +990,10 @@
            :in-theory (e/d* (disjoint-p-commutative disjoint-p$)
                             (mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)))))
 
-(defthm disjoint-p-all-translation-governing-addresses-subset-p
+(defthm disjoint-p-all-xlation-governing-entries-paddrs-subset-p
   ;; This rule is tailored to rewrite terms of the form to t
 
-  ;; (disjoint-p other-p-addrs (all-translation-governing-addresses l-addrs-subset x86))
+  ;; (disjoint-p other-p-addrs (all-xlation-governing-entries-paddrs l-addrs-subset x86))
 
   ;; where l-addrs-subset is a subset of l-addrs, and l-addrs is of
   ;; the form (create-canonical-address-list ...).
@@ -1001,18 +1001,18 @@
   ;; Disjointness of l-addrs with other addresses should be expressed
   ;; in terms of disjoint-p$.
   (implies (and (bind-free (find-l-addrs-like-create-canonical-address-list-from-fn
-                            'all-translation-governing-addresses 'l-addrs mfc state)
+                            'all-xlation-governing-entries-paddrs 'l-addrs mfc state)
                            (l-addrs))
                 ;; (syntaxp (not (cw "~% l-addrs: ~x0~%" l-addrs)))
                 (disjoint-p$ other-p-addrs
-                             (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+                             (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
                 (subset-p l-addrs-subset l-addrs))
-           (disjoint-p other-p-addrs (all-translation-governing-addresses l-addrs-subset x86)))
+           (disjoint-p other-p-addrs (all-xlation-governing-entries-paddrs l-addrs-subset x86)))
   :hints (("Goal" :in-theory (e/d* (subset-p
                                     member-p
                                     disjoint-p
                                     disjoint-p$
-                                    all-translation-governing-addresses)
+                                    all-xlation-governing-entries-paddrs)
                                    ()))))
 
 (defun get-both-l-addrs
@@ -1140,7 +1140,7 @@
                             (mv-nth-1-las-to-pas-subset-p
                              disjoint-p-subset-p)))))
 
-(defthmd infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses
+(defthmd infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses
   (implies (and
             (disjoint-p
              x
@@ -1150,21 +1150,21 @@
             (canonical-address-listp l-addrs))
            (disjoint-p
             x
-            (all-translation-governing-addresses l-addrs x86)))
+            (all-xlation-governing-entries-paddrs l-addrs x86)))
   :hints (("Goal"
            :do-not-induct t
-           :use ((:instance all-translation-governing-addresses-subset-of-paging-structures)
+           :use ((:instance all-xlation-governing-entries-paddrs-subset-of-paging-structures)
                  (:instance disjoint-p-subset-p
                             (x x)
                             (y (open-qword-paddr-list (gather-all-paging-structure-qword-addresses x86)))
                             (a x)
-                            (b (all-translation-governing-addresses l-addrs x86))))
+                            (b (all-xlation-governing-entries-paddrs l-addrs x86))))
            :in-theory (e/d* (disjoint-p-commutative)
-                            (all-translation-governing-addresses-subset-of-paging-structures
+                            (all-xlation-governing-entries-paddrs-subset-of-paging-structures
                              disjoint-p-subset-p))))
   :rule-classes :rewrite)
 
-(defthm infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-both-disjoint-p-and-disjoint-p$
+(defthm infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-both-disjoint-p-and-disjoint-p$
   (implies (and
             (disjoint-p$
              x
@@ -1174,9 +1174,9 @@
             (canonical-address-listp l-addrs))
            (disjoint-p
             x
-            (all-translation-governing-addresses l-addrs x86)))
+            (all-xlation-governing-entries-paddrs l-addrs x86)))
   :hints (("Goal" :in-theory (e/d* (disjoint-p$
-                                    infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses)
+                                    infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses)
                                    ())))
   :rule-classes :rewrite)
 
@@ -1206,7 +1206,7 @@
     (find-first-arg-of-disjoint-p$-when-second-arg-matches-aux
      arg-1-var arg-2 calls)))
 
-(defthm infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$
+(defthm infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$
   (implies (and (bind-free
                  (find-first-arg-of-disjoint-p$-when-second-arg-matches
                   'x
@@ -1226,13 +1226,13 @@
   :hints (("Goal" :in-theory (e/d* (disjoint-p$
                                     disjoint-p
                                     subset-p
-                                    infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses)
+                                    infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses)
                                    ())))
   :rule-classes :rewrite)
 
-(defthm infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-both-disjoint-p-and-disjoint-p$-and-subset-p
+(defthm infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-both-disjoint-p-and-disjoint-p$-and-subset-p
   ;; Less general (and less expensive) than
-  ;; infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-both-disjoint-p-and-disjoint-p$
+  ;; infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-both-disjoint-p-and-disjoint-p$
   ;; because this rule applies only during instruction fetches.
   (implies
    (and
@@ -1250,20 +1250,20 @@
     (canonical-address-listp l-addrs))
    (disjoint-p
     (mv-nth 1 (las-to-pas l-addrs-subset-1 :x cpl x86))
-    (all-translation-governing-addresses l-addrs-subset-2 x86)))
+    (all-xlation-governing-entries-paddrs l-addrs-subset-2 x86)))
   :hints (("Goal"
            :do-not-induct t
            :in-theory (e/d* (disjoint-p$
                              subset-p)
                             ())
-           :use ((:instance infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses
+           :use ((:instance infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses
                             (x (mv-nth 1 (las-to-pas l-addrs :x cpl x86)))
                             (l-addrs l-addrs-subset))
                  (:instance disjoint-p-subset-p
                             (x (mv-nth 1 (las-to-pas l-addrs :x cpl x86)))
-                            (y (all-translation-governing-addresses l-addrs x86))
+                            (y (all-xlation-governing-entries-paddrs l-addrs x86))
                             (a (mv-nth 1 (las-to-pas l-addrs-subset-1 :x cpl x86)))
-                            (b (all-translation-governing-addresses l-addrs-subset-2 x86))))))
+                            (b (all-xlation-governing-entries-paddrs l-addrs-subset-2 x86))))))
 
   :rule-classes :rewrite)
 

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-init.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-init.lisp
@@ -437,7 +437,7 @@
     (:type-prescription true-listp)
     (:rewrite unsigned-byte-p-of-logtail)
     (:rewrite bitops::logbitp-when-bitmaskp)
-    (:type-prescription all-translation-governing-addresses)
+    (:type-prescription all-xlation-governing-entries-paddrs)
     (:type-prescription set::setp-type)
     (:type-prescription set::empty-type)
     (:rewrite acl2::equal-constant-+)
@@ -556,14 +556,14 @@
     mv-nth-1-las-to-pas-when-error
     bitops::logand-with-negated-bitmask
     xlate-equiv-memory-and-xr-mem-from-rest-of-memory
-    disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+    disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
     unsigned-byte-p))
 
 (def-ruleset rewire_dst_to_src-disable-more
   '(mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs-alt
     mv-nth-0-las-to-pas-subset-p
     (:type-prescription true-listp-mv-nth-1-las-to-pas)
-    (:rewrite disjoint-p-all-translation-governing-addresses-subset-p)
+    (:rewrite disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
     (:type-prescription rm-low-64-logand-logior-helper-1)
     (:type-prescription n64p$inline)
     (:definition strip-cars)
@@ -730,7 +730,7 @@
             (las-to-pas
              (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
              :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
      x86))))
 
@@ -780,7 +780,7 @@
                 8
                 (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -837,7 +837,7 @@
                  (xr :rgf *rdi* x86)
                  (pdpt-base-addr (xr :rgf *rdi* x86) x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -865,7 +865,7 @@
                 8
                 (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
      x86))
    ;; The stack physical addresses are disjoint from the
@@ -874,7 +874,7 @@
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
                :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -889,7 +889,7 @@
                8
                (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
     x86)))
 
@@ -917,7 +917,7 @@
                  (xr :rgf *rdi* x86)
                  (pdpt-base-addr (xr :rgf *rdi* x86) x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
      x86))))
 
@@ -932,7 +932,7 @@
                 (xr :rgf *rdi* x86)
                 (pdpt-base-addr (xr :rgf *rdi* x86) x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
     x86)))
 
@@ -947,7 +947,7 @@
                 (xr :rgf *rdi* x86)
                 (pdpt-base-addr (xr :rgf *rdi* x86) x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1013,7 +1013,7 @@
                 8
                 (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1084,7 +1084,7 @@
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1112,7 +1112,7 @@
                 8
                 (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
      x86))
    ;; The stack physical addresses are disjoint from the
@@ -1120,7 +1120,7 @@
    (disjoint-p$
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86))) :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1135,7 +1135,7 @@
                8
                (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
     x86)))
 
@@ -1148,7 +1148,7 @@
                8
                (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1163,7 +1163,7 @@
                8
                (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (page-dir-ptr-table-entry-addr
@@ -1182,7 +1182,7 @@
                 (xr :rgf *rsi* x86)
                 (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
               :w (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1199,7 +1199,7 @@
                 (xr :rgf *rsi* x86)
                 (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
               :w (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (page-dir-ptr-table-entry-addr
@@ -1218,7 +1218,7 @@
                 (xr :rgf *rsi* x86)
                 (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
               :w (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1248,7 +1248,7 @@
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
      x86))
    ;; The stack physical addresses are disjoint from the
@@ -1256,7 +1256,7 @@
    (disjoint-p$
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86))) :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1292,7 +1292,7 @@
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
      x86))
    ;; The program physical addresses are disjoint from the
@@ -1301,7 +1301,7 @@
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
                :x (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1332,14 +1332,14 @@
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (xr :rgf *rsp* x86))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (xr :rgf *rsp* x86))
      x86))
    (disjoint-p$
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (xr :rgf *rsp* x86))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (xr :rgf *rsp* x86))
      x86))))
 
@@ -1351,7 +1351,7 @@
    (mv-nth 1 (las-to-pas
               (create-canonical-address-list 8 (xr :rgf *rsp* x86))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
     x86)))
 
@@ -1364,7 +1364,7 @@
               (create-canonical-address-list 8 (xr :rgf *rsp* x86))
               :r (cpl x86) x86))
 
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1379,7 +1379,7 @@
               (create-canonical-address-list 8 (xr :rgf *rsp* x86))
               :r (cpl x86) x86))
 
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (page-dir-ptr-table-entry-addr
@@ -1396,7 +1396,7 @@
               (create-canonical-address-list 8 (xr :rgf *rsp* x86))
               :r (cpl x86) x86))
 
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1416,7 +1416,7 @@
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (xr :rgf *rsp* x86)) x86))
    ;; The destination PDPTE physical addresses are disjoint from the
    ;; stack containing the return address.
@@ -1437,7 +1437,7 @@
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (xr :rgf *rsp* x86))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1455,7 +1455,7 @@
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list 8 (xr :rgf *rsp* x86))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86))) x86))
    ;; The rest of the stack is disjoint from the physical addresses on
    ;; the stack corresponding to the return address.

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-part-1.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-part-1.lisp
@@ -66,7 +66,7 @@
 ;; (acl2::why rb-alt-wb-disjoint-in-system-level-mode)
 ;; (acl2::why rb-alt-wb-equal-in-system-level-mode)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-rb-alt)
-;; (acl2::why all-translation-governing-addresses-and-mv-nth-1-wb-disjoint)
+;; (acl2::why all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint)
 ;; (acl2::why la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-get-prefixes-alt-no-prefix-byte)
 ;; (acl2::why mv-nth-2-get-prefixes-alt-no-prefix-byte)
@@ -794,7 +794,7 @@
                              car-create-canonical-address-list
                              cdr-create-canonical-address-list
                              loghead-negative
-                             disjoint-p-all-translation-governing-addresses-subset-p)
+                             disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
                             (create-canonical-address-list
                              (:rewrite program-at-values-and-!flgi)
                              (:rewrite get-prefixes-opener-lemma-group-4-prefix-in-marking-mode)

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-part-2.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-part-2.lisp
@@ -66,7 +66,7 @@
 ;; (acl2::why rb-alt-wb-disjoint-in-system-level-mode)
 ;; (acl2::why rb-alt-wb-equal-in-system-level-mode)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-rb-alt)
-;; (acl2::why all-translation-governing-addresses-and-mv-nth-1-wb-disjoint)
+;; (acl2::why all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint)
 ;; (acl2::why la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-get-prefixes-alt-no-prefix-byte)
 ;; (acl2::why mv-nth-2-get-prefixes-alt-no-prefix-byte)
@@ -1823,7 +1823,7 @@
                              car-create-canonical-address-list
                              cdr-create-canonical-address-list
                              loghead-negative
-                             disjoint-p-all-translation-governing-addresses-subset-p)
+                             disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
                             (rewrite-program-at-to-program-at-alt
                              create-canonical-address-list
                              program-at-xw-rgf

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy.lisp
@@ -766,7 +766,7 @@
             :do-not-induct t
             :hands-off (x86-run)
             :use ((:instance rewire_dst_to_src-effects))
-            :in-theory (e/d* (disjoint-p-all-translation-governing-addresses-subset-p)
+            :in-theory (e/d* (disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
                              (
                               ;; x86-state-okp
                               ;; program-ok-p
@@ -835,7 +835,7 @@
                               (:rewrite acl2::loghead-identity)
                               (:definition subset-p)
                               (:rewrite
-                               infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
+                               infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
                               (:meta acl2::mv-nth-cons-meta)
                               (:rewrite bitops::loghead-of-loghead-2)
                               (:type-prescription member-p)
@@ -941,7 +941,7 @@
                               (:rewrite acl2::loghead-identity)
                               (:definition subset-p)
                               (:rewrite
-                               infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
+                               infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
                               (:meta acl2::mv-nth-cons-meta)
                               (:rewrite bitops::loghead-of-loghead-2)
                               (:type-prescription member-p)
@@ -996,7 +996,7 @@
            :use ((:instance rewire_dst_to_src-effects))
            :hands-off (x86-run)
            :in-theory (e/d*
-                       (disjoint-p-all-translation-governing-addresses-subset-p)
+                       (disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
                        (x86-fetch-decode-execute-opener-in-marking-mode
                         mv-nth-0-rb-and-mv-nth-0-las-to-pas-in-system-level-mode
                         mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
@@ -1057,7 +1057,7 @@
                8
                (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list 8 (xr :rgf *rsp* x86))
     x86)))
 
@@ -1082,7 +1082,7 @@
                 8
                 (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1098,7 +1098,7 @@
                  8
                  (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
                 :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1111,7 +1111,7 @@
                8
                (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
               :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list
      8
      (page-dir-ptr-table-entry-addr
@@ -1128,7 +1128,7 @@
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
      :r (cpl x86) x86))
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list 8 (xr :rgf *rsp* x86))
     x86)))
 
@@ -1159,7 +1159,7 @@
        8
        (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
       :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1177,7 +1177,7 @@
                 8
                 (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
                :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1192,7 +1192,7 @@
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1220,7 +1220,7 @@
        8
        (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
       :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -1238,7 +1238,7 @@
        8
        (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
       :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
@@ -1269,7 +1269,7 @@
                   8
                   (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
                  :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1286,7 +1286,7 @@
        (page-dir-ptr-table-entry-addr (xr :rgf *rsi* x86)
                                       (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
       :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
@@ -1314,7 +1314,7 @@
                 8
                 (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
                :r (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses l-addrs-2 (double-rewrite x86)))
+             (all-xlation-governing-entries-paddrs l-addrs-2 (double-rewrite x86)))
             (disjoint-p
              (mv-nth
               1
@@ -1323,7 +1323,7 @@
                 8
                 (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
                :r (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (create-canonical-address-list
                8
                (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
@@ -1350,7 +1350,7 @@
                          8
                          (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
                         :r (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (strip-cars addr-lst) (double-rewrite x86)))
             (disjoint-p
              (mv-nth 1 (las-to-pas
@@ -1358,14 +1358,14 @@
                          8
                          (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
                         :r (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (create-canonical-address-list
                8
                (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
               (double-rewrite x86)))
             (disjoint-p
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) (double-rewrite x86)))
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (create-canonical-address-list
                8
                (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
@@ -1416,7 +1416,7 @@
    :hints (("Goal"
             :use ((:instance rewire_dst_to_src-effects))
             :in-theory (e/d* (pml4-table-base-addr-from-final-state
-                              disjoint-p-all-translation-governing-addresses-subset-p)
+                              disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
                              (page-dir-ptr-table-entry-addr-to-c-program-optimized-form
                               unsigned-byte-p-52-of-left-shifting-a-40-bit-vector-by-12
                               unsigned-byte-p-of-combine-bytes-and-rb-in-system-level-mode
@@ -1501,7 +1501,7 @@
   :hints (("Goal"
            :use ((:instance rewire_dst_to_src-effects))
            :in-theory (e/d* (pml4-table-base-addr-from-final-state
-                             disjoint-p-all-translation-governing-addresses-subset-p)
+                             disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
                             (rewrite-rb-to-rb-alt
                              las-to-pas-values-and-!flgi
                              create-canonical-address-list
@@ -1660,7 +1660,7 @@
                      (xr :rgf *rsi* x86)
                      (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                    :w (cpl x86) x86))
-                 (all-translation-governing-addresses
+                 (all-xlation-governing-entries-paddrs
                   (create-canonical-address-list *2^30* (xr :rgf *rdi* x86))
                   x86)))
            (equal
@@ -1682,7 +1682,7 @@
                              page-dir-ptr-table-entry-addr-to-c-program-optimized-form
                              unsigned-byte-p-52-of-left-shifting-a-40-bit-vector-by-12
                              unsigned-byte-p-of-combine-bytes-and-rb-in-system-level-mode
-                             infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$
+                             infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$
                              mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs
                              subset-p
                              (:meta acl2::mv-nth-cons-meta)
@@ -1735,7 +1735,7 @@
                      (xr :rgf *rsi* x86)
                      (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
                    :w (cpl x86) x86))
-                 (all-translation-governing-addresses
+                 (all-xlation-governing-entries-paddrs
                   (create-canonical-address-list *2^30* (xr :rgf *rdi* x86))
                   x86))
 
@@ -1791,7 +1791,7 @@
                         source-pdpt-base-addr-from-final-state
                         source-addresses-from-final-state
 
-                        disjoint-p-all-translation-governing-addresses-subset-p)
+                        disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
 
                        (rewrite-rb-to-rb-alt
                         page-dir-ptr-table-entry-addr-to-c-program-optimized-form
@@ -1865,7 +1865,7 @@
 
 ;; In order to prove destination-data-from-final-state-*, I first need
 ;; las-to-pas-values-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr,
-;; all-translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr,
+;; all-xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr,
 ;; and rb-values-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr.
 
 ;; ======================================================================
@@ -1966,7 +1966,7 @@
                      (las-to-pas (create-canonical-address-list 8 direct-mapped-addr)
                                  r-w-x (cpl x86)
                                  (double-rewrite x86)))
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (create-canonical-address-list 8 direct-mapped-addr)
               (double-rewrite x86)))
             (not
@@ -2108,7 +2108,7 @@
         8
         (page-dir-ptr-table-entry-addr lin-addr base-addr))
        r-w-x cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8 (page-dir-ptr-table-entry-addr lin-addr base-addr))
       x86))
@@ -2185,7 +2185,7 @@
       1
       (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                   :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 pml4-table-entry-addr)
       x86))
     (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -2201,7 +2201,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       x86))
 
@@ -2276,7 +2276,7 @@
       1
       (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                   :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 pml4-table-entry-addr)
       x86))
     (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -2292,7 +2292,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       x86))
 
@@ -2440,7 +2440,7 @@
       1
       (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                   :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 pml4-table-entry-addr)
       x86))
     (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -2456,7 +2456,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       x86))
 
@@ -2545,7 +2545,7 @@
       1
       (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                   :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 pml4-table-entry-addr)
       x86))
     (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -2561,7 +2561,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       x86))
 
@@ -2648,7 +2648,7 @@
               (las-to-pas (create-canonical-address-list
                            8 (page-dir-ptr-table-entry-addr lin-addr base-addr))
                           r-w-x cpl x86))
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (create-canonical-address-list
                8 (page-dir-ptr-table-entry-addr lin-addr base-addr))
               x86))
@@ -2763,7 +2763,7 @@
       (las-to-pas
        (create-canonical-address-list 8 (pml4-table-entry-addr lin-addr pml4-table-base-addr))
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 (pml4-table-entry-addr lin-addr pml4-table-base-addr))
       x86))
 
@@ -2782,7 +2782,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       x86))
 
@@ -2873,7 +2873,7 @@
       (las-to-pas
        (create-canonical-address-list 8 (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 (pml4-table-entry-addr lin-addr (pml4-table-base-addr x86)))
       (double-rewrite x86)))
 
@@ -2892,7 +2892,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
 
@@ -2993,7 +2993,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -3014,7 +3014,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
 
@@ -3041,7 +3041,7 @@
              (las-to-pas
               (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
               :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
 
     (not (mv-nth 0 (ia32e-la-to-pa lin-addr :r cpl (double-rewrite x86))))
 
@@ -3147,7 +3147,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -3168,7 +3168,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
 
@@ -3195,7 +3195,7 @@
              (las-to-pas
               (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
               :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
 
     (not (mv-nth 0 (ia32e-la-to-pa lin-addr :r cpl (double-rewrite x86))))
 
@@ -3316,7 +3316,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -3337,7 +3337,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
 
@@ -3369,7 +3369,7 @@
              (las-to-pas
               (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
               :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
 
     (not (mv-nth 0 (las-to-pas
                     (create-canonical-address-list *2^30* lin-addr)
@@ -3423,17 +3423,17 @@
 ;; ======================================================================
 
 ;; Begin proof of
-;; all-translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr:
+;; all-xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr:
 
 ;; First, we compute the translation-governing addresses corresponding
 ;; to (+ n lin-addr), given that (+ n lin-addr) lies in the same 1G
 ;; page as lin-addr.  We then generalize this result to
-;; all-translation-governing-addresses (from
-;; translation-governing-addresses).
+;; all-xlation-governing-entries-paddrs (from
+;; xlation-governing-entries-paddrs).
 
-(defthmd translation-governing-addresses-for-same-1G-page
+(defthmd xlation-governing-entries-paddrs-for-same-1G-page
   ;; Similar to ia32e-la-to-pa-values-for-same-1G-page, but for
-  ;; translation-governing-addresses.
+  ;; xlation-governing-entries-paddrs.
   (implies
    (and
     (equal cpl (cpl x86))
@@ -3459,7 +3459,7 @@
       1
       (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                   :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 pml4-table-entry-addr)
       x86))
     (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -3475,7 +3475,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl x86))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       x86))
     (equal (page-size page-dir-ptr-table-entry) 1)
@@ -3486,12 +3486,12 @@
     (equal (loghead 30 (+ n lin-addr)) n)
     (unsigned-byte-p 30 n)
     (x86p x86))
-   (equal (translation-governing-addresses (+ n lin-addr) x86)
-          (translation-governing-addresses lin-addr x86)))
+   (equal (xlation-governing-entries-paddrs (+ n lin-addr) x86)
+          (xlation-governing-entries-paddrs lin-addr x86)))
   :hints (("Goal"
-           :in-theory (e/d* (translation-governing-addresses
-                             translation-governing-addresses-for-pml4-table
-                             translation-governing-addresses-for-page-dir-ptr-table
+           :in-theory (e/d* (xlation-governing-entries-paddrs
+                             xlation-governing-entries-paddrs-for-pml4-table
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table
                              disjoint-p$
                              direct-map-p
                              pdpt-base-addr
@@ -3516,7 +3516,7 @@
    (if (zp n) nil (append x (repeat (- n 1) x)))))
 
 (local
- (defthmd all-translation-governing-addresses-1G-pages-general
+ (defthmd all-xlation-governing-entries-paddrs-1G-pages-general
    (implies
     (and
      (equal cpl (cpl x86))
@@ -3541,7 +3541,7 @@
        1
        (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                    :r cpl x86))
-      (all-translation-governing-addresses
+      (all-xlation-governing-entries-paddrs
        (create-canonical-address-list 8 pml4-table-entry-addr)
        x86))
      (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -3557,7 +3557,7 @@
        (las-to-pas
         (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
         :r cpl x86))
-      (all-translation-governing-addresses
+      (all-xlation-governing-entries-paddrs
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        x86))
      (equal (page-size page-dir-ptr-table-entry) 1)
@@ -3571,13 +3571,13 @@
      (equal (loghead 30 lin-addr) 0)
      (x86p x86))
     (equal
-     (all-translation-governing-addresses (create-canonical-address-list-alt iteration m lin-addr) x86)
-     (repeat (- m iteration) (translation-governing-addresses lin-addr x86))))
+     (all-xlation-governing-entries-paddrs (create-canonical-address-list-alt iteration m lin-addr) x86)
+     (repeat (- m iteration) (xlation-governing-entries-paddrs lin-addr x86))))
    :hints (("Goal"
             :induct (create-canonical-address-list-alt iteration m lin-addr)
             :do-not '(preprocess)
-            :in-theory (e/d* (all-translation-governing-addresses
-                              translation-governing-addresses-for-same-1G-page)
+            :in-theory (e/d* (all-xlation-governing-entries-paddrs
+                              xlation-governing-entries-paddrs-for-same-1G-page)
                              (member-p-strip-cars-of-remove-duplicate-keys
                               page-dir-ptr-table-entry-addr-to-c-program-optimized-form
                               bitops::logand-with-negated-bitmask
@@ -3585,7 +3585,7 @@
                               not))))))
 
 (local
- (defthmd all-translation-governing-addresses-1G-pages
+ (defthmd all-xlation-governing-entries-paddrs-1G-pages
    (implies
     (and
      (equal cpl (cpl x86))
@@ -3617,7 +3617,7 @@
        1
        (las-to-pas (create-canonical-address-list 8 pml4-table-entry-addr)
                    :r cpl x86))
-      (all-translation-governing-addresses
+      (all-xlation-governing-entries-paddrs
        (create-canonical-address-list 8 pml4-table-entry-addr)
        x86))
      (direct-map-p 8 page-dir-ptr-table-entry-addr :r cpl (double-rewrite x86))
@@ -3633,7 +3633,7 @@
        (las-to-pas
         (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
         :r cpl x86))
-      (all-translation-governing-addresses
+      (all-xlation-governing-entries-paddrs
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        x86))
      (disjoint-p$
@@ -3663,11 +3663,11 @@
      (<= m *2^30*)
      (x86p x86))
     (equal
-     (all-translation-governing-addresses (create-canonical-address-list m lin-addr) x86)
-     (repeat m (translation-governing-addresses lin-addr x86))))
+     (all-xlation-governing-entries-paddrs (create-canonical-address-list m lin-addr) x86)
+     (repeat m (xlation-governing-entries-paddrs lin-addr x86))))
    :hints (("Goal"
             :do-not '(preprocess)
-            :use ((:instance all-translation-governing-addresses-1G-pages-general
+            :use ((:instance all-xlation-governing-entries-paddrs-1G-pages-general
                              (iteration 0)))
             :in-theory (e/d* (create-canonical-address-list-alt-is-create-canonical-address-list)
                              (member-p-strip-cars-of-remove-duplicate-keys
@@ -3687,11 +3687,11 @@
                    (rm-low-64 p-addr-1 x86)))
    :hints (("Goal" :in-theory (e/d* (disjoint-p-commutative) ())))))
 
-(defthmd translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
+(defthmd xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
   ;; Similar to
   ;; ia32e-la-to-pa-values-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
   ;; for
-  ;; translation-governing-addresses.
+  ;; xlation-governing-entries-paddrs.
   (implies
    ;; Restricting this rule so that it doesn't apply when lin-addr
    ;; points to a paging entry.
@@ -3729,7 +3729,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -3747,7 +3747,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
     (disjoint-p$
@@ -3770,7 +3770,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst)
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst)
                                           (double-rewrite x86)))
     (equal (page-size page-dir-ptr-table-entry)
            (page-size (combine-bytes (strip-cdrs addr-lst))))
@@ -3780,8 +3780,8 @@
      (+ 7 (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86)))))
     (canonical-address-p (+ 7 page-dir-ptr-table-entry-addr))
     (x86p x86))
-   (equal (translation-governing-addresses lin-addr (mv-nth 1 (wb addr-lst x86)))
-          (translation-governing-addresses lin-addr x86)))
+   (equal (xlation-governing-entries-paddrs lin-addr (mv-nth 1 (wb addr-lst x86)))
+          (xlation-governing-entries-paddrs lin-addr x86)))
   :hints
   (("Goal"
     :do-not-induct t
@@ -3807,9 +3807,9 @@
                  direct-map-p
                  pml4-table-base-addr
                  pdpt-base-addr
-                 translation-governing-addresses
-                 translation-governing-addresses-for-pml4-table
-                 translation-governing-addresses-for-page-dir-ptr-table
+                 xlation-governing-entries-paddrs
+                 xlation-governing-entries-paddrs-for-pml4-table
+                 xlation-governing-entries-paddrs-for-page-dir-ptr-table
                  rm-low-64-and-write-to-physical-memory-disjoint-commuted)
 
                 (rm-low-64-and-write-to-physical-memory-disjoint
@@ -3831,7 +3831,7 @@
 
 
 (local
- (defthmd translation-governing-addresses-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr-helper
+ (defthmd xlation-governing-entries-paddrs-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr-helper
    (implies
     (and
      (equal page-dir-ptr-table-entry-addr
@@ -3865,7 +3865,7 @@
          8
          (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
         :r cpl (double-rewrite x86)))
-      (all-translation-governing-addresses
+      (all-xlation-governing-entries-paddrs
        (create-canonical-address-list
         8 (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        (double-rewrite x86)))
@@ -3884,7 +3884,7 @@
        (las-to-pas
         (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
         :r cpl (double-rewrite x86)))
-      (all-translation-governing-addresses
+      (all-xlation-governing-entries-paddrs
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        (double-rewrite x86)))
      (disjoint-p$
@@ -3908,7 +3908,7 @@
        (las-to-pas
         (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
         :r cpl (double-rewrite x86)))
-      (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+      (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
      (equal (page-size page-dir-ptr-table-entry)
             (page-size (combine-bytes (strip-cdrs addr-lst))))
      (addr-byte-alistp addr-lst)
@@ -4015,7 +4015,7 @@
                               not
                               bitops::logand-with-negated-bitmask))))))
 
-(defthmd translation-governing-addresses-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr
+(defthmd xlation-governing-entries-paddrs-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr
   (implies
    (and
     (syntaxp (not (and (consp lin-addr)
@@ -4051,7 +4051,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -4069,7 +4069,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
     (disjoint-p$
@@ -4092,7 +4092,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst)
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst)
                                           (double-rewrite x86)))
     (equal (page-size page-dir-ptr-table-entry)
            (page-size (combine-bytes (strip-cdrs addr-lst))))
@@ -4108,16 +4108,16 @@
     (unsigned-byte-p 30 n)
     (not (programmer-level-mode x86))
     (x86p x86))
-   (equal (translation-governing-addresses (+ n lin-addr) (mv-nth 1 (wb addr-lst x86)))
-          (translation-governing-addresses lin-addr x86)))
+   (equal (xlation-governing-entries-paddrs (+ n lin-addr) (mv-nth 1 (wb addr-lst x86)))
+          (xlation-governing-entries-paddrs lin-addr x86)))
   :hints (("Goal"
            :do-not-induct t
-           :use ((:instance translation-governing-addresses-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr-helper))
-           :in-theory (e/d* (translation-governing-addresses-for-same-1G-page
-                             translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
-                             translation-governing-addresses
-                             translation-governing-addresses-for-pml4-table
-                             translation-governing-addresses-for-page-dir-ptr-table
+           :use ((:instance xlation-governing-entries-paddrs-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr-helper))
+           :in-theory (e/d* (xlation-governing-entries-paddrs-for-same-1G-page
+                             xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
+                             xlation-governing-entries-paddrs
+                             xlation-governing-entries-paddrs-for-pml4-table
+                             xlation-governing-entries-paddrs-for-page-dir-ptr-table
                              pdpt-base-addr
                              pml4-table-base-addr)
                             (mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs-alt
@@ -4141,7 +4141,7 @@
                              not
                              bitops::logand-with-negated-bitmask)))))
 
-(defthmd all-translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr-general
+(defthmd all-xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr-general
   (implies
    (and
     (equal page-dir-ptr-table-entry-addr
@@ -4172,7 +4172,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -4193,7 +4193,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
 
@@ -4220,7 +4220,7 @@
              (las-to-pas
               (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
               :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
 
 
 
@@ -4250,18 +4250,18 @@
     (not (programmer-level-mode x86))
     (x86p x86))
    (equal
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list-alt iteration m lin-addr) (mv-nth 1 (wb addr-lst x86)))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list-alt iteration m lin-addr) x86)))
   :hints (("Goal"
            :induct (create-canonical-address-list-alt iteration m lin-addr)
            :do-not '(preprocess)
-           :in-theory (e/d* (all-translation-governing-addresses
-                             translation-governing-addresses-for-same-1G-page
-                             translation-governing-addresses-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr
-                             translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
-                             all-translation-governing-addresses-1G-pages-general)
+           :in-theory (e/d* (all-xlation-governing-entries-paddrs
+                             xlation-governing-entries-paddrs-for-same-1G-page
+                             xlation-governing-entries-paddrs-for-same-1G-page-and-wb-to-page-dir-ptr-table-entry-addr
+                             xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
+                             all-xlation-governing-entries-paddrs-1G-pages-general)
                             (member-p
                              subset-p
                              member-p-strip-cars-of-remove-duplicate-keys
@@ -4270,7 +4270,7 @@
                              force (force)
                              not)))))
 
-(defthm all-translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
+(defthm all-xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr
   (implies
    (and
     ;; Restrict this rule so that it fires when lin-addr is either (XR
@@ -4301,7 +4301,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -4314,7 +4314,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
     (disjoint-p$
@@ -4343,7 +4343,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
 
     (equal (page-present page-dir-ptr-table-entry)
            (page-present (combine-bytes (strip-cdrs addr-lst))))
@@ -4366,26 +4366,26 @@
     (<= m *2^30*)
     (x86p x86))
    (equal
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list m lin-addr) (mv-nth 1 (wb addr-lst x86)))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list m lin-addr) (double-rewrite x86))))
   :hints (("Goal"
            :do-not-induct t
            :do-not '(preprocess)
-           :use ((:instance all-translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr-general
+           :use ((:instance all-xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr-general
                             (iteration 0)))
            :in-theory (e/d* (create-canonical-address-list-alt-is-create-canonical-address-list
                              direct-map-p
                              las-to-pas)
-                            (all-translation-governing-addresses
+                            (all-xlation-governing-entries-paddrs
                              mv-nth-0-las-to-pas-subset-p
                              subset-p
                              mv-nth-0-ia32e-la-to-pa-member-of-mv-nth-1-las-to-pas-if-lin-addr-member-p
                              member-p
                              rewrite-rb-to-rb-alt
                              rb-and-rm-low-64-for-direct-map
-                             translation-governing-addresses-for-same-1G-page
+                             xlation-governing-entries-paddrs-for-same-1G-page
                              member-p-strip-cars-of-remove-duplicate-keys
                              page-dir-ptr-table-entry-addr-to-c-program-optimized-form
                              bitops::logand-with-negated-bitmask
@@ -4429,7 +4429,7 @@
         8
         (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list
        8
        (pml4-table-entry-addr lin-addr (pml4-table-base-addr (double-rewrite x86))))
@@ -4442,7 +4442,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses
+     (all-xlation-governing-entries-paddrs
       (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
       (double-rewrite x86)))
     (disjoint-p$
@@ -4473,7 +4473,7 @@
       (las-to-pas
        (create-canonical-address-list 8 page-dir-ptr-table-entry-addr)
        :r cpl (double-rewrite x86)))
-     (all-translation-governing-addresses (strip-cars addr-lst) (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs (strip-cars addr-lst) (double-rewrite x86)))
 
     (not (mv-nth 0
                  (las-to-pas (create-canonical-address-list *2^30* lin-addr)
@@ -4562,7 +4562,7 @@
         (xr :rgf *rsi* x86)
         (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
       :w (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list *2^30* (xr :rgf *rdi* x86))
      x86))
 
@@ -4674,12 +4674,12 @@
 
 ;; Now back to proving destination-data-from-final-state:
 
-;; (acl2::why all-translation-governing-addresses-and-mv-nth-1-wb-disjoint)
+;; (acl2::why all-xlation-governing-entries-paddrs-and-mv-nth-1-wb-disjoint)
 ;; (acl2::why rb-wb-disjoint-in-system-level-mode)
 ;; (acl2::why pdpt-base-addr-after-mv-nth-1-wb)
 ;; (acl2::why la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs)
 ;; (acl2::why las-to-pas-values-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr)
-;; (acl2::why all-translation-governing-addresses-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr)
+;; (acl2::why all-xlation-governing-entries-paddrs-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr)
 ;; (acl2::why rb-values-1G-pages-and-wb-to-page-dir-ptr-table-entry-addr)
 ;; (acl2::why mv-nth-1-rb-after-mv-nth-2-las-to-pas)
 
@@ -4712,7 +4712,7 @@
                   (pml4-table-entry-addr (xr :rgf *rsi* x86)
                                          (pml4-table-base-addr x86)))
                  :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr (xr :rgf *rsi* x86)
@@ -4794,7 +4794,7 @@
                 (page-dir-ptr-table-entry-addr
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86))) x86))
@@ -4807,7 +4807,7 @@
                 (page-dir-ptr-table-entry-addr
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86)
@@ -4822,7 +4822,7 @@
                 (page-dir-ptr-table-entry-addr
                  (xr :rgf *rsi* x86)
                  (pdpt-base-addr (xr :rgf *rsi* x86) x86)))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -4841,7 +4841,7 @@
        (pml4-table-entry-addr (xr :rgf *rsi* x86)
                               (pml4-table-base-addr x86)))
       :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rsi* x86)
@@ -4859,7 +4859,7 @@
        (pml4-table-entry-addr (xr :rgf *rsi* x86)
                               (pml4-table-base-addr x86)))
       :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -4878,7 +4878,7 @@
        (pml4-table-entry-addr (xr :rgf *rsi* x86)
                               (pml4-table-base-addr x86)))
       :r (cpl x86) x86))
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (pml4-table-entry-addr (xr :rgf *rdi* x86)
@@ -5331,7 +5331,7 @@
                         source-addresses-from-final-state
                         destination-pdpt-base-addr-from-final-state
                         destination-pml4-table-entry-from-final-state
-                        disjoint-p-all-translation-governing-addresses-subset-p
+                        disjoint-p-all-xlation-governing-entries-paddrs-subset-p
                         pdpt-base-addr)
 
                        (rewire_dst_to_src-disable
@@ -5377,7 +5377,7 @@
                         (:rewrite acl2::cdr-of-append-when-consp)
                         (:type-prescription binary-append)
                         (:rewrite
-                         all-translation-governing-addresses-1g-pages-and-wb-to-page-dir-ptr-table-entry-addr)
+                         all-xlation-governing-entries-paddrs-1g-pages-and-wb-to-page-dir-ptr-table-entry-addr)
                         (:rewrite
                          int-lists-in-seq-p-and-append-with-create-canonical-address-list-2)
                         (:rewrite greater-logbitp-of-unsigned-byte-p . 2)
@@ -5467,7 +5467,7 @@
       source-addresses-from-final-state
       destination-pdpt-base-addr-from-final-state
       destination-pml4-table-entry-from-final-state
-      disjoint-p-all-translation-governing-addresses-subset-p)
+      disjoint-p-all-xlation-governing-entries-paddrs-subset-p)
      (rewire_dst_to_src-disable
       read-from-physical-memory
       pdpt-base-addr-after-mv-nth-2-las-to-pas
@@ -5513,7 +5513,7 @@
       (:rewrite
        int-lists-in-seq-p-and-append-with-create-canonical-address-list-2)
       (:rewrite
-       infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
+       infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
       (:rewrite car-addr-range)
       (:type-prescription member-p-physical-address-p)
       (:type-prescription n01p-page-size)
@@ -5624,7 +5624,7 @@
      (mv-nth 1
              (las-to-pas (create-canonical-address-list 8 lin-addr)
                          :w (cpl x86) (double-rewrite x86)))
-     (all-translation-governing-addresses l-addrs (double-rewrite x86)))
+     (all-xlation-governing-entries-paddrs l-addrs (double-rewrite x86)))
     (disjoint-p$
      (mv-nth 1
              (las-to-pas (create-canonical-address-list 8 lin-addr)
@@ -6191,7 +6191,7 @@
                               (:rewrite default-+-2)
                               (:rewrite two-mv-nth-1-las-to-pas-subset-p-disjoint-from-las-to-pas)
                               (:rewrite
-                               infer-disjointness-with-all-translation-governing-addresses-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
+                               infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-with-disjoint-p$)
                               (:rewrite loghead-of-non-integerp)
                               (:type-prescription acl2::|x < y  =>  0 < -x+y|)
                               (:rewrite acl2::equal-of-booleans-rewrite)
@@ -6360,7 +6360,7 @@
                               (:rewrite int-lists-in-seq-p-and-append)
                               (:type-prescription consp-create-addr-bytes-alist)
                               (:type-prescription bitp)
-                              (:type-prescription all-translation-governing-addresses)
+                              (:type-prescription all-xlation-governing-entries-paddrs)
                               (:rewrite acl2::expt-with-violated-guards)
                               (:type-prescription consp-create-addr-bytes-alist-in-terms-of-len)
                               (:rewrite acl2::append-of-cons)

--- a/books/projects/x86isa/proofs/zeroCopy/non-marking-mode/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/non-marking-mode/zeroCopy.lisp
@@ -205,7 +205,7 @@
                :r (cpl x86) x86))
              (mv-nth 1 (las-to-pas (strip-cars addr-lst) :w (cpl x86) x86)))
             (disjoint-p
-             (all-translation-governing-addresses
+             (all-xlation-governing-entries-paddrs
               (create-canonical-address-list
                8 (pml4-table-entry-addr lin-addr (pml4t-base-addr x86)))
               x86)
@@ -336,7 +336,7 @@
    ;; Translation-governing addresses of the stack are disjoint from
    ;; the physical addresses of the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
      x86)
     (mv-nth 1 (las-to-pas
@@ -550,7 +550,7 @@
    ;; Translation-governing addresses of the program are disjoint from
    ;; the physical addresses of the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
      x86)
     (mv-nth 1 (las-to-pas
@@ -562,7 +562,7 @@
    ;; The translation-governing addresses of PML4TE addresses are
    ;; disjoint from the physical addresses corresponding to the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8 (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4t-base-addr x86)))
      x86)
@@ -584,7 +584,7 @@
    ;; The translation-governing addresses of PDPTE addresses are
    ;; disjoint from the physical addresses corresponding to the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -611,7 +611,7 @@
    ;; The translation-governing addresses of PML4TE addresses are
    ;; disjoint from the physical addresses corresponding to the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8 (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4t-base-addr x86)))
      x86)
@@ -633,7 +633,7 @@
    ;; The translation-governing addresses of PDPTE addresses are
    ;; disjoint from the physical addresses corresponding to the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list
       8
       (page-dir-ptr-table-entry-addr
@@ -676,7 +676,7 @@
    ;; Translation-governing addresses of the program are disjoint from
    ;; the PDPTE physical addresses (on behalf of a write).
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list *rewire_dst_to_src-len* (xr :rip 0 x86))
      x86)
     (mv-nth 1 (las-to-pas
@@ -692,7 +692,7 @@
    ;; The translation-governing addresses of the ret address are
    ;; disjoint from the destination PDPTE.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (xr :rgf *rsp* x86)) x86)
     (mv-nth 1 (las-to-pas
                (create-canonical-address-list
@@ -731,7 +731,7 @@
    ;; stack are disjoint from the physical addresses of the rest of
    ;; the stack.
    (disjoint-p
-    (all-translation-governing-addresses
+    (all-xlation-governing-entries-paddrs
      (create-canonical-address-list 8 (xr :rgf *rsp* x86)) x86)
     (mv-nth 1
             (las-to-pas (create-canonical-address-list 8 (+ -24 (xr :rgf *rsp* x86)))
@@ -775,7 +775,7 @@
 ;; (acl2::why combine-bytes-rb-in-terms-of-rb-subset-p-in-system-level-non-marking-mode)
 ;; (acl2::why program-at-wb-disjoint-in-system-level-non-marking-mode)
 ;; (acl2::why rb-wb-disjoint-in-system-level-non-marking-mode)
-;; (acl2::why disjointness-of-translation-governing-addresses-from-all-translation-governing-addresses)
+;; (acl2::why disjointness-of-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs)
 ;; (acl2::why la-to-pas-values-and-mv-nth-1-wb-disjoint-from-xlation-gov-addrs-in-non-marking-mode)
 
 ;; Argh, ACL2's default ancestors-check is killing me --- it prevents
@@ -787,7 +787,7 @@
 (def-ruleset rewire_dst_to_src-disable
   '((:rewrite ia32e-la-to-pa-lower-12-bits-error)
     (:rewrite
-     disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p)
+     disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p)
     (:type-prescription natp-pml4-table-entry-addr)
     (:rewrite acl2::consp-when-member-equal-of-atom-listp)
     (:rewrite ia32e-la-to-pa-xw-state)
@@ -888,7 +888,7 @@
     (:type-prescription true-listp)
     (:rewrite unsigned-byte-p-of-logtail)
     (:rewrite bitops::logbitp-when-bitmaskp)
-    (:type-prescription all-translation-governing-addresses)
+    (:type-prescription all-xlation-governing-entries-paddrs)
     (:type-prescription set::setp-type)
     (:type-prescription set::empty-type)
     (:rewrite acl2::equal-constant-+)
@@ -2934,11 +2934,11 @@
                   (xr :rgf *rsi* x86)
                   (pdpt-base-addr (xr :rgf *rsi* x86) x86)))))
 
-(defun-nx destination-translation-governing-addresses-and-stack-no-interfere-p (x86)
+(defun-nx destination-xlation-governing-entries-paddrs-and-stack-no-interfere-p (x86)
   ;; The translation-governing addresses of the destination are disjoint
   ;; from the physical addresses corresponding to the stack.
   (disjoint-p
-   (all-translation-governing-addresses
+   (all-xlation-governing-entries-paddrs
     (create-canonical-address-list *2^30* (xr :rgf *rsi* x86)) x86)
    (mv-nth 1 (las-to-pas
               (create-canonical-address-list
@@ -2968,7 +2968,7 @@
 (defun-nx more-non-interference-assumptions (x86)
   (and (source-physical-addresses-and-destination-PDPTE-no-interfere-p x86)
        (destination-PML4E-and-destination-PDPTE-no-interfere-p x86)
-       (destination-translation-governing-addresses-and-stack-no-interfere-p x86)
+       (destination-xlation-governing-entries-paddrs-and-stack-no-interfere-p x86)
        (source-addresses-and-stack-no-interfere-p x86)))
 
 ;; ----------------------------------------------------------------------
@@ -3012,7 +3012,7 @@
                              pml4-table-entry-addr-to-c-program-optimized-form-gl
                              page-dir-ptr-table-entry-addr-to-c-program-optimized-form
                              page-dir-ptr-table-entry-addr-to-c-program-optimized-form-gl
-                             disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                             disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                              acl2::consp-when-member-equal-of-atom-listp
                              r-w-x-is-irrelevant-for-mv-nth-1-ia32e-la-to-pa-when-no-errors
                              ia32e-la-to-pa-xw-state
@@ -3071,7 +3071,7 @@
                              page-dir-ptr-table-entry-addr-to-c-program-optimized-form
                              page-dir-ptr-table-entry-addr-to-c-program-optimized-form-gl
 
-                             disjointness-of-all-translation-governing-addresses-from-all-translation-governing-addresses-subset-p
+                             disjointness-of-all-xlation-governing-entries-paddrs-from-all-xlation-governing-entries-paddrs-subset-p
                              acl2::consp-when-member-equal-of-atom-listp
                              r-w-x-is-irrelevant-for-mv-nth-1-ia32e-la-to-pa-when-no-errors
                              ia32e-la-to-pa-xw-state

--- a/books/projects/x86isa/tools/execution/examples/zeroCopy/zero-copy-precond-check.lsp
+++ b/books/projects/x86isa/tools/execution/examples/zeroCopy/zero-copy-precond-check.lsp
@@ -6,7 +6,7 @@
 (in-package "X86ISA")
 
 (include-book "../../top" :ttags :all)
-;; For all-translation-governing-addresses:
+;; For all-xlation-governing-entries-paddrs:
 (include-book "../../../../proofs/utilities/system-level-mode/top" :ttags :all)
 (include-book "readValues-addr-byte" :ttags :all)
 
@@ -503,7 +503,7 @@
        ;; Translation-governing addresses of the program are
        ;; disjoint from the physical addresses of the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list (len *rewire_dst_to-src*) (xr :rip 0 x86))
        ;;   x86)
        ;;  (mv-nth 1 (las-to-pas
@@ -511,13 +511,13 @@
        ;;              8 (+ -24 (xr :rgf *rsp* x86)))
        ;;             :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses prog-laddrs x86)
+        (all-xlation-governing-entries-paddrs prog-laddrs x86)
         stack-paddrs-from-write)
 
        ;; Translation-governing addresses of the stack are
        ;; disjoint from the physical addresses of the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list
        ;;    8 (+ -24 (xr :rgf *rsp* x86)))
        ;;   x86)
@@ -526,7 +526,7 @@
        ;;              8 (+ -24 (xr :rgf *rsp* x86)))
        ;;             :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses stack-laddrs x86)
+        (all-xlation-governing-entries-paddrs stack-laddrs x86)
         stack-paddrs-from-write))
 
       (mv :PASSED x86)
@@ -565,7 +565,7 @@
        ;; are disjoint from the physical addresses corresponding
        ;; to the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list
        ;;    8 (pml4-table-entry-addr (xr :rgf *rdi* x86) (pml4-table-base-addr x86)))
        ;;   x86)
@@ -573,7 +573,7 @@
        ;;             (create-canonical-address-list
        ;;              8 (+ -24 (xr :rgf *rsp* x86))) :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses src-pml4-laddrs x86)
+        (all-xlation-governing-entries-paddrs src-pml4-laddrs x86)
         stack-paddrs-from-write)
 
        ;; The PML4TE physical addresses are disjoint from the
@@ -655,7 +655,7 @@
        ;; are disjoint from the physical addresses corresponding
        ;; to the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list
        ;;    8
        ;;    (page-dir-ptr-table-entry-addr
@@ -666,7 +666,7 @@
        ;;             (create-canonical-address-list
        ;;              8 (+ -24 (xr :rgf *rsp* x86))) :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses src-page-dir-ptr-laddrs x86)
+        (all-xlation-governing-entries-paddrs src-page-dir-ptr-laddrs x86)
         stack-paddrs-from-write)
 
        ;; The PDPTE physical addresses are disjoint from the
@@ -750,7 +750,7 @@
        ;; are disjoint from the physical addresses corresponding
        ;; to the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list
        ;;    8 (pml4-table-entry-addr (xr :rgf *rsi* x86) (pml4-table-base-addr x86)))
        ;;   x86)
@@ -758,7 +758,7 @@
        ;;             (create-canonical-address-list
        ;;              8 (+ -24 (xr :rgf *rsp* x86))) :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses dst-pml4-laddrs x86)
+        (all-xlation-governing-entries-paddrs dst-pml4-laddrs x86)
         stack-paddrs-from-write)
 
        ;; The PML4TE physical addresses are disjoint from the
@@ -863,7 +863,7 @@
        ;; are disjoint from the physical addresses corresponding
        ;; to the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list
        ;;    8
        ;;    (page-dir-ptr-table-entry-addr
@@ -874,7 +874,7 @@
        ;;             (create-canonical-address-list
        ;;              8 (+ -24 (xr :rgf *rsp* x86))) :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses dst-page-dir-ptr-laddrs x86)
+        (all-xlation-governing-entries-paddrs dst-page-dir-ptr-laddrs x86)
         stack-paddrs-from-write)
 
        ;; The PDPTE physical addresses are disjoint from the
@@ -912,7 +912,7 @@
        ;; disjoint from the PDPTE physical addresses (on behalf
        ;; of a write).
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list (len *rewire_dst_to-src*) (xr :rip 0 x86))
        ;;   x86)
        ;;  (mv-nth 1 (las-to-pas
@@ -922,7 +922,7 @@
        ;;               (xr :rgf *rsi* x86)
        ;;               (page-dir-ptr-table-base-addr (xr :rgf *rsi* x86) x86)))
        ;;             :w (cpl x86) x86)))
-       (disjoint-p (all-translation-governing-addresses prog-laddrs x86)
+       (disjoint-p (all-xlation-governing-entries-paddrs prog-laddrs x86)
                    dst-page-dir-ptr-paddrs)
 
 
@@ -992,7 +992,7 @@
        ;; The translation-governing addresses of the ret address
        ;; are disjoint from the destination PDPTE.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list 8 (xr :rgf *rsp* x86)) x86)
        ;;  (mv-nth 1 (las-to-pas
        ;;             (create-canonical-address-list
@@ -1002,7 +1002,7 @@
        ;;               (page-dir-ptr-table-base-addr (xr :rgf *rsi* x86) x86)))
        ;;             :r (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses ret-laddrs x86)
+        (all-xlation-governing-entries-paddrs ret-laddrs x86)
         dst-page-dir-ptr-paddrs)
 
        ;; The destination PDPTE is disjoint from the ret address
@@ -1048,14 +1048,14 @@
        ;; address on the stack are disjoint from the physical
        ;; addresses of the rest of the stack.
        ;; (disjoint-p
-       ;;  (all-translation-governing-addresses
+       ;;  (all-xlation-governing-entries-paddrs
        ;;   (create-canonical-address-list 8 (xr :rgf *rsp* x86)) x86)
        ;;  (mv-nth 1
        ;;          (las-to-pas (create-canonical-address-list
        ;;                       8 (+ -24 (xr :rgf *rsp* x86)))
        ;;                      :w (cpl x86) x86)))
        (disjoint-p
-        (all-translation-governing-addresses ret-laddrs x86)
+        (all-xlation-governing-entries-paddrs ret-laddrs x86)
         stack-paddrs-from-write)
 
        ;; Return address on the stack is canonical.
@@ -1221,7 +1221,7 @@
 ;; are disjoint from the physical addresses corresponding
 ;; to the stack.
 ;; (disjoint-p
-;;  (all-translation-governing-addresses
+;;  (all-xlation-governing-entries-paddrs
 ;;   (create-canonical-address-list *2^30* (xr :rgf *rsi* x86)) x86)
 ;;  (mv-nth 1 (las-to-pas
 ;;             (create-canonical-address-list
@@ -1231,7 +1231,7 @@
      ((mv & stack-paddrs-from-write x86)
       (las-to-pas stack-laddrs :w (cpl x86) x86)))
   (if (disjoint-p
-       (all-translation-governing-addresses
+       (all-xlation-governing-entries-paddrs
         (create-canonical-address-list
          8 ;; @@@ This really ought to be *2^30*.
          (xr :rgf *rsi* x86)) x86)


### PR DESCRIPTION
These functions collect the physical addresses of the paging entries
that govern the translation of a given linear address.  The old name
that began with the prefix "translation-governing-addresses" was
misleading.  The new prefix is "xlation-governing-entries-paddrs".