### PR TITLE
Don't ls cert after announcing successful build

### DIFF
--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -867,5 +867,5 @@ if ($success) {
 print "-- Final result appears to be success.\n" if $DEBUG;
 
 # Else, we made it!
-system("ls -l '$goal'");
+system("ls -l '$goal'") if $DEBUG;
 exit(0);


### PR DESCRIPTION
Currently, the cert.pl-based certification process mentions each
certificate in three separate messages -- once when it starts
building, and twice when it finishes building.

Example:

    Making /acl2/books/centaur/sv/svtv/decomp.cert on 04-Apr-2017 10:55:48
    Built /acl2/books/centaur/sv/svtv/decomp.cert (28.753s)
    -rw-rw-r-- 1 kini kini 334873 Apr  4 10:56 decomp.cert

Of the two messages seen when the certificate has finished building,
the first one has plenty of useful information, such as the full path
of the certificate and the amount of time taken to build it, as well
as a nice ANSI color when printed in the terminal.

The final message is just output from `ls -l`.  It only contains the
relative path of the certificate, and some various filesystem metadata
which I imagine is not really relevant to anyone.

I would argue that this final message just adds noise to the terminal
output during the certification process.  Therefore this commit makes
the call to `ls` only happen when $DEBUG is set, thereby removing the
third message from the certification output under normal
circumstances.