### PR TITLE
Remove natp-listp from ordinals/lexicographic-book

### DIFF
--- a/books/coi/defung/defung.lisp
+++ b/books/coi/defung/defung.lisp
@@ -385,7 +385,6 @@
 	    acl2::d<  ;; ??
 	    l<
 	    acl2::lexp
-	    acl2::natp-listp
 	    nfix
 	    not
 	    fix

--- a/books/ordinals/lexicographic-book.lisp
+++ b/books/ordinals/lexicographic-book.lisp
@@ -11,21 +11,13 @@
 ; 2008-07-20, Peter Dillinger:  Added guards and a couple tweaks to make
 ; common lisp compliant.
 
-; A recognizer for a list of natural numbers.
-
-(defun natp-listp (x)
-  (declare (xargs :guard t))
-  (cond ((atom x) (null x))
-        (t (and (natp (car x))
-                (natp-listp (cdr x))))))
-
 ; A recognizer for natural number or a list of natural numbers.
 
 (defun lexp (x)
   (declare (xargs :guard t))
   (or (natp x)
       (and (consp x)
-           (natp-listp x))))
+           (nat-listp x))))
 
 
 ; d< is intended to be applied to lists of natural numbers of
@@ -33,8 +25,8 @@
 ; than y.
 
 (defun d< (x y)
-  (declare (xargs :guard (and (natp-listp x)
-                              (natp-listp y))))
+  (declare (xargs :guard (and (nat-listp x)
+                              (nat-listp y))))
   (and (consp x)
        (consp y)
        (or (< (car x) (car y))
@@ -58,7 +50,7 @@
 ; How to turn a list of naturals into an ordinal.
 
 (defun lsttoo (x)
-  (declare (xargs :guard (natp-listp x)))
+  (declare (xargs :guard (nat-listp x)))
   (if (endp x)
       0
     (o+ (o* (o^ (omega) (len x)) (1+ (car x)))
@@ -86,7 +78,7 @@ Some examples
 
 
 (defthm o-p-lsttoo
-  (implies (natp-listp x)
+  (implies (nat-listp x)
            (o-p (lsttoo x))))
 
 
@@ -96,13 +88,13 @@ Some examples
           (atom x))))
 
 (defthm ltoo-0
-  (implies (natp-listp y)
+  (implies (nat-listp y)
            (equal (equal (lsttoo y) 0)
                   (equal y nil))))
 
 (defthm o-first-expt-ltoo
   (implies (and (consp x)
-                (natp-listp x))
+                (nat-listp x))
            (equal (o-first-expt (lsttoo x))
                   (len x))))
 
@@ -111,9 +103,9 @@ Some examples
 
 (defthm well-founded-l<-case-1
   (implies (and (consp x)
-                (natp-listp x)
+                (nat-listp x)
                 (consp y)
-                (natp-listp y)
+                (nat-listp y)
                 (< (len x) (len y)))
            (o< (lsttoo x) (lsttoo y))))
 |#
@@ -125,7 +117,7 @@ Some examples
     (implies (and (consp x)
                   (natp (car x))
                   (equal (o-first-coeff (lsttoo (cdr x))) (1+ (cadr x)))
-                  (natp-listp (cdr x)))
+                  (nat-listp (cdr x)))
              (equal (o-first-coeff (o+ (o* (o^ (omega) (1+ (len (cdr x))))
                                            (1+ (car x)))
                                        (lsttoo (cdr x))))
@@ -135,7 +127,7 @@ Some examples
 
  (defthm o-first-coeff-ltoo
    (implies (and (consp x)
-                 (natp-listp x))
+                 (nat-listp x))
             (equal (o-first-coeff (lsttoo x))
                    (1+ (car x))))))
 
@@ -148,8 +140,8 @@ Some examples
     (implies (and (consp y)
                   (not (d< (cdr x) (cdr y)))
                   (consp x)
-                  (natp-listp x)
-                  (natp-listp y)
+                  (nat-listp x)
+                  (nat-listp y)
                   (equal (len x) (len y))
                   (d< x y))
              (o< (lsttoo x) (lsttoo y)))
@@ -163,8 +155,8 @@ Some examples
     (implies (and (consp y)
                   (not (d< (cdr x) (cdr y)))
                   (consp x)
-                  (natp-listp x)
-                  (natp-listp y)
+                  (nat-listp x)
+                  (nat-listp y)
                   (equal (len x) (len y))
                   (d< x y))
              (o< (lsttoo x) (lsttoo y)))
@@ -173,9 +165,9 @@ Some examples
 
  (defthm well-founded-l<-case-2
    (implies (and (consp x)
-                 (natp-listp x)
+                 (nat-listp x)
                  (consp y)
-                 (natp-listp y)
+                 (nat-listp y)
                  (equal (len x) (len y))
                  (d< x y))
             (o< (lsttoo x) (lsttoo y))))

--- a/books/ordinals/lexicographic-book.lisp
+++ b/books/ordinals/lexicographic-book.lisp
@@ -90,9 +90,10 @@ Some examples
            (o-p (lsttoo x))))
 
 
-(defthm len-0
-  (equal (equal (len x) 0)
-         (atom x)))
+(local
+ (defthm len-0
+   (equal (equal (len x) 0)
+          (atom x))))
 
 (defthm ltoo-0
   (implies (natp-listp y)


### PR DESCRIPTION
There's a perfectly good nat-listp function built into ACL2 which could be used instead.  I also made one of the theorems local, since it's not a theorem about symbols introduced in the book and seems irrelevant to the purpose of the book (other than that it's used in the proofs of the main theorems in the book).