### PR TITLE
Remove obsolete comments (followup to #693)

### DIFF
--- a/books/nonstd/nsa/continuity.lisp
+++ b/books/nonstd/nsa/continuity.lisp
@@ -1,12 +1,5 @@
 (in-package "ACL2")
 
-; There is a problem with intermediate-value-theorem, which no longer proves
-; after the soundness bug fix for ACL2 7.3.  So we exclude this book from all
-; builds: it already requires ACL2(r), since it depends on nsa.lisp, which
-; specifies the cert_param of uses-acl2r, but now we also specify:
-
-; cert_param: (uses-acl2r)
-
 ;; This book establishes some facts about real continuous functions.
 ;; First, it shows that a function that is continuous on a closed
 ;; interval is uniformly continuous.  Second, it proves the
@@ -881,11 +874,8 @@
    :hints (("Goal"
 	    :use ((:instance rcfn-domain-non-trivial))))
    :rule-classes (:built-in-clause)))
-   
 
-; Matt K. note, 2/5/2017: This theorem took advantage of the soundness bug in
-; functionsl instantiation fixed after ACL2 7.3.  It now fails.  So I'm
-; excluding this book from the build until it's fixed.
+
 (defthm intermediate-value-theorem
    (implies (and (inside-interval-p a (rcfn-domain))
 		 (inside-interval-p b (rcfn-domain))
@@ -921,9 +911,7 @@
 			     (interval (rcfn-domain)))
 		  (:instance inside-trivial-interval
 			     (a y)
-			     (b x))
-		  ))
-	   ))
+                             (b x))))))
 
 ;; Now, what happens when f(a)>z and f(b)<z.  First, we find the root.
 
@@ -1856,4 +1844,3 @@
 			    (x (is-minimum-point-witness a b (find-min-rcfn-x a b)))))
 	   :in-theory (disable achieves-minimum-point-suff
 			       find-min-rcfn-is-minimum))))
-


### PR DESCRIPTION
The comments Matt added in 04a6f6d9084a647dccee1e508e108895bb8c0e6a are no longer meaningful, so this commit removes them.  An alternative would be to edit the comments so it's clear they are historical.  In any case, the `cert_param` declaration seems unnecessary.

(Please check -- I'm not too familiar with how ACL(r) books are certified.)