### PR TITLE
Remove duplicate rule in bitops library

### DIFF
--- a/books/centaur/bitops/ihsext-basics.lisp
+++ b/books/centaur/bitops/ihsext-basics.lisp
@@ -2438,13 +2438,11 @@ off looking at the source code.</p>")
                     :pattern (unsigned-byte-p bits x)
                     :scheme (unsigned-byte-p-ind bits x))))
 
-  (defthmd unsigned-byte-p-incr
+  (defthm unsigned-byte-p-incr
     (implies (and (unsigned-byte-p a x)
                   (natp b)
                   (<= a b))
              (unsigned-byte-p b x)))
-
-  (local (in-theory (enable unsigned-byte-p-incr)))
 
   (defthmd unsigned-byte-p-logcons
     (implies (and (unsigned-byte-p (1- b) x)
@@ -2504,12 +2502,6 @@ off looking at the source code.</p>")
                     (unsigned-byte-p (+ size1 (nfix size)) (ifix i))))
     :hints (("goal" :induct (and (logtail size i)
                                  (logtail size1 i)))))
-
-  (defthm unsigned-byte-p-when-unsigned-byte-p-less
-    (implies (and (unsigned-byte-p n x)
-                  (natp m)
-                  (<= n m))
-             (unsigned-byte-p m x)))
 
   (encapsulate
     nil

--- a/books/projects/x86isa/machine/x86-ia32e-paging.lisp
+++ b/books/projects/x86isa/machine/x86-ia32e-paging.lisp
@@ -700,7 +700,7 @@ accesses.</p>
                             acl2::ifix-negative-to-negp
                             (:rewrite default-<-1)
                             (:rewrite default-<-2)
-                            bitops::unsigned-byte-p-when-unsigned-byte-p-less
+                            bitops::unsigned-byte-p-incr
                             weed-out-irrelevant-logand-when-first-operand-constant
                             negative-logand-to-positive-logand-with-integerp-x)))))
 

--- a/books/projects/x86isa/machine/x86.lisp
+++ b/books/projects/x86isa/machine/x86.lisp
@@ -3852,7 +3852,7 @@
                                      acl2::ash-0
                                      unsigned-byte-p-of-logior
                                      acl2::zip-open
-                                     bitops::unsigned-byte-p-when-unsigned-byte-p-less))))
+                                     bitops::unsigned-byte-p-incr))))
     :rule-classes :type-prescription)
 
   (defthm-usb n44p-get-prefixes

--- a/books/projects/x86isa/proofs/popcount/popcount-general.lisp
+++ b/books/projects/x86isa/proofs/popcount/popcount-general.lisp
@@ -831,7 +831,7 @@
                    (:type-prescription posp)
                    (:rewrite x86-run-halted)
                    (:type-prescription acl2::logtail$inline)
-                   (:rewrite bitops::unsigned-byte-p-when-unsigned-byte-p-less)
+                   (:rewrite bitops::unsigned-byte-p-incr)
                    (:linear bitops::upper-bound-of-logand . 1)
                    (:linear bitops::logand->=-0-linear-1)
                    (:rewrite rb-returns-x86-in-non-marking-mode-if-no-error)

--- a/books/projects/x86isa/proofs/utilities/system-level-mode/marking-mode-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/system-level-mode/marking-mode-utils.lisp
@@ -1964,7 +1964,7 @@
                       (:linear size-of-combine-bytes-of-take)
                       (:linear size-of-combine-bytes)
                       (:linear bitops::expt-2-lower-bound-by-logbitp)
-                      (:rewrite bitops::unsigned-byte-p-when-unsigned-byte-p-less)
+                      (:rewrite bitops::unsigned-byte-p-incr)
                       (:linear size-of-rb)
                       (:rewrite
                        all-mem-except-paging-structures-equal-aux-and-xr-mem-from-rest-of-memory)

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-init.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy-init.lisp
@@ -423,7 +423,7 @@
     (:rewrite member-p-of-subset-is-member-p-of-superset)
     (:linear rgfi-is-i64p)
     (:rewrite member-p-cdr)
-    (:rewrite bitops::unsigned-byte-p-when-unsigned-byte-p-less)
+    (:rewrite bitops::unsigned-byte-p-incr)
     (:rewrite acl2::difference-unsigned-byte-p)
     (:rewrite acl2::append-when-not-consp)
     (:linear rip-is-i48p)

--- a/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-mode/zeroCopy.lisp
@@ -5782,7 +5782,7 @@
                               (:rewrite default-+-2)
                               (:type-prescription acl2::|x < y  =>  0 < -x+y|)
                               (:rewrite acl2::equal-of-booleans-rewrite)
-                              (:rewrite bitops::unsigned-byte-p-when-unsigned-byte-p-less)
+                              (:rewrite bitops::unsigned-byte-p-incr)
                               (:rewrite loghead-negative)
                               (:linear rip-is-i48p)
                               (:type-prescription subset-p)

--- a/books/projects/x86isa/proofs/zeroCopy/non-marking-mode/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/non-marking-mode/zeroCopy.lisp
@@ -724,7 +724,7 @@
     (:rewrite member-p-of-subset-is-member-p-of-superset)
     (:linear rgfi-is-i64p)
     (:rewrite member-p-cdr)
-    (:rewrite bitops::unsigned-byte-p-when-unsigned-byte-p-less)
+    (:rewrite bitops::unsigned-byte-p-incr)
     (:rewrite acl2::difference-unsigned-byte-p)
     (:rewrite acl2::append-when-not-consp)
     (:linear rip-is-i48p)


### PR DESCRIPTION
The enabled rule `bitops::unsigned-byte-p-when-unsigned-byte-p-less`
is an duplicate of the disabled rule `bitops::unsigned-byte-p-incr`.
To simplify this state of affairs, I removed the former and enabled
the latter.