### PR TITLE
Update filesystem books

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -150,7 +150,7 @@
 
  <h4>Filesystem Books</h4>
 
- <p>The filesystem books @('books/projects/filesystems/') have been
+ <p>The filesystem books @('[books]/projects/filesystems/') have been
  substantially expanded; in particular, they now contain a new model which
  faithfully represents the state of a FAT32 disk image. More details about this
  work are available in the paper <i>Formalising Filesystems in the ACL2 Theorem
@@ -168,11 +168,11 @@
  @('[books]/kestrel/utilities/typed-list-theorems.lisp') into separate files
  under a new directory @('[books]/kestrel/utilities/typed-lists').</p>
 
- <h4>Other Kestrel Utilities</h4>
+ <h4>Other Utilities</h4>
 
  <p>In support of changes to the filesystem books (see above), the Kestrel
- string libraries as well as the byte-combining libraries
- @('books/std/io/combine.lisp') have been expanded with several new
+ string libraries as well as the <see topic='@(url combine-functions)'>std/io
+ byte-combining libraries </see> have been expanded with several new
  lemmas. Some existing lemmas have also been generalized.</p>
 
  <h3>Licensing Changes</h3>

--- a/books/projects/filesystems/file-system-2.lisp
+++ b/books/projects/filesystems/file-system-2.lisp
@@ -215,7 +215,7 @@
           (if (atom sd)
               fs
             (let ((contents (cdr sd)))
-              (if (stringp (car contents)) 
+              (if (stringp (car contents))
                   fs ;; we still have names but we're at a regular file - error
                 (cons (cons (car sd)
                             (l2-unlink (cdr hns) contents))

--- a/books/projects/filesystems/file-system-3.lisp
+++ b/books/projects/filesystems/file-system-3.lisp
@@ -685,7 +685,7 @@
            (equal (stringp (l3-stat hns (mv-nth 0 (l3-wrchs hns fs disk start text))
                                     (mv-nth 1 (l3-wrchs hns fs disk start text))))
                   (stringp (l3-stat hns fs disk))))
-  :hints (("Subgoal *1/7.2'" 
+  :hints (("Subgoal *1/7.2'"
            :in-theory (disable l3-wrchs-returns-fs)
            :use (:instance l3-wrchs-returns-fs (hns (cdr hns))
                            (fs (cdr (assoc-equal (car hns) fs))))) ))
@@ -873,7 +873,7 @@
                      (l3-rdchs hns1 fs disk start1 n1)))))
   :hints (("Goal"
            :in-theory (disable
-                       (:rewrite l2-read-after-create-2) 
+                       (:rewrite l2-read-after-create-2)
                        (:rewrite l3-to-l2-fs-correctness-1)
                        (:rewrite l3-stat-correctness-2)
                        (:rewrite l3-create-returns-fs)

--- a/books/projects/filesystems/file-system-lemmas.lisp
+++ b/books/projects/filesystems/file-system-lemmas.lisp
@@ -30,28 +30,62 @@
            (equal (first-n-ac i (binary-append x y) ac)
                   (first-n-ac i x ac))))
 
-(defthm by-slice-you-mean-the-whole-cake-1
-  (implies (true-listp l)
-           (equal (first-n-ac (len l) l ac)
-                  (revappend ac l)))
-  :hints (("Goal" :induct (revappend l ac)) )
-  :rule-classes ((:rewrite :corollary
-                           (implies (and (equal i (len l)) (true-listp l))
-                                    (equal (first-n-ac i l ac) (revappend ac
-                                                                          l))))))
+(defthm
+  by-slice-you-mean-the-whole-cake-1
+  (equal (first-n-ac (len l) l ac)
+         (revappend ac (fix-true-list l)))
+  :hints (("goal" :induct (revappend l ac)))
+  :rule-classes
+  ((:rewrite
+    :corollary
+    (implies (equal i (len l))
+             (equal (first-n-ac i l ac)
+                    (revappend ac (fix-true-list l)))))))
 
 (defthm by-slice-you-mean-the-whole-cake-2
-  (implies (and (equal i (len l)) (true-listp l))
-           (equal (take i l) l)))
+  (implies (equal i (len l))
+           (equal (take i l) (fix-true-list l))))
 
 (defthm assoc-after-delete-assoc
   (implies (not (equal name1 name2))
            (equal (assoc-equal name1 (delete-assoc name2 alist))
                   (assoc-equal name1 alist))))
 
-(defthm character-listp-of-first-n-ac
-  (implies (and (character-listp l) (character-listp acc) (<= n (len l)))
-           (character-listp (first-n-ac n l acc))))
+(defthm character-listp-of-revappend
+  (equal (character-listp (revappend x y))
+         (and (character-listp (fix-true-list x))
+              (character-listp y))))
+
+(defthm
+  character-listp-of-fix-true-list
+  (implies (true-listp x)
+           (equal (character-listp (fix-true-list x))
+                  (character-listp x)))
+  :rule-classes
+  (:rewrite
+   (:rewrite
+    :corollary (implies (character-listp x)
+                        (character-listp (fix-true-list x))))))
+
+(encapsulate
+  ()
+
+  (local
+   (defthm character-listp-of-first-n-ac-lemma-1
+     (implies (not (character-listp (fix-true-list ac)))
+              (not (character-listp (first-n-ac i l ac))))))
+
+  (defthm
+    character-listp-of-first-n-ac
+    (implies (character-listp l)
+             (equal (character-listp (first-n-ac n l acc))
+                    (and (character-listp (fix-true-list acc))
+                         (<= (nfix n) (len l)))))))
+
+(defthm character-listp-of-take
+  (implies (character-listp l)
+           (equal (character-listp (take n l))
+                  (<= (nfix n) (len l)))))
 
 (defthm character-listp-of-nthcdr
   (implies (and (character-listp l))
@@ -121,9 +155,8 @@
            (boolean-listp (update-nth key val l))))
 
 (defthm nat-listp-of-binary-append
-  (implies (true-listp x)
-           (equal (nat-listp (binary-append x y))
-                  (and (nat-listp x) (nat-listp y)))))
+  (equal (nat-listp (binary-append x y))
+         (and (nat-listp (fix-true-list x)) (nat-listp y))))
 
 (defthm eqlable-listp-if-nat-listp (implies (nat-listp l) (eqlable-listp l)))
 
@@ -238,19 +271,6 @@
            (member-equal (nth n l) l))
   :hints (("Goal" :in-theory (enable nth))))
 
-(encapsulate
-  ()
-
-  (local (include-book "ihs/logops-lemmas" :dir :system))
-
-  (local (include-book "arithmetic-5/top" :dir :system))
-
-  (defthm
-    logand-ash-lemma-1
-    (implies (and (natp c))
-             (unsigned-byte-p c (logand i (- (ash 1 c) 1)))))
-  )
-
 (defthm make-character-list-of-revappend
   (equal (make-character-list (revappend x y))
          (revappend (make-character-list x)
@@ -263,61 +283,67 @@
                               (make-character-list ac))
                   (make-character-list (first-n-ac i l ac)))))
 
+(defthm revappend-of-fix-true-list
+  (equal (revappend x (fix-true-list y))
+         (fix-true-list (revappend x y))))
+
+(defthm append-of-fix-true-list
+  (equal (append (fix-true-list x) y)
+         (append x y)))
+
 (defthm
   take-more
   (implies
-   (and (true-listp l)
-        (natp i)
-        (>= i (len l)))
-   (equal (binary-append (first-n-ac i l ac1) ac2)
-          (revappend ac1
-                     (binary-append l
-                                    (make-list-ac (- i (len l)) nil ac2)))))
+   (and (integerp i) (>= i (len l)))
+   (equal
+    (binary-append (first-n-ac i l ac1) ac2)
+    (revappend
+     ac1
+     (binary-append l
+                    (make-list-ac (- i (len l)) nil ac2)))))
   :hints
-  (("goal'" :induct (first-n-ac i l ac1))
-   ("subgoal *1/6'''" :expand (make-list-ac i nil ac2))
-   ("subgoal *1/1''" :use (:instance revappend-is-append-of-rev (x ac1)
-                                     (y l)
-                                     (z ac2)))))
+  (("goal" :induct (first-n-ac i l ac1))
+   ("subgoal *1/2" :expand (make-list-ac i nil ac2))
+   ("subgoal *1/1"
+    :use (:instance revappend-is-append-of-rev (x ac1)
+                    (y l)
+                    (z ac2)))))
 
 (defthm
   take-of-take
-  (implies (and (true-listp l)
-                (natp m)
+  (implies (and (natp m)
                 (integerp n)
                 (<= m n)
                 (<= m (len l)))
            (equal (first-n-ac m (take n l) ac)
                   (first-n-ac m l ac)))
   :hints
-  (("goal" :do-not-induct t
+  (("goal"
+    :do-not-induct t
     :in-theory (disable binary-append-first-n-ac-nthcdr
-                        first-n-ac-of-binary-append-1)
+                        first-n-ac-of-binary-append-1 take-more)
     :use ((:instance binary-append-first-n-ac-nthcdr (ac nil)
                      (i n))
           (:instance first-n-ac-of-binary-append-1 (i m)
                      (x (first-n-ac n l nil))
-                     (y (nthcdr n l)))))
-   ("goal'4'" :in-theory (disable take-more)
-    :use (:instance take-more (i n)
-                    (ac1 nil)
-                    (ac2 nil)))
-   ("goal'6'"
-    :in-theory (disable first-n-ac-of-binary-append-1)
-    :use (:instance first-n-ac-of-binary-append-1 (i m)
-                    (x l)
-                    (y (make-list-ac (+ n (- (len l)))
-                                     nil nil))))))
+                     (y (nthcdr n l)))
+          (:instance take-more (i n)
+                     (ac1 nil)
+                     (ac2 nil))
+          (:instance first-n-ac-of-binary-append-1 (i m)
+                     (x l)
+                     (y (make-list-ac (+ n (- (len l)))
+                                      nil nil)))))))
 
 (defthm boolean-listp-of-revappend
-  (implies (boolean-listp x)
-           (equal (boolean-listp (revappend x y))
-                  (boolean-listp y))))
+  (equal (boolean-listp (revappend x y))
+         (and (boolean-listp (fix-true-list x))
+              (boolean-listp y))))
 
 (defthm boolean-listp-of-first-n-ac
-  (implies (and (boolean-listp l)
-                (boolean-listp ac))
-           (boolean-listp (first-n-ac i l ac))))
+  (implies (boolean-listp l)
+           (equal (boolean-listp (first-n-ac i l ac))
+                  (boolean-listp (fix-true-list ac)))))
 
 (defthm consp-of-first-n-ac
   (iff (consp (first-n-ac i l ac))
@@ -440,10 +466,9 @@
               (or (zp n) (characterp val)))))
 
 (defthm string-listp-of-append
-  (implies (true-listp x)
-           (equal (string-listp (append x y))
-                  (and (string-listp x)
-                       (string-listp y)))))
+  (equal (string-listp (append x y))
+         (and (string-listp (fix-true-list x))
+              (string-listp y))))
 
 (defthm true-listp-when-string-list
   (implies (string-listp x)
@@ -477,3 +502,65 @@
            (equal (binary-append (take i l)
                                  (nthcdr i l))
                   l)))
+
+(encapsulate
+  ()
+
+  (local
+   (defthm fix-true-list-when-true-listp
+     (implies (true-listp x)
+              (equal (fix-true-list x) x))))
+
+  (defthm fix-true-list-of-coerce
+    (equal (fix-true-list (coerce text 'list))
+           (coerce text 'list))))
+
+(defthm len-of-fix-true-list
+  (equal (len (fix-true-list x)) (len x)))
+
+(defthm string-listp-of-fix-true-list
+  (implies (string-listp x)
+           (string-listp (fix-true-list x))))
+
+(defthm nat-listp-of-fix-true-list
+  (implies (true-listp x)
+           (equal (nat-listp (fix-true-list x))
+                  (nat-listp x)))
+  :rule-classes (:rewrite
+                 (:rewrite :corollary
+                           (implies (nat-listp x)
+                                    (nat-listp (fix-true-list x))))))
+
+(defthm nth-of-make-character-list
+  (equal (nth n (make-character-list x))
+         (cond ((>= (nfix n) (len x)) nil)
+               ((characterp (nth n x)) (nth n x))
+               (t (code-char 0)))))
+
+(defthm nth-of-first-n-ac
+  (equal (nth n (first-n-ac i l ac))
+         (cond ((>= (nfix n) (+ (len ac) (nfix i)))
+                nil)
+               ((< (nfix n) (len ac))
+                (nth (- (len ac) (+ (nfix n) 1)) ac))
+               (t (nth (- (nfix n) (len ac)) l)))))
+
+(defthm nth-of-take
+  (equal (nth n (take i l))
+         (if (>= (nfix n) (nfix i))
+             nil (nth (nfix n) l))))
+
+(defthm nthcdr-of-nil (equal (nthcdr n nil) nil))
+
+(defthmd nthcdr-when->=-n-len-l
+  (implies (and (true-listp l)
+                (>= (nfix n) (len l)))
+           (equal (nthcdr n l) nil)))
+
+(defthmd fix-true-list-when-true-listp
+  (implies (true-listp x)
+           (equal (fix-true-list x) x)))
+
+(defthm revappend-of-revappend
+  (equal (revappend (revappend x y1) y2)
+         (revappend y1 (append x y2))))

--- a/books/projects/filesystems/file-system-m1.lisp
+++ b/books/projects/filesystems/file-system-m1.lisp
@@ -18,27 +18,6 @@
 (include-book "insert-text")
 (include-book "fat32")
 
-;; This was moved to one of the main books, but still kept
-(defthm unsigned-byte-listp-of-update-nth
-  (implies (and (unsigned-byte-listp n l)
-                (< key (len l)))
-           (equal (unsigned-byte-listp n (update-nth key val l))
-                  (unsigned-byte-p n val)))
-  :hints (("goal" :in-theory (enable unsigned-byte-listp))))
-
-;; This was taken from Alessandro Coglio's book at
-;; books/kestrel/utilities/typed-list-theorems.lisp
-(defthm unsigned-byte-listp-of-rev
-  (equal (unsigned-byte-listp n (rev bytes))
-         (unsigned-byte-listp n (list-fix bytes)))
-  :hints (("goal" :in-theory (enable unsigned-byte-listp rev))))
-
-(defthm nth-of-unsigned-byte-list
-  (implies (and (unsigned-byte-listp bits l)
-                (natp n)
-                (< n (len l)))
-           (unsigned-byte-p bits (nth n l))))
-
 (defthm nth-of-string=>nats
   (equal (nth n (string=>nats string))
          (if (< (nfix n) (len (explode string)))

--- a/books/projects/filesystems/find-n-free-blocks.lisp
+++ b/books/projects/filesystems/find-n-free-blocks.lisp
@@ -213,6 +213,11 @@
   :hints (("goal" :induct (first-n-ac n alv ac))))
 
 (defthm
+  count-free-blocks-alt-correctness-2-lemma-1
+  (equal (count-free-blocks (fix-true-list alv))
+         (count-free-blocks alv)))
+
+(defthm
   count-free-blocks-alt-correctness-2
   (implies (and (boolean-listp alv)
                 (equal n (len alv)))


### PR DESCRIPTION
This pull request touches only my own books, with one exception. I have reworked some of @MattKaufmann 's edits to the 8.2 release notes from earlier today, to correct the unintended implication that the std/io byte-combining libraries are part of the Kestrel books - so it would be neat if he could review and merge.