### PR TITLE
VL: clocking blocks and "default disable" parsing

### DIFF
--- a/books/centaur/sv/failtest/Makefile
+++ b/books/centaur/sv/failtest/Makefile
@@ -62,7 +62,8 @@ FAILING_TEST_TARGETS := \
   clocking3.svok \
   clocking4.svok \
   clocking5.svok \
-  clocking6.svok
+  clocking6.svok \
+  clocking9.svok
 
 $(CORE):
 	cd $(COSIM_DIR); $(MAKE) cosim-core

--- a/books/centaur/vl/linttest/parse/check.rb
+++ b/books/centaur/vl/linttest/parse/check.rb
@@ -41,4 +41,6 @@ match_warning(:m2, "VL-PARSE-ERROR", "")
 # Make sure we still process m3 even though it comes after and instantiates a module with a parse error
 match_warning_ss(:m3, "VL-LUCID-SPURIOUS", "another_spurious_wire")
 
+outlaw_warning(:m4, "VL-PARSE-ERROR", "")
+
 test_passed()

--- a/books/centaur/vl/linttest/parse/spec.sv
+++ b/books/centaur/vl/linttest/parse/spec.sv
@@ -48,3 +48,10 @@ module m3 ();
    wire another_spurious_wire;
 
 endmodule
+
+module m4 (input clock, input reset);
+
+   default clocking my_clock @(posedge clock); endclocking
+   default disable iff (reset);
+
+endmodule

--- a/books/centaur/vl/loader/parser/elements.lisp
+++ b/books/centaur/vl/loader/parser/elements.lisp
@@ -458,10 +458,18 @@ rules:</p>
                (gclkdecl := (vl-parse-global-clocking-declaration atts))
                (return (list gclkdecl))))
 
-         ((when (eq type1 :vl-kwd-clocking))
+         ((when (or (and (eq type1 :vl-kwd-default)
+                         (vl-lookahead-is-token? :vl-kwd-clocking (cdr tokens)))
+                    (eq type1 :vl-kwd-clocking)))
           (seq tokstream
                (clkdecl := (vl-parse-normal-clocking-declaration atts))
                (return (list clkdecl))))
+
+         ((when (eq type1 :vl-kwd-default))
+          ;; Note that we already checked for 'default clocking' above
+          (seq tokstream
+               (disable := (vl-parse-defaultdisable atts))
+               (return (list disable))))
 
          ((when (eq type1 :vl-kwd-let))
           (vl-parse-error "BOZO not yet implemented: let declarations"))
@@ -964,6 +972,7 @@ returns a @(see vl-genblock).</li>
     (:vl-sequence   "sequence declaration")
     (:vl-clkdecl    "clocking declaration")
     (:vl-gclkdecl   "global clocking declaration")
+    (:vl-defaultdisable "default disable")
     (:vl-dpiimport  "DPI import")
     (:vl-dpiexport  "DPI export")
     (:vl-bind       "bind declaration")

--- a/books/centaur/vl/loader/parser/interfaces.lisp
+++ b/books/centaur/vl/loader/parser/interfaces.lisp
@@ -104,6 +104,7 @@ interface_ansi_header ::=
                                               :vl-sequence
                                               :vl-clkdecl
                                               :vl-gclkdecl
+                                              :vl-defaultdisable
                                               :vl-dpiimport
                                               :vl-dpiexport
                                               :vl-bind
@@ -138,6 +139,7 @@ interface_ansi_header ::=
                         :sequences   c.sequences
                         :clkdecls    c.clkdecls
                         :gclkdecls   c.gclkdecls
+                        :defaultdisables c.defaultdisables
                         :binds       c.binds
                         :classes     c.classes
                         :elabtasks   c.elabtasks

--- a/books/centaur/vl/loader/parser/modules.lisp
+++ b/books/centaur/vl/loader/parser/modules.lisp
@@ -80,6 +80,7 @@
                                               :vl-sequence
                                               :vl-clkdecl
                                               :vl-gclkdecl
+                                              :vl-defaultdisable
                                               :vl-dpiimport
                                               :vl-dpiexport
                                               :vl-bind
@@ -121,6 +122,7 @@
                     :sequences   c.sequences
                     :clkdecls    c.clkdecls
                     :gclkdecls   c.gclkdecls
+                    :defaultdisables c.defaultdisables
                     :assertions  c.assertions
                     :cassertions c.cassertions
                     :dpiimports  c.dpiimports

--- a/books/centaur/vl/mlib/fmt.lisp
+++ b/books/centaur/vl/mlib/fmt.lisp
@@ -209,7 +209,7 @@ formerly the \"location directive\" and printed a location.</p>")
         :vl-typedef :vl-fwdtypedef :vl-assertion :vl-cassertion
         :vl-property :vl-sequence :vl-clkdecl :vl-gclkdecl
         :vl-import :vl-dpiimport :vl-dpiexport :vl-bind :vl-class
-        :vl-covergroup :vl-elabtask
+        :vl-covergroup :vl-elabtask :vl-defaultdisable
         :vl-genarray :vl-genbegin :vl-genbase :vl-genif :vl-gencase :vl-genloop :vl-modport)
        (vl-fmt-tilde-a-case vl-ctxelement-p vl-pp-ctxelement-summary))
       ((:vl-genvar)

--- a/books/centaur/vl/mlib/immdeps.lisp
+++ b/books/centaur/vl/mlib/immdeps.lisp
@@ -922,6 +922,7 @@ elements.")
     (:vl-sequence      (vl-sequence-immdeps x ans))
     (:vl-clkdecl       ans) ;; BOZO figure out what to do here -- also update module-immdeps!!
     (:vl-gclkdecl      ans) ;; BOZO figure out what to do here -- also update module-immdeps!!
+    (:vl-defaultdisable ans) ;; BOZO figure out what to do here -- also update module-immdeps!!
     (:vl-dpiimport     ans) ;; I don't think we care?
     (:vl-dpiexport     ans) ;; I don't think we care?
     (:vl-bind          ans) ;; BOZO figure out what to do here -- also update module/interface-immdeps!!
@@ -1166,7 +1167,7 @@ depends on.  The format is compatible with @(see depgraph::toposort)."
        (ans (vl-typedeflist-immdeps    x.typedefs   ans))
        (ans (vl-propertylist-immdeps   x.properties ans))
        (ans (vl-sequencelist-immdeps   x.sequences  ans))
-       ;; BOZO clkdecls, gclkdecls
+       ;; BOZO clkdecls, gclkdecls, defaultdisables
        (ans (vl-assertionlist-immdeps  x.assertions ans))
        (ans (vl-cassertionlist-immdeps x.cassertions ans))
        (ans (vl-genelementlist-immdeps x.generates  ans)))
@@ -1250,7 +1251,7 @@ depends on.  The format is compatible with @(see depgraph::toposort)."
        (ans (vl-typedeflist-immdeps    x.typedefs   ans))
        (ans (vl-propertylist-immdeps   x.properties ans))
        (ans (vl-sequencelist-immdeps   x.sequences  ans))
-       ;; BOZO clkdecls, gclkdecls
+       ;; BOZO clkdecls, gclkdecls, defaultdisables
        (ans (vl-modinstlist-immdeps    x.modinsts   ans))
        (ans (vl-assignlist-immdeps     x.assigns    ans))
        (ans (vl-aliaslist-immdeps      x.aliases    ans))

--- a/books/centaur/vl/mlib/print-context.lisp
+++ b/books/centaur/vl/mlib/print-context.lisp
@@ -234,6 +234,10 @@
                     (vl-ps-seq (vl-print "Global clocking block at ")
                                (vl-print-loc (vl-gclkdecl->loc x))))))
 
+      (:vl-defaultdisable
+       (vl-ps-seq (vl-print "Default disable statement at ")
+                  (vl-print-loc (vl-defaultdisable->loc x))))
+
       (:vl-assertion
        (vl-ps-seq (vl-print "Assertion ")
                   (vl-print-str (or (vl-assertion->name x) ""))
@@ -350,6 +354,7 @@ quick summary instead, see @(see vl-pp-ctxelement-summary).</p>"
       (:vl-sequence      (vl-pp-sequence x))
       (:vl-clkdecl       (vl-pp-clkdecl x))
       (:vl-gclkdecl      (vl-pp-gclkdecl x))
+      (:vl-defaultdisable (vl-pp-defaultdisable x))
       (:vl-dpiimport     (vl-pp-dpiimport x))
       (:vl-dpiexport     (vl-pp-dpiexport x))
       (:vl-bind          (vl-pp-bind x nil))

--- a/books/centaur/vl/mlib/writer.lisp
+++ b/books/centaur/vl/mlib/writer.lisp
@@ -4088,6 +4088,20 @@ expression into a string."
     (vl-ps-seq (vl-pp-clkdecl (car x))
                (vl-pp-clkdecllist (cdr x)))))
 
+(define vl-pp-defaultdisable ((x vl-defaultdisable-p) &key (ps 'ps))
+  (b* (((vl-defaultdisable x)))
+    (vl-ps-seq (vl-progindent)
+               (vl-ps-span "vl_key"
+                           (vl-print "default disable iff "))
+               (vl-pp-exprdist x.exprdist)
+               (vl-println ";"))))
+
+(define vl-pp-defaultdisablelist ((x vl-defaultdisablelist-p) &key (ps 'ps))
+  (if (atom x)
+      ps
+    (vl-ps-seq (vl-pp-defaultdisable (car x))
+               (vl-pp-defaultdisablelist (cdr x)))))
+
 (define vl-pp-gclkdecl ((x vl-gclkdecl-p) &key (ps 'ps))
   (b* (((vl-gclkdecl x)))
     (vl-ps-seq (vl-progindent)
@@ -4184,6 +4198,7 @@ expression into a string."
       (:vl-sequence   (vl-pp-sequence x))
       (:vl-clkdecl    (vl-pp-clkdecl x))
       (:vl-gclkdecl   (vl-pp-gclkdecl x))
+      (:vl-defaultdisable (vl-pp-defaultdisable x))
       (:vl-dpiimport  (vl-pp-dpiimport x))
       (:vl-dpiexport  (vl-pp-dpiexport x))
       (:vl-bind       (vl-pp-bind x nil))
@@ -4340,6 +4355,7 @@ expression into a string."
                (vl-pp-sequencelist x.sequences)
                (vl-pp-clkdecllist x.clkdecls)
                (vl-pp-gclkdecllist x.gclkdecls)
+               (vl-pp-defaultdisablelist x.defaultdisables)
                (vl-pp-assertionlist x.assertions)
                (vl-pp-cassertionlist x.cassertions)
                (vl-pp-bindlist x.binds ss)

--- a/books/centaur/vl/parsetree.lisp
+++ b/books/centaur/vl/parsetree.lisp
@@ -3521,6 +3521,18 @@ flops, and to set up other simulation events.  A simple example would be:</p>
 (fty::deflist vl-gclkdecllist
   :elt-type vl-gclkdecl)
 
+(defprod vl-defaultdisable
+  :short "Representation of a @('default disable iff') construct."
+  :tag :vl-defaultdisable
+  :layout :tree
+  ((exprdist vl-exprdist-p
+             "The argument, e.g., @('reset') in @('default disable iff reset')")
+   (loc  vl-location-p)
+   (atts vl-atts-p)))
+
+(fty::deflist vl-defaultdisablelist
+  :elt-type vl-defaultdisable)
+
 
 ;; (defenum vl-taskporttype-p
 ;;   (:vl-unsigned
@@ -4200,6 +4212,7 @@ be non-sliceable, at least if it's an input.</p>"
       sequence
       clkdecl
       gclkdecl
+      defaultdisable
       dpiimport
       dpiexport
       bind
@@ -4969,6 +4982,9 @@ the type information between the variable and port declarations.</p>"
                  allow a list here because it makes things work much more
                  smoothly with modelements.")
 
+   (defaultdisables vl-defaultdisablelist-p
+                    "Any @('default disable ...') constructs for the module.")
+
    (dpiimports  vl-dpiimportlist-p
                 "DPI imports for this module.")
 
@@ -5330,6 +5346,7 @@ packages.  Eventually there will be new fields here.</p>")
    (sequences   vl-sequencelist-p)   ;; allowed via package_or_generate_item (assertion_item_declaration)
    (clkdecls    vl-clkdecllist-p)
    (gclkdecls   vl-gclkdecllist-p)
+   (defaultdisables vl-defaultdisablelist-p)
    (binds       vl-bindlist-p)
    (classes     vl-classlist-p)
    ;; can interfaces have covergroups?? (covergroups vl-covergrouplist-p)

--- a/books/centaur/vl/transforms/annotate/make-implicit-wires.lisp
+++ b/books/centaur/vl/transforms/annotate/make-implicit-wires.lisp
@@ -748,6 +748,7 @@ Our version of VCS says this isn't yet implemented.</li>
                   ;; BOZO not sure how these are scoped yet.
                   (eq tag :vl-clkdecl)
                   (eq tag :vl-gclkdecl)
+                  (eq tag :vl-defaultdisable)
                   (eq tag :vl-bind)
                   (eq tag :vl-class)
                   (eq tag :vl-covergroup)

--- a/books/centaur/vl/transforms/annotate/shadowcheck.lisp
+++ b/books/centaur/vl/transforms/annotate/shadowcheck.lisp
@@ -1751,6 +1751,7 @@ explicit declarations.</p>")
        ((when (eq tag :vl-sequence))   (mv st warnings)) ;; BOZO figure out what we want to do here.
        ((when (eq tag :vl-clkdecl))    (mv st warnings)) ;; BOZO figure out what we want to do here.
        ((when (eq tag :vl-gclkdecl))   (mv st warnings)) ;; BOZO figure out what we want to do here.
+       ((when (eq tag :vl-defaultdisable)) (mv st warnings)) ;; BOZO figure out what we want to do here.
        ((when (eq tag :vl-dpiexport))  (mv st warnings)) ;; BOZO figure out what we want to do here.
        ((when (eq tag :vl-fwdtypedef)) (mv st warnings)) ;; BOZO figure out what we want to do here.
        ((when (eq tag :vl-bind))       (mv st warnings)) ;; BOZO figure out what we want to do here.


### PR DESCRIPTION
Fix confusion in the parsing code for clocking blocks.  We had been using
backtracking to handle cases where the clocking_event begins with an
identifier, but that is impossible: they always start with @.  Also fix an
oversight in the element parsing code: it was only invoking the clocking block
parser for "clocking", but not for "default clocking."

Add a parser and representation for "default disable" blocks.  Note that like
clocking blocks, these are effectively ignored throughout most of VL and are
not supported in any sensible way, but at least we will now be able to parse
them.

Extend linttest/parse to check that we can parse a module with a default
clocking block and a default disable construct.