### PR TITLE
Trim an STD rule

### DIFF
--- a/books/centaur/aignet/mark-impls.lisp
+++ b/books/centaur/aignet/mark-impls.lisp
@@ -1257,6 +1257,16 @@
 
   (local (in-theory (disable ACL2::TAKE-OF-TOO-MANY)))
 
+  (local (defthm member-take-when-index-of-greater-than-length-lemma-1
+           (implies (and k (member-equal k (take w x)))
+                    (< (acl2::index-of k (take w x))
+                       (len x)))
+           :hints
+           (("goal" :induct (take w x)
+             :expand (:free (k x y)
+                            (acl2::index-of k (cons x y)))))
+           :rule-classes (:rewrite :linear)))
+
   (local (defthm member-take-when-index-of-greater-than-length
            (implies (and (member k (take w x))
                          k)

--- a/books/projects/filesystems/file-system-lemmas.lisp
+++ b/books/projects/filesystems/file-system-lemmas.lisp
@@ -531,8 +531,9 @@
 ;; Contributed to books/std/lists/nth.lisp
 (defthm nth-of-take
   (equal (nth i (take n l))
-         (if (>= (nfix i) (nfix n))
-             nil (nth (nfix i) l))))
+         (if (< (nfix i) (nfix n))
+             (nth i l)
+             nil)))
 
 (defthm nthcdr-of-nil (equal (nthcdr n nil) nil))
 

--- a/books/projects/filesystems/file-system-m2.lisp
+++ b/books/projects/filesystems/file-system-m2.lisp
@@ -1694,8 +1694,7 @@
 (encapsulate
   ()
 
-  (local (include-book "rtl/rel9/arithmetic/top"
-                       :dir :system))
+  (local (include-book "rtl/rel9/arithmetic/top" :dir :system))
 
   (defthm
     cluster-size-of-read-reserved-area

--- a/books/std/lists/nth.lisp
+++ b/books/std/lists/nth.lisp
@@ -139,7 +139,7 @@
 
   (defthm nth-of-take
     (equal (nth i (take n l))
-           (if (< (nfix i) (min (nfix n) (len l)))
+           (if (< (nfix i) (nfix n))
                (nth i l)
              nil)))
 


### PR DESCRIPTION
This pull request trims an unnecessary function call from an STD rule, fixes a regression which arises, and incorporates the new rule into the filesystem books.