### PR TITLE
Improve formatting of non-Boolean masks

### DIFF
--- a/books/centaur/sv/svtv/process.lisp
+++ b/books/centaur/sv/svtv/process.lisp
@@ -1410,11 +1410,12 @@ decomposition proof.</li>
                      (lower (str::hexify (4vec->lower (cdar al))))
                      (mask  (str::hexify (logxor (4vec->upper (cdar al))
                                                  (4vec->lower (cdar al)))))
-                     ;; padding for right-aligning the three values;
-                     ;; mask doesn't need padding
-                     (ul (length upper)) (ll (length lower)) (ml (max ul ll))
-                     (pad-u (- ml ul))
-                     (pad-l (- ml ll)))
+                     ;; padding for right-aligning the three values
+                     (ul (length upper)) (ll (length lower)) (ml (length mask))
+                     (maxl (max ml (max ul ll)))
+                     (pad-u (- maxl ul))
+                     (pad-l (- maxl ll))
+                     (pad-m (- maxl ml)))
                 (progn$
                  (cw! front)
                  (acl2::fmt-to-comment-window!
@@ -1425,7 +1426,7 @@ decomposition proof.</li>
                   3 nil)
                  (cw! "~t0. ~_1~s2" 23 pad-l lower)
                  (cw! back)
-                 (cw! ";;;    non-Boolean mask: ~s0~%" mask)))))))
+                 (cw! ";;;    non-Boolean mask: ~_0~s1~%" pad-m mask)))))))
      (svtv-print-alist-readable-aux (cdr al) nil))))
 
 (define svtv-print-alist-readable ((al svex-env-p))

--- a/books/centaur/sv/svtv/process.lisp
+++ b/books/centaur/sv/svtv/process.lisp
@@ -1391,30 +1391,35 @@ decomposition proof.</li>
       nil
     (progn$
      (and (mbt (consp (car al)))
-          (progn$
-           (if firstp
-               (cw! " ((")
-             (cw! "  ("))
-           (if (2vec-p (cdar al))
+          (let ((front (if firstp " ((" "  ("))
+                (back (if (consp (cdr al)) ")~%" "))~%")))
+            (cond
+             ((2vec-p (cdar al))
+              (progn$
+               (cw! front)
                (acl2::fmt-to-comment-window!
-                "~x0 ~t1. ~s2)"
+                "~x0 ~t1. ~s2"
                 (pairlis2 '(#\0 #\1 #\2 #\3 #\4
                             #\5 #\6 #\7 #\8 #\9)
-                          (list (caar al) 23 (str::hexify (2vec->val (cdar al)))))
+                          (list (caar al) 23
+                                (str::hexify (2vec->val (cdar al)))))
                 3 nil)
-             (progn$
-              (acl2::fmt-to-comment-window!
-               "~x0   ~t1~s2         ;; non-Boolean mask: ~s3~%"
-               (pairlis2 '(#\0 #\1 #\2 #\3 #\4
-                           #\5 #\6 #\7 #\8 #\9)
-                         (list (caar al) 25 (str::hexify (4vec->upper (cdar al)))
-                               (str::hexify (logxor (4vec->upper (cdar al))
-                                                    (4vec->lower (cdar al))))))
-               3 nil)
-              (cw! "       ~t0. ~s1)" 23 (str::hexify (4vec->lower (cdar al))))))
-           (if (consp (cdr al))
-               (cw! "~%")
-             (cw! ")~%"))))
+               (cw! back)))
+             (t
+              (progn$
+               (cw! front)
+               (acl2::fmt-to-comment-window!
+                "~x0 ~t1  ~s2~%"
+                (pairlis2 '(#\0 #\1 #\2 #\3 #\4
+                            #\5 #\6 #\7 #\8 #\9)
+                          (list (caar al) 23
+                                (str::hexify (4vec->upper (cdar al)))))
+                3 nil)
+               (cw! "~t0. ~s1" 23 (str::hexify (4vec->lower (cdar al))))
+               (cw! back)
+               (cw! ";;;    non-Boolean mask: ~s0~%"
+                    (str::hexify (logxor (4vec->upper (cdar al))
+                                         (4vec->lower (cdar al))))))))))
      (svtv-print-alist-readable-aux (cdr al) nil))))
 
 (define svtv-print-alist-readable ((al svex-env-p))
@@ -1927,5 +1932,3 @@ either package.</p>
 instead just use STV symbols in the SVEX package.  We don't have much of an
 excuse other than sometimes we're working in the ACL2 package and want to just
 type an extra V rather than an extra @('SV::').</p>")
-
-

--- a/books/centaur/sv/svtv/process.lisp
+++ b/books/centaur/sv/svtv/process.lisp
@@ -1406,20 +1406,26 @@ decomposition proof.</li>
                 3 nil)
                (cw! back)))
              (t
-              (progn$
-               (cw! front)
-               (acl2::fmt-to-comment-window!
-                "~x0 ~t1  ~s2~%"
-                (pairlis2 '(#\0 #\1 #\2 #\3 #\4
-                            #\5 #\6 #\7 #\8 #\9)
-                          (list (caar al) 23
-                                (str::hexify (4vec->upper (cdar al)))))
-                3 nil)
-               (cw! "~t0. ~s1" 23 (str::hexify (4vec->lower (cdar al))))
-               (cw! back)
-               (cw! ";;;    non-Boolean mask: ~s0~%"
-                    (str::hexify (logxor (4vec->upper (cdar al))
-                                         (4vec->lower (cdar al))))))))))
+              (let* ((upper (str::hexify (4vec->upper (cdar al))))
+                     (lower (str::hexify (4vec->lower (cdar al))))
+                     (mask  (str::hexify (logxor (4vec->upper (cdar al))
+                                                 (4vec->lower (cdar al)))))
+                     ;; padding for right-aligning the three values;
+                     ;; mask doesn't need padding
+                     (ul (length upper)) (ll (length lower)) (ml (max ul ll))
+                     (pad-u (- ml ul))
+                     (pad-l (- ml ll)))
+                (progn$
+                 (cw! front)
+                 (acl2::fmt-to-comment-window!
+                  "~x0 ~t1  ~_2~s3~%"
+                  (pairlis2 '(#\0 #\1 #\2 #\3 #\4
+                              #\5 #\6 #\7 #\8 #\9)
+                            (list (caar al) 23 pad-u upper))
+                  3 nil)
+                 (cw! "~t0. ~_1~s2" 23 pad-l lower)
+                 (cw! back)
+                 (cw! ";;;    non-Boolean mask: ~s0~%" mask)))))))
      (svtv-print-alist-readable-aux (cdr al) nil))))
 
 (define svtv-print-alist-readable ((al svex-env-p))


### PR DESCRIPTION
When printing `svex-env-p` values using `svtv-print-alist-readable`,
every 4vec value which has some non-Boolean component (i.e. is not a
2vec) is (before this commit) displayed with a comment off to the
right giving a "non-Boolean mask", which is a bitvector showing which
bits are either X or Z, i.e. not a Boolean value 0 or 1.

This commit moves the non-Boolean mask to a separate line and aligns
it with the upper and lower components of the 4vec.  With the new
positioning, it's easier to visually compare the non-Boolean mask with
the 4vec's components, as well as with other nearby values of the same
bit width.

Also, this change makes it far less likely for the pretty-printed
svex-env-p value to run into word wrapping issues.  Formerly, due to
the spacing used, the non-Boolean mask would commonly (in my
experience) be wrapped to the next line if the 4vec was 32 bits or
wider and had a non-Boolean MSB.  Now it shouldn't need to wrap until
it's around 160 bits wide, assuming the default right margin of around
77 columns.

Before:

```lisp
  (FOO                   #ux1_FFFF         ;; non-Boolean mask: #ux1_-
FFFF
                       . #ux0)
```

After:

```lisp
  (FOO                   #ux1_FFFF
                       . #ux0)
;;;    non-Boolean mask: #ux1_FFFF
```