### PR TITLE
Removing unused variable in make_cert_help.pl and unused argument in …

### DIFF
--- a/books/build/make_cert
+++ b/books/build/make_cert
@@ -103,10 +103,19 @@ export MAKE_CERT_PL ?= $(ACL2_SYSTEM_BOOKS)/build/make_cert_help.pl
 # then be subject to shell expansion.  Putting it in single quotes should help
 # to defend against this, although it of course won't work for file names with
 # single quotes.
+# @$(MAKE_CERT_PL) '$*' \
+#                        $(if $(findstring 1,$(pcert)),"complete","certify") \
+#                        $(if $(findstring 1,$(pcert)),"no_acl2x",$(if $(findstring 1,$(acl2x)),"yes","no")) \
+#                        $^
+# Bug fix 2017-02-09: In the old version commented out above, the last argument
+# $^ never gets used in @$(MAKE_CERT_PL). It also causes bash to fail when the
+# number of dependencies gets huge and results in an error of "bash: argument
+# list too long". The new version removes $^ from the list of arguments to
+# @$(MAKE_CERT_PL).
+# Refer to https://github.com/acl2/acl2/issues/694 for more information.
 	@$(MAKE_CERT_PL) '$*' \
                          $(if $(findstring 1,$(pcert)),"complete","certify") \
-                         $(if $(findstring 1,$(pcert)),"no_acl2x",$(if $(findstring 1,$(acl2x)),"yes","no")) \
-                         $^
+                         $(if $(findstring 1,$(pcert)),"no_acl2x",$(if $(findstring 1,$(acl2x)),"yes","no"))
 
 %.pcert1 : %.lisp
 	@$(MAKE_CERT_PL) '$*' $(if $(findstring 1,$(pcert)),"convert","pcertifyplus") \

--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -464,7 +464,11 @@ sub parse_certify_flags
 my $TARGET = shift;
 my $STEP = shift;      # certify, acl2x, acl2xskip, pcertify, pcertifyplus, convert, or complete
 my $ACL2X = shift;     # "yes" or otherwise no. use ACL2X file in certify/pcertify/pcertifyplus/convert steps
-my $PREREQS = \@ARGV;
+# Bug fix 2017-02-09: Uses of this variable #PREREQS only exist in code
+# that is commented out. Therefore commenting this assignment out to
+# fix the "argument list too long" issue.
+# Refer to https://github.com/acl2/acl2/issues/694 for more information.
+# my $PREREQS = \@ARGV;
 
 # print "Prereqs for $TARGET $STEP: \n";
 # foreach my $prereq (@$PREREQS) {


### PR DESCRIPTION
Remove unused variable in make_cert_help.pl and unused argument in make_cert to solve the "bash: argument list too long" problem. This happens when running cert.pl on a book which has a huge number of dependencies. See Issue #694