### PR TITLE
Add support for &ndash; to XDOC

### DIFF
--- a/books/xdoc/fancy/xdata2html.pl
+++ b/books/xdoc/fancy/xdata2html.pl
@@ -58,6 +58,7 @@ sub read_whole_file {
 sub wrap_xdoc_fragment {
 	my $str = shift;
     my $wrap = "<!DOCTYPE xdoc [";
+    $wrap .= "<!ENTITY ndash \"&#8211;\">";
     $wrap .= "<!ENTITY mdash \"&#8212;\">";
     $wrap .= "<!ENTITY rarr \"&#8594;\">";
     $wrap .= "<!ENTITY nbsp \"&#160;\">";

--- a/books/xdoc/fancy/xslt.js
+++ b/books/xdoc/fancy/xslt.js
@@ -41,6 +41,7 @@
 function wrapXdocFragment(str)
 {
     var wrap = "<!DOCTYPE xdoc [";
+    wrap += "<!ENTITY ndash \"&#8211;\">";
     wrap += "<!ENTITY mdash \"&#8212;\">";
     wrap += "<!ENTITY rarr \"&#8594;\">";
     wrap += "<!ENTITY nbsp \"&#160;\">";

--- a/books/xdoc/parse-xml.lisp
+++ b/books/xdoc/parse-xml.lisp
@@ -65,7 +65,7 @@
 ;
 ;    (:ENTITY TYPE) represents entities like &amp;
 ;
-;      - TYPE is :AMP, :LT, :GT, :APOS, :NBSP, :MDASH, :RARR, LSQUO, RSQUO, LDQUO, or RDQUO
+;      - TYPE is :AMP, :LT, :GT, :APOS, :NBSP, :NDASH, :MDASH, :RARR, LSQUO, RSQUO, LDQUO, or RDQUO
 
 (defun opentok-p (x) (eq (first x) :OPEN))
 (defun opentok-name (x) (second x))
@@ -279,6 +279,7 @@
        ((when (equal str "quot")) (mv nil n '(:ENTITY :QUOT)))
        ((when (equal str "apos")) (mv nil n '(:ENTITY :APOS)))
        ((when (equal str "nbsp")) (mv nil n '(:ENTITY :NBSP)))
+       ((when (equal str "ndash")) (mv nil n '(:ENTITY :NDASH)))
        ((when (equal str "mdash")) (mv nil n '(:ENTITY :MDASH)))
        ((when (equal str "rarr")) (mv nil n '(:ENTITY :RARR)))
        ((when (equal str "lsquo")) (mv nil n '(:ENTITY :LSQUO)))
@@ -330,6 +331,7 @@
     (:QUOT  "&quot;")
     (:APOS  "&apos;")
     (:NBSP  "&nbsp;")
+    (:NDASH "&ndash;")
     (:MDASH "&mdash;")
     (:RARR  "&rarr;")
     (:LSQUO "&lsquo;")
@@ -346,6 +348,7 @@
     (:QUOT  "\"")
     (:APOS  "'")
     (:NBSP  " ")
+    (:NDASH "--")
     (:MDASH "---")
     (:RARR  "-->")
     (:LSQUO "`")

--- a/books/xdoc/prepare-topic.lisp
+++ b/books/xdoc/prepare-topic.lisp
@@ -86,6 +86,7 @@
 
 (defconst *xml-entity-stuff*
   "<!DOCTYPE xdoc [
+  <!ENTITY ndash \"&#8211;\">
   <!ENTITY mdash \"&#8212;\">
   <!ENTITY rarr \"&#8594;\">
   <!ENTITY nbsp \"&#160;\">


### PR DESCRIPTION
This also fixes the broken build caused by the &ndash; entities I
added in 5ff084930591689ca022e7d2bca65b976a10fe8a.

Thanks to @acoglio for noticing the build failure and letting me know.