### PR TITLE
 Make defpointer support package-external symbols

### DIFF
--- a/books/acl2s/cgen/top.lisp
+++ b/books/acl2s/cgen/top.lisp
@@ -239,6 +239,9 @@ package.</p>
 "
  )
 
+#!ACL2
+(defpointer counter-example-generation cgen)
+
 (defxdoc cgen::flush
   :parents (acl2::cgen)
   :short "Flush/Reset the Cgen state globals to sane values."

--- a/books/xdoc/top.lisp
+++ b/books/xdoc/top.lisp
@@ -470,20 +470,30 @@
       (concatenate-symbol-names (list ,@args))
       mksym-package-symbol)))
 
-; Moved from acl2-doc.lisp to make it more widely available
 (defmacro defpointer (from to &optional keyword-p)
-  `(defxdoc ,from
-     :parents (pointers)
-     :short ,(concatenate 'string
-                          "See @(see "
-                          (acl2::string-downcase (symbol-name to))
-                          ")"
-                          (if keyword-p
-                              (concatenate 'string
-                                           " for keyword @(':"
-                                           (acl2::string-downcase (symbol-name from))
-                                           "').")
-                            "."))))
+  (declare (xargs :guard (and (symbolp from) (symbolp to))))
+  (let ((from-pkg  (acl2::string-downcase (symbol-package-name from)))
+        (from-name (acl2::string-downcase (symbol-name         from)))
+        (to-pkg    (acl2::string-downcase (symbol-package-name to)))
+        (to-name   (acl2::string-downcase (symbol-name         to))))
+    `(defxdoc ,from
+       :parents (pointers)
+       :short ,(concatenate
+                'string
+                "See <see topic='@(url "
+                to-pkg "::" to-name
+                ")'>"
+                (if (equal to-pkg from-pkg)
+                    to-name
+                  (concatenate 'string to-pkg "::" to-name))
+                "</see>"
+                (if keyword-p
+                    (concatenate
+                     'string
+                     " for information about the keyword @(':"
+                     from-name
+                     "').")
+                  ".")))))
 
 
 (defun add-resource-directory-fn (dirname fullpath world)

--- a/books/xdoc/topics.lisp
+++ b/books/xdoc/topics.lisp
@@ -1761,7 +1761,15 @@ terminal with @(':doc') or in the ACL2-Doc Emacs viewer.</p>")
 <p>This is a simple macro that expands to a @(see defxdoc) form.  It introduces
 a new @(see xdoc) topic, @('new-topic'), that merely links to
 @('target-topic').  The new topic will only be listed under @(see
-pointers).</p>")
+pointers).</p>
+
+<p>A common practice when documenting keyword symbols is to create a
+doc topic in in the \"ACL2\" package or some other relevant package,
+rather than the \"KEYWORD\" package to which the keyword symbol
+rightfully belongs.  In keeping with this practice, the @('keywordp')
+argument to @('defpointer'), if non-nil, adds a clarification that the
+doc topic is really about the keyword symbol with the same name as
+@('new-topic'), rather than @('new-topic') itself.</p>")
 
 
 (defxdoc add-resource-directory


### PR DESCRIPTION
Previously, defpointer took its arguments and ignored what package
they were in, incorrectly using the symbols with the same names in the
current package instead.  Now it respects the package in which its
arguments lie.

In making this change, I also had to decide what the link text of the
pointer should look like, depending on what package the linked doc
topic's symbol was in.  I decided that if the `from` and `to` symbols
were both in the same package, we should leave off the package
qualification in the text, and otherwise we should include it.

I also added a guard to the macro to ensure that only symbols are
accepted.

----

Something's still kind of weird here -- if you look at the generated HTML manual, XDOC's notion of what the "base package" is for both the "acl2::counter-example-generation" and the "acl2::cgen" topics is actually "ACL2S". But at least the build still works, and the doc topics are still readable.