### PR TITLE
Make `find-lemmas` much faster

### DIFF
--- a/books/misc/find-lemmas.lisp
+++ b/books/misc/find-lemmas.lisp
@@ -14,32 +14,31 @@
 
 (defun find-lemmas-fn (fns omit-boot-strap acc wrld-tail wrld)
   (declare (xargs :mode :program))
-  (let ((fns (deref-macro-name-list fns (macro-aliases wrld))))
-    (if (or (endp wrld-tail)
-            (and omit-boot-strap
-                 (and (eq (caar wrld-tail) 'command-landmark)
-                      (eq (cadar wrld-tail) 'global-value)
-                      (equal (access-command-tuple-form (cddar wrld-tail))
-                             '(exit-boot-strap-mode)))))
-        acc
-      (let* ((trip (car wrld-tail))
-             (ev-tuple (and (consp trip)
-                            (eq (car trip) 'event-landmark)
-                            (eq (cadr trip) 'global-value)
-                            (cddr trip)))
-             (type (and ev-tuple (access-event-tuple-type ev-tuple)))
-             (namex (and type (access-event-tuple-namex ev-tuple)))
-             (formula (and namex
-                           (symbolp namex)
-                           (member-eq type '(defthm defaxiom defchoose))
-                           (formula namex t wrld))))
-        (if (and formula
-                 (subsetp-eq fns (all-fnnames formula)))
-            (find-lemmas-fn fns omit-boot-strap
-                            (cons (access-event-tuple-form ev-tuple) acc)
-                            (cdr wrld-tail)
-                            wrld)
-          (find-lemmas-fn fns omit-boot-strap acc (cdr wrld-tail) wrld))))))
+  (if (or (endp wrld-tail)
+          (and omit-boot-strap
+               (and (eq (caar wrld-tail) 'command-landmark)
+                    (eq (cadar wrld-tail) 'global-value)
+                    (equal (access-command-tuple-form (cddar wrld-tail))
+                           '(exit-boot-strap-mode)))))
+      acc
+    (let* ((trip (car wrld-tail))
+           (ev-tuple (and (consp trip)
+                          (eq (car trip) 'event-landmark)
+                          (eq (cadr trip) 'global-value)
+                          (cddr trip)))
+           (type (and ev-tuple (access-event-tuple-type ev-tuple)))
+           (namex (and type (access-event-tuple-namex ev-tuple)))
+           (formula (and namex
+                         (symbolp namex)
+                         (member-eq type '(defthm defaxiom defchoose))
+                         (formula namex t wrld))))
+      (if (and formula
+               (subsetp-eq fns (all-fnnames formula)))
+          (find-lemmas-fn fns omit-boot-strap
+                          (cons (access-event-tuple-form ev-tuple) acc)
+                          (cdr wrld-tail)
+                          wrld)
+        (find-lemmas-fn fns omit-boot-strap acc (cdr wrld-tail) wrld)))))
 
 (defmacro find-lemmas (fns &optional (omit-boot-strap 't))
   (declare (xargs :guard (let ((fns (if (and (true-listp fns)
@@ -57,19 +56,20 @@
 
 ; If fns is a symbol, then fns is replaced by (list fns).
 
-  (let ((fns (if (and (true-listp fns)
-                      (eq (car fns) 'quote)
-                      (eql (length fns) 2))
-                 (cadr fns)
-               fns)))
-    (let ((fns (cond
-                ((symbolp fns) (list fns))
-                ((symbol-listp fns) fns)
-                (t (er hard 'find-lemmas
-                       "The first argument to find-lemmas must be a symbol or ~
-                        a list of symbols, but ~x0 is not."
-                       fns)))))
-      `(find-lemmas-fn ',fns ',omit-boot-strap nil (w state) (w state)))))
+  (let* ((fns (if (and (true-listp fns)
+                       (eq (car fns) 'quote)
+                       (eql (length fns) 2))
+                  (cadr fns)
+                fns))
+         (fns (cond
+               ((symbolp fns) (list fns))
+               ((symbol-listp fns) fns)
+               (t (er hard 'find-lemmas
+                      "The first argument to find-lemmas must be a symbol or ~
+                       a list of symbols, but ~x0 is not."
+                      fns))))
+         (fns `(deref-macro-name-list ',fns (macro-aliases (w state)))))
+    `(find-lemmas-fn ,fns ',omit-boot-strap nil (w state) (w state))))
 
 ; Documentation:
 


### PR DESCRIPTION
`find-lemmas-fn` was repeatedly calling `deref-macro-name` on the
function names supplied by the user, every time it inspected an event
recorded in the world.  When the world is very long, this can be very
time consuming because `deref-macro-name` uses tables, which as
pointed out in `:doc tables` are "not especially efficient".

This commit makes it so that `deref-macro-name-list` is only called
once per invocation of `find-lemmas`.  In one example, running
`find-lemmas` in a world containing more than 1.5 million triples used
to take more than 5 minutes, but now it completes in 0.15 seconds.