### PR TITLE
Generalize `why` and `why-explain`

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -143,6 +143,12 @@
  that opened input and output channels remain open until closed, to
  aid guard theorem proofs.  See @(see open-channel-lemmas).</p>
 
+ <h4>Miscellaneous @(see std) changes</h4>
+
+ <p>The @('why') and @('why-explain') convenience macros in
+ @('std/std-customization.lsp') now support rule classes other than
+ @(':rewrite').</p>
+
  <h4>@(see kestrel-utilities)</h4>
 
  <p>Improved an error message for @('verify-guards-program') (thanks to Eric

--- a/books/interface/infix/infix.lisp
+++ b/books/interface/infix/infix.lisp
@@ -2033,7 +2033,7 @@ call princ and write-char on just one argument, the thing to be printed.
                                (let ((*rightmost-char-number* (- *rightmost-char-number* 6)))
                                  (infix-print-term1 (cadr (car tail))))
 			       ;; TESTING.  Inserted (math-space 1) and deleted the following
-			       ;; Swithced back, using to-current-margin.
+			       ;; Switched back, using to-current-margin.
 			       (if some-line-broken
 				   (to-current-margin)
 				   (math-space 1))

--- a/books/std/std-customization.lsp
+++ b/books/std/std-customization.lsp
@@ -79,7 +79,7 @@
       ;; syntax.
       `(er-progn
         (brr t)
-        (monitor '(:rewrite ,rule) ''(:eval :go t))))
+        (monitor ',rule ''(:eval :go t))))
 
     (defun explain-fn (state)
       (declare (xargs :stobjs (state)
@@ -100,9 +100,9 @@
     (defmacro why-explain (rule)
       `(er-progn
         (brr t)
-        (monitor '(:rewrite ,rule) ''(:eval
-                                      :ok-if (brr@ :wonp)
-                                      (explain)))))
+        (monitor ',rule ''(:eval
+                           :ok-if (brr@ :wonp)
+                           (explain)))))
 
     (defmacro with-redef (&rest forms)
       ;; A handy macro you can use to temporarily enable redefinition, but then


### PR DESCRIPTION
Starting with a7ad6e8b7f80ca87777d6ff679975efd3d21118c (in 2015),
`:monitor` has been able to accept symbols and some other runic
designators instead of just runes, as before.  So `why` and
`why-explain` need no longer wrap symbol names with `(:rewrite ...)`.
This generalizes `why` and `why-explain` by allowing one to monitor
linear rules as well, for example.