### PR TITLE
Fix XDOC errors

### DIFF
--- a/books/std/io/open-channels.lisp
+++ b/books/std/io/open-channels.lisp
@@ -103,7 +103,7 @@
 ;;;; Open input channels stay open
 ;;;;;;;;;;;;;;;;
 
-  "<p>First are lemmas about @(tsee open-input-channel-p1).</p>"
+  "<p>First are lemmas about @({open-input-channel-p1}).</p>"
 
   (defthm open-input-channel-p1-under-open-input-channel
     ;; Desired version:
@@ -182,7 +182,7 @@
 ;;;; Open output channels stay open
 ;;;;;;;;;;;;;;;;
 
-  "<p>Next are lemmas about @(tsee open-output-channel-p1).</p>"
+  "<p>Next are lemmas about @({open-output-channel-p1}).</p>"
 
   (defthm open-output-channel-p1-under-open-input-channel
     (implies (open-output-channel-p1 channel type state)


### PR DESCRIPTION
`open-input-channel-p1` and `open-output-channel-p1` have no doc
topics about them, so I changed the @(tsee)s to @({})s.

This should fix a build failure caused by #742.