### PR TITLE
Display cert.pl build times to the millisecond

### DIFF
--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -71,6 +71,7 @@ use FindBin qw($RealBin);
 use POSIX qw(strftime);
 use Cwd;
 use utf8;
+use Time::HiRes qw(time);
 
 binmode(STDOUT,':utf8');
 
@@ -818,7 +819,7 @@ if ($success) {
 	$hostname = " " . extract_hostname_from_outfile($outfile);
     }
 
-    printf("%sBuilt %s (%ds%s)%s\n", $color, $printgoal, $ELAPSED, $hostname, $black);
+    printf("%sBuilt %s (%.3fs%s)%s\n", $color, $printgoal, $ELAPSED, $hostname, $black);
 
 } else {
     my $taskname = ($STEP eq "acl2x" || $STEP eq "acl2xskip") ? "ACL2X GENERATION" :


### PR DESCRIPTION
A lot of books certify in "0s" or "1s", so I thought it would be nice to
offer a little higher precision for ranking purposes.  Millisecond
precision is also the default output for the `time` command in recent
Bash versions.

The Time::HiRes module is shipped with the base Perl system since Perl
5.8, which was released in 2002, so I think it should be safe to use.