### PR TITLE
(setq sentence-end-double-space t)

### DIFF
--- a/books/xdoc/parse-xml.lisp
+++ b/books/xdoc/parse-xml.lisp
@@ -337,8 +337,7 @@
     (:LSQUO "&lsquo;")
     (:RSQUO "&rsquo;")
     (:LDQUO "&ldquo;")
-    (:RDQUO "&rdquo;")
-    ))
+    (:RDQUO "&rdquo;")))
 
 (defun entitytok-as-plaintext (x)
   (case (entitytok-type x)


### PR DESCRIPTION
Most of the code comments and XDOC docstrings in the ACL2 codebase are
written with double spaces between sentences.  This is natural since
many ACL2 developers are Emacs users, and by default Emacs considers
sentence boundaries to contain a double space (i.e. the Emacs Lisp
variable `sentence-end-double-space` is set to `t` by default).

However, when XDOC docstrings are converted into plain text for use in
the acl2-doc Emacs documentation browser, those double spaces are
converted into single spaces during "whitespace normalization".

That inconsistency always got on my nerves, and this commit finally
gets around to fixing it.  The sentence end detection logic is
simplistic, but it seems to work in most cases.  It looks for periods,
exclamation points, and question marks, possibly behind a single
closing element such as a closing parenthesis or closing quotation
mark, among others.

Note that this commit does not cause XDOC to *create* double spaces
between sentences, only to *preserve* them from the original
text.  (That's the whole point of `sentence-end-double-space`, after
all -- "Mr. Bean", for example, is properly read as part of a single
sentence rather than as straddling the boundary between two
sentences.)