### PR TITLE
Fixing Smtlink documentation

### DIFF
--- a/books/projects/smtlink/verified/Smtlink.lisp
+++ b/books/projects/smtlink/verified/Smtlink.lisp
@@ -769,7 +769,6 @@
   (encapsulate ()
                (local (in-theory (enable smtlink-option-name-fix)))
                (deffixtype smtlink-option-name
-                 :parents (smtlink-hint-syntax)
                  :pred  smtlink-option-name-p
                  :fix   smtlink-option-name-fix
                  :equiv smtlink-option-name-equiv
@@ -778,7 +777,7 @@
                  :topic smtlink-option-name-p)
 
                (deflist smtlink-option-name-lst
-                 :parents (smtlink-option-name)
+                 :parents (smtlink-option-name-p)
                  :elt-type smtlink-option-name
                  :true-listp t))
 

--- a/books/projects/smtlink/verified/Smtlink.lisp
+++ b/books/projects/smtlink/verified/Smtlink.lisp
@@ -739,13 +739,13 @@
     (remove-duplicates-equal (strip-cdrs *smtlink-options*)))
 
   (define smtlink-option-type-p ((option-type t))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (syntax-good? booleanp)
     :short "Recoginizer for smtlink-option-type."
     (if (member-equal option-type *smtlink-option-types*) t nil))
 
   (define smtlink-option-type-fix ((opttype smtlink-option-type-p))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (fixed-opttype smtlink-option-type-p
                             :hints (("Goal" :in-theory (enable
                                                         smtlink-option-type-p))))
@@ -754,13 +754,13 @@
          :exec opttype))
 
   (define smtlink-option-name-p ((option-name t))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (syntax-good? booleanp)
     :short "Recoginizer for an smtlink-option-name."
     (if (member-equal option-name *smtlink-option-names*) t nil))
 
   (define smtlink-option-name-fix ((option smtlink-option-name-p))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (fixed-smtlink-option-name smtlink-option-name-p)
     :short "Fixing function for smtlink-option-name."
     (mbe :logic (if (smtlink-option-name-p option) option ':functions)
@@ -769,6 +769,7 @@
   (encapsulate ()
                (local (in-theory (enable smtlink-option-name-fix)))
                (deffixtype smtlink-option-name
+                 :parents (smtlink-hint-syntax)
                  :pred  smtlink-option-name-p
                  :fix   smtlink-option-name-fix
                  :equiv smtlink-option-name-equiv
@@ -823,7 +824,7 @@
     :rule-classes(:congruence))
 
   (define eval-smtlink-option-type ((option-type smtlink-option-type-p) (term t))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (type-correct? booleanp)
     :short "Evaluating types for smtlink option body."
     (case option-type
@@ -838,7 +839,7 @@
       (t (natp term))))
 
   (define smtlink-option-syntax-p ((term t) (used smtlink-option-name-lst-p))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (mv (ok booleanp)
                  (new-used smtlink-option-name-lst-p
                            :hints (("Goal" :in-theory (enable smtlink-option-name-lst-p smtlink-option-name-p)))))
@@ -890,7 +891,7 @@
                :name smtlink-option-syntax-p--new-used-when-ok)))
 
   (define smtlink-hint-syntax-p-helper ((term t) (used smtlink-option-name-lst-p))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (syntax-good? booleanp)
     :short "Helper function for smtlink-hint-syntax-p."
     (b* (((unless (true-listp term)) nil)
@@ -942,14 +943,14 @@
                                              (used nil))))))))
 
   (define smtlink-hint-syntax-p ((term t))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :returns (syntax-good? booleanp)
     :short "Recognizer for smtlink-hint-syntax."
     (smtlink-hint-syntax-p-helper term nil))
 
   ;; Strange fixing function.
   (define smtlink-hint-syntax-fix ((term smtlink-hint-syntax-p))
-    :parents (smt-solver-params)
+    :parents (smtlink-hint-syntax)
     :short "Fixing function for smtlink-hint-syntax."
     :returns (fixed-smtlink-hint-syntax smtlink-hint-syntax-p)
     (mbe :logic (if (smtlink-hint-syntax-p term) term nil)

--- a/books/projects/smtlink/verified/extractor.lisp
+++ b/books/projects/smtlink/verified/extractor.lisp
@@ -52,7 +52,7 @@
                             pseudo-term-list-fix)))
 
   (defines extract
-    :parents (SMT-extractor)
+    :parents (SMT-extract)
     :short "Functions for extracting type declarations from clause."
 
     (define extract-disjunct ((term pseudo-termp) (fty-info fty-info-alist-p))

--- a/books/projects/smtlink/verified/uninterpreted-fn-cp.lisp
+++ b/books/projects/smtlink/verified/uninterpreted-fn-cp.lisp
@@ -51,7 +51,7 @@
 
 (local (in-theory (enable lambda->formals-fix lambda->actuals-fix)))
 (defprod lambda-binding
-  :parents (SMT-goal-generate)
+  :parents (uninterpreted-fn-cp)
   ((formals symbol-listp
             :default nil
             :reqfix (lambda->formals-fix formals actuals))
@@ -67,7 +67,7 @@
   :true-listp t)
 
 (defprod fhg-single-args
-  :parents (SMT-goal-generate)
+  :parents (uninterpreted-fn-cp)
   ((fn func-p :default nil)
    (actuals pseudo-term-listp :default nil)
    (fn-returns-hint-acc hint-pair-listp :default nil)
@@ -191,7 +191,7 @@
 
 ;; function hypotheses generation arguments
 (defprod fhg-args
-  :parents (SMT-goal-generate)
+  :parents (uninterpreted-fn-cp)
   ((term-lst pseudo-term-listp :default nil)
    (fn-lst func-alistp :default nil)
    (fn-returns-hint-acc hint-pair-listp :default nil)
@@ -321,7 +321,7 @@
 ;;     theorems.
 ;;
 (define generate-fn-hint-lst ((args fhg-args-p))
-  :parents (SMT-goal-generate)
+  :parents (uninterpreted-fn-cp)
   :short "@(call generate-fn-hint-lst) generate auxiliary hypotheses from ~
            function expansion"
   :returns (fn-hint-lst fhg-args-p)


### PR DESCRIPTION
Fixing non-existent parents warning from Smtlink documentation