### PR TITLE
Add some theorems left out from the last pull request

### DIFF
--- a/books/projects/filesystems/block-listp.lisp
+++ b/books/projects/filesystems/block-listp.lisp
@@ -1,0 +1,218 @@
+; Copyright (C) 2017, Regents of the University of Texas
+; Written by Mihir Mehta
+; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
+
+(in-package "ACL2")
+
+;  block-listp.lisp                                  Mihir Mehta
+
+; Here we define the size of a block to be 8 characters, and define functions
+; for making blocks from text and retrieving text from blocks, with proofs of
+; their correctness and their one-way inverse relationship.
+
+(include-book "file-system-lemmas")
+
+;; I don't think blocks are 8 characters long in any system; I simply set this
+;; in order to actually get fragmentation without having to make unreasonably
+;; large examples.
+(defconst *blocksize* 8)
+
+;; This fragments a character-list into blocks that are *blocksize*-character
+;; long. If the character-list is not exactly aligned to a block boundary, we
+;; fill the space with null characters.
+;; It will be used in wrchs.
+(defund make-blocks (text)
+  (declare (xargs :guard (character-listp text)
+                  :measure (len text)))
+  (if (atom text)
+      nil
+    (cons (make-character-list (take *blocksize* text))
+          (make-blocks (nthcdr *blocksize* text)))))
+
+(defthm
+  make-blocks-correctness-5
+  (iff (consp (make-blocks text))
+       (consp text))
+  :rule-classes
+  (:rewrite
+   (:rewrite
+    :corollary (iff (equal (len (make-blocks text)) 0)
+                    (atom text))
+    :hints (("goal''" :expand (len (make-blocks text))))))
+  :hints (("goal" :in-theory (enable make-blocks))))
+
+;; Characterisation of a disk, which is a list of blocks as described before.
+(defun block-listp (block-list)
+  (declare (xargs :guard t))
+  (if (atom block-list)
+      (eq block-list nil)
+    (and (character-listp (car block-list))
+         (equal (len (car block-list)) *blocksize*)
+         (block-listp (cdr block-list)))))
+
+;; Proving that we get a proper block-list out of make-blocks.
+(defthm make-blocks-correctness-2
+        (implies (character-listp text)
+                 (block-listp (make-blocks text)))
+        :hints (("Goal" :in-theory (enable make-blocks))))
+
+(defthm block-listp-correctness-1
+  (implies (block-listp block-list)
+           (true-listp block-list))
+  :rule-classes (:forward-chaining))
+
+(defthm block-listp-correctness-2
+  (implies (true-listp block-list1)
+           (equal (block-listp (binary-append block-list1 block-list2))
+                  (and (block-listp block-list1)
+                       (block-listp block-list2)))))
+
+;; This function spells out how many characters can be in a file given the
+;; number of blocks associated with it. It is kept disabled in order to avoid
+;; huge arithmetic-heavy subgoals where they're not wanted.
+(defund feasible-file-length-p (index-list-length file-length)
+  (declare (xargs :guard (and (natp file-length) (natp index-list-length))))
+  (and (> file-length
+          (* *blocksize* (- index-list-length 1)))
+       (<= file-length
+           (* *blocksize* index-list-length))))
+
+;; This is the counterpart of make-blocks that collapses blocks into a
+;; character-list of the appropriate length.
+;; It will be used in stat and, by extension, in rdchs.
+(defun
+  unmake-blocks (blocks n)
+  (declare
+   (xargs
+    :guard (and (block-listp blocks)
+                (natp n)
+                (feasible-file-length-p (len blocks) n))
+    :guard-hints
+    (("goal" :in-theory (enable feasible-file-length-p)))))
+  (if (atom blocks)
+      nil
+      (if (atom (cdr blocks))
+          (take n (car blocks))
+          (binary-append (car blocks)
+                         (unmake-blocks (cdr blocks)
+                                        (- n *blocksize*))))))
+
+;; Proving that we get a proper character-list out provided we don't ask for
+;; more characters than we have.
+(defthm unmake-blocks-correctness-1
+  (implies (and (block-listp blocks)
+                (natp n)
+                (feasible-file-length-p (len blocks) n))
+           (character-listp (unmake-blocks blocks n)))
+  :hints (("Goal" :in-theory (enable feasible-file-length-p)) ))
+
+(defthm
+  unmake-blocks-correctness-2
+  (implies (and (block-listp blocks)
+                (natp n)
+                (feasible-file-length-p (len blocks) n))
+           (equal (len (unmake-blocks blocks n))
+                  n))
+  :rule-classes
+  ((:rewrite :corollary (implies (and (block-listp blocks)
+                                      (natp n)
+                                      (feasible-file-length-p (len blocks) n))
+                                 (iff (consp (unmake-blocks blocks n))
+                                      (not (zp n))))))
+  :hints (("goal" :in-theory (enable feasible-file-length-p))
+          ("subgoal *1/5'''" :expand (len (cdr blocks)))))
+
+(defthm unmake-make-blocks-lemma-1
+        (implies (natp n)
+                 (iff (consp (nthcdr n l)) (> (len l) n)))
+        :hints (("Goal" :induct (nthcdr n l))))
+
+(encapsulate ()
+  (local (include-book "std/lists/repeat" :dir :system))
+
+  ;; Proving that make and unmake are, in a sense, inverse functions of each
+  ;; other.
+  (defthm
+    unmake-make-blocks
+    (implies (and (character-listp text))
+             (equal (unmake-blocks (make-blocks text)
+                                   (len text))
+                    text))
+    :hints
+    (("goal" :in-theory (enable make-blocks))
+     ("subgoal *1/3.3'"
+      :in-theory (disable first-n-ac-of-make-character-list
+                          take-of-too-many)
+      :use ((:instance first-n-ac-of-make-character-list
+                       (i (len text))
+                       (l (first-n-ac 8 text nil))
+                       (ac nil))
+            (:instance take-of-too-many (x text)
+                       (n *blocksize*)))))))
+
+;; This is a constant that might be needed later.
+;; This is to be returned when a block is not found. It's full of null
+;; characters and is *blocksize* long.
+(defconst *nullblock* (make-character-list (take *blocksize* nil)))
+
+(defthm
+  make-blocks-correctness-1
+  (implies (character-listp text)
+           (and (< (- (* *blocksize* (len (make-blocks text)))
+                      *blocksize*)
+                   (len text))
+                (not (< (* *blocksize* (len (make-blocks text)))
+                        (len text)))))
+  :hints (("goal" :in-theory (enable make-blocks)
+           :induct t)))
+
+(defthm
+  make-blocks-correctness-3
+  (implies (and (character-listp cl))
+           (feasible-file-length-p (len (make-blocks cl))
+                                   (len cl)))
+  :hints
+  (("goal"
+    :in-theory (e/d (feasible-file-length-p)
+                    (make-blocks-correctness-1))
+    :use (:instance make-blocks-correctness-1 (text cl)))))
+
+(encapsulate ()
+  (local (include-book "std/lists/nthcdr" :dir :system))
+
+  (local (defun nthcdr-*blocksize*-induction-2 (text1 text2)
+           (cond ((or (atom text1) (atom text2))
+                  (list text1 text2))
+                 (t (nthcdr-*blocksize*-induction-2 (nthcdr *blocksize* text1)
+                                                    (nthcdr *blocksize* text2))))))
+
+  (defthm
+    make-blocks-correctness-4
+    (implies (equal (len text1) (len text2))
+             (equal (len (make-blocks text1))
+                    (len (make-blocks text2))))
+    :hints (("goal" :in-theory (enable make-blocks)
+             :induct (nthcdr-*blocksize*-induction-2 text1 text2)))))
+
+(defthm
+  len-of-make-unmake
+  (implies (and (block-listp blocks)
+                (natp n)
+                (feasible-file-length-p (len blocks) n))
+           (equal (len (make-blocks (unmake-blocks blocks n)))
+                  (len blocks)))
+  :hints
+  (("goal" :in-theory (enable make-blocks feasible-file-length-p))
+   ("subgoal *1/8.1'"
+    :expand (append (car blocks)
+                    (unmake-blocks (cdr blocks) (+ -8 n))))
+   ("subgoal *1/5.1'"
+    :expand (append (car blocks)
+                    (unmake-blocks (cdr blocks) (+ -8 n))))
+   ("subgoal *1/2'4'" :expand (make-blocks (first-n-ac n (car blocks) nil)))
+   ("subgoal *1/2.1'" :in-theory (disable len-of-first-n-ac)
+    :use (:instance len-of-first-n-ac (i n)
+                    (l (car blocks))
+                    (ac nil)))
+   ("subgoal *1/5.2'" :cases ((atom (cdr blocks))))
+   ("subgoal *1/5.2'''" :expand (len (cdr blocks)))))

--- a/books/projects/filesystems/file-system-1.lisp
+++ b/books/projects/filesystems/file-system-1.lisp
@@ -258,21 +258,9 @@
            (equal (car (assoc-equal name alist)) name)))
 
 (defthm l1-read-after-write-1-lemma-2
-  (implies (and (l1-fs-p fs) (stringp text) (stringp (l1-stat hns fs)))
-           (stringp (l1-stat hns (l1-wrchs hns fs start text)))))
-
-(defthm l1-read-after-write-1-lemma-3
-  (implies (l1-rdchs hns fs start n)
-           (stringp (l1-stat hns fs))))
-
-(defthm l1-read-after-write-1
-  (implies (and (l1-fs-p fs)
-                (stringp text)
-                (symbol-listp hns)
-                (natp start)
-                (equal n (length text))
-                (stringp (l1-stat hns fs)))
-           (equal (l1-rdchs hns (l1-wrchs hns fs start text) start n) text)))
+  (implies (l1-fs-p fs)
+           (equal (stringp (l1-stat hns (l1-wrchs hns fs start text)))
+                  (stringp (l1-stat hns fs)))))
 
 (defthm l1-read-after-write-2-lemma-1
   (implies (l1-fs-p fs)
@@ -290,48 +278,70 @@
 
 (encapsulate
   ()
-  (local (defun induction-scheme (hns1 hns2 fs)
-           (if (atom hns1)
-               fs
-             (if (atom fs)
-                 nil
-               (let ((sd (assoc (car hns2) fs)))
-                 (if (atom sd)
-                     fs
-                   (if (atom hns2)
-                       fs
-                     (if (not (equal (car hns1) (car hns2)))
-                         fs
-                       (let ((contents (cdr sd)))
-                         (if (atom (cdr hns1))
-                             (cons (cons (car sd)
-                                         contents)
-                                   (delete-assoc (car hns2) fs))
-                           (cons (cons (car sd)
-                                       (induction-scheme (cdr hns1) (cdr hns2) contents))
-                                 (delete-assoc (car hns2) fs)))
-                         ))))
-                 )))))
 
-  (defthm l1-read-after-write-2-lemma-3
+  (local
+   (defun
+       induction-scheme (hns1 hns2 fs)
+     (if
+         (atom hns1)
+         fs
+       (if
+           (atom fs)
+           nil
+         (let
+             ((sd (assoc (car hns2) fs)))
+           (if
+               (atom sd)
+               fs
+             (if
+                 (atom hns2)
+                 fs
+               (if (not (equal (car hns1) (car hns2)))
+                   fs
+                 (let ((contents (cdr sd)))
+                   (if (atom (cdr hns1))
+                       (cons (cons (car sd) contents)
+                             (delete-assoc (car hns2) fs))
+                     (cons (cons (car sd)
+                                 (induction-scheme (cdr hns1)
+                                                   (cdr hns2)
+                                                   contents))
+                           (delete-assoc (car hns2) fs))))))))))))
+
+  (defthm
+    l1-read-after-write-2-lemma-3
+    (implies
+     (l1-fs-p fs)
+     (equal
+      (stringp (l1-stat hns1 (l1-wrchs hns2 fs start2 text2)))
+      (stringp (l1-stat hns1 fs))))
+    :hints (("goal" :induct (induction-scheme hns1 hns2 fs))))
+
+  (defthm
+    l1-stat-after-write
     (implies (and (l1-fs-p fs)
                   (stringp text2)
                   (symbol-listp hns1)
                   (symbol-listp hns2)
-                  (not (equal hns1 hns2))
                   (natp start2)
                   (stringp (l1-stat hns1 fs)))
-             (equal (l1-stat hns1 (l1-wrchs hns2 fs start2 text2)) (l1-stat hns1 fs)))
-    :hints (("Goal"  :induct (induction-scheme hns1 hns2 fs))
-            ("Subgoal *1/7.1''" :in-theory (disable alistp-l1-fs-p)
-             :use (:instance alistp-l1-fs-p (fs (l1-wrchs (cdr hns2)
-                                                    (cdr (assoc-equal (car hns1) fs))
-                                                    start2 text2))))))
+             (equal (l1-stat hns1 (l1-wrchs hns2 fs start2 text2))
+                    (if (not (equal hns1 hns2))
+                        (l1-stat hns1 fs)
+                        (coerce (insert-text (coerce (l1-stat hns1 fs) 'list)
+                                             start2 text2)
+                                'string))))
+    :hints (("goal" :induct (induction-scheme hns1 hns2 fs)))))
 
-  )
+(defthm l1-read-after-write-1
+  (implies (and (l1-fs-p fs)
+                (stringp text)
+                (symbol-listp hns)
+                (natp start)
+                (equal n (length text))
+                (stringp (l1-stat hns fs)))
+           (equal (l1-rdchs hns (l1-wrchs hns fs start text) start n) text)))
 
-;; to be revisited - (stringp (l1-stat hns1 fs)) is not a necessary condition
-;; but the proof doesn't go through without it
 (defthm l1-read-after-write-2
   (implies (and (l1-fs-p fs)
                 (stringp text2)
@@ -340,19 +350,9 @@
                 (not (equal hns1 hns2))
                 (natp start1)
                 (natp start2)
-                (natp n1)
-                (stringp (l1-stat hns1 fs)))
+                (natp n1))
            (equal (l1-rdchs hns1 (l1-wrchs hns2 fs start2 text2) start1 n1)
                   (l1-rdchs hns1 fs start1 n1))))
-
-(defthm l1-read-after-create-1
-  (implies (and (l1-fs-p fs)
-                (stringp text)
-                (symbol-listp hns)
-                (equal n (length text))
-                (not (l1-stat hns fs))
-                (stringp (l1-stat hns (l1-create hns fs text))))
-           (equal (l1-rdchs hns (l1-create hns fs text) 0 n) text)))
 
 ;; Induction argument for the proof of
 ;; (implies
@@ -394,44 +394,61 @@
 ;; (l1-stat (cdr hns1) (cdr (assoc (car hns1) fs))) =
 ;; (l1-stat hns1 fs)
 
-(encapsulate ()
+(encapsulate
+  ()
 
-  (local (defun induction-scheme (hns1 hns2 fs)
-           (if (atom hns1)
+  (local
+   (defun
+       induction-scheme (hns1 hns2 fs)
+     (if
+         (atom hns1)
+         fs
+       (if
+           (atom fs)
+           nil
+         (let
+             ((sd (assoc (car hns1) fs)))
+           (if
+               (atom sd)
                fs
-             (if (atom fs)
-                 nil
-               (let ((sd (assoc (car hns1) fs)))
-                 (if (atom sd)
-                     fs
-                   (if (atom hns2)
-                       fs
-                     (if (not (equal (car hns1) (car hns2)))
-                         fs
-                       (let ((contents (cdr sd)))
-                         (if (stringp (cdr sd))
-                             (cons (cons (car sd)
-                                         contents)
-                                   (delete-assoc (car hns2) fs))
-                           (cons (cons (car sd)
-                                       (induction-scheme (cdr hns1) (cdr hns2) contents))
-                                 (delete-assoc (car hns2) fs)))
-                         ))))
-                 )))))
+             (if
+                 (atom hns2)
+                 fs
+               (if (not (equal (car hns1) (car hns2)))
+                   fs
+                 (let ((contents (cdr sd)))
+                   (if (stringp (cdr sd))
+                       (cons (cons (car sd) contents)
+                             (delete-assoc (car hns2) fs))
+                     (cons (cons (car sd)
+                                 (induction-scheme (cdr hns1)
+                                                   (cdr hns2)
+                                                   contents))
+                           (delete-assoc (car hns2) fs))))))))))))
 
-  (defthm l1-read-after-create-2-lemma-1
+  (defthm
+    l1-stat-after-create
     (implies
      (and (l1-fs-p fs)
           (stringp text2)
           (symbol-listp hns1)
           (symbol-listp hns2)
-          (not (equal hns1 hns2))
           (not (l1-stat hns2 fs))
           (stringp (l1-stat hns2 (l1-create hns2 fs text2)))
           (stringp (l1-stat hns1 fs)))
-     (equal (l1-stat hns1 (l1-create hns2 fs text2)) (l1-stat hns1 fs)))
-    :hints (("Goal" :induct (induction-scheme hns1 hns2 fs)) ))
-  )
+     (equal (l1-stat hns1 (l1-create hns2 fs text2))
+            (if (equal hns1 hns2)
+                text2 (l1-stat hns1 fs))))
+    :hints (("goal" :induct (induction-scheme hns1 hns2 fs)))))
+
+(defthm l1-read-after-create-1
+  (implies (and (l1-fs-p fs)
+                (stringp text)
+                (symbol-listp hns)
+                (equal n (length text))
+                (not (l1-stat hns fs))
+                (stringp (l1-stat hns (l1-create hns fs text))))
+           (equal (l1-rdchs hns (l1-create hns fs text) 0 n) text)))
 
 (defthm l1-read-after-create-2
   (implies (and (l1-fs-p fs)

--- a/books/projects/filesystems/file-system-2.lisp
+++ b/books/projects/filesystems/file-system-2.lisp
@@ -115,8 +115,7 @@
 (defthm l2-stat-correctness-1-lemma-4
   (implies (and (l2-fs-p fs) (stringp (cadr (assoc-equal name fs))))
            (equal (cdr (assoc-equal name (l2-to-l1-fs fs)))
-                  (cadr (assoc-equal name fs))
-                  )))
+                  (cadr (assoc-equal name fs)))))
 
 (defthm l2-stat-correctness-1-lemma-5
   (implies (and (consp (assoc-equal name fs))
@@ -126,12 +125,17 @@
 
 ;; This is the first of two theorems showing the equivalence of the l2 and l1
 ;; versions of stat.
-(defthm l2-stat-correctness-1
-  (implies (and (symbol-listp hns)
-                (l2-fs-p fs)
+(defthm
+  l2-stat-correctness-1
+  (implies (and (l2-fs-p fs)
                 (stringp (l2-stat hns fs)))
            (equal (l1-stat hns (l2-to-l1-fs fs))
-                  (l2-stat hns fs))))
+                  (l2-stat hns fs)))
+  :hints
+  (("subgoal *1/5.2'"
+    :in-theory (disable l2-to-l1-fs-correctness-1)
+    :use (:instance l2-to-l1-fs-correctness-1
+                    (fs (cdr (assoc-equal (car hns) fs)))))))
 
 (defthm l2-stat-correctness-2-lemma-1
   (implies (and (l2-fs-p fs) (consp (assoc-equal name fs)))
@@ -145,12 +149,10 @@
 ;; This is the second of two theorems showing the equivalence of the l2 and l1
 ;; versions of stat.
 (defthm l2-stat-correctness-2
-  (implies (and (symbol-listp hns)
-                (l2-fs-p fs)
+  (implies (and (l2-fs-p fs)
                 (l2-fs-p (l2-stat hns fs)))
            (equal (l1-stat hns (l2-to-l1-fs fs))
-                  (l2-to-l1-fs (l2-stat hns fs))))
-  )
+                  (l2-to-l1-fs (l2-stat hns fs)))))
 
 ;; This is simply a useful property of stat.
 (defthm l2-stat-of-stat
@@ -220,16 +222,6 @@
                       (delete-assoc (car hns) fs))))))))
     ))
 
-;; putting these lemmas on the back burner because we would need to add uniquep
-;; to our l2-fs-p definition to make this work
-;; (defthm l2-unlink-works-lemma-1 (not (assoc-equal key (delete-assoc-equal key alist))))
-
-;; (defthm l2-unlink-works (implies (l2-fs-p fs) (not (l2-stat hns (l2-unlink hns fs)))))
-
-(defthm l2-wrchs-guard-lemma-1
-  (implies (and (stringp str))
-           (character-listp (nthcdr n (coerce str 'list)))))
-
 ; This function writes a specified text string to a specified position to a
 ; text file at a specified path.
 (defun l2-wrchs (hns fs start text)
@@ -250,7 +242,7 @@
             (cons (cons (car sd)
                         (if (and (consp (cdr sd)) (stringp (cadr sd)))
                             (let ((file (cdr sd)))
-                              (if (cdr hns)
+                              (if (consp (cdr hns))
                                   file ;; error, so leave fs unchanged
                                 (let* ((oldtext (coerce (car file) 'list))
                                        (newtext
@@ -260,8 +252,7 @@
                                    (coerce newtext 'string)
                                    newlength))))
                           (l2-wrchs (cdr hns) contents start text)))
-                  (delete-assoc (car hns) fs))
-            ))))))
+                  (delete-assoc (car hns) fs))))))))
 
 (defthm l2-wrchs-returns-fs-lemma-1
   (implies (and (consp (assoc-equal s fs))
@@ -278,7 +269,7 @@
                 (not (stringp (cadr (assoc-equal s fs)))))
            (l2-fs-p (cdr (assoc-equal s fs)))))
 
-(defthm l2-wrchs-returns-fs-lemma-4
+(defthmd l2-wrchs-returns-fs-lemma-4
   (implies (and (consp (assoc-equal name fs))
                 (l2-fs-p fs)
                 (consp (cdr (assoc-equal name fs)))
@@ -293,10 +284,11 @@
   :rule-classes :forward-chaining)
 
 ;; This theorem shows that the property l2-fs-p is preserved by wrchs.
-(defthm l2-wrchs-returns-fs
+(defthm
+  l2-wrchs-returns-fs
   (implies (l2-fs-p fs)
            (l2-fs-p (l2-wrchs hns fs start text)))
-  :rule-classes (:rewrite :type-prescription))
+  :hints (("goal" :in-theory (enable l2-wrchs-returns-fs-lemma-4))))
 
 ;; This theorem shows that the property l2-fs-p is preserved by unlink.
 (defthm l2-unlink-returns-fs
@@ -314,13 +306,17 @@
            (consp (l2-to-l1-fs fs))))
 
 ;; This theorem shows the equivalence of the l2 and l1 versions of wrchs.
-(defthm l2-wrchs-correctness-1
-  (implies (and (l2-fs-p fs)
-                (stringp text)
-                (natp start)
-                (symbol-listp (cdr hns)))
-           (equal (l1-wrchs hns (l2-to-l1-fs fs) start text)
-                  (l2-to-l1-fs (l2-wrchs hns fs start text)))))
+(defthm
+  l2-wrchs-correctness-1
+  (implies (l2-fs-p fs)
+           (equal (l1-wrchs hns (l2-to-l1-fs fs)
+                            start text)
+                  (l2-to-l1-fs (l2-wrchs hns fs start text))))
+  :hints
+  (("subgoal *1/5.1''"
+    :in-theory (disable l2-wrchs-returns-fs)
+    :use (:instance l2-wrchs-returns-fs (hns (cdr hns))
+                    (fs (cdr (assoc-equal (car hns) fs)))))))
 
 ;; This function creates a text file (and all necessary subdirectories) given a
 ;; path and some initial text.
@@ -348,12 +344,13 @@
           )))))
 
 ;; This theorem shows that the property l2-fs-p is preserved by create.
-(defthm l2-create-returns-fs
+(defthm
+  l2-create-returns-fs
   (implies (and (symbol-listp hns)
                 (l2-fs-p fs)
                 (stringp text))
            (l2-fs-p (l2-create hns fs text)))
-  :rule-classes (:rewrite :type-prescription))
+  :hints (("goal" :in-theory (enable l2-wrchs-returns-fs-lemma-4))))
 
 (defthm l2-create-correctness-1-lemma-1
   (implies (and (not (consp (cdr (assoc-equal name fs))))
@@ -378,10 +375,6 @@
   (implies (consp (assoc-equal name alist))
            (equal (car (assoc-equal name alist)) name)))
 
-(defthm l2-read-after-write-1-lemma-2
-  (implies (and (l2-fs-p fs) (stringp text) (stringp (l2-stat hns fs)))
-           (stringp (l2-stat hns (l2-wrchs hns fs start text)))))
-
 (defthm l2-read-after-write-1-lemma-3
   (implies (l2-rdchs hns fs start n)
            (stringp (l2-stat hns fs))))
@@ -395,58 +388,6 @@
            (<= (+ start (len (coerce text 'list)))
                (len (coerce (l2-stat hns (l2-wrchs hns fs start text))
                             'list)))))
-
-;; This is a new proof of the first read-after-write property, which
-;; does not rely upon the l1 proof of the same property.
-(defthm l2-read-after-write-1
-  (implies (and (l2-fs-p fs)
-                (stringp text)
-                (symbol-listp hns)
-                (natp start)
-                (equal n (length text))
-                (stringp (l2-stat hns fs)))
-           (equal (l2-rdchs hns (l2-wrchs hns fs start text) start n) text)))
-
-;; The following comment details the induction scheme for the proof of
-;; l2-read-after-write-2.
-;; we want to prove
-;; (implies (and (l2-fs-p fs)
-;;               (stringp text2)
-;;               (symbol-listp hns1)
-;;               (symbol-listp hns2)
-;;               (not (equal hns1 hns2))
-;;               (natp start2)
-;;               (stringp (l2-stat hns1 fs)))
-;;          (equal (l2-stat hns1 (l2-wrchs hns2 fs start2 text2))
-;;                 (l2-stat hns1 fs)))
-;; now, let's semi-formally write the cases we want.
-;; case 1: (atom hns1) - this will violate the hypothesis
-;; (stringp (l2-stat hns1 fs))
-;; case 2: (and (consp hns1) (atom fs)) - this will yield nil in both cases
-;; case 3: (and (consp hns1) (consp fs) (atom (assoc (car hns1) fs))) - this
-;; will yield nil in both cases (might need a lemma)
-;; case 4: (and (consp hns1) (consp fs) (consp (assoc (car hns1) fs))
-;;              (atom hns2)) - in this case
-;; (l2-wrchs hns2 fs start2 text2) will be the same as fs
-;; case 5: (and (consp hns1) (consp fs) (consp (assoc (car hns1) fs))
-;;              (consp hns2) (not (equal (car hns1) (car hns2)))) - in this
-;; case, (assoc (car hns1) (l2-wrchs hns2 fs start2 text2)) =
-;; (assoc (car hns1) (delete-assoc (car hns2) fs)) =
-;; (assoc (car hns1) fs) and from here on the terms will be equal
-;; case 6: (and (consp hns1) (consp fs) (consp (assoc (car hns1) fs))
-;;              (consp hns2) (equal (car hns1) (car hns2)) (atom (cdr hns1))) -
-;; in this case (consp (cdr hns2)) is implicit because of
-;; (not (equal hns1 hns2)) and (stringp (l2-stat hns1 fs)) implies that
-;; (l2-wrchs hns2 fs start2 text2) = fs
-;; case 7: (and (consp hns1) (consp fs) (consp (assoc (car hns1) fs))
-;;              (consp hns2) (equal (car hns1) (car hns2)) (consp (cdr hns1))) -
-;; (l2-stat hns1 (l2-wrchs hns2 fs start2 text2)) =
-;; (l2-stat hns1 (cons (cons (car hns1)
-;;                        (l2-wrchs (cdr hns2) (cdr (assoc (car hns1) fs)) start2 text2))
-;;                  (delete-assoc (car hns1) fs)) =
-;; (l2-stat (cdr hns1) (l2-wrchs (cdr hns2) (cdr (assoc (car hns1) fs)) start2 text2)) =
-;; (l2-stat (cdr hns1) (cdr (assoc (car hns1) fs))) = (induction hypothesis)
-;; (l2-stat hns1 fs)
 
 (defthm l2-read-after-write-2-lemma-1
   (implies (l2-fs-p fs)
@@ -462,51 +403,65 @@
                 (stringp (l2-stat hns1 fs)))
            (equal (l2-stat hns1 fs) (cadr (assoc (car hns1) fs)))))
 
-(encapsulate
-  ()
-  (local (defun induction-scheme (hns1 hns2 fs)
-           (if (atom hns1)
-               fs
-             (if (atom fs)
-                 nil
-               (let ((sd (assoc (car hns2) fs)))
-                 (if (atom sd)
-                     fs
-                   (if (atom hns2)
-                       fs
-                     (if (not (equal (car hns1) (car hns2)))
-                         fs
-                       (let ((contents (cdr sd)))
-                         (if (atom (cdr hns1))
-                             (cons (cons (car sd)
-                                         contents)
-                                   (delete-assoc (car hns2) fs))
-                           (cons (cons (car sd)
-                                       (induction-scheme (cdr hns1) (cdr hns2) contents))
-                                 (delete-assoc (car hns2) fs)))
-                         ))))
-                 )))))
+(defthm l2-read-after-write-2-lemma-3
+  (implies (and (not (stringp (l2-stat hns fs)))
+                (l2-fs-p fs))
+           (l2-fs-p (l2-stat hns fs))))
 
-  (defthm l2-read-after-write-2-lemma-3
-    (implies (and (l2-fs-p fs)
-                  (stringp text2)
-                  (symbol-listp hns1)
-                  (symbol-listp hns2)
-                  (not (equal hns1 hns2))
-                  (natp start2)
-                  (stringp (l2-stat hns1 fs)))
-             (equal (l2-stat hns1 (l2-wrchs hns2 fs start2 text2)) (l2-stat hns1 fs)))
-    :hints (("Goal"  :induct (induction-scheme hns1 hns2 fs))
-            ("Subgoal *1/7.1''" :in-theory (disable alistp-l2-fs-p)
-             :use (:instance alistp-l2-fs-p (fs (l2-wrchs (cdr hns2)
-                                                    (cdr (assoc-equal (car hns1) fs))
-                                                    start2 text2))))))
+(defthm
+  l2-read-after-write-2-lemma-4
+  (implies
+   (l2-fs-p fs)
+   (equal
+    (stringp (l2-stat hns1 (l2-wrchs hns2 fs start2 text2)))
+    (stringp (l2-stat hns1 fs))))
+  :hints
+  (("goal"
+    :in-theory (disable l1-read-after-write-2-lemma-3
+                        l2-stat-correctness-1)
+    :use ((:instance l1-read-after-write-2-lemma-3
+                     (fs (l2-to-l1-fs fs)))
+          (:instance l2-stat-correctness-1 (hns hns1)
+                     (fs (l2-wrchs hns2 fs start2 text2)))
+          (:instance l2-stat-correctness-1 (hns hns1))))))
 
-  )
+(defthm
+  l2-stat-after-write
+  (implies
+   (and (l2-fs-p fs)
+        (stringp text2)
+        (symbol-listp hns1)
+        (symbol-listp hns2)
+        (natp start2)
+        (stringp (l2-stat hns1 fs)))
+   (equal
+    (l2-stat hns1 (l2-wrchs hns2 fs start2 text2))
+    (if (equal hns1 hns2)
+        (coerce (insert-text (coerce (l2-stat hns1 fs) 'list)
+                             start2 text2)
+                'string)
+        (l2-stat hns1 fs))))
+  :hints
+  (("goal"
+    :in-theory (disable l2-stat-correctness-1
+                        l1-stat-after-write)
+    :use ((:instance l2-stat-correctness-1 (hns hns1))
+          (:instance l2-stat-correctness-1 (hns hns1)
+                     (fs (l2-wrchs hns2 fs start2 text2)))
+          (:instance l1-stat-after-write
+                     (fs (l2-to-l1-fs fs)))))))
 
-;; This is a new proof of the second read-after-write property, which does not
-;; rely on the equivalent proof in l1.
-(defthm l2-read-after-write-2
+(defthm l2-read-after-write-1
+  (implies (and (l2-fs-p fs)
+                (stringp text)
+                (symbol-listp hns)
+                (natp start)
+                (equal n (length text))
+                (stringp (l2-stat hns fs)))
+           (equal (l2-rdchs hns (l2-wrchs hns fs start text) start n) text)))
+
+(defthm
+  l2-read-after-write-2
   (implies (and (l2-fs-p fs)
                 (stringp text2)
                 (symbol-listp hns1)
@@ -514,9 +469,9 @@
                 (not (equal hns1 hns2))
                 (natp start1)
                 (natp start2)
-                (natp n1)
-                (stringp (l2-stat hns1 fs)))
-           (equal (l2-rdchs hns1 (l2-wrchs hns2 fs start2 text2) start1 n1)
+                (natp n1))
+           (equal (l2-rdchs hns1 (l2-wrchs hns2 fs start2 text2)
+                            start1 n1)
                   (l2-rdchs hns1 fs start1 n1))))
 
 ;; This proves the equivalent of the first read-after-write property for

--- a/books/projects/filesystems/file-system-3.lisp
+++ b/books/projects/filesystems/file-system-3.lisp
@@ -12,152 +12,8 @@
 
 (include-book "misc/assert" :dir :system)
 (include-book "bounded-nat-listp")
+(include-book "block-listp")
 (include-book "file-system-2")
-
-;; I don't think blocks are 8 characters long in any system; I simply set this
-;; in order to actually get fragmentation without having to make unreasonably
-;; large examples.
-(defconst *blocksize* 8)
-
-;; This fragments a character-list into blocks that are *blocksize*-character
-;; long. If the character-list is not exactly aligned to a block boundary, we
-;; fill the space with null characters.
-;; It will be used in wrchs.
-(defund make-blocks (text)
-  (declare (xargs :guard (character-listp text)
-                  :measure (len text)))
-  (if (atom text)
-      nil
-    (cons (make-character-list (take *blocksize* text))
-          (make-blocks (nthcdr *blocksize* text)))))
-
-(defthm
-  make-blocks-correctness-5
-  (iff (consp (make-blocks text))
-       (consp text))
-  :rule-classes
-  (:rewrite
-   (:rewrite
-    :corollary (iff (equal (len (make-blocks text)) 0)
-                    (atom text))
-    :hints (("goal''" :expand (len (make-blocks text))))))
-  :hints (("goal" :in-theory (enable make-blocks))))
-
-;; Characterisation of a disk, which is a list of blocks as described before.
-(defun block-listp (block-list)
-  (declare (xargs :guard t))
-  (if (atom block-list)
-      (eq block-list nil)
-    (and (character-listp (car block-list))
-         (equal (len (car block-list)) *blocksize*)
-         (block-listp (cdr block-list)))))
-
-;; Proving that we get a proper block-list out of make-blocks.
-(defthm make-blocks-correctness-2
-        (implies (character-listp text)
-                 (block-listp (make-blocks text)))
-        :hints (("Goal" :in-theory (enable make-blocks))))
-
-;; Lemma
-(defthm block-listp-correctness-1
-  (implies (block-listp block-list)
-           (true-listp block-list))
-  :rule-classes (:forward-chaining))
-
-;; Lemma
-(defthm block-listp-correctness-2
-  (implies (true-listp block-list1)
-           (equal (block-listp (binary-append block-list1 block-list2))
-                  (and (block-listp block-list1)
-                       (block-listp block-list2)))))
-
-;; This function spells out how many characters can be in a file given the
-;; number of blocks associated with it. It is kept disabled in order to avoid
-;; huge arithmetic-heavy subgoals where they're not wanted.
-(defund feasible-file-length-p (index-list-length file-length)
-  (declare (xargs :guard (and (natp file-length) (natp index-list-length))))
-  (and (> file-length
-          (* *blocksize* (- index-list-length 1)))
-       (<= file-length
-           (* *blocksize* index-list-length))))
-
-;; This is the counterpart of make-blocks that collapses blocks into a
-;; character-list of the appropriate length.
-;; It will be used in stat and, by extension, in rdchs.
-(defun
-  unmake-blocks (blocks n)
-  (declare
-   (xargs
-    :guard (and (block-listp blocks)
-                (natp n)
-                (feasible-file-length-p (len blocks) n))
-    :guard-hints
-    (("goal" :in-theory (enable feasible-file-length-p)))))
-  (if (atom blocks)
-      nil
-      (if (atom (cdr blocks))
-          (take n (car blocks))
-          (binary-append (car blocks)
-                         (unmake-blocks (cdr blocks)
-                                        (- n *blocksize*))))))
-
-;; Proving that we get a proper character-list out provided we don't ask for
-;; more characters than we have.
-(defthm unmake-blocks-correctness-1
-  (implies (and (block-listp blocks)
-                (natp n)
-                (feasible-file-length-p (len blocks) n))
-           (character-listp (unmake-blocks blocks n)))
-  :hints (("Goal" :in-theory (enable feasible-file-length-p)) ))
-
-(defthm
-  unmake-blocks-correctness-2
-  (implies (and (block-listp blocks)
-                (natp n)
-                (feasible-file-length-p (len blocks) n))
-           (equal (len (unmake-blocks blocks n))
-                  n))
-  :rule-classes
-  ((:rewrite :corollary (implies (and (block-listp blocks)
-                                      (natp n)
-                                      (feasible-file-length-p (len blocks) n))
-                                 (iff (consp (unmake-blocks blocks n))
-                                      (not (zp n))))))
-  :hints (("goal" :in-theory (enable feasible-file-length-p))
-          ("subgoal *1/5'''" :expand (len (cdr blocks)))))
-
-(defthm unmake-make-blocks-lemma-1
-        (implies (natp n)
-                 (iff (consp (nthcdr n l)) (> (len l) n)))
-        :hints (("Goal" :induct (nthcdr n l))))
-
-(encapsulate ()
-  (local (include-book "std/lists/repeat" :dir :system))
-
-  ;; Proving that make and unmake are, in a sense, inverse functions of each
-  ;; other.
-  (defthm
-    unmake-make-blocks
-    (implies (and (character-listp text))
-             (equal (unmake-blocks (make-blocks text)
-                                   (len text))
-                    text))
-    :hints
-    (("goal" :in-theory (enable make-blocks))
-     ("subgoal *1/3.3'"
-      :in-theory (disable first-n-ac-of-make-character-list
-                          take-of-too-many)
-      :use ((:instance first-n-ac-of-make-character-list
-                       (i (len text))
-                       (l (first-n-ac 8 text nil))
-                       (ac nil))
-            (:instance take-of-too-many (x text)
-                       (n *blocksize*)))))))
-
-;; This is a constant that might be needed later.
-;; This is to be returned when a block is not found. It's full of null
-;; characters and is *blocksize* long.
-(defconst *nullblock* (make-character-list (take *blocksize* nil)))
 
 ;; This function serves to get the specified blocks from a disk. If the block
 ;; is not found (most likely because of an invalid index) we return a null block
@@ -197,18 +53,6 @@
    (equal (fetch-blocks-by-indices (binary-append block-list extra-blocks)
                                    index-list)
           (fetch-blocks-by-indices block-list index-list))))
-
-
-(defthm
-  make-blocks-correctness-1
-  (implies (character-listp text)
-           (and (< (- (* *blocksize* (len (make-blocks text)))
-                      *blocksize*)
-                   (len text))
-                (not (< (* *blocksize* (len (make-blocks text)))
-                        (len text)))))
-  :hints (("goal" :in-theory (enable make-blocks)
-           :induct t)))
 
 ;; This function, which is kept disabled, recognises a regular file entry. I am
 ;; deciding not to make things overly complicated by making getter and setter
@@ -594,17 +438,6 @@
      :hints (("Goal" :induct (induction-scheme disk newblocks))))
   
   )
-
-(defthm
-  make-blocks-correctness-3
-  (implies (and (character-listp cl))
-           (feasible-file-length-p (len (make-blocks cl))
-                                   (len cl)))
-  :hints
-  (("goal"
-    :in-theory (e/d (feasible-file-length-p)
-                    (make-blocks-correctness-1))
-    :use (:instance make-blocks-correctness-1 (text cl)))))
 
 ; This function writes a specified text string to a specified position to a
 ; text file at a specified path.

--- a/books/projects/filesystems/file-system-4.lisp
+++ b/books/projects/filesystems/file-system-4.lisp
@@ -1385,46 +1385,6 @@
                      (l index-list)
                      (b (len alv)))))))
 
-(encapsulate ()
-  (local (include-book "std/lists/nthcdr" :dir :system))
-
-  (local (defun nthcdr-*blocksize*-induction-2 (text1 text2)
-           (cond ((or (atom text1) (atom text2))
-                  (list text1 text2))
-                 (t (nthcdr-*blocksize*-induction-2 (nthcdr *blocksize* text1)
-                                                    (nthcdr *blocksize* text2))))))
-
-  (defthm
-    make-blocks-correctness-4
-    (implies (equal (len text1) (len text2))
-             (equal (len (make-blocks text1))
-                    (len (make-blocks text2))))
-    :hints (("goal" :in-theory (enable make-blocks)
-             :induct (nthcdr-*blocksize*-induction-2 text1 text2)))))
-
-(defthm
-  len-of-make-unmake
-  (implies (and (block-listp blocks)
-                (natp n)
-                (feasible-file-length-p (len blocks) n))
-           (equal (len (make-blocks (unmake-blocks blocks n)))
-                  (len blocks)))
-  :hints
-  (("goal" :in-theory (enable make-blocks feasible-file-length-p))
-   ("subgoal *1/8.1'"
-    :expand (append (car blocks)
-                    (unmake-blocks (cdr blocks) (+ -8 n))))
-   ("subgoal *1/5.1'"
-    :expand (append (car blocks)
-                    (unmake-blocks (cdr blocks) (+ -8 n))))
-   ("subgoal *1/2'4'" :expand (make-blocks (first-n-ac n (car blocks) nil)))
-   ("subgoal *1/2.1'" :in-theory (disable len-of-first-n-ac)
-    :use (:instance len-of-first-n-ac (i n)
-                    (l (car blocks))
-                    (ac nil)))
-   ("subgoal *1/5.2'" :cases ((atom (cdr blocks))))
-   ("subgoal *1/5.2'''" :expand (len (cdr blocks)))))
-
 (defthm
   l4-wrchs-correctness-1-lemma-19
   (implies

--- a/books/projects/filesystems/file-system-4.lisp
+++ b/books/projects/filesystems/file-system-4.lisp
@@ -558,7 +558,7 @@
             l
             (l4-collect-all-index-lists (cdr (assoc-equal name fs))))))
 
-(defthm
+(defthmd
   l4-wrchs-returns-stricter-fs-lemma-27
   (implies
    (and
@@ -622,13 +622,18 @@
         (equal (len alv) (len disk))
         (bounded-nat-listp (flatten l)
                            (len alv))
-        (not (member-intersectp-equal l (l4-collect-all-index-lists fs)))
+        (not (member-intersectp-equal
+              l (l4-collect-all-index-lists fs)))
         (indices-marked-listp l alv)
         (true-list-listp l))
-   (indices-marked-listp l
-                         (mv-nth 2
-                                 (l4-wrchs hns fs disk alv start text))))
-  :hints (("Goal" :induct (indices-marked-listp l alv))))
+   (indices-marked-listp
+    l
+    (mv-nth 2
+            (l4-wrchs hns fs disk alv start text))))
+  :hints
+  (("goal"
+    :in-theory (enable l4-wrchs-returns-stricter-fs-lemma-27)
+    :induct (indices-marked-listp l alv))))
 
 (defthm
   l4-wrchs-returns-stricter-fs-lemma-29
@@ -997,13 +1002,6 @@
                     (index (car index-list))
                     (value (car value-list))))))
 
-(defthm
-  l4-wrchs-correctness-1-lemma-10
-  (implies (and (natp n)
-                (boolean-listp alv)
-                (indices-marked-p index-list alv))
-           (not (intersectp-equal index-list (find-n-free-blocks alv n)))))
-
 (defthm l4-wrchs-correctness-1-lemma-11
   (implies (and (natp n)
                 (boolean-listp alv)
@@ -1298,34 +1296,6 @@
                                    index-list)
           value-list)))
 
-(defun count-free-blocks-alt (alv n)
-  (declare (xargs :guard (and (natp n) (boolean-listp alv))))
-  (if (zp n)
-      0
-    (+ (if (nth (- n 1) alv) 0 1)
-       (count-free-blocks-alt alv (- n 1)))))
-
-(defthm
-  count-free-blocks-alt-correctness-1
-  (implies (and (boolean-listp alv)
-                (boolean-listp ac)
-                (natp n)
-                (<= n (len alv)))
-           (equal (count-free-blocks-alt (revappend ac alv)
-                                         (+ n (len ac)))
-                  (count-free-blocks (first-n-ac n alv ac))))
-  :hints (("goal" :induct (first-n-ac n alv ac))))
-
-(defthm
-  count-free-blocks-alt-correctness-2
-  (implies (and (boolean-listp alv)
-                (equal n (len alv)))
-           (equal (count-free-blocks-alt alv n)
-                  (count-free-blocks alv)))
-  :hints (("goal" :in-theory (disable count-free-blocks-alt-correctness-1)
-           :use (:instance count-free-blocks-alt-correctness-1
-                           (ac nil)))))
-
 (defthm
   l4-wrchs-correctness-1-lemma-14
   (implies (and (boolean-listp alv)
@@ -1335,23 +1305,6 @@
            (equal (count-free-blocks-alt (set-indices-in-alv alv nil nil)
                                          n)
                   (count-free-blocks-alt alv n))))
-
-(defun count-before-n (l b)
-      (declare (xargs :guard (and (natp b) (nat-listp l))))
-      (if (atom l) 0 (+ (if (< (car l) b) 1 0) (count-before-n (cdr l) b))))
-
-(defthm count-before-n-correctness-1
-  (<= (count-before-n l b) (len l))
-  :rule-classes (:linear))
-
-(defthm count-before-n-correctness-2
-  (implies (nat-listp l)
-           (iff (equal (count-before-n l b) (len l))
-                (bounded-nat-listp l b))))
-
-(defthm count-before-n-correctness-3
-  (implies (nat-listp l)
-           (equal (count-before-n l 0) 0)))
 
 (defthm l4-wrchs-correctness-1-lemma-15
   (implies (and (boolean-listp alv)
@@ -1607,24 +1560,6 @@
                     (declare (ignore new-alv))
                     (l4-to-l2-fs new-fs new-disk)))))
 
-(defthm
-  l4-read-after-write-1
-  (implies (and (l4-stricter-fs-p fs alv)
-                (stringp text)
-                (natp start)
-                (symbol-listp hns)
-                (block-listp disk)
-                (equal (len alv) (len disk))
-                (<= (len (make-blocks (insert-text nil start text)))
-                    (count-free-blocks alv))
-                (equal n (length text))
-                (stringp (l4-stat hns fs disk)))
-           (mv-let (new-fs new-disk new-alv)
-             (l4-wrchs hns fs disk alv start text)
-             (declare (ignore new-alv))
-             (equal (l4-rdchs hns new-fs new-disk start n)
-                    text))))
-
 (defthm l4-wrchs-returns-disk-lemma-1
   (implies (and (equal (len index-list)
                        (len value-list))
@@ -1660,50 +1595,138 @@
            (block-listp (mv-nth 1 (l4-wrchs hns fs disk alv start text)))))
 
 (defthm
-  l4-read-after-write-2
-  (implies (and (l4-stricter-fs-p fs alv)
-                (stringp text1)
-                (stringp text2)
-                (natp start1)
-                (natp start2)
-                (symbol-listp hns1)
-                (symbol-listp hns2)
-                (not (equal hns1 hns2))
-                (natp n1)
-                (natp n2)
-                (block-listp disk)
-                (boolean-listp alv)
-                (equal (len alv) (len disk))
-                (<= (len (make-blocks (insert-text nil start2 text2)))
-                    (count-free-blocks alv))
-                (stringp (l4-stat hns1 fs disk)))
-           (mv-let (new-fs new-disk new-alv)
-             (l4-wrchs hns2 fs disk alv start2 text2)
-             (declare (ignore new-alv))
-             (equal (l4-rdchs hns1 new-fs new-disk start1 n1)
-                    (l4-rdchs hns1 fs disk start1 n1))))
+  l4-stat-after-write-lemma-1
+  (implies
+   (and (l4-stricter-fs-p fs alv)
+        (block-listp disk)
+        (symbol-listp hns1)
+        (symbol-listp hns2)
+        (natp start2)
+        (stringp text2)
+        (equal (len disk) (len alv))
+        (<= (len (make-blocks (insert-text nil start2 text2)))
+            (count-free-blocks alv)))
+   (mv-let (new-fs new-disk new-alv)
+     (l4-wrchs hns2 fs disk alv start2 text2)
+     (declare (ignore new-alv))
+     (equal (stringp (l4-stat hns1 new-fs new-disk))
+            (stringp (l4-stat hns1 fs disk)))))
+  :hints
+  (("goal" :in-theory (disable l2-read-after-write-2-lemma-4
+                               l4-wrchs-correctness-1)
+    :use ((:instance l2-read-after-write-2-lemma-4
+                     (fs (l4-to-l2-fs fs disk)))
+          (:instance l4-wrchs-correctness-1 (hns hns2)
+                     (start start2)
+                     (text text2))))))
+
+(defthm
+  l4-stat-after-write
+  (implies
+   (and (l4-stricter-fs-p fs alv)
+        (stringp text2)
+        (symbol-listp hns1)
+        (symbol-listp hns2)
+        (natp start2)
+        (stringp (l4-stat hns1 fs disk))
+        (boolean-listp alv)
+        (equal (len alv) (len disk))
+        (block-listp disk)
+        (<= (len (make-blocks (insert-text nil start2 text2)))
+            (count-free-blocks alv)))
+   (mv-let
+     (new-fs new-disk new-alv)
+     (l4-wrchs hns2 fs disk alv start2 text2)
+     (declare (ignore new-alv))
+     (equal
+      (l4-stat hns1 new-fs new-disk)
+      (if
+       (equal hns1 hns2)
+       (coerce (insert-text (coerce (l4-stat hns1 fs disk) 'list)
+                            start2 text2)
+               'string)
+       (l4-stat hns1 fs disk)))))
   :hints
   (("goal"
-    :in-theory (disable l4-rdchs-correctness-1
-                        l4-wrchs-correctness-1
-                        l4-wrchs-returns-fs)
+    :do-not-induct t
+    :in-theory (disable l3-stat-correctness-1
+                        l3-stat-correctness-2
+                        l2-stat-after-write l4-wrchs-returns-fs
+                        l4-wrchs-returns-disk
+                        l4-stat-after-write-lemma-1
+                        l4-wrchs-correctness-1)
     :use
-    ((:instance l4-rdchs-correctness-1 (hns hns1)
-                (start start1)
-                (n n1))
-     (:instance l4-rdchs-correctness-1 (hns hns1)
-                (start start1)
-                (n n1)
-                (fs (mv-nth 0
-                            (l4-wrchs hns2 fs disk alv start2 text2)))
-                (disk (mv-nth 1
-                              (l4-wrchs hns2 fs disk alv start2 text2))))
-     (:instance l4-wrchs-correctness-1 (hns hns2)
-                (start start2)
-                (text text2))
+    ((:instance l3-stat-correctness-1 (hns hns1))
+     (:instance
+      l3-stat-correctness-1 (hns hns1)
+      (fs (mv-nth 0
+                  (l4-wrchs hns2 fs disk alv start2 text2)))
+      (disk (mv-nth 1
+                    (l4-wrchs hns2 fs disk alv start2 text2))))
+     (:instance l3-stat-correctness-2 (hns hns1))
+     (:instance
+      l3-stat-correctness-2 (hns hns1)
+      (fs (mv-nth 0
+                  (l4-wrchs hns2 fs disk alv start2 text2)))
+      (disk (mv-nth 1
+                    (l4-wrchs hns2 fs disk alv start2 text2))))
+     (:instance l2-stat-after-write
+                (fs (l3-to-l2-fs fs disk)))
      (:instance l4-wrchs-returns-fs (hns hns2)
                 (start start2)
+                (text text2))
+     (:instance l4-wrchs-returns-disk (hns hns2)
+                (start start2)
+                (text text2))
+     l4-stat-after-write-lemma-1
+     (:instance l4-wrchs-correctness-1 (hns hns2)
+                (start start2)
                 (text text2))))))
+
+(defthm
+  l4-read-after-write-1
+  (implies (and (l4-stricter-fs-p fs alv)
+                (stringp text)
+                (natp start)
+                (symbol-listp hns)
+                (block-listp disk)
+                (equal (len alv) (len disk))
+                (<= (len (make-blocks (insert-text nil start text)))
+                    (count-free-blocks alv))
+                (equal n (length text))
+                (stringp (l4-stat hns fs disk)))
+           (mv-let (new-fs new-disk new-alv)
+             (l4-wrchs hns fs disk alv start text)
+             (declare (ignore new-alv))
+             (equal (l4-rdchs hns new-fs new-disk start n)
+                    text))))
+
+(defthm
+  l4-read-after-write-2
+  (implies
+   (and (l4-stricter-fs-p fs alv)
+        (stringp text2)
+        (natp start1)
+        (natp start2)
+        (symbol-listp hns1)
+        (symbol-listp hns2)
+        (not (equal hns1 hns2))
+        (natp n1)
+        (block-listp disk)
+        (boolean-listp alv)
+        (equal (len alv) (len disk))
+        (<= (len (make-blocks (insert-text nil start2 text2)))
+            (count-free-blocks alv)))
+   (mv-let (new-fs new-disk new-alv)
+     (l4-wrchs hns2 fs disk alv start2 text2)
+     (declare (ignore new-alv))
+     (equal (l4-rdchs hns1 new-fs new-disk start1 n1)
+            (l4-rdchs hns1 fs disk start1 n1))))
+  :hints
+  (("goal"
+    :in-theory (disable l4-stat-after-write-lemma-1
+                        l4-stat-after-write)
+    :use (l4-stat-after-write-lemma-1 l4-stat-after-write))))
 
 (defun l4-create (hns fs disk alv text)
   (declare (xargs :guard (and (symbol-listp hns)
@@ -1950,6 +1973,7 @@
                 (boolean-listp alv))
            (l3-fs-p (mv-nth 0 (l4-unlink hns fs alv)))))
 
+;; This theorem shows the equivalence of the l4 and l2 versions of unlink.
 (defthm
     l4-unlink-correctness-1
   (implies (and (l4-stricter-fs-p fs alv)

--- a/books/projects/filesystems/file-system-5.lisp
+++ b/books/projects/filesystems/file-system-5.lisp
@@ -909,28 +909,33 @@
   ()
 
   (local
-   (defun induction-scheme (hns1 hns2 fs)
-     (if (atom hns1)
+   (defun
+       induction-scheme (hns1 hns2 fs)
+     (if
+         (atom hns1)
          fs
-       (if (atom fs)
+       (if
+           (atom fs)
            nil
-         (let ((sd (assoc (car hns2) fs)))
-           (if (atom sd)
+         (let
+             ((sd (assoc (car hns2) fs)))
+           (if
+               (atom sd)
                fs
-             (if (atom hns2)
+             (if
+                 (atom hns2)
                  fs
                (if (not (equal (car hns1) (car hns2)))
                    fs
                  (let ((contents (cdr sd)))
                    (if (atom (cdr hns1))
-                       (cons (cons (car sd)
-                                   contents)
+                       (cons (cons (car sd) contents)
                              (delete-assoc (car hns2) fs))
                      (cons (cons (car sd)
-                                 (induction-scheme (cdr hns1) (cdr hns2) contents))
-                           (delete-assoc (car hns2) fs)))
-                   ))))
-           )))))
+                                 (induction-scheme (cdr hns1)
+                                                   (cdr hns2)
+                                                   contents))
+                           (delete-assoc (car hns2) fs))))))))))))
 
   (defthm
     l5-read-after-write-2-lemma-5

--- a/books/projects/filesystems/find-n-free-blocks.lisp
+++ b/books/projects/filesystems/find-n-free-blocks.lisp
@@ -191,3 +191,48 @@
   :hints (("goal" :in-theory (enable find-n-free-blocks)
            :use (:instance find-n-free-blocks-helper-correctness-7
                            (start 0)))))
+
+(defun count-free-blocks-alt (alv n)
+  (declare (xargs :guard (and (natp n) (boolean-listp alv))))
+  (if (zp n)
+      0
+    (+ (if (nth (- n 1) alv) 0 1)
+       (count-free-blocks-alt alv (- n 1)))))
+
+(defthm
+  count-free-blocks-alt-correctness-1
+  (implies (and (boolean-listp alv)
+                (boolean-listp ac)
+                (natp n)
+                (<= n (len alv)))
+           (equal (count-free-blocks-alt (revappend ac alv)
+                                         (+ n (len ac)))
+                  (count-free-blocks (first-n-ac n alv ac))))
+  :hints (("goal" :induct (first-n-ac n alv ac))))
+
+(defthm
+  count-free-blocks-alt-correctness-2
+  (implies (and (boolean-listp alv)
+                (equal n (len alv)))
+           (equal (count-free-blocks-alt alv n)
+                  (count-free-blocks alv)))
+  :hints (("goal" :in-theory (disable count-free-blocks-alt-correctness-1)
+           :use (:instance count-free-blocks-alt-correctness-1
+                           (ac nil)))))
+
+(defun count-before-n (l b)
+      (declare (xargs :guard (and (natp b) (nat-listp l))))
+      (if (atom l) 0 (+ (if (< (car l) b) 1 0) (count-before-n (cdr l) b))))
+
+(defthm count-before-n-correctness-1
+  (<= (count-before-n l b) (len l))
+  :rule-classes (:linear))
+
+(defthm count-before-n-correctness-2
+  (implies (nat-listp l)
+           (iff (equal (count-before-n l b) (len l))
+                (bounded-nat-listp l b))))
+
+(defthm count-before-n-correctness-3
+  (implies (nat-listp l)
+           (equal (count-before-n l 0) 0)))


### PR DESCRIPTION
Thanks are owed to @myall86 who suggested proving results about overlapping reads in the context of read-over-write properties, during my seminar talk. Such a result already existed for L1 (defthm l1-stat-after-write ...), but I have now done the thing for L2, L3, L4 and L6 as well. This also allowed me to revise my existing read-after-write proofs and speed them up in some cases. I've also re-factored in order to move certain functions and related theorems to a separate book. Finally, I've added read-over-write proofs for L6.

(These changes have been tested with "make all" in the books/ directory.)