### PR TITLE
ASYNC: Replaced 'pairs' with 'pairlis$' in 'se' and 'de'

### DIFF
--- a/books/projects/async/de.lisp
+++ b/books/projects/async/de.lisp
@@ -289,15 +289,14 @@
     (let* ((module (car netlist))
            (rest-netlist (cdr netlist)))
       (and
-       (consp module)
+       (module-syntax-okp module)
        (let ((module-name (car module)))
          (and (net-syntax-okp rest-netlist)
               (not (primp module-name))    ; Module name is not a primitive
               (not (assoc-eq module-name   ; nor previously defined module
-                             rest-netlist))
-              (module-syntax-okp module)))))))
+                             rest-netlist))))))))
 
-; Some facts about our netlist syntax.
+; Some facts about our netlist syntax
 
 (defthm net-syntax-okp-forward-to-symbol-alistp
   ;; For effeciency, this lemms before guard proof for NET-SYNTAX-OKP
@@ -583,8 +582,8 @@
                 (md-outs    (md-outs  module))
                 (md-sts     (md-sts   module))
                 (md-occs    (md-occs  module))
-                (wire-alist (pairs md-ins ins))
-                (sts-alist  (pairs md-sts sts)))
+                (wire-alist (pairlis$ md-ins ins))
+                (sts-alist  (pairlis$ md-sts sts)))
            (assoc-eq-values
             md-outs
             (se-occ md-occs wire-alist sts-alist
@@ -604,7 +603,7 @@
             (ins       (assoc-eq-values occ-ins wire-alist))
             (sts       (assoc-eq-value  occ-name sts-alist))
             (new-vals  (se occ-fn ins sts netlist))
-            (new-alist (pairs occ-outs new-vals))
+            (new-alist (pairlis$ occ-outs new-vals))
             (new-wire-alist
              (append new-alist wire-alist)))
        (se-occ (cdr occs) new-wire-alist sts-alist netlist)))))
@@ -623,8 +622,8 @@
          (let* ((md-ins      (md-ins   module))
                 (md-sts      (md-sts   module))
                 (md-occs     (md-occs  module))
-                (wire-alist  (pairs    md-ins ins))
-                (sts-alist   (pairs    md-sts sts))
+                (wire-alist  (pairlis$ md-ins ins))
+                (sts-alist   (pairlis$ md-sts sts))
                 (new-netlist (delete-to-eq fn netlist)))
            (assoc-eq-values
             md-sts
@@ -673,8 +672,8 @@
                               (md-outs (md-outs module))
                               (md-sts (md-sts module))
                               (md-occs (md-occs module))
-                              (wire-alist (pairs md-ins ins))
-                              (sts-alist (pairs md-sts sts)))
+                              (wire-alist (pairlis$ md-ins ins))
+                              (sts-alist (pairlis$ md-sts sts)))
                          (assoc-eq-values
                           md-outs
                           (se-occ md-occs wire-alist sts-alist
@@ -694,7 +693,7 @@
            (ins       (assoc-eq-values occ-ins  wire-alist))
            (sts       (assoc-eq-value  occ-name sts-alist))
            (new-vals  (se occ-fn ins sts netlist))
-           (new-alist (pairs occ-outs new-vals))
+           (new-alist (pairlis$ occ-outs new-vals))
            (new-wire-alist
             (append new-alist wire-alist)))
       (se-occ-induct (cdr occs) new-wire-alist sts-alist netlist))))
@@ -731,18 +730,14 @@
      :in-theory (disable symbol-alistp occ-outs
                          occ-arity-okp occs-arity-okp)))))
 
+(local
+ (defthm symbol-listp=>true-listp
+   (implies (symbol-listp x)
+            (true-listp x))))
+
 (verify-guards se
   ;;:guard-debug t
-  :hints
-  (("Goal" :in-theory
-    (e/d ()
-         (not
-          occ-accessors-defuns
-          md-accessors-defuns
-          md-occs md-sts)))
-   ("Subgoal 2"
-    :use net-syntax-okp->module-syntax-okp))
-  :otf-flg t)
+  :hints (("Subgoal 2" :use net-syntax-okp->module-syntax-okp)))
 
 (make-event
  `(progn
@@ -830,8 +825,8 @@
                        (let* ((md-ins      (md-ins   module))
                               (md-sts      (md-sts   module))
                               (md-occs     (md-occs  module))
-                              (wire-alist  (pairs    md-ins ins))
-                              (sts-alist   (pairs    md-sts sts))
+                              (wire-alist  (pairlis$ md-ins ins))
+                              (sts-alist   (pairlis$ md-sts sts))
                               (new-netlist (delete-to-eq fn netlist)))
                          (assoc-eq-values
                           md-sts
@@ -904,13 +899,9 @@
                   alist))
   :hints (("Goal" :in-theory (enable update-alist))))
 
-(verify-guards
-  de
-  :hints
-  (("Goal"
-    :in-theory (enable occ-name assoc-eq-value))
-   ("Subgoal 2"
-    :use net-syntax-okp->module-syntax-okp)))
+(verify-guards de
+  :hints (("Goal" :in-theory (enable occ-name assoc-eq-value))
+          ("Subgoal 2" :use net-syntax-okp->module-syntax-okp)))
 
 (make-event
  `(progn

--- a/books/projects/async/fifo/comp-v-or.lisp
+++ b/books/projects/async/fifo/comp-v-or.lisp
@@ -4,7 +4,7 @@
 ;; ACL2.
 
 ;; Cuong Chau <ckcuong@cs.utexas.edu>
-;; November 2018
+;; December 2018
 
 (in-package "ADE")
 
@@ -874,5 +874,5 @@
 
 ;; The multi-step input-output relationship
 
-(in-out-stream-lemma comp-v-or :op t :inv t)
+(in-out-stream-lemma comp-v-or :op comp-v-or$op :inv t)
 

--- a/books/projects/async/gcd/README
+++ b/books/projects/async/gcd/README
@@ -16,7 +16,9 @@ See Makefile file for the detail.
 Book Organization
 ----------------------------------------------------------------------
 
-gcd-alg.lisp: the correctness proof of the GCD algorithm.
+gcd-alg.lisp: a GCD algorithm and its correctness theorems.
+
+gcd-spec.lisp: a GCD specification at the bit-vector level.
 
 gcd.lisp: a circuit family, gcd, computing the Greatest Common Divisor
 (GCD) of two natural numbers.

--- a/books/projects/async/gcd/comp-gcd-body.lisp
+++ b/books/projects/async/gcd/comp-gcd-body.lisp
@@ -31,8 +31,8 @@
 
 ;; 1. DE Module Generator of COMP-GCD-BODY
 ;;
-;; COMP-GCD-BODY performs the GCD operation in one iteration.  It is constructed
-;; using the ripple-carry subtractor RIPPLE-SUB.
+;; COMP-GCD-BODY performs the GCD operation in one iteration.  It is
+;; constructed using the ripple-carry subtractor RIPPLE-SUB.
 
 (defconst *comp-gcd-body$go-num* 3)
 (defconst *comp-gcd-body$st-len* 3)
@@ -513,8 +513,8 @@
          (append (comp-gcd-body$op-map x)
                  (comp-gcd-body$op-map y))))
 
-;; The extraction function for COMP-GCD-BODY that extracts the future
-;; output sequence from the current state.
+;; The extraction function for COMP-GCD-BODY that extracts the future output
+;; sequence from the current state.
 
 (defund comp-gcd-body$extract (st data-width)
   (b* ((l0 (get-field *comp-gcd-body$l0* st))

--- a/books/projects/async/gcd/comp-gcd-body2.lisp
+++ b/books/projects/async/gcd/comp-gcd-body2.lisp
@@ -34,7 +34,7 @@
 
 (defconst *comp-gcd-body2$prim-go-num* 2)
 (defconst *comp-gcd-body2$go-num* (+ *comp-gcd-body2$prim-go-num*
-                                    *serial-sub$go-num*))
+                                     *serial-sub$go-num*))
 (defconst *comp-gcd-body2$st-len* 4)
 
 (defun comp-gcd-body2$data-ins-len (data-width)
@@ -548,8 +548,8 @@
          (append (comp-gcd-body2$op-map x)
                  (comp-gcd-body2$op-map y))))
 
-;; The extraction function for COMP-GCD-BODY2 that extracts the future
-;; output sequence from the current state.
+;; The extraction function for COMP-GCD-BODY2 that extracts the future output
+;; sequence from the current state.
 
 (defund comp-gcd-body2$extract (st data-width)
   (b* ((l0 (get-field *comp-gcd-body2$l0* st))
@@ -742,8 +742,8 @@
           (sub-inputs (comp-gcd-body2$sub-inputs inputs st data-width)))
        (implies (fullp l2.s)
                 (not (serial-sub$out-act sub-inputs
-                                                sub
-                                                data-width))))
+                                         sub
+                                         data-width))))
      :hints (("Goal" :in-theory (enable get-field
                                         comp-gcd-body2$sub-inputs)))))
 

--- a/books/projects/async/gcd/comp-gcd-cond.lisp
+++ b/books/projects/async/gcd/comp-gcd-cond.lisp
@@ -4,7 +4,7 @@
 ;; ACL2.
 
 ;; Cuong Chau <ckcuong@cs.utexas.edu>
-;; November 2018
+;; December 2018
 
 (in-package "ADE")
 
@@ -1176,5 +1176,5 @@
 
 ;; The multi-step input-output relationship
 
-(in-out-stream-lemma comp-gcd-cond :op t :inv t)
+(in-out-stream-lemma comp-gcd-cond :op comp-gcd-cond$op :inv t)
 

--- a/books/projects/async/gcd/comp-gcd2.lisp
+++ b/books/projects/async/gcd/comp-gcd2.lisp
@@ -10,9 +10,9 @@
 
 (include-book "comp-gcd-body2")
 (include-book "gcd-cond")
+(include-book "gcd-spec")
 (include-book "../merge")
 
-(local (include-book "gcd-alg"))
 (local (include-book "arithmetic-3/top" :dir :system))
 
 (local (in-theory (disable nth)))
@@ -568,221 +568,15 @@
 
 ;; 3. Single-Step-Update Property
 
-;; Specify the functionality of COMP-GCD2, i.e., compute the greatest common
-;; divisor of two natural numbers (see comp-gcd2$op).  Prove the correctness of
-;; comp-gcd2$op.
-
-(encapsulate
-  ()
-
-  (local
-   (defthm v-<-correct-instance
-     (implies (and (natp data-width)
-                   (equal (len x) (* 2 data-width))
-                   (bvp x)
-                   (v-< nil t
-                        (rev (take data-width x))
-                        (rev (nthcdr data-width x))))
-              (< (v-to-nat (take data-width x))
-                 (v-to-nat (nthcdr data-width x))))
-     :hints (("Goal"
-              :use (:instance v-<-correct-1
-                              (a (take data-width x))
-                              (b (nthcdr data-width x)))
-              :in-theory (disable v-<-correct-1)))
-     :rule-classes :linear))
-
-  (local
-   (defthm v-to-nat-of-v-zp
-     (equal (v-zp x)
-            (equal (v-to-nat x) 0))
-     :hints (("Goal" :in-theory (enable v-zp v-nzp v-to-nat)))))
-
-  (local
-   (defun my-count (x)
-     (nfix (+ (v-to-nat (take (/ (len x) 2) x))
-              (v-to-nat (nthcdr (/ (len x) 2) x))))))
-
-  (local
-   (defun comp-gcd2$op (x)
-     (declare
-      (xargs :hints (("Goal"
-                      :in-theory (e/d ()
-                                      (v-not-take
-                                       v-not-nthcdr))))
-             :measure (my-count x)))
-     (b* ((data-width (/ (len x) 2))
-          (a (take data-width x))
-          (b (nthcdr data-width x))
-          (a-b (take data-width
-                     (v-adder t a (v-not b))))
-          (b-a (take data-width
-                     (v-adder t b (v-not a))))
-          (a<b (v-< nil t (rev a) (rev b))))
-       (cond
-        ((or (atom x)
-             (zp data-width)
-             (not (bvp x)))
-         x)
-        ((v-zp a) b)
-        ((v-zp b) a)
-        ((equal a b) a)
-        (t (comp-gcd2$op
-            (v-if a<b
-                  (append a b-a)
-                  (append a-b b))))))))
-
-  (defun comp-gcd2$op (x)
-    (declare (xargs :measure (:? x)))
-    (b* ((data-width (/ (len x) 2))
-         (a (take data-width x))
-         (b (nthcdr data-width x))
-         (a-b (take data-width
-                    (v-adder t a (v-not b))))
-         (b-a (take data-width
-                    (v-adder t b (v-not a))))
-         (a<b (v-< nil t (rev a) (rev b))))
-      (cond
-       ((or (atom x)
-            (zp data-width)
-            (not (bvp x)))
-        x)
-       ((v-zp a) b)
-       ((v-zp b) a)
-       ((equal a b) a)
-       (t (comp-gcd2$op
-           (v-if a<b
-                 (append a b-a)
-                 (append a-b b)))))))
-
-  (defthm bvp-comp-gcd2$op
-    (implies (and (natp (/ (len x) 2))
-                  (bvp x))
-             (bvp (comp-gcd2$op x))))
-
-  (defthm len-comp-gcd2$op
-    (implies (and (natp (/ (len x) 2))
-                  (bvp x))
-             (equal (len (comp-gcd2$op x))
-                    (/ (len x) 2))))
-
-  (local
-   (defthm comp-gcd2$op-lemma-aux-1
-     (implies (and (bv2p a b)
-                   (not (v-< nil t (rev a) (rev b)))
-                   (equal (v-to-nat a) 0))
-              (equal a b))
-     :hints (("Goal" :use (v-to-nat-equality
-                           v-<-correct-2)))
-     :rule-classes nil))
-
-  (local
-   (defthm comp-gcd2$op-lemma-aux-2
-     (b* ((a (take data-width x))
-          (b (nthcdr data-width x))
-          (a-b (take data-width
-                     (v-adder t a (v-not b))))
-          (b-a (take data-width
-                     (v-adder t b (v-not a))))
-          (a<b (v-< nil t (rev a) (rev b))))
-       (implies (and (natp data-width)
-                     (equal data-width (/ (len x) 2))
-                     (bvp x))
-                (equal (comp-gcd2$op (v-if a<b
-                                           (append a b-a)
-                                           (append a-b b)))
-                       (comp-gcd2$op x))))
-     :hints (("Goal"
-              :induct (comp-gcd2$op x)
-              :in-theory (e/d ()
-                              (v-to-nat-equality
-                               v-not-take
-                               v-not-nthcdr)))
-             ("Subgoal *1/3"
-              :use (:instance
-                    v-to-nat-equality
-                    (a (take data-width
-                             (v-adder t (take data-width x)
-                                      (v-not (nthcdr data-width x)))))
-                    (b (take data-width x))))
-             ("Subgoal *1/2"
-              :use ((:instance
-                     v-to-nat-equality
-                     (a (take data-width
-                              (v-adder t (nthcdr data-width x)
-                                       (v-not (take data-width x)))))
-                     (b (nthcdr data-width x)))
-                    (:instance
-                     comp-gcd2$op-lemma-aux-1
-                     (a (take data-width x))
-                     (b (nthcdr data-width x))))))))
-
-  ;; Prove that comp-gcd2$op correctly computes the greatest common divisor
-
-  (local
-   (defthm v-to-nat-of-COMP-GCD2$OP-is-GCD-ALG
-     (implies (and (equal data-width (/ (len x) 2))
-                   (bvp x))
-              (equal (v-to-nat (comp-gcd2$op x))
-                     (gcd-alg (v-to-nat (take data-width x))
-                              (v-to-nat (nthcdr data-width x)))))
-     :hints (("Goal" :in-theory (e/d ()
-                                     (v-not-take
-                                      v-not-nthcdr))))))
-
-  (in-theory (disable comp-gcd2$op))
-
-  (defthmd comp-gcd2$op-commutative
-    (implies (bv2p a b)
-             (equal (comp-gcd2$op (append a b))
-                    (comp-gcd2$op (append b a))))
-    :hints (("Goal"
-             :use (:instance v-to-nat-equality
-                             (a (comp-gcd2$op (append a b)))
-                             (b (comp-gcd2$op (append b a))))
-             :in-theory (e/d (gcd-alg-commutative)
-                             (v-to-nat-equality))))
-    :rule-classes ((:rewrite :loop-stopper ((a b)))))
-
-  (defthm comp-gcd2$op-lemma
-    (implies (and (natp (/ (len x) 2))
-                  (bvp x))
-             (equal (comp-gcd2$op (comp-gcd-body2$op x))
-                    (comp-gcd2$op x)))
-    :hints (("Goal"
-             :use (:instance comp-gcd2$op-lemma-aux-2
-                             (data-width (/ (len x) 2)))
-             :in-theory (e/d (serial-sub$op
-                              comp-gcd-body2$op
-                              comp-gcd2$op-commutative)
-                             (comp-gcd2$op-lemma-aux-2)))))
-  )
-
-;; The operation of COMP-GCD2 over a data sequence
-
-(defun comp-gcd2$op-map (x)
-  (if (atom x)
-      nil
-    (cons (comp-gcd2$op (car x))
-          (comp-gcd2$op-map (cdr x)))))
-
-(defthm len-of-comp-gcd2$op-map
-  (equal (len (comp-gcd2$op-map x))
-         (len x)))
-
-(defthm comp-gcd2$op-map-of-append
-  (equal (comp-gcd2$op-map (append x y))
-         (append (comp-gcd2$op-map x) (comp-gcd2$op-map y))))
-
-;; The extraction function for COMP-GCD2 that extracts the future output sequence
-;; from the current state.
+;; The extraction function for COMP-GCD2 that extracts the future output
+;; sequence from the current state.
 
 (defund comp-gcd2$extract (st data-width)
   (b* ((l0 (get-field *comp-gcd2$l0* st))
        (l1 (get-field *comp-gcd2$l1* st))
        (l2 (get-field *comp-gcd2$l2* st))
        (body (get-field *comp-gcd2$body* st)))
-    (comp-gcd2$op-map
+    (gcd$op-map
      (append (extract-valid-data (list l1 l2 l0))
              (comp-gcd-body2$extract body data-width)))))
 
@@ -884,7 +678,7 @@
 ;; avoids exploring the internal computation of COMP-GCD2.
 
 (defund comp-gcd2$extracted-step (inputs st data-width)
-  (b* ((data (comp-gcd2$op (comp-gcd2$data-in inputs data-width)))
+  (b* ((data (gcd$op (comp-gcd2$data-in inputs data-width)))
        (extracted-st (comp-gcd2$extract st data-width))
        (n (1- (len extracted-st))))
     (cond
@@ -929,6 +723,20 @@
      :hints (("Goal" :in-theory (enable get-field
                                         comp-gcd-body2$data-in
                                         comp-gcd2$body-inputs)))))
+
+  (local
+   (defthm gcd$op-of-comp-gcd-body2$op
+     (implies (and (natp (/ (len x) 2))
+                   (bvp x))
+              (equal (gcd$op (comp-gcd-body2$op x))
+                     (gcd$op x)))
+     :hints (("Goal"
+              :use (:instance gcd$op-lemma
+                              (data-width (/ (len x) 2)))
+              :in-theory (e/d (serial-sub$op
+                               comp-gcd-body2$op
+                               gcd$op-commutative)
+                              (gcd$op-lemma))))))
 
   (defthm comp-gcd2$extracted-step-correct
     (b* ((next-st (comp-gcd2$step inputs st data-width cnt-width)))
@@ -1042,7 +850,7 @@
                             comp-gcd2$valid-st
                             comp-gcd2$inv
                             comp-gcd2$extract
-                            comp-gcd2$op
+                            gcd$op
                             comp-gcd2$br-inputs
                             comp-gcd2$out-act
                             comp-gcd2$data-out)
@@ -1070,9 +878,9 @@
   (local
    (defthm comp-gcd2$dataflow-correct-aux
      (implies (equal (append x y1)
-                     (append (comp-gcd2$op-map seq) y2))
+                     (append (gcd$op-map seq) y2))
               (equal (append x y1 z)
-                     (append (comp-gcd2$op-map seq)
+                     (append (gcd$op-map seq)
                              y2 z)))
      :hints (("Goal" :in-theory (e/d (left-associativity-of-append)
                                      (associativity-of-append))))))
@@ -1089,7 +897,7 @@
        (equal (append final-extracted-st
                       (comp-gcd2$out-seq
                        inputs-seq st data-width cnt-width n))
-              (append (comp-gcd2$op-map
+              (append (gcd$op-map
                        (comp-gcd2$in-seq
                         inputs-seq st data-width cnt-width n))
                       extracted-st))))
@@ -1109,7 +917,7 @@
        (equal (append final-extracted-st
                       (comp-gcd2$netlist-out-seq
                        inputs-seq st netlist data-width n))
-              (append (comp-gcd2$op-map
+              (append (gcd$op-map
                        (comp-gcd2$netlist-in-seq
                         inputs-seq st netlist data-width n))
                       extracted-st))))

--- a/books/projects/async/gcd/gcd-alg.lisp
+++ b/books/projects/async/gcd/gcd-alg.lisp
@@ -20,7 +20,7 @@
                   :measure (nfix (+ a b))))
   (cond ((zp a) (nfix b))
         ((zp b) (nfix a))
-        ((equal a b) (nfix a))
+        ((equal a b) a)
         ((< a b)
          (gcd-alg a (- b a)))
         (t (gcd-alg (- a b) b))))

--- a/books/projects/async/gcd/gcd-spec.lisp
+++ b/books/projects/async/gcd/gcd-spec.lisp
@@ -1,0 +1,205 @@
+;; Copyright (C) 2018, Regents of the University of Texas
+;; Written by Cuong Chau
+;; License: A 3-clause BSD license.  See the LICENSE file distributed with
+;; ACL2.
+
+;; Cuong Chau <ckcuong@cs.utexas.edu>
+;; December 2018
+
+(in-package "ADE")
+
+(include-book "../comparators/v-less")
+
+(local (include-book "gcd-alg"))
+(local (include-book "../adders/subtractor"))
+
+(local (include-book "arithmetic-3/top" :dir :system))
+
+;; ======================================================================
+
+;; A greatest-common-divisor specification
+
+(local
+ (defthm v-<-correct-instance
+   (implies (and (natp data-width)
+                 (equal (len x) (* 2 data-width))
+                 (bvp x)
+                 (v-< nil t
+                      (rev (take data-width x))
+                      (rev (nthcdr data-width x))))
+            (< (v-to-nat (take data-width x))
+               (v-to-nat (nthcdr data-width x))))
+   :hints (("Goal"
+            :use (:instance v-<-correct-1
+                            (a (take data-width x))
+                            (b (nthcdr data-width x)))
+            :in-theory (disable v-<-correct-1)))
+   :rule-classes :linear))
+
+(local
+ (defthm v-to-nat-of-v-zp
+   (equal (v-zp x)
+          (equal (v-to-nat x) 0))
+   :hints (("Goal" :in-theory (enable v-zp v-nzp v-to-nat)))))
+
+(local
+ (defun my-count (x)
+   (nfix (+ (v-to-nat (take (/ (len x) 2) x))
+            (v-to-nat (nthcdr (/ (len x) 2) x))))))
+
+(local
+ (defun gcd$op (x)
+   (declare (xargs :hints (("Goal"
+                            :in-theory (e/d ()
+                                            (v-not-take
+                                             v-not-nthcdr))))
+                   :measure (my-count x)))
+   (b* ((data-width (/ (len x) 2))
+        (a (take data-width x))
+        (b (nthcdr data-width x))
+        (a-b (take data-width
+                   (v-adder t a (v-not b))))
+        (b-a (take data-width
+                   (v-adder t b (v-not a))))
+        (a<b (v-< nil t (rev a) (rev b))))
+     (cond
+      ((or (atom x)
+           (zp data-width)
+           (not (bvp x)))
+       x)
+      ((v-zp a) b)
+      ((v-zp b) a)
+      ((equal a b) a)
+      (t (gcd$op
+          (v-if a<b
+                (append a b-a)
+                (append a-b b))))))))
+
+(defun gcd$op (x)
+  (declare (xargs :measure (:? x)))
+  (b* ((data-width (/ (len x) 2))
+       (a (take data-width x))
+       (b (nthcdr data-width x))
+       (a-b (take data-width
+                  (v-adder t a (v-not b))))
+       (b-a (take data-width
+                  (v-adder t b (v-not a))))
+       (a<b (v-< nil t (rev a) (rev b))))
+    (cond
+     ((or (atom x)
+          (zp data-width)
+          (not (bvp x)))
+      x)
+     ((v-zp a) b)
+     ((v-zp b) a)
+     ((equal a b) a)
+     (t (gcd$op
+         (v-if a<b
+               (append a b-a)
+               (append a-b b)))))))
+
+(defthm bvp-gcd$op
+  (implies (and (natp (/ (len x) 2))
+                (bvp x))
+           (bvp (gcd$op x))))
+
+(defthm len-gcd$op
+  (implies (and (natp (/ (len x) 2))
+                (bvp x))
+           (equal (len (gcd$op x))
+                  (/ (len x) 2))))
+
+(local
+ (defthm gcd$op-lemma-aux
+   (implies (and (bv2p a b)
+                 (not (v-< nil t (rev a) (rev b)))
+                 (equal (v-to-nat a) 0))
+            (equal a b))
+   :hints (("Goal" :use (v-to-nat-equality
+                         v-<-correct-2)))
+   :rule-classes nil))
+
+(defthm gcd$op-lemma
+  (b* ((a (take data-width x))
+       (b (nthcdr data-width x))
+       (a-b (take data-width
+                  (v-adder t a (v-not b))))
+       (b-a (take data-width
+                  (v-adder t b (v-not a))))
+       (a<b (v-< nil t (rev a) (rev b))))
+    (implies (and (natp data-width)
+                  (equal data-width (/ (len x) 2))
+                  (bvp x))
+             (equal (gcd$op (v-if a<b
+                                  (append a b-a)
+                                  (append a-b b)))
+                    (gcd$op x))))
+  :hints (("Goal"
+           :induct (gcd$op x)
+           :in-theory (e/d ()
+                           (v-to-nat-equality
+                            v-not-take
+                            v-not-nthcdr)))
+          ("Subgoal *1/3"
+           :use (:instance
+                 v-to-nat-equality
+                 (a (take data-width
+                          (v-adder t (take data-width x)
+                                   (v-not (nthcdr data-width x)))))
+                 (b (take data-width x))))
+          ("Subgoal *1/2"
+           :use ((:instance
+                  v-to-nat-equality
+                  (a (take data-width
+                           (v-adder t (nthcdr data-width x)
+                                    (v-not (take data-width x)))))
+                  (b (nthcdr data-width x)))
+                 (:instance
+                  gcd$op-lemma-aux
+                  (a (take data-width x))
+                  (b (nthcdr data-width x)))))))
+
+;; Prove that gcd$op correctly computes the greatest common divisor
+
+(local
+ (defthm v-to-nat-of-GCD$OP-is-GCD-ALG
+   (implies (and (equal data-width (/ (len x) 2))
+                 (bvp x))
+            (equal (v-to-nat (gcd$op x))
+                   (gcd-alg (v-to-nat (take data-width x))
+                            (v-to-nat (nthcdr data-width x)))))
+   :hints (("Goal" :in-theory (e/d ()
+                                   (v-not-take
+                                    v-not-nthcdr))))))
+
+(in-theory (disable gcd$op))
+
+(defthmd gcd$op-commutative
+  (implies (bv2p a b)
+           (equal (gcd$op (append a b))
+                  (gcd$op (append b a))))
+  :hints (("Goal"
+           :use (:instance v-to-nat-equality
+                           (a (gcd$op (append a b)))
+                           (b (gcd$op (append b a))))
+           :in-theory (e/d (gcd-alg-commutative)
+                           (v-to-nat-equality))))
+  :rule-classes ((:rewrite :loop-stopper ((a b)))))
+
+;; The operation of GCD over a data sequence
+
+(defun gcd$op-map (x)
+  (if (atom x)
+      nil
+    (cons (gcd$op (car x))
+          (gcd$op-map (cdr x)))))
+
+(defthm len-of-gcd$op-map
+  (equal (len (gcd$op-map x))
+         (len x)))
+
+(defthm gcd$op-map-of-append
+  (equal (gcd$op-map (append x y))
+         (append (gcd$op-map x) (gcd$op-map y))))
+
+

--- a/books/projects/async/gcd/gcd.lisp
+++ b/books/projects/async/gcd/gcd.lisp
@@ -4,14 +4,13 @@
 ;; ACL2.
 
 ;; Cuong Chau <ckcuong@cs.utexas.edu>
-;; November 2018
+;; December 2018
 
 (in-package "ADE")
 
 (include-book "gcd-body")
 (include-book "gcd-cond")
-
-(local (include-book "gcd-alg"))
+(include-book "gcd-spec")
 
 (local (include-book "arithmetic-3/top" :dir :system))
 
@@ -536,173 +535,6 @@
 
 ;; 3. Single-Step-Update Property
 
-;; Specify the functionality of GCD, i.e., compute the greatest common divisor
-;; of two natural numbers (see gcd$op).  Prove the correctness of gcd$op.
-
-(encapsulate
-  ()
-
-  (local
-   (defthm v-<-correct-instance
-     (implies (and (natp data-width)
-                   (equal (len x) (* 2 data-width))
-                   (bvp x)
-                   (v-< nil t
-                        (rev (take data-width x))
-                        (rev (nthcdr data-width x))))
-              (< (v-to-nat (take data-width x))
-                 (v-to-nat (nthcdr data-width x))))
-     :hints (("Goal"
-              :use (:instance v-<-correct-1
-                              (a (take data-width x))
-                              (b (nthcdr data-width x)))
-              :in-theory (disable v-<-correct-1)))
-     :rule-classes :linear))
-
-  (local
-   (defthm v-to-nat-of-v-zp
-     (equal (v-zp x)
-            (equal (v-to-nat x) 0))
-     :hints (("Goal" :in-theory (enable v-zp v-nzp v-to-nat)))))
-
-  (local
-   (defun my-count (x)
-     (nfix (+ (v-to-nat (take (/ (len x) 2) x))
-              (v-to-nat (nthcdr (/ (len x) 2) x))))))
-
-  (local
-   (defun gcd$op (x)
-     (declare (xargs :hints (("Goal"
-                              :in-theory (e/d ()
-                                              (v-not-take
-                                               v-not-nthcdr))))
-                     :measure (my-count x)))
-     (b* ((data-width (/ (len x) 2))
-          (a (take data-width x))
-          (b (nthcdr data-width x))
-          (a-b (take data-width
-                     (v-adder t a (v-not b))))
-          (b-a (take data-width
-                     (v-adder t b (v-not a))))
-          (a<b (v-< nil t (rev a) (rev b))))
-       (cond
-        ((or (atom x)
-             (zp data-width)
-             (not (bvp x)))
-         x)
-        ((v-zp a) b)
-        ((v-zp b) a)
-        ((equal a b) a)
-        (t (gcd$op
-            (v-if a<b
-                  (append a b-a)
-                  (append a-b b))))))))
-
-  (defun gcd$op (x)
-    (declare (xargs :measure (:? x)))
-    (b* ((data-width (/ (len x) 2))
-         (a (take data-width x))
-         (b (nthcdr data-width x))
-         (a-b (take data-width
-                    (v-adder t a (v-not b))))
-         (b-a (take data-width
-                    (v-adder t b (v-not a))))
-         (a<b (v-< nil t (rev a) (rev b))))
-      (cond
-       ((or (atom x)
-            (zp data-width)
-            (not (bvp x)))
-        x)
-       ((v-zp a) b)
-       ((v-zp b) a)
-       ((equal a b) a)
-       (t (gcd$op
-           (v-if a<b
-                 (append a b-a)
-                 (append a-b b)))))))
-
-  (local
-   (defthm gcd$op-lemma-aux
-     (implies (and (bv2p a b)
-                   (not (v-< nil t (rev a) (rev b)))
-                   (equal (v-to-nat a) 0))
-              (equal a b))
-     :hints (("Goal" :use (v-to-nat-equality
-                           v-<-correct-2)))
-     :rule-classes nil))
-
-  (defthm gcd$op-lemma
-    (b* ((a (take data-width x))
-         (b (nthcdr data-width x))
-         (a-b (take data-width
-                    (v-adder t a (v-not b))))
-         (b-a (take data-width
-                    (v-adder t b (v-not a))))
-         (a<b (v-< nil t (rev a) (rev b))))
-      (implies (and (natp data-width)
-                    (equal data-width (/ (len x) 2))
-                    (bvp x))
-               (equal (gcd$op (v-if a<b
-                                    (append a b-a)
-                                    (append a-b b)))
-                      (gcd$op x))))
-    :hints (("Goal"
-             :induct (gcd$op x)
-             :in-theory (e/d ()
-                             (v-to-nat-equality
-                              v-not-take
-                              v-not-nthcdr)))
-            ("Subgoal *1/3"
-             :use (:instance
-                   v-to-nat-equality
-                   (a (take data-width
-                            (v-adder t (take data-width x)
-                                     (v-not (nthcdr data-width x)))))
-                   (b (take data-width x))))
-            ("Subgoal *1/2"
-             :use ((:instance
-                    v-to-nat-equality
-                    (a (take data-width
-                             (v-adder t (nthcdr data-width x)
-                                      (v-not (take data-width x)))))
-                    (b (nthcdr data-width x)))
-                   (:instance
-                    gcd$op-lemma-aux
-                    (a (take data-width x))
-                    (b (nthcdr data-width x)))))))
-
-  ;; Prove that gcd$op correctly computes the greatest common divisor
-
-  (local
-   (defthm v-to-nat-of-GCD$OP-is-GCD-ALG
-     (implies (and (equal data-width (/ (len x) 2))
-                   (bvp x))
-              (equal (v-to-nat (gcd$op x))
-                     (gcd-alg (v-to-nat (take data-width x))
-                              (v-to-nat (nthcdr data-width x)))))
-     :hints (("Goal" :in-theory (e/d ()
-                                     (v-not-take
-                                      v-not-nthcdr))))))
-
-  (in-theory (disable gcd$op))
-  )
-
-;; The operation of GCD over a data sequence
-
-(defun gcd$op-map (x)
-  (if (atom x)
-      nil
-    (cons (gcd$op (car x))
-          (gcd$op-map (cdr x)))))
-
-(defthm len-of-gcd$op-map
-  (equal (len (gcd$op-map x))
-         (len x)))
-
-(defthm gcd$op-map-of-append
-  (equal (gcd$op-map (append x y))
-         (append (gcd$op-map x) (gcd$op-map y))))
-
 ;; The extraction function for GCD that extracts the future output sequence
 ;; from the current state.
 
@@ -1004,5 +836,5 @@
 
 ;; The multi-step input-output relationship
 
-(in-out-stream-lemma gcd :op t :inv t)
+(in-out-stream-lemma gcd :op gcd$op :inv t)
 

--- a/books/projects/async/gcd/q10-comp-gcd3.lisp
+++ b/books/projects/async/gcd/q10-comp-gcd3.lisp
@@ -451,22 +451,6 @@
 
 ;; 3. Single-Step-Update Property
 
-;; The operation of Q10-COMP-GCD3 over a data sequence
-
-(defun q10-comp-gcd3$op-map (x)
-  (if (atom x)
-      nil
-    (cons (comp-gcd3$op (car x))
-          (q10-comp-gcd3$op-map (cdr x)))))
-
-(defthm len-of-q10-comp-gcd3$op-map
-  (equal (len (q10-comp-gcd3$op-map x))
-         (len x)))
-
-(defthm q10-comp-gcd3$op-map-of-append
-  (equal (q10-comp-gcd3$op-map (append x y))
-         (append (q10-comp-gcd3$op-map x) (q10-comp-gcd3$op-map y))))
-
 ;; The extraction function for Q10-COMP-GCD3 that extracts the future output
 ;; sequence from the current state.
 
@@ -475,7 +459,7 @@
        (q10  (get-field *q10-comp-gcd3$q10* st))
        (comp-gcd3 (get-field *q10-comp-gcd3$comp-gcd3* st)))
     (append
-     (q10-comp-gcd3$op-map
+     (gcd$op-map
       (append (queue10$extract q10)
               (extract-valid-data (list l))))
      (comp-gcd3$extract comp-gcd3))))
@@ -516,7 +500,7 @@
 ;; function avoids exploring the internal computation of Q10-COMP-GCD3.
 
 (defund q10-comp-gcd3$extracted-step (inputs st data-width)
-  (b* ((data (comp-gcd3$op (q10-comp-gcd3$data-in inputs data-width)))
+  (b* ((data (gcd$op (q10-comp-gcd3$data-in inputs data-width)))
        (extracted-st (q10-comp-gcd3$extract st))
        (n (1- (len extracted-st))))
     (cond
@@ -588,10 +572,10 @@
                                         comp-gcd3$data-in)))))
 
   (local
-   (defthm q10-comp-gcd3$op-map-of-append-instance
-     (equal (q10-comp-gcd3$op-map (append x (list (strip-cars d))))
-            (append (q10-comp-gcd3$op-map x)
-                    (q10-comp-gcd3$op-map (list (strip-cars d)))))))
+   (defthm gcd$op-map-of-append-instance
+     (equal (gcd$op-map (append x (list (strip-cars d))))
+            (append (gcd$op-map x)
+                    (gcd$op-map (list (strip-cars d)))))))
 
   (defthm q10-comp-gcd3$extracted-step-correct
     (b* ((next-st (q10-comp-gcd3$step inputs st data-width)))
@@ -620,7 +604,7 @@
                        q10-comp-gcd3$extract)
                       (q10-comp-gcd3$input-format=>q10$input-format
                        q10-comp-gcd3$input-format=>comp-gcd3$input-format
-                       q10-comp-gcd3$op-map-of-append
+                       gcd$op-map-of-append
                        nfix)))))
   )
 
@@ -676,5 +660,5 @@
 
 ;; The multi-step input-output relationship
 
-(in-out-stream-lemma q10-comp-gcd3 :op t :inv t)
+(in-out-stream-lemma q10-comp-gcd3 :op gcd$op :inv t)
 

--- a/books/projects/async/gcd/q10-gcd.lisp
+++ b/books/projects/async/gcd/q10-gcd.lisp
@@ -4,7 +4,7 @@
 ;; ACL2.
 
 ;; Cuong Chau <ckcuong@cs.utexas.edu>
-;; November 2018
+;; December 2018
 
 (in-package "ADE")
 
@@ -28,11 +28,11 @@
 
 ;; 1. DE Module Generator of Q10-GCD
 ;;
-;; Construct a DE module generator that concatenates Q10 with GCD via a
-;; link.  Prove the value and state lemmas for this module generator.
+;; Construct a DE module generator that concatenates Q10 with GCD via a link.
+;; Prove the value and state lemmas for this module generator.
 
 (defconst *q10-gcd$go-num* (+ *queue10$go-num*
-                             *gcd$go-num*))
+                              *gcd$go-num*))
 (defconst *q10-gcd$st-len* 3)
 
 (defun q10-gcd$data-ins-len (data-width)
@@ -221,8 +221,8 @@
 
   (defund q10-gcd$in-act (inputs st data-width)
     (queue10$in-act (q10-gcd$q10-inputs inputs st data-width)
-                   (get-field *q10-gcd$q10* st)
-                   (* 2 data-width)))
+                    (get-field *q10-gcd$q10* st)
+                    (* 2 data-width)))
 
   (defthm q10-gcd$in-act-inactive
     (implies (not (nth 0 inputs))
@@ -441,31 +441,15 @@
 
 ;; 3. Single-Step-Update Property
 
-;; The operation of Q10-GCD over a data sequence
-
-(defun q10-gcd$op-map (x)
-  (if (atom x)
-      nil
-    (cons (gcd$op (car x))
-          (q10-gcd$op-map (cdr x)))))
-
-(defthm len-of-q10-gcd$op-map
-  (equal (len (q10-gcd$op-map x))
-         (len x)))
-
-(defthm q10-gcd$op-map-of-append
-  (equal (q10-gcd$op-map (append x y))
-         (append (q10-gcd$op-map x) (q10-gcd$op-map y))))
-
-;; The extraction function for Q10-GCD that extracts the future output
-;; sequence from the current state.
+;; The extraction function for Q10-GCD that extracts the future output sequence
+;; from the current state.
 
 (defund q10-gcd$extract (st)
   (b* ((l   (get-field *q10-gcd$l* st))
        (q10  (get-field *q10-gcd$q10* st))
        (gcd (get-field *q10-gcd$gcd* st)))
     (append
-     (q10-gcd$op-map
+     (gcd$op-map
       (append (queue10$extract q10)
               (extract-valid-data (list l))))
      (gcd$extract gcd))))
@@ -528,8 +512,8 @@
                           (nth *q10-gcd$l* st))
                      '(t))
               (not (queue10$out-act (q10-gcd$q10-inputs inputs st data-width)
-                                   (nth *q10-gcd$q10* st)
-                                   (* 2 data-width))))
+                                    (nth *q10-gcd$q10* st)
+                                    (* 2 data-width))))
      :hints (("Goal"
               :in-theory (e/d (get-field
                                q10-gcd$q10-inputs)
@@ -574,10 +558,10 @@
                                         gcd$data-in)))))
 
   (local
-   (defthm q10-gcd$op-map-of-append-instance
-     (equal (q10-gcd$op-map (append x (list (strip-cars d))))
-            (append (q10-gcd$op-map x)
-                    (q10-gcd$op-map (list (strip-cars d)))))))
+   (defthm gcd$op-map-of-append-instance
+     (equal (gcd$op-map (append x (list (strip-cars d))))
+            (append (gcd$op-map x)
+                    (gcd$op-map (list (strip-cars d)))))))
 
   (defthm q10-gcd$extracted-step-correct
     (b* ((next-st (q10-gcd$step inputs st data-width)))
@@ -605,7 +589,7 @@
                               q10-gcd$extract)
                              (q10-gcd$input-format=>q10$input-format
                               q10-gcd$input-format=>gcd$input-format
-                              q10-gcd$op-map-of-append
+                              gcd$op-map-of-append
                               nfix)))))
   )
 
@@ -657,5 +641,5 @@
 
 ;; The multi-step input-output relationship
 
-(in-out-stream-lemma q10-gcd :op t :inv t)
+(in-out-stream-lemma q10-gcd :op gcd$op :inv t)
 

--- a/books/projects/async/hard-spec.lisp
+++ b/books/projects/async/hard-spec.lisp
@@ -922,6 +922,12 @@
   (equal (len (v-adder-output c a b))
          (len a)))
 
+(defthm bvp-v-adder-output
+  (bvp (v-adder-output c a b))
+  :rule-classes (:rewrite :type-prescription))
+
+(in-theory (disable v-adder-output))
+
 (defun v-adder-carry-out (c a b)
   (declare (xargs :guard (true-listp b)))
   (nth (len a) (v-adder c a b)))

--- a/books/projects/async/serial-adder/serial-add.lisp
+++ b/books/projects/async/serial-adder/serial-add.lisp
@@ -623,27 +623,12 @@
 
 ;; 3. Single-Step-Update Property
 
-;; Specify the functionality of SERIAL-ADD
-
-(defun serial-add$op (c a b)
-  (take (len a)
-        (v-adder c a b)))
-
-(defthm bvp-serial-add$op
-  (bvp (serial-add$op c a b)))
-
-(defthm len-serial-add$op
-  (equal (len (serial-add$op c a b))
-         (len a)))
-
-(in-theory (disable serial-add$op))
-
 ;; The operation of SERIAL-ADD over a data sequence
 
 (defun serial-add$op-map (x)
   (if (atom x)
       nil
-    (cons (serial-add$op nil (caar x) (cdar x))
+    (cons (v-adder-output nil (caar x) (cdar x))
           (serial-add$op-map (cdr x)))))
 
 (defthm serial-add$op-map-of-append
@@ -677,20 +662,20 @@
        (b.valid-d (if (fullp b.s) b.d nil))
        (c (if (fullp ci.s) (car ci.d) (car co.d)))
        (s.valid-d (if (fullp s.s) s.d nil))
-       (sipo0.valid-data (piso2-sreg$extract0 piso2))
-       (sipo1.valid-data (piso2-sreg$extract1 piso2))
+       (piso0.valid-data (piso2-sreg$extract0 piso2))
+       (piso1.valid-data (piso2-sreg$extract1 piso2))
        (sipo.valid-data (sipo-sreg$extract sipo)))
     (cond
-     ((equal (+ (len (append a.valid-d sipo0.valid-data))
+     ((equal (+ (len (append a.valid-d piso0.valid-data))
                 (len (append sipo.valid-data s.valid-d)))
              (* 2 data-width))
       (cond
        ((< (len (append sipo.valid-data s.valid-d))
            data-width)
         (list
-         (serial-add$op nil
-                        sipo0.valid-data
-                        sipo1.valid-data)
+         (v-adder-output nil
+                         piso0.valid-data
+                         piso1.valid-data)
          (append
           sipo.valid-data
           s.valid-d
@@ -698,34 +683,34 @@
        ((equal (len (append sipo.valid-data s.valid-d))
                data-width)
         (list
-         (serial-add$op nil
-                        (append a.valid-d sipo0.valid-data)
-                        (append b.valid-d sipo1.valid-data))
+         (v-adder-output nil
+                         (append a.valid-d piso0.valid-data)
+                         (append b.valid-d piso1.valid-data))
          (append sipo.valid-data s.valid-d)))
        (t (list
            (append s.valid-d
-                   (serial-add$op c
-                                  (append a.valid-d sipo0.valid-data)
-                                  (append b.valid-d sipo1.valid-data)))
+                   (v-adder-output c
+                                   (append a.valid-d piso0.valid-data)
+                                   (append b.valid-d piso1.valid-data)))
            sipo.valid-data))))
-     ((equal (+ (len (append a.valid-d sipo0.valid-data))
+     ((equal (+ (len (append a.valid-d piso0.valid-data))
                 (len (append sipo.valid-data s.valid-d)))
              data-width)
       (cond
        ((equal (len (append sipo.valid-data s.valid-d))
                0)
-        (list (serial-add$op nil
-                             (append a.valid-d sipo0.valid-data)
-                             (append b.valid-d sipo1.valid-data))))
+        (list (v-adder-output nil
+                              (append a.valid-d piso0.valid-data)
+                              (append b.valid-d piso1.valid-data))))
        ((< (len (append sipo.valid-data s.valid-d))
            data-width)
         (list
          (append
           sipo.valid-data
           s.valid-d
-          (serial-add$op c
-                         (append a.valid-d sipo0.valid-data)
-                         (append b.valid-d sipo1.valid-data)))))
+          (v-adder-output c
+                          (append a.valid-d piso0.valid-data)
+                          (append b.valid-d piso1.valid-data)))))
        (t (list (append sipo.valid-data s.valid-d)))))
      (t nil))))
 
@@ -757,8 +742,8 @@
          (a.valid-d (if (fullp a.s) a.d nil))
          (b.valid-d (if (fullp b.s) b.d nil))
          (s.valid-d (if (fullp s.s) s.d nil))
-         (sipo0.valid-data (piso2-sreg$extract0 piso2))
-         (sipo1.valid-data (piso2-sreg$extract1 piso2))
+         (piso0.valid-data (piso2-sreg$extract0 piso2))
+         (piso1.valid-data (piso2-sreg$extract1 piso2))
          (sipo.valid-data (sipo-sreg$extract sipo)))
       (and (not (equal ci.s co.s))
            (or (emptyp ci.s) (emptyp done.s))
@@ -767,9 +752,9 @@
            (or (emptyp s.s) (fullp co.s))
            (not (and (fullp s.s) (fullp done.s)))
            (or (emptyp ci.s)
-               (and (not (equal (len (append a.valid-d sipo0.valid-data))
+               (and (not (equal (len (append a.valid-d piso0.valid-data))
                                 0))
-                    (not (equal (len (append a.valid-d sipo0.valid-data))
+                    (not (equal (len (append a.valid-d piso0.valid-data))
                                 data-width)))
                (not (car ci.d)))
            (or (emptyp done.s)
@@ -778,15 +763,15 @@
                                  0)
                           (equal (len sipo.valid-data)
                                  data-width))))
-           (equal (len (append a.valid-d sipo0.valid-data))
-                  (len (append b.valid-d sipo1.valid-data)))
-           (or (equal (+ (len (append a.valid-d sipo0.valid-data))
+           (equal (len (append a.valid-d piso0.valid-data))
+                  (len (append b.valid-d piso1.valid-data)))
+           (or (equal (+ (len (append a.valid-d piso0.valid-data))
                          (len (append sipo.valid-data s.valid-d)))
                       0)
-               (equal (+ (len (append a.valid-d sipo0.valid-data))
+               (equal (+ (len (append a.valid-d piso0.valid-data))
                          (len (append sipo.valid-data s.valid-d)))
                       data-width)
-               (equal (+ (len (append a.valid-d sipo0.valid-data))
+               (equal (+ (len (append a.valid-d piso0.valid-data))
                          (len (append sipo.valid-data s.valid-d)))
                       (* 2 data-width)))
            (piso2-sreg$inv piso2)
@@ -814,8 +799,8 @@
           (piso2 (nth *serial-add$piso2* st)))
        (implies (fullp a.s)
                 (not (piso2-sreg$out0-act piso2-inputs
-                                                    piso2
-                                                    data-width))))
+                                          piso2
+                                          data-width))))
      :hints (("Goal" :in-theory (enable get-field
                                         serial-add$piso2-inputs)))))
 
@@ -827,8 +812,8 @@
           (piso2 (nth *serial-add$piso2* st)))
        (implies (fullp b.s)
                 (not (piso2-sreg$out1-act piso2-inputs
-                                                    piso2
-                                                    data-width))))
+                                          piso2
+                                          data-width))))
      :hints (("Goal" :in-theory (enable get-field
                                         serial-add$piso2-inputs)))))
 
@@ -853,10 +838,10 @@
      :hints (("Goal" :in-theory (enable v-zp v-nzp v-to-nat)))))
 
   (local
-     (defthm len-cdr
-       (implies (< 0 (len x))
-                (equal (len (cdr x))
-                       (1- (len x))))))
+   (defthm len-cdr
+     (implies (< 0 (len x))
+              (equal (len (cdr x))
+                     (1- (len x))))))
 
   (encapsulate
     ()
@@ -916,12 +901,12 @@
      ((equal (serial-add$out-act inputs st data-width) t)
       (cond
        ((equal (serial-add$in-act inputs st data-width) t)
-        (cons (serial-add$op nil data0 data1)
+        (cons (v-adder-output nil data0 data1)
               (take n extracted-st)))
        (t (take n extracted-st))))
      (t (cond
          ((equal (serial-add$in-act inputs st data-width) t)
-          (cons (serial-add$op nil data0 data1)
+          (cons (v-adder-output nil data0 data1)
                 extracted-st))
          (t extracted-st))))))
 
@@ -1006,7 +991,7 @@
                               serial-add$in-act
                               serial-add$out-act
                               serial-add$extract
-                              serial-add$op)
+                              v-adder-output)
                              (serial-add$input-format=>piso2$input-format
                               serial-add$input-format=>sipo$input-format
                               sipo-sreg$out-act-inactive

--- a/books/projects/async/serial-adder/serial-sub.lisp
+++ b/books/projects/async/serial-adder/serial-sub.lisp
@@ -632,7 +632,8 @@
         (v-adder c a (v-not b))))
 
 (defthm bvp-serial-sub$op
-  (bvp (serial-sub$op c a b)))
+  (bvp (serial-sub$op c a b))
+  :rule-classes (:rewrite :type-prescription))
 
 (defthm len-serial-sub$op
   (equal (len (serial-sub$op c a b))
@@ -679,11 +680,11 @@
        (b.valid-d (if (fullp b.s) b.d nil))
        (c (if (fullp ci.s) (car ci.d) (car co.d)))
        (s.valid-d (if (fullp s.s) s.d nil))
-       (sipo0.valid-data (piso2-sreg$extract0 piso2))
-       (sipo1.valid-data (piso2-sreg$extract1 piso2))
+       (piso0.valid-data (piso2-sreg$extract0 piso2))
+       (piso1.valid-data (piso2-sreg$extract1 piso2))
        (sipo.valid-data (sipo-sreg$extract sipo)))
     (cond
-     ((equal (+ (len (append a.valid-d sipo0.valid-data))
+     ((equal (+ (len (append a.valid-d piso0.valid-data))
                 (len (append sipo.valid-data s.valid-d)))
              (* 2 data-width))
       (cond
@@ -691,8 +692,8 @@
            data-width)
         (list
          (serial-sub$op t
-                        sipo0.valid-data
-                        sipo1.valid-data)
+                        piso0.valid-data
+                        piso1.valid-data)
          (append
           sipo.valid-data
           s.valid-d
@@ -701,24 +702,24 @@
                data-width)
         (list
          (serial-sub$op t
-                        (append a.valid-d sipo0.valid-data)
-                        (append b.valid-d sipo1.valid-data))
+                        (append a.valid-d piso0.valid-data)
+                        (append b.valid-d piso1.valid-data))
          (append sipo.valid-data s.valid-d)))
        (t (list
            (append s.valid-d
                    (serial-sub$op c
-                                  (append a.valid-d sipo0.valid-data)
-                                  (append b.valid-d sipo1.valid-data)))
+                                  (append a.valid-d piso0.valid-data)
+                                  (append b.valid-d piso1.valid-data)))
            sipo.valid-data))))
-     ((equal (+ (len (append a.valid-d sipo0.valid-data))
+     ((equal (+ (len (append a.valid-d piso0.valid-data))
                 (len (append sipo.valid-data s.valid-d)))
              data-width)
       (cond
        ((equal (len (append sipo.valid-data s.valid-d))
                0)
         (list (serial-sub$op t
-                             (append a.valid-d sipo0.valid-data)
-                             (append b.valid-d sipo1.valid-data))))
+                             (append a.valid-d piso0.valid-data)
+                             (append b.valid-d piso1.valid-data))))
        ((< (len (append sipo.valid-data s.valid-d))
            data-width)
         (list
@@ -726,8 +727,8 @@
           sipo.valid-data
           s.valid-d
           (serial-sub$op c
-                         (append a.valid-d sipo0.valid-data)
-                         (append b.valid-d sipo1.valid-data)))))
+                         (append a.valid-d piso0.valid-data)
+                         (append b.valid-d piso1.valid-data)))))
        (t (list (append sipo.valid-data s.valid-d)))))
      (t nil))))
 
@@ -759,8 +760,8 @@
          (a.valid-d (if (fullp a.s) a.d nil))
          (b.valid-d (if (fullp b.s) b.d nil))
          (s.valid-d (if (fullp s.s) s.d nil))
-         (sipo0.valid-data (piso2-sreg$extract0 piso2))
-         (sipo1.valid-data (piso2-sreg$extract1 piso2))
+         (piso0.valid-data (piso2-sreg$extract0 piso2))
+         (piso1.valid-data (piso2-sreg$extract1 piso2))
          (sipo.valid-data (sipo-sreg$extract sipo)))
       (and (not (equal ci.s co.s))
            (or (emptyp ci.s) (emptyp done.s))
@@ -769,9 +770,9 @@
            (or (emptyp s.s) (fullp co.s))
            (not (and (fullp s.s) (fullp done.s)))
            (or (emptyp ci.s)
-               (and (not (equal (len (append a.valid-d sipo0.valid-data))
+               (and (not (equal (len (append a.valid-d piso0.valid-data))
                                 0))
-                    (not (equal (len (append a.valid-d sipo0.valid-data))
+                    (not (equal (len (append a.valid-d piso0.valid-data))
                                 data-width)))
                (car ci.d))
            (or (emptyp done.s)
@@ -780,15 +781,15 @@
                                  0)
                           (equal (len sipo.valid-data)
                                  data-width))))
-           (equal (len (append a.valid-d sipo0.valid-data))
-                  (len (append b.valid-d sipo1.valid-data)))
-           (or (equal (+ (len (append a.valid-d sipo0.valid-data))
+           (equal (len (append a.valid-d piso0.valid-data))
+                  (len (append b.valid-d piso1.valid-data)))
+           (or (equal (+ (len (append a.valid-d piso0.valid-data))
                          (len (append sipo.valid-data s.valid-d)))
                       0)
-               (equal (+ (len (append a.valid-d sipo0.valid-data))
+               (equal (+ (len (append a.valid-d piso0.valid-data))
                          (len (append sipo.valid-data s.valid-d)))
                       data-width)
-               (equal (+ (len (append a.valid-d sipo0.valid-data))
+               (equal (+ (len (append a.valid-d piso0.valid-data))
                          (len (append sipo.valid-data s.valid-d)))
                       (* 2 data-width)))
            (piso2-sreg$inv piso2)

--- a/books/projects/async/serial-adder/sipo-sreg.lisp
+++ b/books/projects/async/serial-adder/sipo-sreg.lisp
@@ -994,21 +994,16 @@
       nil
     (b* ((inputs (car inputs-seq))
          (out-act (sipo-sreg$out-act inputs st))
-         (data (sipo-sreg$data-out st)))
+         (data (sipo-sreg$data-out st))
+         (seq (sipo-sreg$out-seq
+               (cdr inputs-seq)
+               (sipo-sreg$step inputs st data-width cnt-width)
+               data-width
+               cnt-width
+               (1- n))))
       (if (equal out-act t)
-          (append (sipo-sreg$out-seq
-                   (cdr inputs-seq)
-                   (sipo-sreg$step inputs st data-width cnt-width)
-                   data-width
-                   cnt-width
-                   (1- n))
-                  (list data))
-        (sipo-sreg$out-seq
-         (cdr inputs-seq)
-         (sipo-sreg$step inputs st data-width cnt-width)
-         data-width
-         cnt-width
-         (1- n))))))
+          (append seq (list data))
+        seq))))
 
 (defun sipo-sreg$netlist-out-seq
     (inputs-seq st netlist data-width n)
@@ -1019,23 +1014,17 @@
          (outputs (se (si 'sipo-sreg data-width)
                       inputs st netlist))
          (out-act (nth 1 outputs))
-         (data (take data-width (nthcdr 3 outputs))))
+         (data (take data-width (nthcdr 3 outputs)))
+         (seq (sipo-sreg$netlist-out-seq
+               (cdr inputs-seq)
+               (de (si 'sipo-sreg data-width)
+                   inputs st netlist)
+               netlist
+               data-width
+               (1- n))))
       (if (equal out-act t)
-          (append (sipo-sreg$netlist-out-seq
-                   (cdr inputs-seq)
-                   (de (si 'sipo-sreg data-width)
-                       inputs st netlist)
-                   netlist
-                   data-width
-                   (1- n))
-                  (list data))
-        (sipo-sreg$netlist-out-seq
-         (cdr inputs-seq)
-         (de (si 'sipo-sreg data-width)
-             inputs st netlist)
-         netlist
-         data-width
-         (1- n))))))
+          (append seq (list data))
+        seq))))
 
 (defthm sipo-sreg$out-seq-lemma
   (implies (and (sipo-sreg& netlist data-width cnt-width)

--- a/books/projects/async/utils.lisp
+++ b/books/projects/async/utils.lisp
@@ -4,7 +4,7 @@
 ;; ACL2.
 
 ;; Cuong Chau <ckcuong@cs.utexas.edu>
-;; November 2018
+;; December 2018
 
 (in-package "ADE")
 
@@ -155,29 +155,6 @@
   (implies (and (member e x)
                 (true-list-listp x))
            (true-listp e)))
-
-(defun pair-with-nil (x)
-  (declare (xargs :guard t))
-  (if (atom x)
-      nil
-    (cons (cons (car x) nil)
-          (pair-with-nil (cdr x)))))
-
-(defun pairs (x y)
-  (declare (xargs :guard t))
-  (if (atom x)
-      nil
-    (if (atom y)
-        (pair-with-nil x)
-      (cons (cons (car x)
-                  (car y))
-            (pairs (cdr x) (cdr y))))))
-
-(defthm pairs-is-pairlis$
-  (equal (pairs    x y)
-         (pairlis$ x y)))
-
-(in-theory (disable pairs))
 
 ;; Some facts about pairlis$
 


### PR DESCRIPTION
ASYNC: Replaced 'pairs' with 'pairlis$' in the definitions of the 'se' and 'de' functions