### PR TITLE
Move stateman into SMAN package

### DIFF
--- a/books/projects/stateman/README
+++ b/books/projects/stateman/README
@@ -30,3 +30,6 @@ The user wishing to run a few simple examples, to understand better the
 input/output conventions and capabilities of some of the functions defined in
 stateman22.lisp, should then execute the forms in simple-examples.lsp one by
 one at the top-level of an ACL2 session.
+
+After the publication of the Stateman paper, it was decided to put the
+stateman work in a separate package named "SMAN" (contributed by David Rager).

--- a/books/projects/stateman/acl2-customization.lsp
+++ b/books/projects/stateman/acl2-customization.lsp
@@ -1,0 +1,5 @@
+(ld "~/acl2-customization.lsp" :ld-missing-input-ok t)
+
+(ld "package.lsp")
+
+(in-package "SMAN")

--- a/books/projects/stateman/byte-addressed-state.lisp
+++ b/books/projects/stateman/byte-addressed-state.lisp
@@ -16,7 +16,7 @@
 
 ; Most comments have been stripped out to keep this file as simple as possible.
 
-(in-package "ACL2")
+(in-package "SMAN")
 
 (local (include-book "arithmetic-5/top" :dir :system))
 
@@ -410,7 +410,7 @@
           (expt 256 sz)))
   :hints (("Goal"
            :expand ((expt 256 sz))
-           :in-theory (disable normalize-factors-gather-exponents)
+           :in-theory (disable acl2::normalize-factors-gather-exponents)
            ))
   :rule-classes :linear)
 
@@ -1195,8 +1195,8 @@
   :hints (("Goal" :in-theory (e/d (one-byte-read r-1-!mi)
                                   (mod floor ash logior logxor
                                        ash-to-floor
-                                       logand-constant-mask
-                                       |(* x (- y))|)))
+                                       acl2::logand-constant-mask
+                                       acl2::|(* x (- y))|)))
           ("Subgoal 12" :cases ((< b 0)))
           ("Subgoal 11" :cases ((< b 0)))))
 
@@ -1259,8 +1259,8 @@
                            (!r b sz v2
                                st)))
                    ))
-   :hints (("Goal" :in-theory '((:COMPOUND-RECOGNIZER NATP-COMPOUND-RECOGNIZER)
-                                (:COMPOUND-RECOGNIZER ZP-COMPOUND-RECOGNIZER)
+   :hints (("Goal" :in-theory '((:COMPOUND-RECOGNIZER acl2::NATP-COMPOUND-RECOGNIZER)
+                                (:COMPOUND-RECOGNIZER acl2::ZP-COMPOUND-RECOGNIZER)
                                 (:DEFINITION ASH)
                                 (:DEFINITION FIX)
                                 (:DEFINITION FLOOR)
@@ -1500,8 +1500,8 @@
                                                    (integerp (* v (expt base n))))
                                               (integerp (* v (expt base (+ n delta))))))
                            (delta (- m n)))
-           :in-theory (e/d (scatter-exponents-theory)
-                           (gather-exponents-theory)))))
+           :in-theory (e/d (acl2::scatter-exponents-theory)
+                           (acl2::gather-exponents-theory)))))
 
 ; We need to express (expt 2 (* 8 sum)) as (expt 256 sum), except the product
 ; is distributed over the sum, there are 1, 2, or 3 terms in the sums in

--- a/books/projects/stateman/cert.acl2
+++ b/books/projects/stateman/cert.acl2
@@ -1,0 +1,2 @@
+(include-book "portcullis")
+;; cert-flags: ? t

--- a/books/projects/stateman/package.lsp
+++ b/books/projects/stateman/package.lsp
@@ -1,0 +1,30 @@
+(in-package "ACL2")
+
+(include-book "std/portcullis" :dir :system)
+
+#!ACL2
+(defpkg "SMAN"
+  (union-eq
+   *acl2-exports*
+   *common-lisp-symbols-from-main-lisp-package*
+   STD::*std-exports*
+   '(binary-logand binary-logior binary-logxor
+		   ASH-TO-FLOOR *ts-nil* *ts-t* ts= *t* *nil* *0*
+		   ffn-symb fargn type-alistp nvariablep variablep conjoin fquotep
+		   flambdap fargs memb llist l<
+		   distributivity-of-minus-over-+
+		   tau-bounder-+ tau-bounder-* tau-bounder-mod tau-bounder-logand
+		   tau-bounder-logior tau-bounder-logxor tau-bounder-ash
+		   find-minimal-logand2 find-minimal-logand1 find-minimal-logand
+		   find-maximal-logand2 find-maximal-logand1 find-maximal-logand
+		   TAU-BOUNDER-LOGIOR-CORRECT TAU-BOUNDER-LOGXOR-CORRECT
+		   int1 int2 tau-interval-dom tau-intervalp x y
+		   nonlinearp-default-hint
+		   merge-term-order merge-sort-term-order how-many perm
+		   convert-perm-to-how-many
+		   )))
+
+     
+
+; (acl2::deffalias fquotep acl2::fquotep)
+

--- a/books/projects/stateman/portcullis.acl2
+++ b/books/projects/stateman/portcullis.acl2
@@ -1,0 +1,1 @@
+(ld "package.lsp")

--- a/books/projects/stateman/portcullis.lisp
+++ b/books/projects/stateman/portcullis.lisp
@@ -1,0 +1,1 @@
+(in-package "SMAN")

--- a/books/projects/stateman/stateman22.lisp
+++ b/books/projects/stateman/stateman22.lisp
@@ -6,7 +6,7 @@
 ; (ld "stateman22.lisp" :ld-pre-eval-print t)
 ; (certify-book "stateman22")
 
-(in-package "ACL2")
+(in-package "SMAN")
 
 (set-state-ok t)
 
@@ -7003,4 +7003,7 @@
 (memoize 'memoizable-meta-!r)
 (memoize 'memoizable-meta-mod)
 (memoize 'memoizable-meta-<)
-(memoize 'sublis-var1 :condition '(and (null alist) (consp form) (eq (car form) 'HIDE)))
+(memoize 'acl2::sublis-var1
+         :condition '(and (null acl2::alist)
+                          (consp acl2::form)
+                          (eq (car acl2::form) 'HIDE)))


### PR DESCRIPTION
Moved stateman into SMAN package.  Turns out the .lsp file didn't need to be updated -- potentially a sign of a good interface.

I may add some more license information later.