### PR TITLE
Shnf

### DIFF
--- a/books/projects/curve25519/reduce.lisp
+++ b/books/projects/curve25519/reduce.lisp
@@ -184,8 +184,8 @@
                 (eql (car h) 'pow))
            (not (zp (cadr h))))
   :hints (("Goal" :use ((:instance shfp (x h))
-                        (:instance normp (x h)))
-                  :in-theory (disable shfp normp))))
+                        (:instance shf-normp (x h)))
+                  :in-theory (disable shfp shf-normp))))
 
 (local-defthm split$-case-5-2
   (implies (and (shnfp h)
@@ -193,8 +193,8 @@
                 (eql (car h) 'pow))
            (natp (cadr h)))
   :hints (("Goal" :use ((:instance shfp (x h))
-                        (:instance normp (x h)))
-                  :in-theory (disable shfp normp)))
+                        (:instance shf-normp (x h)))
+                  :in-theory (disable shfp shf-normp)))
   :rule-classes (:type-prescription :rewrite))
 
 (local-defthm split$-case-5-3
@@ -207,8 +207,8 @@
                   (shnfp q))))
   :hints (("Goal" :use ((:instance shfp (x h))
                         (:instance shnfp (x h))
-                        (:instance normp (x h)))
-                  :in-theory (disable shfp normp))))
+                        (:instance shf-normp (x h)))
+                  :in-theory (disable shfp shf-normp))))
 
 (local-defthm nthcdr-cdr
   (equal (nthcdr i (cdr l))
@@ -1460,8 +1460,8 @@
                 (eql (car h) 'pop))
            (not (zp (cadr h))))
   :hints (("Goal" :use ((:instance shfp (x h))
-                        (:instance normp (x h)))
-                  :in-theory (disable shfp normp))))
+                        (:instance shf-normp (x h)))
+                  :in-theory (disable shfp shf-normp))))
 
 (local-defthm split$-case-2-2
   (implies (and (shnfp h)
@@ -1469,8 +1469,8 @@
                 (eql (car h) 'pop))
            (natp (cadr h)))
   :hints (("Goal" :use ((:instance shfp (x h))
-                        (:instance normp (x h)))
-                  :in-theory (disable shfp normp)))
+                        (:instance shf-normp (x h)))
+                  :in-theory (disable shfp shf-normp)))
   :rule-classes (:type-prescription :rewrite))
 
 (local-defthm split$-case-2-3
@@ -1481,8 +1481,8 @@
            (shnfp (caddr h)))
   :hints (("Goal" :use ((:instance shfp (x h))
                         (:instance shnfp (x h))
-                        (:instance normp (x h)))
-                  :in-theory (disable shfp normp))))
+                        (:instance shf-normp (x h)))
+                  :in-theory (disable shfp shf-normp))))
 
 (local-defthmd split$-case-2-4
   (implies (and (natp k)

--- a/books/projects/shnf/support.lisp
+++ b/books/projects/shnf/support.lisp
@@ -217,7 +217,7 @@
 ;;    (1) x = (POP i p) => p is a POW
 ;;    (2) x = (POW i p q) => p neither 0 nor (POW j r 0)
 
-(defun normp (x)
+(defun shf-normp (x)
   (declare (xargs :guard (shfp x)))
   (if (atom x)
       t
@@ -226,17 +226,17 @@
         (pop (and (not (= i 0))
                   (consp p)
                   (eql (car p) 'pow)
-                  (normp p)))
+                  (shf-normp p)))
         (pow (and (not (= i 0))
-                  (normp p)
-                  (normp q)
+                  (shf-normp p)
+                  (shf-normp q)
                   (if (atom p)
                       (not (= p 0))
                     (not (and (eql (car p) 'pow)
                               (equal (cadddr p) 0))))))))))
 
 (defn shnfp (x)
-  (and (shfp x) (normp x)))
+  (and (shfp x) (shf-normp x)))
 
 (defthm shnfp-shfp
   (implies (shnfp x)
@@ -299,7 +299,7 @@
                 (eql (car x) 'pow))
            (posp (cadr x)))
   :rule-classes :type-prescription
-  :expand (normp x)))
+  :expand (shf-normp x)))
 
 (defthm shnfp-pow-q
   (implies (and (shnfp x) (eql (car x) 'pow))
@@ -319,7 +319,7 @@
                 (eql (car x) 'pop))
            (posp (cadr x)))
   :rule-classes :type-prescription
-  :expand (normp x)))
+  :expand (shf-normp x)))
 
 (local (defruled shnfp-pop-p
   (implies (and (shnfp x) (eql (car x) 'pop))
@@ -399,7 +399,7 @@
                 (all-integers vals))
            (integerp (evalh x vals)))))
 
-;; [Dima] Two theories for reasoning about shnfp.
+;; [Dima] Thow theories for reasoning about shnfp.
 
 ;; Old theory enables definition and a few public theorems.
 (local (deftheory shnfp-old
@@ -462,7 +462,7 @@
 
 (defthm norm-pop-normp
   (implies (and (shnfp p) (natp i))
-           (normp (norm-pop i p)))
+           (shf-normp (norm-pop i p)))
   :hints (("Goal" :use norm-pop-shnfp)))
 
 (defthm norm-pop-shfp
@@ -508,7 +508,7 @@
 
 (defthm norm-pow-normp
   (implies (and (shnfp p) (shnfp q) (not (zp i)))
-           (normp (norm-pow i p q)))
+           (shf-normp (norm-pow i p q)))
   :hints (("Goal" :use norm-pow-shnfp)))
 
 (defthm norm-pow-shfp
@@ -640,10 +640,10 @@
       (pop (list 'pop (cadr y) (add-int x (caddr y)))))))
 
 (defthm normp-add-int
-  (implies (and (normp x)
-                (normp y)
+  (implies (and (shf-normp x)
+                (shf-normp y)
                 (atom x))
-           (normp (add-int x y)))
+           (shf-normp (add-int x y)))
   :hints (("Subgoal *1/5" :expand ((add-int x (caddr y))))))
 
 (defrule shnfp-add-int
@@ -737,7 +737,7 @@
 (defthm normp-norm-add
   (implies (and (shnfp x)
                 (shnfp y))
-           (normp (norm-add x y)))
+           (shf-normp (norm-add x y)))
   :hints (("Goal" :use shnfp-norm-add)))
 
 (defun norm-add-induct (x y vals)
@@ -788,7 +788,7 @@
                         (evalh (caddr x) vals))
                      (evalh (cadddr x) (cdr vals))))))
 
-(in-theory (disable normp norm-add evalh))
+(in-theory (disable shf-normp norm-add evalh))
 
 (local (defrule evalh-add-pop-pop
   (let ((i (cadr x)) (p (caddr x))
@@ -948,7 +948,7 @@
 ; new 0.38 36010
 ; dis 0.72 64087
 
-(in-theory (enable normp evalh))
+(in-theory (enable shf-normp evalh))
 
 ;; The remaining cases are handled by norm-neg, norm-mul, and norm-expt:
 
@@ -1028,7 +1028,7 @@
   (implies (and (shnfp x)
                 (shnfp y)
                 (atom x))
-           (normp (mul-int x y)))
+           (shf-normp (mul-int x y)))
   :hints (("Goal" :use shnfp-mul-int :in-theory (disable shnfp-mul-int))))
 
 (defrule evalh-mul-int
@@ -1249,7 +1249,7 @@
 ; old XXXX
 ; new 3.45   281321
 
-(in-theory (disable shnfp normp norm-mul evalh))
+(in-theory (disable shnfp shf-normp norm-mul evalh))
 
 (defrule evalh-norm-mul
   (implies (and (shnfp x)
@@ -1390,7 +1390,7 @@
                 (equal (cdr n1) (cdr n2)))
            (= (evalh z n1) (evalh z n2)))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp z) (normp z))
+  :hints (("Goal" :expand ((shnfp z) (shf-normp z))
                   :use ((:instance ew-4 (n n1))
                         (:instance ew-4 (n n2))))))
 
@@ -1408,7 +1408,7 @@
                    (evalh q (cdr n))))))
   :rule-classes ()
   :hints (("Goal" :use ((:instance ew-5 (z (caddr x)) (n1 n) (n2 (cons k (cdr n)))))
-                  :expand ((evalh x (cons k (cdr n))) (shnfp x) (shfp x) (normp x)))))
+                  :expand ((evalh x (cons k (cdr n))) (shnfp x) (shfp x) (shf-normp x)))))
 
 (local-defthm ew-7
   (implies (and (not (zp k))
@@ -1435,7 +1435,7 @@
 		    (abs (evalh q (cdr n)))))))
   :rule-classes ()
   :hints (("Goal" :use (ew-6) :in-theory (disable evalh evalh-pow-rewrite)
-                  :expand ((normp x) (normp (caddr x)) (shnfp x)))))
+                  :expand ((shf-normp x) (shf-normp (caddr x)) (shnfp x)))))
 
 (local (defrule ew-9
   (let* ((i (cadr x))
@@ -1453,7 +1453,7 @@
 	          (integerp (evalh q (cdr n)))
 	          (integerp (expt k i)))))
   :rule-classes ()
-  :expand ((normp x) (normp (caddr x)) (shnfp x))
+  :expand ((shf-normp x) (shf-normp (caddr x)) (shnfp x))
   :enable shnfp-old
   :disable (evalh evalh-pow-rewrite)))
 ; old 0.14 20084
@@ -1520,7 +1520,7 @@
              (and (not (zp i))
                   (shnfp p)
                   (shnfp q))))
-  :hints (("Goal" :expand ((normp x) (shfp x) (shnfp x)))))
+  :hints (("Goal" :expand ((shf-normp x) (shfp x) (shnfp x)))))
 
 (local (defruled ew-15
   (let ((p (caddr x))
@@ -1803,7 +1803,7 @@
   (implies (and (shnfp x) (eq (car x) 'pow))
            (not (= (caddr x) 0)))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp x) (shfp x) (normp x)))))
+  :hints (("Goal" :expand ((shnfp x) (shfp x) (shf-normp x)))))
 
 (local-defthm ew-34
   (implies (and (shnfp x) (eq (car x) 'pop))
@@ -1811,7 +1811,7 @@
 	        (shnfp (caddr x))
 		(eq (caaddr x) 'pow)))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp x) (shfp x) (normp x)))))
+  :hints (("Goal" :expand ((shnfp x) (shfp x) (shf-normp x)))))
 
 (local-in-theory (disable evalh-int shnfp-pow-p shnfp-pow-q shnfp-norm-add shnfp-norm-mul shfp-pop-pow-atom evalh-norm-add evalh-norm-mul evalh-pow-rewrite ew-11 ew-19))
 
@@ -1955,7 +1955,7 @@
 		           (equal q (norm-neg (list 'pop (- i j) p)))))
 	     (not (> i j))))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp y) (normp y))
+  :hints (("Goal" :expand ((shnfp y) (shf-normp y))
                   :use (na0-4 na0-8))))
 
 (local-defthm na0-10
@@ -2004,7 +2004,7 @@
 		           (equal p (norm-neg (list 'pop (- j i) q)))))
 	     (not (< i j))))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp x) (normp x))
+  :hints (("Goal" :expand ((shnfp x) (shf-normp x))
                   :use (na0-4 na0-11))))
 
 (local-defthmd na0-13
@@ -2023,7 +2023,7 @@
 		  (implies (and (< i j) (equal (norm-add (list 'pop (- j i) q) p) 0))
 		           (equal p (norm-neg (list 'pop (- j i) q)))))
 	     (equal (norm-neg x) y)))
-  :hints (("Goal" :expand ((shnfp x) (normp x))
+  :hints (("Goal" :expand ((shnfp x) (shf-normp x))
                   :use (na0-6 na0-9 na0-12))))
 
 (local-defthmd na0-14
@@ -2040,9 +2040,9 @@
 		  (implies (> i j) (shnfp (list 'pop (- i j) p)))
 		  (implies (< i j) (shnfp (list 'pop (- j i) q))))))
   :hints (("Goal" :use (na0-4)
-                  :expand ((:free (x) (shnfp x)) (normp x) (normp y)
+                  :expand ((:free (x) (shnfp x)) (shf-normp x) (shf-normp y)
                            (:free (i p) (shnfp (list 'pop i p)))
-                           (:free (i p) (normp (list 'pop i p)))))))
+                           (:free (i p) (shf-normp (list 'pop i p)))))))
 
 (local-defthmd na0-15
   (let ((i (cadr x))
@@ -2171,7 +2171,7 @@
 		           (equal r (norm-neg (list 'pow (- i j) p 0)))))
 	     (not (> i j))))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp y) (normp y))
+  :hints (("Goal" :expand ((shnfp y) (shf-normp y))
                   :use (na0-16 na0-20))))
 
 (local-defthm na0-22
@@ -2226,7 +2226,7 @@
 		           (equal p (norm-neg (list 'pow (- j i) r 0)))))
 	     (not (< i j))))
   :rule-classes ()
-  :hints (("Goal" :expand ((shnfp x) (normp x))
+  :hints (("Goal" :expand ((shnfp x) (shf-normp x))
                   :use (na0-16 na0-23))))
 
 (local (defrule na0-25
@@ -2250,7 +2250,7 @@
 		           (equal p (norm-neg (list 'pow (- j i) r 0)))))
 	     (equal (norm-neg x) y)))
   :rule-classes ()
-;  :expand ((shnfp x) (normp x))
+;  :expand ((shnfp x) (shf-normp x))
   :use (na0-18 na0-21 na0-24)
   :enable shnfp-new))
 ; old-expand  6.34 1240744
@@ -2276,9 +2276,9 @@
 		  (implies (> i j) (shnfp (list 'pow (- i j) p 0)))
 		  (implies (< i j) (shnfp (list 'pow (- j i) r 0))))))
   :hints (("Goal" :use (na0-16)
-                  :expand ((:free (x) (shnfp x)) (normp x) (normp y)
+                  :expand ((:free (x) (shnfp x)) (shf-normp x) (shf-normp y)
                            (:free (i p q) (shnfp (list 'pow i p q)))
-                           (:free (i p q) (normp (list 'pow i p q)))))))
+                           (:free (i p q) (shf-normp (list 'pow i p q)))))))
 
 (local-defthmd na0-27
   (let ((i (cadr x))
@@ -2397,8 +2397,8 @@
            (equal (evalh x n)
                   (evalh x n0)))
   :hints (("Goal" :induct (induct-evalh-2 x n n0))
-          ("Subgoal *1/3" :expand ((evalh x n) (evalh x n0) (shnfp x) (shfp x) (normp x)))
-          ("Subgoal *1/2" :expand ((evalh x n) (evalh x n0) (shnfp x) (shfp x) (normp x)))))
+          ("Subgoal *1/3" :expand ((evalh x n) (evalh x n0) (shnfp x) (shfp x) (shf-normp x)))
+          ("Subgoal *1/2" :expand ((evalh x n) (evalh x n0) (shnfp x) (shfp x) (shf-normp x)))))
 
 (defun list0 (k)
   (if (zp k)

--- a/books/projects/shnf/support.lisp
+++ b/books/projects/shnf/support.lisp
@@ -106,6 +106,46 @@
       (pow (+ 2 (shf-count (caddr x)) (shf-count (cadddr x))))
       (t 0))))
 
+(local (defrule shf-count-atom
+  (implies (atom x)
+           (equal (shf-count x) 1))))
+
+(local (defrule shf-count-pop
+  (equal (shf-count (list 'pop i p))
+         (+ 2 (shf-count p)))))
+
+(local (defrule shf-count-pow
+  (equal (shf-count (list 'pow i p q))
+         (+ 2 (shf-count p) (shf-count q)))))
+
+(local (defrule shf-count-pop-p
+  (implies (eql (car x) 'pop)
+           (equal (shf-count (caddr x))
+                  (- (shf-count x) 2)))))
+
+(local (defrule shf-count-pow-p
+  (implies (eql (car x) 'pow)
+           (equal (shf-count (caddr x))
+                  (- (shf-count x) (+ 2 (shf-count (cadddr x))))))))
+
+(local (defrule shf-count-shfp
+  (implies (shfp x)
+           (>= (shf-count x) 1))
+  :rule-classes :linear))
+
+(local (defrule shf-cound-pow-q
+  (implies (eql (car x) 'pow)
+           (<= (shf-count (cadddr x)) (- (shf-count x) 2)))
+  :rule-classes :linear))
+
+(local (defrule shf-cound-pow-q-shfp
+  (implies (and (shfp x)
+                (eql (car x) 'pow))
+           (<= (shf-count (cadddr x)) (- (shf-count x) 3)))
+  :rule-classes :linear))
+
+(local (in-theory (disable shf-count)))
+
 ;; A SHF represents a polynomial term relative to an ordering of variables.
 ;; We shall define a procedure that derives a SHF x from a term z and show
 ;; that the value of z may be computed by the function evalh as defined
@@ -425,8 +465,7 @@
         (norm-pow i (norm-add (list 'pow (- j i) r 0) p) (norm-add s q))))))
 
 (defun norm-add (x y)
-  (declare (xargs :measure (+ (shf-count x) (shf-count y))
-                  :hints(("Goal" :in-theory (enable jared-disables)))))
+  (declare (xargs :measure (+ (shf-count x) (shf-count y))))
   (and (shfp x)
        (if (atom x)
            (add-int x y)
@@ -459,8 +498,7 @@
   :hints (("Goal" :use shnfp-norm-add)))
 
 (defun norm-add-induct (x y vals)
-  (declare (xargs :measure (+ (shf-count x) (shf-count y))
-                  :hints(("Goal" :in-theory (enable jared-disables)))))
+  (declare (xargs :measure (+ (shf-count x) (shf-count y))))
   (if (or (not (shnfp x))
           (not (shnfp y))
           (atom x)
@@ -1096,8 +1134,7 @@
 (in-theory (enable norm-pop norm-pow))
 
 (defun norm-mul (x y)
-  (declare (xargs :measure (+ (shf-count x) (shf-count y))
-                  :hints(("Goal" :in-theory (enable jared-disables)))))
+  (declare (xargs :measure (+ (shf-count x) (shf-count y))))
   (and (shfp x)
        (if (atom x)
            (mul-int x y)
@@ -1129,8 +1166,7 @@
 (in-theory (enable norm-pop norm-pow))
 
 (defun norm-mul-induct (x y vals)
-  (declare (xargs :measure (+ (shf-count x) (shf-count y))
-                  :hints(("Goal" :in-theory (enable jared-disables)))))
+  (declare (xargs :measure (+ (shf-count x) (shf-count y))))
   (if (or (not (shnfp x))
           (not (shnfp y))
           (atom x)

--- a/books/projects/shnf/support.lisp
+++ b/books/projects/shnf/support.lisp
@@ -59,11 +59,11 @@
       (let ((y (cadr x)) (z (caddr x)))
         (case (car x)
           (+ (+ (evalp y alist) (evalp z alist)))
-          (- (if (cddr x) (- (evalp y alist) (evalp z alist)) (- (evalp y alist)))) 
+          (- (if (cddr x) (- (evalp y alist) (evalp z alist)) (- (evalp y alist))))
           (* (* (evalp y alist) (evalp z alist)))
           (expt (expt (evalp y alist) (evalp z alist))))))))
 
-;; As a matter of curiosity, it will be interesting to count the monomials 
+;; As a matter of curiosity, it will be interesting to count the monomials
 ;; that would result from the expansion of a term:
 
 (defun mono-count (x)
@@ -103,9 +103,9 @@
       (t 0))))
 
 ;; A SHF represents a polynomial term relative to an ordering of variables.
-;; We shall define a procedure that derives a SHF x from a term z and show 
+;; We shall define a procedure that derives a SHF x from a term z and show
 ;; that the value of z may be computed by the function evalh as defined
-;; below.  That is, if vars is the ordered list of variables and vals is a 
+;; below.  That is, if vars is the ordered list of variables and vals is a
 ;; list of corresponding values, then
 
 ;;      (evalh x vals) = (evalp z (pairlis vars vals)).
@@ -648,9 +648,9 @@
                   (eql (car x) 'pow)
                   (eql (car y) 'pow))
              (and (shnfp p)
-                  (shnfp q) 
-                  (shnfp r) 
-                  (shnfp s) 
+                  (shnfp q)
+                  (shnfp r)
+                  (shnfp s)
                   (integerp (car0 vals))
                   (integerp (evalh p vals))
                   (integerp (evalh q (cdr vals)))
@@ -787,9 +787,9 @@
                   (eql (car y) 'pow)
                   (> i j))
              (and (shnfp (list 'pow (- i j) p 0))
-                  (shnfp q) 
-                  (shnfp r) 
-                  (shnfp s) 
+                  (shnfp q)
+                  (shnfp r)
+                  (shnfp s)
                   (integerp (car0 vals))
                   (integerp (evalh (list 'pow (- i j) p 0) vals))
                   (integerp (evalh q (cdr vals)))
@@ -863,8 +863,8 @@
                        (evalh s (cdr vals))))))
   :rule-classes ()
   :hints (("Goal" :do-not '(eliminate-destructors generalize)
-                  :in-theory (disable ACL2::|(equal x (if a b c))| ACL2::|(+ x (if a b c))| ACL2::|(equal (if a b c) x)| 
-                                      ACL2::|(+ (if a b c) x)| ACL2::|(* (if a b c) x)| car0 evalh-pow-rewrite evalh norm-add 
+                  :in-theory (disable ACL2::|(equal x (if a b c))| ACL2::|(+ x (if a b c))| ACL2::|(equal (if a b c) x)|
+                                      ACL2::|(+ (if a b c) x)| ACL2::|(* (if a b c) x)| car0 evalh-pow-rewrite evalh norm-add
                                       ACL2::|(* x (if a b c))|)
                   :use ((:instance hack-1 (i (expt (car0 vals) (cadr y)))
                                           (p (evalh (list 'pow (- (cadr x) (cadr y)) (caddr x) 0) vals))
@@ -874,7 +874,7 @@
                                           (pr (evalh (norm-add (list 'pow (- (cadr x) (cadr y)) (caddr x) 0) (caddr y)) vals))
                                           (qs (evalh (norm-add (cadddr x) (cadddr y)) (cdr vals))))))))
 
-(local-defthm evalh-add-pow-pow-15 
+(local-defthm evalh-add-pow-pow-15
   (let ((i (cadr y)) (p (caddr y)) (q (cadddr y))
         (j (cadr x)) (r (caddr x)) (s (cadddr x)))
     (implies (and (shnfp x)
@@ -924,9 +924,9 @@
                   (eql (car y) 'pow)
                   (> i j))
              (and (shnfp (list 'pow (- i j) p 0))
-                  (shnfp q) 
-                  (shnfp r) 
-                  (shnfp s) 
+                  (shnfp q)
+                  (shnfp r)
+                  (shnfp s)
                   (integerp (car0 vals))
                   (integerp (evalh (list 'pow (- i j) p 0) vals))
                   (integerp (evalh q (cdr vals)))
@@ -1319,7 +1319,7 @@
       (let ((y (cadr x)) (z (caddr x)))
         (case (car x)
           (+ (norm-add (norm y vars) (norm z vars)))
-          (- (if (cddr x) (norm-add (norm y vars) (norm-neg (norm z vars))) (norm-neg (norm y vars)))) 
+          (- (if (cddr x) (norm-add (norm y vars) (norm-neg (norm z vars))) (norm-neg (norm y vars))))
           (* (norm-mul (norm y vars) (norm z vars)))
           (expt (norm-expt (norm y vars) (norm z vars))))))))
 
@@ -1435,7 +1435,7 @@
 		(integerp p)
 		(not (= p 0)))
            (>= (abs (* (expt k i) p)) k))
-  :rule-classes ()  
+  :rule-classes ()
   :hints (("Goal" :nonlinearp t)))
 
 (local-defthm ew-8
@@ -1489,7 +1489,7 @@
                  (- k (abs (evalh q (cdr n)))))))
   :rule-classes ()
   :hints (("Goal" :in-theory (disable evalh evalh-pow-rewrite)
-                  :use (ew-8 ew-9 
+                  :use (ew-8 ew-9
                         (:instance ew-7 (i (cadr x)) (p (evalh (caddr x) n)))))))
 
 (local-defthm ew-11
@@ -1608,7 +1608,7 @@
   		  (all-integers n))
       (equal (evalh yp (cdr n))
              (+ (* (evalh q (cdr n)) (evalh q (cdr n)))
-                (* (evalh y (cdr n)) (evalh y (cdr n)))))))              
+                (* (evalh y (cdr n)) (evalh y (cdr n)))))))
   :hints (("Goal" :use (ew-14)
            :in-theory (disable shnfp-pow-p shnfp-pow-q))))
 
@@ -1654,7 +1654,7 @@
                   (all-integers n))
       (equal (abs (evalh yp (cdr n)))
              (+ (* (evalh q (cdr n)) (evalh q (cdr n)))
-                (* (evalh y (cdr n)) (evalh y (cdr n)))))))              
+                (* (evalh y (cdr n)) (evalh y (cdr n)))))))
   :hints (("Goal" :use (ew-20 ew-22))))
 
 (local-defthmd ew-24
@@ -1842,7 +1842,7 @@
 
 (local-defthm na0-1
   (implies (equal (norm-pop i p) 0)
-           (equal p 0))	   
+           (equal p 0))
   :rule-classes ()
   :hints (("Goal" :expand ((norm-pop i p)))))
 
@@ -2313,13 +2313,13 @@
                 (shnfp y)
 		(equal (norm-add x y) 0))
            (equal (norm-neg x) y))
-  :rule-classes ()  
+  :rule-classes ()
   :hints (("Goal" :induct (norm-add x y) :expand ((shnfp x) (shfp x) (shnfp y) (shfp y) (norm-add x y)))
           ("Subgoal *1/13" :use (na0-27))
           ("Subgoal *1/12" :use (na0-27))
           ("Subgoal *1/11" :use (na0-27))
           ("Subgoal *1/10" :use (na0-16))
-          ("Subgoal *1/9" :use (na0-16))	  
+          ("Subgoal *1/9" :use (na0-16))
           ("Subgoal *1/5" :use (na0-15))
           ("Subgoal *1/4" :use (na0-15))
           ("Subgoal *1/3" :use (na0-15))
@@ -2373,7 +2373,7 @@
 
 (local-defthm induct-evalh-2-non-nil
   (induct-evalh-2 x n n0))
-  
+
 (local-defthm evalh-append0p
   (implies (and (shnfp x) (append0p n n0))
            (equal (evalh x n)
@@ -2431,7 +2431,7 @@
                   (polyp x vars)
   		  (polyp y vars)
 		  (equal (evalp x a) (evalp y a)))
-	     (equal (norm x vars) 
+	     (equal (norm x vars)
 	            (norm y vars))))
   :rule-classes ()
   :hints (("Goal" :expand ((evalp-witness x y vars)) :in-theory (enable evalh-append-0)

--- a/books/projects/shnf/top.lisp
+++ b/books/projects/shnf/top.lisp
@@ -42,7 +42,7 @@
       (let ((y (cadr x)) (z (caddr x)))
         (case (car x)
           (+ (+ (evalp y alist) (evalp z alist)))
-          (- (if (cddr x) (- (evalp y alist) (evalp z alist)) (- (evalp y alist)))) 
+          (- (if (cddr x) (- (evalp y alist) (evalp z alist)) (- (evalp y alist))))
           (* (* (evalp y alist) (evalp z alist)))
           (expt (expt (evalp y alist) (evalp z alist))))))))
 
@@ -67,7 +67,7 @@
            (integerp (evalp x (pairlis$ vars vals))))
   :rule-classes ())
 
-;; As a matter of curiosity, it will be interesting to count the monomials 
+;; As a matter of curiosity, it will be interesting to count the monomials
 ;; that would result from the expansion of a term:
 
 (defun mono-count (x)
@@ -107,9 +107,9 @@
       (t 0))))
 
 ;; A SHF represents a polynomial term relative to an ordering of variables.
-;; We shall define a procedure that derives a SHF x from a term z and show 
+;; We shall define a procedure that derives a SHF x from a term z and show
 ;; that the value of z may be computed by the function evalh as defined
-;; below.  That is, if vars is the ordered list of variables and vals is a 
+;; below.  That is, if vars is the ordered list of variables and vals is a
 ;; list of corresponding values, then
 
 ;;      (evalh x vals) = (evalp z (pairlis vars vals)).
@@ -478,7 +478,7 @@
       (let ((y (cadr x)) (z (caddr x)))
         (case (car x)
           (+ (norm-add (norm y vars) (norm z vars)))
-          (- (if (cddr x) (norm-add (norm y vars) (norm-neg (norm z vars))) (norm-neg (norm y vars)))) 
+          (- (if (cddr x) (norm-add (norm y vars) (norm-neg (norm z vars))) (norm-neg (norm y vars))))
           (* (norm-mul (norm y vars) (norm z vars)))
           (expt (norm-expt (norm y vars) (norm z vars))))))))
 
@@ -500,7 +500,7 @@
 ;;                                   Completeness
 ;;*********************************************************************************
 
-;; We shall show that if two polynomials have the same values for all variable 
+;; We shall show that if two polynomials have the same values for all variable
 ;; assignments, then they produce the same SHNF.
 
 (defun pad0 (i n)
@@ -562,6 +562,6 @@
                   (polyp x vars)
   		  (polyp y vars)
 		  (equal (evalp x a) (evalp y a)))
-	     (equal (norm x vars) 
+	     (equal (norm x vars)
 	            (norm y vars))))
   :rule-classes ())

--- a/books/projects/shnf/top.lisp
+++ b/books/projects/shnf/top.lisp
@@ -149,7 +149,7 @@
 ;;    (1) x = (POP i p) => p is a POW
 ;;    (2) x = (POW i p q) => p neither 0 nor (POW j r 0)
 
-(defund normp (x)
+(defund shf-normp (x)
   (declare (xargs :guard (shfp x)))
   (if (atom x)
       t
@@ -158,17 +158,17 @@
         (pop (and (not (= i 0))
                   (consp p)
                   (eql (car p) 'pow)
-                  (normp p)))
+                  (shf-normp p)))
         (pow (and (not (= i 0))
-                  (normp p)
-                  (normp q)
+                  (shf-normp p)
+                  (shf-normp q)
                   (if (atom p)
                       (not (= p 0))
                     (not (and (eql (car p) 'pow)
                               (equal (cadddr p) 0))))))))))
 
 (defnd shnfp (x)
-  (and (shfp x) (normp x)))
+  (and (shfp x) (shf-normp x)))
 
 (defthm shnfp-shfp
   (implies (shnfp x)
@@ -216,7 +216,7 @@
 
 (defthm norm-pop-normp
   (implies (and (shnfp p) (natp i))
-           (normp (norm-pop i p))))
+           (shf-normp (norm-pop i p))))
 
 (defthm norm-pop-shfp
   (implies (and (shnfp p) (natp i))
@@ -245,7 +245,7 @@
 
 (defthm norm-pow-normp
   (implies (and (shnfp p) (shnfp q) (not (zp i)))
-           (normp (norm-pow i p q))))
+           (shf-normp (norm-pow i p q))))
 
 (defthm norm-pow-shfp
   (implies (and (shnfp p) (shnfp q) (not (zp i)))
@@ -299,10 +299,10 @@
       (pop (list 'pop (cadr y) (add-int x (caddr y)))))))
 
 (defthm normp-add-int
-  (implies (and (normp x)
-                (normp y)
+  (implies (and (shf-normp x)
+                (shf-normp y)
                 (atom x))
-           (normp (add-int x y))))
+           (shf-normp (add-int x y))))
 
 (defthm shnfp-add-int
   (implies (and (shnfp x)
@@ -373,7 +373,7 @@
 (defthm normp-norm-add
   (implies (and (shnfp x)
                 (shnfp y))
-           (normp (norm-add x y))))
+           (shf-normp (norm-add x y))))
 
 (defthm evalh-norm-add
   (implies (and (shnfp x)


### PR DESCRIPTION
Add guards to some functions in projects/shnf .
Also rename `rtl::count` from `projects/shnf.lisp` to `rtl::shf-count` because it conflicted with
rtl/rel11/lib/reps.list .
Tried to make proofs faster.