### PR TITLE
Add ifdef feature to support conditional dependence on external tools…

### DIFF
--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -135,12 +135,21 @@
 ### Section: Preliminaries
 ##############################
 
+# GNU Make exports exported variables to the shell inside recipes, but
+# not inside $(shell ...).  To work around this, we'll add every
+# variable we export to a list and manually provide the environment we
+# want when we need it.
+EXPORTED_VARS :=
+
+
 # For cygwin, we need to do something special to get a Unix-like
 # pathname.
 ifneq (,$(findstring CYGWIN, $(shell uname)))
 export ACL2_SYSTEM_BOOKS := $(shell cygpath -m $(CURDIR))
+EXPORTED_VARS += ACL2_SYSTEM_BOOKS
 else
 export ACL2_SYSTEM_BOOKS := $(CURDIR)
+EXPORTED_VARS += ACL2_SYSTEM_BOOKS
 endif
 
 $(info ACL2_SYSTEM_BOOKS is $(ACL2_SYSTEM_BOOKS))
@@ -201,54 +210,6 @@ ACL2_CUSTOM_TARGETS :=
 ### invoked with INFO=warning; otherwise, same as $(info just a test).
 ## $(eval $$($(INFO) just a test))
 
-ifndef NO_RESCAN
-
-# We skip the scan for excluded prefixes.  This change was implemented
-# by Matt Kaufmann on 9/25/2013 as part of the process of fixing
-# ACL2(r) regressions.  (Note that nonstd/Makefile includes this
-# Makefile.)
-ifneq ($(EXCLUDED_PREFIXES), )
-space =  # just a space
-EGREP_EXTRA_EXCLUDE_STRING = |$(subst $(space) $(space),|,$(strip $(EXCLUDED_PREFIXES)))
-endif # ifneq ($(EXCLUDED_PREFIXES), )
-
-# We exclude some directories because there are subdirectories and it's just
-# easiest to stop at the root.
-
-# We also exclude centaur/satlink/solvers because it depends on all kinds of
-# extra SAT solvers.
-$(info Scanning for books...)
-REBUILD_MAKEFILE_BOOKS := $(shell \
-  rm -f $(BUILD_DIR)/Makefile-books; \
-  time find . -name "*.lisp" \
-    | egrep -v '^(\./)?(interface|centaur/satlink/solvers|projects/milawa/ACL2|clause-processors/SULFA|workshops/2003/kaufmann/support$(EGREP_EXTRA_EXCLUDE_STRING))' \
-    | fgrep -v '.\#' \
-  > $(BUILD_DIR)/Makefile-books; \
-  ls -l $(BUILD_DIR)/Makefile-books)
-#$(info $(REBUILD_MAKEFILE_BOOKS))
-
-$(info Scanning for dependencies...)
-REBUILD_MAKEFILE_DEPS := $(shell \
-  rm -f $(BUILD_DIR)/Makefile-deps $(BUILD_DIR)/Makefile-deps.out; \
-  time ($(BUILD_DIR)/cert.pl \
-          --quiet \
-          --static-makefile $(BUILD_DIR)/Makefile-deps \
-          --cache $(BUILD_DIR)/Makefile-cache \
-          --acl2-books `pwd` \
-          --targets $(BUILD_DIR)/Makefile-books \
-          --write-sources $(BUILD_DIR)/Makefile-sources \
-          --write-certs $(BUILD_DIR)/Makefile-certs \
-          1>&2) ;\
-  echo 'MFDEPS_DEBUG := $$(shell echo Reading book deps ' \
-       'Makefile-deps created on' `date` '1>&2)' \
-    >> $(BUILD_DIR)/Makefile-deps; \
-  ls -l $(BUILD_DIR)/Makefile-deps)
-#$(info $(REBUILD_MAKEFILE_DEPS))
-$(info Done scanning.)
-
-endif # ifndef NO_RESCAN
-
-include $(BUILD_DIR)/Makefile-deps
 
 $(info Determining ACL2 features (for ACL2 = $(ACL2)))
 ACL2_FEATURES := $(shell \
@@ -264,14 +225,16 @@ $(info Determining whether Glucose is installed)
 # GLUCOSE_EXISTS
 GLUCOSE_EXISTS := $(shell glucose --help 2>/dev/null)
 ifdef GLUCOSE_EXISTS
-  OS_HAS_GLUCOSE ?= 1
+  export OS_HAS_GLUCOSE ?= 1
+  EXPORTED_VARS += OS_HAS_GLUCOSE
 endif # ifdef GLUCOSE_EXISTS
 
 $(info Determining whether an ipasir shared library is installed)
 ifdef IPASIR_SHARED_LIBRARY
   IPASIR_LIB_EXISTS := $(wildcard $(IPASIR_SHARED_LIBRARY))
   ifdef IPASIR_LIB_EXISTS
-    OS_HAS_IPASIR ?= 1
+    export OS_HAS_IPASIR ?= 1
+    EXPORTED_VARS += OS_HAS_IPASIR
     $(info Ipasir library supposedly exists)
   else # ifdef IPASIR_LIB_EXISTS
     $(info !!!WARNING: IPASIR_SHARED_LIBRARY was set to \
@@ -285,14 +248,16 @@ $(info Determining whether ABC is installed)
 # ABC_EXISTS
 ABC_EXISTS := $(shell abc -h 2>&1 | fgrep 'UC Berkeley, ABC' 2>/dev/null)
 ifdef ABC_EXISTS
-  OS_HAS_ABC ?= 1
+  export OS_HAS_ABC ?= 1
+  EXPORTED_VARS += OS_HAS_ABC
 endif # ifdef ABC_EXISTS
 
 
 $(info Determining whether Z3 is installed, for use by SMTLink)
 SMTLINK_EXISTS := $(shell z3 --version 2>/dev/null)
 ifdef SMTLINK_EXISTS
-  OS_HAS_SMTLINK ?= 1
+  export OS_HAS_SMTLINK ?= 1
+  EXPORTED_VARS += OS_HAS_SMTLINK
 endif # ifdef SMTLINK_EXISTS
 
 # The default for USE_QUICKLISP is now 1 for all ACL2 host Lisps
@@ -302,7 +267,8 @@ endif # ifdef SMTLINK_EXISTS
 # like :=.
 ifndef USE_QUICKLISP
   ifneq ($(ACL2_HOST_LISP), GCL)
-    USE_QUICKLISP := 1
+    export USE_QUICKLISP := 1
+    EXPORTED_VARS += USE_QUICKLISP
   endif
 endif
 
@@ -343,6 +309,60 @@ endif
 
 endif # ACL2_FEATURES_DETECTED
 
+# $(info EXPORTED_VARS = $(EXPORTED_VARS))
+EXPORT_SHELL_ENV := $(foreach v,$(EXPORTED_VARS),$(v)='$($(v))')
+
+# $(info EXPORT_SHELL_ENV = $(EXPORT_SHELL_ENV))
+
+ifndef NO_RESCAN
+
+# We skip the scan for excluded prefixes.  This change was implemented
+# by Matt Kaufmann on 9/25/2013 as part of the process of fixing
+# ACL2(r) regressions.  (Note that nonstd/Makefile includes this
+# Makefile.)
+ifneq ($(EXCLUDED_PREFIXES), )
+space =  # just a space
+EGREP_EXTRA_EXCLUDE_STRING = |$(subst $(space) $(space),|,$(strip $(EXCLUDED_PREFIXES)))
+endif # ifneq ($(EXCLUDED_PREFIXES), )
+
+# We exclude some directories because there are subdirectories and it's just
+# easiest to stop at the root.
+
+# We also exclude centaur/satlink/solvers because it depends on all kinds of
+# extra SAT solvers.
+$(info Scanning for books...)
+REBUILD_MAKEFILE_BOOKS := $(shell \
+  rm -f $(BUILD_DIR)/Makefile-books; \
+  time find . -name "*.lisp" \
+    | egrep -v '^(\./)?(interface|centaur/satlink/solvers|projects/milawa/ACL2|clause-processors/SULFA|workshops/2003/kaufmann/support$(EGREP_EXTRA_EXCLUDE_STRING))' \
+    | fgrep -v '.\#' \
+  > $(BUILD_DIR)/Makefile-books; \
+  ls -l $(BUILD_DIR)/Makefile-books)
+#$(info $(REBUILD_MAKEFILE_BOOKS))
+
+$(info Scanning for dependencies...)
+REBUILD_MAKEFILE_DEPS := $(shell \
+  rm -f $(BUILD_DIR)/Makefile-deps $(BUILD_DIR)/Makefile-deps.out; \
+    time ($(EXPORT_SHELL_ENV) \
+          $(BUILD_DIR)/cert.pl \
+          --quiet \
+          --static-makefile $(BUILD_DIR)/Makefile-deps \
+          --cache $(BUILD_DIR)/Makefile-cache \
+          --acl2-books `pwd` \
+          --targets $(BUILD_DIR)/Makefile-books \
+          --write-sources $(BUILD_DIR)/Makefile-sources \
+          --write-certs $(BUILD_DIR)/Makefile-certs \
+          1>&2) ;\
+  echo 'MFDEPS_DEBUG := $$(shell echo Reading book deps ' \
+       'Makefile-deps created on' `date` '1>&2)' \
+    >> $(BUILD_DIR)/Makefile-deps; \
+  ls -l $(BUILD_DIR)/Makefile-deps)
+#$(info $(REBUILD_MAKEFILE_DEPS))
+$(info Done scanning.)
+
+endif # ifndef NO_RESCAN
+
+include $(BUILD_DIR)/Makefile-deps
 
 
 # Cause error for illegal certification attempts:

--- a/books/build/cert_features.lsp
+++ b/books/build/cert_features.lsp
@@ -41,32 +41,46 @@
       (progn$
        (er hard? '|Makefile-features| "Error opening Makefile-features?")
        state)
-    (let* ((state (princ$ "ACL2_FEATURES_DETECTED := 1" channel state))
+    (let* ((state (princ$ "export ACL2_FEATURES_DETECTED := 1" channel state))
            (state (newline channel state))
-           (state (princ$ #+hons "ACL2_HAS_HONS := 1"
-                          #-hons "ACL2_HAS_HONS := "
+           (state (princ$ #+hons "export ACL2_HAS_HONS := 1"
+                          #-hons "export ACL2_HAS_HONS := "
                           channel state))
            (state (newline channel state))
-           (state (princ$ #-(and gcl (not ansi-cl)) "ACL2_HAS_ANSI := 1"
-                          #+(and gcl (not ansi-cl)) "ACL2_HAS_ANSI := "
+           (state (princ$ "EXPORTED_VARS += ACL2_HAS_HONS" channel state))
+           (state (newline channel state))
+           (state (princ$ #-(and gcl (not ansi-cl)) "export ACL2_HAS_ANSI := 1"
+                          #+(and gcl (not ansi-cl)) "export ACL2_HAS_ANSI := "
                           channel state))
            (state (newline channel state))
-           (state (princ$ #+acl2-par "ACL2_HAS_PARALLEL := 1"
-                          #-acl2-par "ACL2_HAS_PARALLEL := "
+           (state (princ$ "EXPORTED_VARS += ACL2_HAS_ANSI" channel state))
+           (state (newline channel state))
+           (state (princ$ #+acl2-par "export ACL2_HAS_PARALLEL := 1"
+                          #-acl2-par "export ACL2_HAS_PARALLEL := "
                           channel state))
            (state (newline channel state))
-           (state (princ$ #+non-standard-analysis "ACL2_HAS_REALS := 1"
-                          #-non-standard-analysis "ACL2_HAS_REALS := "
+           (state (princ$ "EXPORTED_VARS += ACL2_HAS_PARALLEL" channel state))
+           (state (newline channel state))
+           (state (princ$ #+non-standard-analysis "export ACL2_HAS_REALS := 1"
+                          #-non-standard-analysis "export ACL2_HAS_REALS := "
                           channel state))
            (state (newline channel state))
-           (state (princ$ "ACL2_COMP_EXT := " channel state))
+           (state (princ$ "EXPORTED_VARS += ACL2_HAS_REALS" channel state))
+           (state (newline channel state))
+           (state (princ$ "export ACL2_COMP_EXT := " channel state))
            (state (princ$ (@ compiled-file-extension) channel state))
            (state (newline channel state))
-           (state (princ$ "ACL2_HOST_LISP := " channel state))
+           (state (princ$ "EXPORTED_VARS += ACL2_COMP_EXT" channel state))
+           (state (newline channel state))
+           (state (princ$ "export ACL2_HOST_LISP := " channel state))
            (state (princ$ (symbol-name (@ host-lisp)) channel state))
            (state (newline channel state))
-           (state (princ$ "ACL2_THINKS_BOOK_DIR_IS := " channel state))
+           (state (princ$ "EXPORTED_VARS += ACL2_HOST_LISP" channel state))
+           (state (newline channel state))
+           (state (princ$ "export ACL2_THINKS_BOOK_DIR_IS := " channel state))
            (state (princ$ (f-get-global 'system-books-dir state) channel state))
+           (state (newline channel state))
+           (state (princ$ "EXPORTED_VARS += ACL2_THINKS_BOOK_DIR_IS" channel state))
            (state (newline channel state))
            (state (close-output-channel channel state)))
       state)))

--- a/books/build/doc.lisp
+++ b/books/build/doc.lisp
@@ -69,6 +69,9 @@ build time for multi-core environments.</li>
 <li>Dependency scanning is cached for better performance on NFS file
 systems.</li>
 
+<li>Ifdef/ifndef constructs are supported for conditional build features -- see
+@(see acl2::ifdef) and @(see acl2::ifndef).</li>
+
 </ul>
 
 <p>@('cert.pl') was originally developed in 2008 by Sol Swords at <a
@@ -591,8 +594,8 @@ above in far greater detail.</p>
 these extra @('defpkg') commands that can't go directly into the book.</p>
 
 <p>If you are using only packages from existing libraries, these should be
-dealt with automatically by the build system, which loads the portcullus
-(@('.port') file) of each included book before certifying a book.  (To defeat
+dealt with automatically by the build system, which loads the portcullis
+ (@('.port') file) of each included book before certifying a book.  (To defeat
 this mechanism, add a comment containing \"no_port\" at the end of the line of
 each include-book whose portculli you don't want.) However, if you are defining
 a new package, you need to know how to put it in your book's portcullis.</p>
@@ -1172,7 +1175,7 @@ to the head node before returning control to the Makefile.</p>")
                  custom-certify-book-commands optimizing-build-time
                  raw-lisp-and-other-dependencies static-makefiles
                  using-extended-acl2-images ; rename to remove "using"
-                 distributed-builds cert_param))
+                 distributed-builds cert_param acl2::ifdef acl2::ifndef))
 
 
 ; added by Matt K., 8/14/2014
@@ -1246,3 +1249,45 @@ certification using @('make')"
  <li>@('uses-quicklisp'): only certify when quicklisp is available</li>
 
  </ul>"))
+
+
+(defxdoc acl2::ifdef
+  :parents (cert.pl)
+  :short "Run some events only if an environment variable is defined and nonempty,
+          with build system support."
+  :long "<p>Ifdef and @(see ifndef), defined in \"books/build/ifdef.lisp\",
+support conditionally running some events depending on the build environment.
+This works as follows:</p>
+
+#({
+ (ifdef \"MY_ENV_VAR\"
+    (defun foo (x) x)
+    (include-book \"bar\")
+    :endif)
+ })
+<p>produces the given defun and include-book events only if \"MY_ENV_VAR\" is
+defined in the environment and is not the empty string.  @(see Ifndef) has the
+opposite behavior.</p>
+
+<p>There is special support in the @(see build::cert.pl) build system for these
+constructs, so that if the environment in which the cert.pl scan is run matches
+the environment in which the ACL2 job is run, the build system will know the
+true dependencies of the file, taking ifdefs into account.</p>
+
+<p>For this to work correctly, it is important to write the ifdef forms in a
+standard manner, as shown above: the @('(ifdef \"VARNAME\"') must be on a
+single line with nothing preceding it, and the @(':endif)') should be on a line
+without any other dependency-relevant items.  E.g., the following will not work
+as expected:</p>
+@({
+ (ifdef \"USE_FOO\" (include-book \"foo\") :endif)
+ })
+"
+  :pkg "ACL2")
+
+(defxdoc acl2::ifndef
+  :parents (cert.pl)
+  :short "Run some events only if an environment variable is undefined or empty,
+          with build system support."
+  :long "<p>See @(see ifdef).</p>"
+  :pkg "ACL2")

--- a/books/build/ifdef.lisp
+++ b/books/build/ifdef.lisp
@@ -1,0 +1,60 @@
+; cert.pl build system
+; Copyright (C) 2018 Centaur Technology
+;
+; Contact:
+;   Centaur Technology Formal Verification Group
+;   7600-C N. Capital of Texas Highway, Suite 300, Austin, TX 78731, USA.
+;   http://www.centtech.com/
+;
+; License: (An MIT/X11-style license)
+;
+;   Permission is hereby granted, free of charge, to any person obtaining a
+;   copy of this software and associated documentation files (the "Software"),
+;   to deal in the Software without restriction, including without limitation
+;   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+;   and/or sell copies of the Software, and to permit persons to whom the
+;   Software is furnished to do so, subject to the following conditions:
+;
+;   The above copyright notice and this permission notice shall be included in
+;   all copies or substantial portions of the Software.
+;
+;   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;   DEALINGS IN THE SOFTWARE.
+;
+; Original author: Sol Swords <sswords@centtech.com>
+
+(in-package "ACL2")
+
+(defun ifdef-fn (varname forms negate state)
+  (declare (xargs :stobjs state :mode :program))
+  (let* ((endif-tail (member :endif forms)))
+    (cond ((or (not endif-tail)
+               (consp (cdr endif-tail)))
+           (er soft 'ifdef-fn
+               "IFDEF requires that the last argument to it be the keyword ~
+                symbol :ENDIF, in order to support scanning by cert.pl.  ~
+                Additionally, that symbol should be on a separate line from ~
+                other forms."))
+          ((not (stringp varname))
+           (er soft 'ifdef-fn
+               "IFDEF requires that its first argument be a literal string. ~
+                Additionally, to support scanning by cert.pl, that string ~
+                should be on the same line of the file as the IFDEF."))
+          (t (er-let*
+              ((var (getenv$ varname state)))
+              (if (xor negate (and var (not (equal var ""))))
+                  (value (cons 'progn (butlast forms 1))) ;; remove the :endif
+                (value '(value-triple :skipped))))))))
+
+(defmacro ifdef (varname &rest forms)
+  `(make-event (ifdef-fn ,varname ',forms nil state)))
+
+(defmacro ifndef (varname &rest forms)
+  `(make-event (ifdef-fn ,varname ',forms t state)))
+  
+               

--- a/books/doc/top.lisp
+++ b/books/doc/top.lisp
@@ -30,6 +30,8 @@
 
 (in-package "ACL2")
 
+(include-book "build/ifdef" :dir :system)
+
 ; Note, 7/28/2014: if we include
 ; (include-book "std/system/top" :dir :system)
 ; instead of the following, we get a name conflict.
@@ -153,8 +155,38 @@
 (include-book "centaur/ubdds/param" :dir :system)
 
 (include-book "centaur/sv/top" :dir :system)
-(include-book "centaur/sv/tutorial/alu" :dir :system)
-(include-book "centaur/sv/tutorial/boothpipe" :dir :system)
+
+(ifdef "OS_HAS_GLUCOSE"
+       (include-book "centaur/sv/tutorial/alu" :dir :system)
+       (include-book "centaur/sv/tutorial/boothpipe" :dir :system)
+
+       (ifdef "OS_HAS_ABC"
+              (include-book "centaur/glmc/glmc-test" :dir :system)
+              (include-book "centaur/glmc/counter" :dir :system)
+              :endif)
+
+       (ifdef "OS_HAS_IPASIR"
+              (include-book "centaur/sv/tutorial/sums" :dir :system)
+              :endif)
+       :endif)
+
+(ifndef "OS_HAS_GLUCOSE"
+        ;; This is needed to avoid broken topic link errors
+        (defxdoc sv::sv-tutorial
+          :parents (sv::sv)
+          :short "Stub for missing topic"
+          :long "<p>This topic was omitted from the manual because it is in a
+book that depends on Glucose being installed.</p>")
+        (defxdoc sv::stvs-and-testing
+          :parents (sv::sv-tutorial)
+          :short "Stub for missing topic"
+          :long "<p>This topic was omitted from the manual because it is in a
+book that depends on Glucose being installed.</p>")
+        :endif)
+
+
+
+
 (include-book "centaur/esim/vcd/vcd" :dir :system)
 (include-book "centaur/esim/vcd/esim-snapshot" :dir :system)
 (include-book "centaur/esim/vcd/vcd-stub" :dir :system)


### PR DESCRIPTION
… etc.  Fixes #824 

Changes:
 - added a book that has ifdef and ifndef macros (see the added documentation in build/doc.lisp)
 - added support for ifdef/ifndef in certlib.pl dependency tracking
 - messed around in books/GNUmakefile a lot to make sure the relevant environment variables are visible to both ACL2 and the cert.pl invocation (surprisingly awkward).

I tested this with a couple different manual builds and I think it should be adequate.  Let me know if you have feedback.  Might be good to document somewhere how to add an optional external tool.
