### PR TITLE
Make an inclusion local

### DIFF
--- a/books/projects/x86isa/tools/execution/exec-loaders/mach-o/mach-o-reader.lisp
+++ b/books/projects/x86isa/tools/execution/exec-loaders/mach-o/mach-o-reader.lisp
@@ -11,6 +11,7 @@
 (include-book "std/io/read-file-bytes" :dir :system)
 (include-book "mach-o-stobj"
               :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+(local (include-book "std/lists/take" :dir :system))
 
 ;; ======================================================================
 

--- a/books/std/io/take-bytes.lisp
+++ b/books/std/io/take-bytes.lisp
@@ -37,6 +37,7 @@
 (local (include-book "base"))
 (local (include-book "arithmetic/top" :dir :system))
 (local (include-book "tools/mv-nth" :dir :system))
+(local (include-book "std/lists/take" :dir :system))
 (set-state-ok t)
 
 (defsection take-bytes

--- a/books/std/typed-lists/unsigned-byte-listp.lisp
+++ b/books/std/typed-lists/unsigned-byte-listp.lisp
@@ -34,7 +34,7 @@
 (in-package "ACL2")
 (set-verify-guards-eagerness 2)
 (include-book "std/lists/repeat" :dir :system)
-(include-book "std/lists/take" :dir :system)
+(local (include-book "std/lists/take" :dir :system))
 (include-book "arithmetic/nat-listp" :dir :system)
 
 

--- a/books/unicode/utf8-decode.lisp
+++ b/books/unicode/utf8-decode.lisp
@@ -43,6 +43,7 @@
 (local (include-book "tools/mv-nth" :dir :system))
 (local (include-book "std/lists/append" :dir :system))
 (local (include-book "std/lists/revappend" :dir :system))
+(include-book "std/lists/take" :dir :system)
 (set-verify-guards-eagerness 2)
 (set-state-ok t)
 


### PR DESCRIPTION
This pull request supersedes  #848, the description is reproduced below, sans a comment which no longer applies.
--
The non-local inclusion of "std/lists/take" in std/typed-lists/unsigned-byte-listp.lisp was causing a number of very permissive lemmas from the former to be included in every book that included the latter. This meant the output of (show-accumulated-persistence :useless) was full of these lemmas in the books I'm working on, and probably in others as well. The proposed change could potentially have been very broad, but I've tried to choose the smallest set of books that allow the regression go through.