### PR TITLE
I made a number of changes to defunc and definec, some of which may h…

### DIFF
--- a/books/acl2s/mode-acl2s-dependencies.lisp
+++ b/books/acl2s/mode-acl2s-dependencies.lisp
@@ -34,6 +34,7 @@
 (include-book "system/doc/acl2-doc-wrap" :dir :system)
 (include-book "misc/eval" :dir :system)
 (include-book "kestrel/utilities/symbols" :dir :system)
+(include-book "centaur/misc/outer-local" :dir :system)
 
 #|
  (include-book 


### PR DESCRIPTION
…ave large consequences. One of the changes is that the output contract theorem are now forward chaining and rewrite rules, but not type prescription rules. I reduced the amount of exploration defunc does by better integrating any extra hints we get from users. I added force to each hypof function contracts for defunc. I added support for defuncb, where acl2s-bool-undefined is used for output contracts that state the function returns a boolean. All of this allowed me to unify the way defunc and definec work, so that led to simplifications to definec. Finally I added/fixed support for version of defunc, definec that disable the functions, don't test during function admissions, etc.