### PR TITLE
Added the skeleton for :doc note-7-5-books

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -51,7 +51,50 @@
 ;    considered a bug until we are very close to a release.
 
 ; Starting with Version 7.3, we no longer maintain release notes
-; note-x-x-books.  This could change if someone wants to volunteer.
+; note-x-x-books.  Instead, we hope that the ACL2 Community will track
+; changes to the books by maintaining note-x-x-books as they go.
+
+(defxdoc note-7-5-books
+
+; Shilpi Goel: As discussed in the ACL2 2017 Workshop, I am adding
+; this doc topic in the hopes that the members of the ACL2 community
+; will track changes to their books as they go by logging them here.
+; The idea is that the information in this topic can be somewhat more
+; high-level than is normally provided in commit messages.
+
+; Please add information about your library in the appropriate
+; category below --- the category title is enclosed in <h3>..</h3>
+; tags (of course, feel free to add a new category if needed).  To
+; ensure consistency with the style of previous book release doc
+; topics, please follow the following convention:
+
+;  <h4>Your Library Title</h4>
+;  <p>Details go here.</p>
+
+; I will change :doc note-7-5 in books/system/acl2-doc to point to
+; this topic, when (if?) this topic gets fleshed out (see :doc
+; note-7-2 for precedent).
+
+  :parents (note-7-5)
+  :short "Release notes for the ACL2 Community Books for ACL2 7.5"
+
+  :long "<p>The following is a brief summary of changes made to the @(see
+ community-books) between the releases of ACL2 7.4 and 7.5.</p>
+
+ <p>See also @(see note-7-5) for the changes made to ACL2 itself.  For
+ additional details, you may also see the raw <a
+ href='https://github.com/acl2/acl2/commits/master'>commit log</a>.</p>
+
+ <h3>New Libraries</h3>
+
+ <h3>Changes to Existing Libraries</h3>
+
+ <h3>Licensing Changes</h3>
+
+ <h3>Build System Updates</h3>
+
+ <h3>Miscellaneous</h3>
+ ")
 
 (defxdoc note-7-2-books
 


### PR DESCRIPTION
As discussed in the ACL2 2017 Workshop, I've added the skeleton for :doc note-7-5-books in books/doc/relnotes.lisp.

I also edited topics github-commit-code-using-push and github-commit-code-using-pull-requests to urge people to add high-level information about their changes to the appropriate note-x-x-books topic.
