### PR TITLE
Add the license file that I plan to use for open sourcing my work.

### DIFF
--- a/books/3BSD-mod.txt
+++ b/books/3BSD-mod.txt
@@ -1,0 +1,36 @@
+[This license is based on:
+https://opensource.org/licenses/BSD-3-Clause, as retrieved on Oct 31,
+2018.  It expects each individual source code file to have copyright
+notices and a reference to this license but not the full text of this
+license.  It allows for the case of multiple copyright holders, in
+which case the source code files should have multiple copyright
+notices.]
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the copyright notices in
+   the individual source code files, this list of conditions, and the
+   following disclaimer.
+
+2. Redistributions in binary form must reproduce the copyright notices
+   from the individual source code files, this list of conditions, and
+   the following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+
+3. Neither the names of the copyright holders nor the names of their
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
I'm adding this license directly in books/ to allow others to conveniently use it as well (even from outside the kestrel/ directory).  A precedent for this is the presence of GPL2 directly under books/.