### PR TITLE
Remove notice about ACL2 v7.4

### DIFF
--- a/books/workshops/2017/README
+++ b/books/workshops/2017/README
@@ -1,12 +1,3 @@
-Note: This directory will likely be updated with more contributions
-after the ACL2 Version 7.4 release.  Updates are on github:
-
-https://github.com/acl2/acl2/tree/master/books/workshops/2017
-
-============================================================
-
-To authors:
-
 Supporting materials should go into directories named after
 authors of accepted papers.  Typically, they go into a support/
 subdirectory of each such directory; see past directories


### PR DESCRIPTION
This text needed to be included in the version of the README which was
included in the v7.4 release of ACL2, but now that that release has
passed, the text is no longer needed.

Adapted from b6b7b03d84da45a87a5cc058d3d329cf6e63f52a, one of
the commits in #704.