### PR TITLE
VL: linter tweaks

### DIFF
--- a/books/centaur/vl/lint/leftright.lisp
+++ b/books/centaur/vl/lint/leftright.lisp
@@ -492,15 +492,19 @@ warnings.  We also use it to suppress warnings in certain cases.</p>"
 (define vl-expr-indexy-via-ctx ((expr vl-expr-p)
                                 (ctx  vl-context1-p))
   :returns (indexy booleanp :rule-classes :type-prescription)
-  ;; Horrible godawful hack to treat the msb/lsb exprs from things like `wire
-  ;; [msb:lsb] foo` as indexy to begin with.
   (b* ((elem (vl-context1->elem ctx)))
     (case (tag elem)
       (:vl-vardecl
+       ;; Horrible godawful hack to treat the msb/lsb exprs from things like
+       ;; `wire [msb:lsb] foo` as indexy to begin with.
        (if (member-equal (vl-expr-fix expr)
                          (vl-datatype-allexprs (vl-vardecl->type elem)))
            t
          nil))
+      (:vl-paramdecl
+       ;; Similarly horrible hack, treat all expressions from parameters as
+       ;; being indexy.
+       t)
       (otherwise
        nil))))
 

--- a/books/centaur/vl/linttest/fussy/check.rb
+++ b/books/centaur/vl/linttest/fussy/check.rb
@@ -186,7 +186,13 @@ fuss("shift_xor_warn2")
 normal("shift_xor_normal1")
 normal("shift_xor_normal2")
 
+normal("normal_sysfun1")
+normal("normal_sysfun2")
+normal("normal_sysfun3")
+normal("normal_sysfun4")
+
+outlaw_warning(:a1, "VL-WARN-QMARK-WIDTH", "foo")
+match_warning(:a1, "VL-WARN-QMARK-WIDTH", "bar")
+match_warning(:a1, "VL-WARN-QMARK-WIDTH", "baz")
+
 test_passed()
-
-
-

--- a/books/centaur/vl/linttest/fussy/spec.sv
+++ b/books/centaur/vl/linttest/fussy/spec.sv
@@ -176,4 +176,27 @@ module a0;
    wire rand3 = $random() % 2;
    wire rand4 = $urandom() % 2;
 
+
+  wire [3:0] normal_sysfun1 = xx0 & $countones(xx2);
+  wire [2:0] normal_sysfun2 = yy0 & $countones(xx2);
+  wire [3:0] normal_sysfun3 = xx0 == $bits(xx2);
+  wire [2:0] normal_sysfun4 = yy0 == $bits(xx2);
+
+endmodule
+
+
+module a1 ;
+
+   parameter foo = 7;
+   wire [3:0] bar;
+   parameter [4:0] baz = 6;
+
+   wire x0, x1, x2;
+   wire y0, y1, y2;
+   wire z0, z1, z2;
+
+   assign x0 = foo ? x1 : x2;  // don't warn about wide, untyped parameters like foo
+   assign y0 = bar ? y1 : y2;  // do warn about wide wires like bar
+   assign z0 = baz ? z1 : z2;  // do warn about wide, typed parameters
+
 endmodule

--- a/books/centaur/vl/linttest/trunc/check.rb
+++ b/books/centaur/vl/linttest/trunc/check.rb
@@ -74,6 +74,19 @@ outlaw_warning(:a0, "VL-WARN-TRUNCATION", "mod3")
 match_warning(:a0, "VL-WARN-TRUNCATION", "mod4")
 match_warning(:a0, "VL-WARN-TRUNCATION", "mod5")
 
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "xx0")
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "xx1")
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "xx2")
+
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "yy0")
+match_warning(:a1, "VL-WARN-EXTENSION", "yy0")
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "yy1")
+match_warning(:a1, "VL-WARN-TRUNCATION", "yy2")
+
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "zz0")
+outlaw_warning(:a1, "VL-WARN-TRUNCATION", "zz1")
+match_warning(:a1, "VL-WARN-TRUNCATION", "zz2")
+
 test_passed()
 
 

--- a/books/centaur/vl/linttest/trunc/spec.sv
+++ b/books/centaur/vl/linttest/trunc/spec.sv
@@ -136,3 +136,20 @@ module a0 ;
 
 endmodule
 
+module a1;
+
+   wire [3:0] w;
+
+   wire [3:0] xx0 = {3{1'b0}}; // no warning, fits
+   wire [3:0] xx1 = {4{1'b0}}; // no warning, fits
+   wire [3:0] xx2 = {5{1'b0}}; // no warning, still getting all zeroes
+
+   wire [3:0] yy0 = {3{1'b1}}; // warn, extension
+   wire [3:0] yy1 = {4{1'b1}}; // no warning, correct
+   wire [3:0] yy2 = {5{1'b1}}; // warn, truncating a 1
+
+   wire [3:0] zz0 = $countones(w);  // no warning, integer-valued system function
+   wire [3:0] zz1 = $bits(w);       // no warning, integer-valued system function
+   wire [2:0] zz2 = $unsigned(w);   // warn, wrong size
+
+endmodule

--- a/books/centaur/vl/mlib/json.lisp
+++ b/books/centaur/vl/mlib/json.lisp
@@ -343,9 +343,17 @@ the warning into a printed message here.  We'll include both HTML and plain
 TEXT versions of the message.</p>"
 
   (b* (((vl-warning x) x)
-       (text (with-local-ps (if x.context
-                                (vl-cw-obj "~a0: ~@1" (list x.context (vl-msg x.msg x.args)))
-                              (vl-cw-obj x.msg x.args))))
+       (text (with-local-ps
+               ;; Historically, we used the default auto-wrap here.  But this
+               ;; often results in long Verilog expressions getting
+               ;; word-wrapped (1) by their author, and (2) by us after the
+               ;; fact.  This often results in unfortunate formatting.  So now
+               ;; we bump this up to a pretty large wrap, deferring to the
+               ;; user's formatting unless they have really gone off the ranch.
+               (vl-ps-update-autowrap-col 1000)
+               (if x.context
+                   (vl-cw-obj "~a0: ~@1" (list x.context (vl-msg x.msg x.args)))
+                 (vl-cw-obj x.msg x.args))))
        ((when no-html)
         ;; Suppressing HTML output can be useful for reducing file sizes of
         ;; vl-warnings.json in VL Lint.


### PR DESCRIPTION
 - Suppress truncation and extension warnings when the RHS has the form {n{0}}.
   In either case you're just getting zeroes anyway and this seems fine.

 - Suppress extension warnings when the RHS has the form {'0,...}.  This will
   get zero extended as intended so all is well.

 - For fussy size-warnings, treat integer-valued system calls like
   $countones(...) more like plain integer constants.

 - Suppress qmark-width warnings for (foo ? bar : baz) where foo refers to a
   plain, untyped parameter.  This is a bow to, e.g., `parameter WITH_FOO = 1`
   where the user intends the parameter to be 0 or 1 but has not bothered to
   give a type.

 - Treat all expressions within parameter declarations as "indexy" for the
   purposes of left-right checking.  This should suppress warnings about
   constructs like `parameter foo = size + size`, which are unlikely to be
   errors.

 - JSON format: increase the wrap-column for the text of each warning to a
   larger number.  We previously word-wrapped the warnings to 80 columns, which
   was resulting in ugly wrapping in many cases.  (It probably made good sense
   originally, i.e., until the pretty-printer started preserving newlines.)

 - Add some test cases to validate the above.