### PR TITLE
Remove ACL2_SAVE_QUICKLISP hack in Makefile

### DIFF
--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -529,25 +529,6 @@ quicklisp_clean:
 	@echo "Cleaning up Quicklisp files"
 	cd $(QUICKLISP_DIR); ./clean.sh
 
-# The following hack was useful briefly in late January, 2014, when
-# there were issues with quicklisp that caused us not to want to clean
-# quicklisp files.  Rager likes this hack (because his company-wide
-# ACL2 installation isn't writable by those that use it and he doesn't
-# always want to clean quicklisp since proxies have to be configured
-# and because it's good to preserve the
-# quicklisp/inst/cache/asdf-installs directory), and so he prefers
-# that the "hack" be preserved.
-
-# May 2015 update: since the quicklisp installation procedure has
-# changed, the conditional part of this code is hypothetically dead.
-# We leave it commented for now, but if December 2015 comes around,
-# and it's still unnecessary, the conditional part of this (and the
-# above comments) should be deleted.
-#ifndef ACL2_SAVE_QUICKLISP
-clean: quicklisp_clean
-#endif # ifndef ACL2_SAVE_QUICKLISP
-
-
 ifeq ($(REALLY_USE_QUICKLISP), 0)
 $(info Excluding books that depend on Quicklisp: [$(CERT_PL_USES_QUICKLISP)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_QUICKLISP), $(OK_CERTS))

--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -529,6 +529,8 @@ quicklisp_clean:
 	@echo "Cleaning up Quicklisp files"
 	cd $(QUICKLISP_DIR); ./clean.sh
 
+clean: quicklisp_clean
+
 ifeq ($(REALLY_USE_QUICKLISP), 0)
 $(info Excluding books that depend on Quicklisp: [$(CERT_PL_USES_QUICKLISP)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_QUICKLISP), $(OK_CERTS))


### PR DESCRIPTION
The comment says that if this hack is no longer needed by December
2015, it should be removed.  Clearly, it is already past December
2015, so we should remove it.

---

Or so confidently declares my commit message, but what do you think?