### PR TITLE
Update filesystem books and add IO lemmas

### DIFF
--- a/books/projects/filesystems/LICENSE
+++ b/books/projects/filesystems/LICENSE
@@ -1,0 +1,3 @@
+Copyright (C) 2017, Regents of the University of Texas
+Written by Mihir Mehta
+License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.

--- a/books/projects/filesystems/block-listp.lisp
+++ b/books/projects/filesystems/block-listp.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  block-listp.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/bounded-nat-listp.lisp
+++ b/books/projects/filesystems/bounded-nat-listp.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 (defun bounded-nat-listp (l b)

--- a/books/projects/filesystems/cluster-listp.lisp
+++ b/books/projects/filesystems/cluster-listp.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  cluster-listp.lisp                                Mihir Mehta

--- a/books/projects/filesystems/fat32.lisp
+++ b/books/projects/filesystems/fat32.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  fat32.lisp                                  Mihir Mehta
@@ -32,7 +28,7 @@
 (defconst *ms-bad-cluster* 268435447)
 
 ;; from page 15 of the FAT specification
-(defconst *ms-fat32-min-count-of-clusters* 65525)
+(defconst *ms-min-count-of-clusters* 65525)
 
 ;; from page 9 of the FAT specification
 (defconst *ms-min-bytes-per-sector* 512)
@@ -40,7 +36,7 @@
 ;; inferred - there can be as few as one sectors in a cluster
 (defconst *ms-min-data-region-size* (* *ms-min-bytes-per-sector*
                                        1
-                                       *ms-fat32-min-count-of-clusters*))
+                                       *ms-min-count-of-clusters*))
 
 (defconst *ms-max-bytes-per-sector* 4096)
 

--- a/books/projects/filesystems/file-system-1.lisp
+++ b/books/projects/filesystems/file-system-1.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-1.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/file-system-2.lisp
+++ b/books/projects/filesystems/file-system-2.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-2.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/file-system-3.lisp
+++ b/books/projects/filesystems/file-system-3.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-3.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/file-system-4.lisp
+++ b/books/projects/filesystems/file-system-4.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-4.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/file-system-5.lisp
+++ b/books/projects/filesystems/file-system-5.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-5.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/file-system-6.lisp
+++ b/books/projects/filesystems/file-system-6.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-6.lisp                                  Mihir Mehta

--- a/books/projects/filesystems/file-system-lemmas.lisp
+++ b/books/projects/filesystems/file-system-lemmas.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;; Some lemmas below are taken from other books with credit; in most cases they
@@ -533,7 +529,7 @@
   (equal (nth i (take n l))
          (if (< (nfix i) (nfix n))
              (nth i l)
-             nil)))
+           nil)))
 
 (defthm nthcdr-of-nil (equal (nthcdr n nil) nil))
 
@@ -585,7 +581,7 @@
   (equal (len (remove1-equal x l))
          (if (member-equal x l)
              (- (len l) 1)
-             (len l))))
+           (len l))))
 
 (defthm
   assoc-equal-of-remove1-assoc-equal
@@ -611,8 +607,8 @@
 ;; The following is redundant with the eponymous theorem in
 ;; books/std/lists/nthcdr.lisp, from where it was taken with thanks.
 (defthm car-of-nthcdr
-    (equal (car (nthcdr i x))
-           (nth i x)))
+  (equal (car (nthcdr i x))
+         (nth i x)))
 
 (defthm stringp-of-nth
   (implies (string-listp l)
@@ -733,9 +729,9 @@
              (revappend (update-nth (- (len x) (+ 1 (nfix key)))
                                     val x)
                         y)
-             (revappend x
-                        (update-nth (- (nfix key) (len x))
-                                    val y)))))
+           (revappend x
+                      (update-nth (- (nfix key) (len x))
+                                  val y)))))
 
 (defthm
   true-listp-of-update-nth
@@ -768,7 +764,7 @@
   (equal (last (member-equal x lst))
          (if (member-equal x lst)
              (last lst)
-             nil)))
+           nil)))
 
 (defthm acl2-count-of-member-equal
   (<= (acl2-count (member-equal x lst))
@@ -780,3 +776,41 @@
   (implies (and (string-listp lst)
                 (stringp default-value))
            (string-listp (resize-list lst n default-value))))
+
+(encapsulate
+  ()
+
+  (local
+   (defthm
+     update-nth-of-first-n-ac
+     (implies
+      (< (nfix key) (+ (nfix i) (len ac)))
+      (equal
+       (update-nth key val (first-n-ac i l ac))
+       (if (< (nfix key) (len ac))
+           (first-n-ac i l
+                       (update-nth (- (len ac) (+ (nfix key) 1))
+                                   val ac))
+         (first-n-ac i
+                     (update-nth (- (nfix key) (len ac))
+                                 val l)
+                     ac))))
+     :hints (("goal" :induct (first-n-ac i l ac)
+              :in-theory (enable update-nth-of-revappend)))))
+
+  (defthm
+    first-n-ac-of-update-nth
+    (equal (first-n-ac i (update-nth key val l) ac)
+           (if (< (nfix key) (nfix i))
+               (update-nth (+ (nfix key) (len ac))
+                           val (first-n-ac i l ac))
+             (first-n-ac i l ac)))
+    :hints
+    (("goal" :induct (mv (first-n-ac i l ac)
+                         (update-nth key val l))))))
+
+(defthm take-of-update-nth
+  (equal (take n (update-nth key val l))
+         (if (< (nfix key) (nfix n))
+             (update-nth key val (take n l))
+           (take n l))))

--- a/books/projects/filesystems/file-system-m1.lisp
+++ b/books/projects/filesystems/file-system-m1.lisp
@@ -1,13 +1,8 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  file-system-m1.lisp                                 Mihir Mehta
 
-; An abstract model used, for the time being, for doing file operations such as
-; lstat on the filesystem.
+; M1, a model which abstracts M2.
 
 (include-book "std/typed-lists/unsigned-byte-listp" :dir :system)
 (include-book "std/io/read-ints" :dir :system)
@@ -169,17 +164,18 @@
   (implies (not (rational-listp x))
            (not (unsigned-byte-listp n x))))
 
-;; At some point, the following two theorems have to be moved to
+;; At some point, the following theorem has to be moved to
 ;; file-system-lemmas.lisp.
-(defthm take-of-update-nth
-  (equal (take n (update-nth key val l))
-         (if (< (nfix key) (nfix n))
-             (update-nth key val (take n l))
-           (take n l))))
-
 (defthmd take-of-nthcdr
   (equal (take n1 (nthcdr n2 l))
          (nthcdr n2 (take (+ (nfix n1) (nfix n2)) l))))
+
+;; This cannot be moved to to file-system-lemmas.lisp, because it's expressed
+;; in terms of explode.
+(defthm len-of-explode-of-string-append
+  (equal (len (explode (string-append str1 str2)))
+         (+ (len (explode str1))
+            (len (explode str2)))))
 
 (defthm
   unsigned-byte-listp-of-make-list-ac
@@ -252,6 +248,194 @@
     :hints
     (("goal" :in-theory (enable chars=>nats)
       :induct (cdr-cdr-induct x str::x-equiv)))))
+
+(defthm
+  consecutive-read-file-into-string-1
+  (implies
+   (and
+    (natp bytes1)
+    (natp bytes2)
+    (natp start1)
+    (stringp (read-file-into-string2 filename (+ start1 bytes1)
+                                     bytes2 state))
+    (<=
+     bytes2
+     (len
+      (explode
+       (read-file-into-string2 filename (+ start1 bytes1)
+                               bytes2 state)))))
+   (equal
+    (string-append
+     (read-file-into-string2 filename start1 bytes1 state)
+     (read-file-into-string2 filename (+ start1 bytes1)
+                             bytes2 state))
+    (read-file-into-string2 filename start1 (+ bytes1 bytes2)
+                            state)))
+  :hints
+  (("goal"
+    :in-theory (e/d (take-of-nthcdr)
+                    (binary-append-take-nthcdr))
+    :use
+    ((:theorem (implies (natp bytes1)
+                        (equal (+ bytes1 bytes1 (- bytes1)
+                                  bytes2 start1)
+                               (+ bytes1 bytes2 start1))))
+     (:instance
+      binary-append-take-nthcdr (i bytes1)
+      (l
+       (nthcdr
+        start1
+        (take
+         (+ bytes1 bytes2 start1)
+         (explode
+          (mv-nth
+           0
+           (read-file-into-string1
+            (mv-nth 0
+                    (open-input-channel filename
+                                        :character state))
+            (mv-nth 1
+                    (open-input-channel filename
+                                        :character state))
+            nil 1152921504606846975))))))))))
+  :rule-classes
+  ((:rewrite
+    :corollary
+    (implies
+     (and
+      (natp bytes1)
+      (natp bytes2)
+      (natp start1)
+      (stringp
+       (read-file-into-string2 filename (+ start1 bytes1)
+                               bytes2 state))
+      (<=
+       bytes2
+       (len
+        (explode
+         (read-file-into-string2 filename (+ start1 bytes1)
+                                 bytes2 state))))
+      (equal start2 (+ start1 bytes1)))
+     (equal
+      (string-append
+       (read-file-into-string2 filename start1 bytes1 state)
+       (read-file-into-string2 filename start2 bytes2 state))
+      (read-file-into-string2 filename start1 (+ bytes1 bytes2)
+                              state))))))
+
+(defthm
+  consecutive-read-file-into-string-2
+  (implies
+   (and
+    (natp bytes1)
+    (natp start1)
+    (stringp (read-file-into-string2 filename (+ start1 bytes1)
+                                     nil state)))
+   (equal
+    (string-append
+     (read-file-into-string2 filename start1 bytes1 state)
+     (read-file-into-string2 filename (+ start1 bytes1)
+                             nil state))
+    (read-file-into-string2 filename start1 nil state)))
+  :hints
+  (("goal"
+    :in-theory (e/d (take-of-nthcdr)
+                    (binary-append-take-nthcdr))
+    :do-not-induct t
+    :use
+    ((:instance
+      binary-append-take-nthcdr (i bytes1)
+      (l
+       (nthcdr
+        start1
+        (explode
+         (mv-nth
+          0
+          (read-file-into-string1
+           (mv-nth 0
+                   (open-input-channel filename
+                                       :character state))
+           (mv-nth 1
+                   (open-input-channel filename
+                                       :character state))
+           nil 1152921504606846975))))))
+     (:theorem
+      (implies
+       (and (natp bytes1) (natp start1))
+       (equal
+        (+
+         bytes1 (- bytes1)
+         start1 (- start1)
+         (len
+          (explode
+           (mv-nth
+            0
+            (read-file-into-string1
+             (mv-nth 0
+                     (open-input-channel filename
+                                         :character state))
+             (mv-nth 1
+                     (open-input-channel filename
+                                         :character state))
+             nil 1152921504606846975)))))
+        (len
+         (explode
+          (mv-nth
+           0
+           (read-file-into-string1
+            (mv-nth 0
+                    (open-input-channel filename
+                                        :character state))
+            (mv-nth 1
+                    (open-input-channel filename
+                                        :character state))
+            nil 1152921504606846975)))))))
+     (:theorem
+      (implies
+       (natp start1)
+       (equal
+        (+
+         start1 (- start1)
+         (len
+          (explode
+           (mv-nth
+            0
+            (read-file-into-string1
+             (mv-nth 0
+                     (open-input-channel filename
+                                         :character state))
+             (mv-nth 1
+                     (open-input-channel filename
+                                         :character state))
+             nil 1152921504606846975)))))
+        (len
+         (explode
+          (mv-nth
+           0
+           (read-file-into-string1
+            (mv-nth 0
+                    (open-input-channel filename
+                                        :character state))
+            (mv-nth 1
+                    (open-input-channel filename
+                                        :character state))
+            nil 1152921504606846975))))))))))
+  :rule-classes
+  ((:rewrite
+    :corollary
+    (implies
+     (and
+      (natp bytes1)
+      (natp start1)
+      (stringp
+       (read-file-into-string2 filename (+ start1 bytes1)
+                               nil state))
+      (equal start2 (+ start1 bytes1)))
+     (equal
+      (string-append
+       (read-file-into-string2 filename start1 bytes1 state)
+       (read-file-into-string2 filename start2 nil state))
+      (read-file-into-string2 filename start1 nil state))))))
 
 ;; This is to get the theorem about the nth element of a list of unsigned
 ;; bytes.
@@ -1376,9 +1560,6 @@
 (defcong m1-file-equiv equal
   (place-file-by-pathname fs pathname file) 3)
 
-;; This function should continue to take pathnames which refer to top-level
-;; fs... but what happens when "." and ".." appear in a pathname? We'll have to
-;; modify the code to deal with that.
 (defun
     remove-file-by-pathname
     (fs pathname)
@@ -1387,32 +1568,37 @@
                   :measure (acl2-count pathname)))
   (b*
       ((fs (m1-file-alist-fix fs))
+       ;; Design choice - calls which ask for the entire root directory to be
+       ;; affected will fail.
        ((unless (consp pathname))
         (mv fs *enoent*))
        (name (fat32-filename-fix (car pathname)))
-       (alist-elem (assoc-equal name fs)))
-    (if
-        (consp alist-elem)
-        (if
-            (m1-directory-file-p (cdr alist-elem))
-            (mv-let
-              (new-contents error-code)
-              (remove-file-by-pathname
-               (m1-file->contents (cdr alist-elem))
-               (cdr pathname))
-              (mv
-               (put-assoc-equal
-                name
-                (make-m1-file
-                 :dir-ent (m1-file->dir-ent (cdr alist-elem))
-                 :contents new-contents)
-                fs)
-               error-code))
-          (if (consp (cdr pathname))
-              (mv fs *enotdir*)
-            (mv (remove1-assoc-equal name fs) 0)))
-      ;; if it's not there, it can't be removed
-      (mv fs *enoent*))))
+       (alist-elem (assoc-equal name fs))
+       ;; If it's not there, it can't be removed
+       ((unless
+            (consp alist-elem))
+        (mv fs *enoent*))
+       ;; Design choice - this lower-level function will unquestioningly delete
+       ;; entire subdirectory trees, as long as they are not the root.
+       ((when (atom (cdr pathname)))
+        (mv (remove1-assoc-equal name fs) 0))
+       ;; ENOTDIR - can't delete anything that supposedly exists inside a
+       ;; regular file.
+       ((unless (m1-directory-file-p (cdr alist-elem)))
+        (mv fs *enotdir*))
+       ;; Recursion
+       ((mv new-contents error-code)
+        (remove-file-by-pathname
+         (m1-file->contents (cdr alist-elem))
+         (cdr pathname))))
+    (mv
+     (put-assoc-equal
+      name
+      (make-m1-file
+       :dir-ent (m1-file->dir-ent (cdr alist-elem))
+       :contents new-contents)
+      fs)
+     error-code)))
 
 (defthm
   remove-file-by-pathname-correctness-1
@@ -1610,401 +1796,6 @@
            (append abspathname relpathname))))
   :hints
   (("goal" :in-theory (enable realpath))))
-
-;; From the common man page basename(3)/dirname(3):
-;; --
-;; If  path  does  not contain a slash, dirname() returns the string "." while
-;; basename() returns a copy of path.  If path is the string  "/",  then  both
-;; dirname()  and basename() return the string "/".  If path is a NULL pointer
-;; or points to an empty string, then both dirname() and basename() return the
-;; string ".".
-;; --
-;; Of course, an empty list means something went wrong with the parsing code,
-;; because even in the case of an empty path string, (list "") should be passed
-;; to these functions. Still, we do the default thing, because neither of these
-;; functions sets errno.
-
-;; Also, an empty string right in the beginning indicates that the path began
-;; with a "/". While not documented properly in the man page, for a path such
-;; as "/home" or "/tmp", the dirname will be "/".
-(defund
-  m1-basename-dirname-helper (path)
-  (declare (xargs :guard (string-listp path)
-                  :guard-hints (("Goal" :in-theory (disable
-                                                    make-list-ac-removal)))
-                  :guard-debug t))
-  (b*
-      (((when (atom path))
-        (mv *current-dir-fat32-name* (list *current-dir-fat32-name*)))
-       (coerced-basename
-        (if
-            (or (atom (cdr path))
-                (and (not (streqv (car path) ""))
-                     (atom (cddr path))
-                     (streqv (cadr path) "")))
-            (coerce (str-fix (car path)) 'list)
-          (coerce (str-fix (cadr path)) 'list)))
-       (basename
-        (coerce
-         (append
-          (take (min 11 (len coerced-basename)) coerced-basename)
-          (make-list
-           (nfix (- 11 (len coerced-basename)))
-           :initial-element (code-char 0)))
-         'string))
-       ((when (or (atom (cdr path))
-                  (and (not (streqv (car path) ""))
-                       (atom (cddr path))
-                       (streqv (cadr path) ""))))
-        (mv
-         basename
-         (list *current-dir-fat32-name*)))
-       ((when (atom (cddr path)))
-        (mv basename
-            (list (str-fix (car path)))))
-       ((mv tail-basename tail-dirname)
-        (m1-basename-dirname-helper (cdr path))))
-    (mv tail-basename
-        (list* (str-fix (car path))
-               tail-dirname))))
-
-(defthm
-  m1-basename-dirname-helper-correctness-1
-  (mv-let (basename dirname)
-    (m1-basename-dirname-helper path)
-    (and (stringp basename)
-         (equal (len (explode basename)) 11)
-         (string-listp dirname)))
-  :hints
-  (("goal" :induct (m1-basename-dirname-helper path)
-    :in-theory (enable m1-basename-dirname-helper)))
-  :rule-classes
-  (:rewrite
-   (:type-prescription
-    :corollary
-    (stringp (mv-nth 0 (m1-basename-dirname-helper path))))
-   (:type-prescription
-    :corollary
-    (true-listp (mv-nth 1 (m1-basename-dirname-helper path))))))
-
-(defun m1-basename (path)
-  (declare (xargs :guard (string-listp path)))
-  (mv-let (basename dirname)
-    (m1-basename-dirname-helper path)
-    (declare (ignore dirname))
-    basename))
-
-(defun m1-dirname (path)
-  (declare (xargs :guard (string-listp path)))
-  (mv-let (basename dirname)
-    (m1-basename-dirname-helper path)
-    (declare (ignore basename))
-    dirname))
-
-;; This used to be guard verified, and then we brought in the
-;; fat32-filename-list-p predicate and made everything complicated. Let's let
-;; the system calls remain guard-unverified until we can test some more and
-;; demonstrate that they work. That should give us enough time to figure out
-;; the point at which we want to figure out the correct level of abstraction at
-;; which to clean up all the weird pathnames such as "/home/ ihir" and
-;; and "/home/ihir" and "/../home/mihir".
-(defun m1-lstat (fs pathname)
-  (declare (xargs :guard (and (m1-file-alist-p fs)
-                              (fat32-filename-list-p pathname))
-                  :verify-guards nil))
-  (b*
-      (((mv file errno)
-        (find-file-by-pathname fs pathname))
-       ((when (not (equal errno 0)))
-        (mv (make-struct-stat) -1 errno)))
-    (mv
-       (make-struct-stat
-        :st_size (dir-ent-file-size
-                  (m1-file->dir-ent file)))
-       0 0)))
-
-(defthm m1-open-guard-lemma-1
-  (implies (fd-table-p fd-table)
-           (alistp fd-table)))
-
-(defun m1-open (pathname fs fd-table file-table)
-  (declare (xargs :guard (and (m1-file-alist-p fs)
-                              (fat32-filename-list-p pathname)
-                              (fd-table-p fd-table)
-                              (file-table-p file-table))))
-  (b*
-      ((fd-table (fd-table-fix fd-table))
-       (file-table (file-table-fix file-table))
-       ((mv & errno)
-        (find-file-by-pathname fs pathname))
-       ((unless (equal errno 0))
-        (mv fd-table file-table -1 errno))
-       (file-table-index
-        (find-new-index (strip-cars file-table)))
-       (fd-table-index
-        (find-new-index (strip-cars fd-table))))
-    (mv
-     (cons
-      (cons fd-table-index file-table-index)
-      fd-table)
-     (cons
-      (cons file-table-index (make-file-table-element :pos 0 :fid pathname))
-      file-table)
-     fd-table-index 0)))
-
-(defthm m1-open-correctness-1
-  (b*
-      (((mv fd-table file-table & &) (m1-open pathname fs fd-table file-table)))
-    (and
-     (fd-table-p fd-table)
-     (file-table-p file-table))))
-
-(defthm
-  m1-pread-guard-lemma-1
-  (implies
-   (and (file-table-p file-table)
-        (consp (assoc-equal x file-table)))
-   (file-table-element-p (cdr (assoc-equal x file-table)))))
-
-;; Per the man page pread(2), this should not change the offset of the file
-;; descriptor in the file table. Thus, there's no need for the file table to be
-;; an argument.
-(defun
-  m1-pread
-  (fd count offset fs fd-table file-table)
-  (declare (xargs :guard (and (natp fd)
-                              (natp count)
-                              (natp offset)
-                              (fd-table-p fd-table)
-                              (file-table-p file-table)
-                              (m1-file-alist-p fs))
-                  :guard-debug t))
-  (b*
-      ((fd-table-entry (assoc-equal fd fd-table))
-       ((unless (consp fd-table-entry))
-        (mv "" -1 *ebadf*))
-       (file-table-entry (assoc-equal (cdr fd-table-entry)
-                                      file-table))
-       ((unless (consp file-table-entry))
-        (mv "" -1 *ebadf*))
-       (pathname (file-table-element->fid (cdr file-table-entry)))
-       ((mv file error-code)
-        (find-file-by-pathname fs pathname))
-       ((unless (and (equal error-code 0)
-                     (m1-regular-file-p file)))
-        (mv "" -1 error-code))
-       (new-offset (min (+ offset count)
-                        (length (m1-file->contents file))))
-       (buf (subseq (m1-file->contents file)
-                    (min offset
-                         (length (m1-file->contents file)))
-                    new-offset)))
-    (mv buf (length buf) 0)))
-
-(defthm
-  m1-pread-correctness-1
-  (mv-let (buf ret error-code)
-    (m1-pread fd count offset fs fd-table file-table)
-    (and (stringp buf)
-         (integerp ret)
-         (integerp error-code)
-         (implies (>= ret 0)
-                  (equal (length buf) ret)))))
-
-(defun
-  m1-pwrite
-  (fd buf offset fs fd-table file-table)
-  (declare (xargs :guard (and (natp fd)
-                              (stringp buf)
-                              (natp offset)
-                              (fd-table-p fd-table)
-                              (file-table-p file-table)
-                              (m1-file-alist-p fs))
-                  :guard-debug t
-                  :guard-hints (("Goal" :in-theory (enable len-of-insert-text))
-                                ("Subgoal 2'" :in-theory (disable
-                                                          consp-assoc-equal)
-                                 :use (:instance consp-assoc-equal
-                                                 (name (CDR (CAR FD-TABLE)))
-                                                 (l
-                                                  FILE-TABLE))))))
-  (b*
-      ((fd-table-entry (assoc-equal fd fd-table))
-       (fs (m1-file-alist-fix fs))
-       ((unless (consp fd-table-entry))
-        (mv fs -1 *ebadf*))
-       (file-table-entry (assoc-equal (cdr fd-table-entry)
-                                      file-table))
-       ((unless (consp file-table-entry))
-        (mv fs -1 *ebadf*))
-       (pathname (file-table-element->fid (cdr file-table-entry)))
-       ((mv file error-code)
-        (find-file-by-pathname fs pathname))
-       ((mv oldtext dir-ent)
-        (if (and (equal error-code 0)
-                 (m1-regular-file-p file))
-            (mv (coerce (m1-file->contents file) 'list)
-                (m1-file->dir-ent file))
-            (mv nil (dir-ent-fix nil))))
-       ((unless (unsigned-byte-p 32 (+ OFFSET (length BUF))))
-        (mv fs -1 *enospc*))
-       (file
-        (make-m1-file
-         :dir-ent dir-ent
-         :contents (coerce (insert-text oldtext offset buf)
-                           'string)))
-       ((mv fs error-code)
-        (place-file-by-pathname fs pathname file)))
-    (mv fs (if (equal error-code 0) 0 -1)
-        error-code)))
-
-;; I'm leaving this guard unverified because that's not what I want to put my
-;; time and energy into right now...
-(defun
-    m1-mkdir (fs pathname)
-  (declare
-   (xargs
-    :guard (and (m1-file-alist-p fs)
-                (fat32-filename-list-p pathname))
-    :guard-hints
-    (("goal"
-      :in-theory
-      (disable
-       (:rewrite m1-basename-dirname-helper-correctness-1))
-      :use
-      (:instance
-       (:rewrite m1-basename-dirname-helper-correctness-1)
-       (path pathname))))
-    :verify-guards nil))
-  (b* ((dirname (m1-dirname pathname))
-       ;; Never pass relative pathnames to syscalls - make them always begin
-       ;; with "/".
-       ((when (atom dirname))
-        (mv fs -1 *enoent*))
-       ((mv parent-dir errno)
-        (find-file-by-pathname fs dirname))
-       ((unless (or (atom dirname)
-                    (and (equal errno 0)
-                         (m1-directory-file-p parent-dir))))
-        (mv fs -1 *enoent*))
-       ((mv & errno)
-        (find-file-by-pathname fs pathname))
-       ((unless (not (equal errno 0)))
-        (mv fs -1 *eexist*))
-       (basename (m1-basename pathname))
-       ((unless (equal (length basename) 11))
-        (mv fs -1 *enametoolong*))
-       (dir-ent
-        (DIR-ENT-INSTALL-DIRECTORY-BIT
-         (dir-ent-fix nil)
-         t))
-       (file (make-m1-file :dir-ent dir-ent
-                           :contents nil))
-       ((mv fs error-code)
-        (place-file-by-pathname fs pathname file))
-       ((unless (equal error-code 0))
-        (mv fs -1 error-code)))
-    (mv fs 0 0)))
-
-;; I'm leaving this guard unverified because that's not what I want to put my
-;; time and energy into right now...
-(defun
-    m1-mknod (fs pathname)
-  (declare
-   (xargs
-    :guard (and (m1-file-alist-p fs)
-                (string-listp pathname))
-    :guard-hints
-    (("goal"
-      :in-theory
-      (disable
-       (:rewrite m1-basename-dirname-helper-correctness-1))
-      :use
-      (:instance
-       (:rewrite m1-basename-dirname-helper-correctness-1)
-       (path pathname))))
-    :verify-guards nil))
-  (b* ((dirname (m1-dirname pathname))
-       (basename (m1-basename pathname))
-       ((mv parent-dir errno)
-        (find-file-by-pathname fs dirname))
-       ((unless (or (atom dirname)
-                    (and (equal errno 0)
-                         (m1-directory-file-p parent-dir))))
-        (mv fs -1 *enoent*))
-       ((mv & errno)
-        (find-file-by-pathname fs pathname))
-       ((unless (not (equal errno 0)))
-        (mv fs -1 *eexist*))
-       ((unless (equal (length basename) 11))
-        (mv fs -1 *enametoolong*))
-       (dir-ent (append (string=>nats basename)
-                        (nthcdr 11 (dir-ent-fix nil))))
-       (file (make-m1-file :dir-ent dir-ent
-                           :contents nil))
-       ((mv fs error-code)
-        (place-file-by-pathname fs pathname file))
-       ((unless (equal error-code 0))
-        (mv fs -1 error-code)))
-    (mv fs 0 0)))
-
-(defthm
-  m1-unlink-guard-lemma-1
-  (implies (m1-file-p file)
-           (and
-            (true-listp (m1-file->dir-ent file))
-            (equal (len (m1-file->dir-ent file)) *ms-dir-ent-length*)
-            (unsigned-byte-listp 8 (m1-file->dir-ent file))))
-  :hints
-  (("goal" :in-theory (e/d (dir-ent-p)
-                           (dir-ent-p-of-m1-file->dir-ent))
-    :use (:instance dir-ent-p-of-m1-file->dir-ent
-                    (x file)))))
-
-;; I'm leaving this guard unverified because that's not what I want to put my
-;; time and energy into right now...
-
-;; The fat driver in Linux actually keeps the directory entries of files it is
-;; deleting, while removing links to their contents. Thus, in the special case
-;; where the last file is deleted from the root directory, the root directory
-;; will still occupy one cluster, which in turn contains one entry which
-;; points to the deleted file, with the filename's first character changed to
-;; #xe5, which signifies a deleted file, its file length changed to 0, and
-;; the first cluster changed to 0. This may even hold for other directories
-;; than root.
-
-;; This may be a place where co-simulation of statfs may have to be
-;; compromised... because, now, we don't have m1-file-alist-p as an invariant
-;; unless we delete the file from our tree representation. The way forward, I
-;; think, is to delete the file from the tree, and make an m2-unlink that does
-;; the same thing as m1-unlink.
-(defun
-    m1-unlink (fs pathname)
-  (declare
-   (xargs
-    :guard (and (m1-file-alist-p fs)
-                (string-listp pathname))
-    :guard-debug t
-    :guard-hints
-    (("goal"
-      :in-theory
-      (disable
-       (:rewrite m1-basename-dirname-helper-correctness-1)
-       return-type-of-string=>nats update-nth)
-      :use
-      ((:instance
-        (:rewrite m1-basename-dirname-helper-correctness-1)
-        (path pathname))
-       (:instance return-type-of-string=>nats
-                  (string
-                   (mv-nth 0
-                           (m1-basename-dirname-helper pathname)))))))
-    :verify-guards nil))
-  (b* (((mv fs error-code)
-        (remove-file-by-pathname fs pathname))
-       ((unless (equal error-code 0))
-        (mv fs -1 error-code)))
-    (mv fs 0 0)))
 
 (defun
     name-to-fat32-name-helper

--- a/books/projects/filesystems/find-n-free-blocks.lisp
+++ b/books/projects/filesystems/find-n-free-blocks.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  find-n-free-blocks.lisp                     Mihir Mehta

--- a/books/projects/filesystems/flatten-lemmas.lisp
+++ b/books/projects/filesystems/flatten-lemmas.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 (local (include-book "file-system-lemmas"))

--- a/books/projects/filesystems/generate-index-list.lisp
+++ b/books/projects/filesystems/generate-index-list.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  generate-index-list.lisp                            Mihir Mehta

--- a/books/projects/filesystems/insert-text.lisp
+++ b/books/projects/filesystems/insert-text.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  insert-list.lisp                                    Mihir Mehta

--- a/books/projects/filesystems/m1-dir-equiv.lisp
+++ b/books/projects/filesystems/m1-dir-equiv.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  m1-dir-equiv.lisp                                   Mihir Mehta

--- a/books/projects/filesystems/m1-entry-count.lisp
+++ b/books/projects/filesystems/m1-entry-count.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 ;  m1-entry-count.lisp                                 Mihir Mehta

--- a/books/projects/filesystems/m1-syscalls.lisp
+++ b/books/projects/filesystems/m1-syscalls.lisp
@@ -1,0 +1,424 @@
+(in-package "ACL2")
+
+;  m1-syscalls.lisp                                    Mihir Mehta
+
+; Syscalls for mode M1. These syscalls usually return, among other things, a
+; return value (corresponding to the C return value) and an errno.
+
+(include-book "file-system-m1")
+
+;; This implementation of basename+dirname is not exactly compliant with the
+;; man pages basename(3)/dirname(3) - it assumes all paths provided to it are
+;; absolute paths (thus, the empty pathname is treated like "/"), and further
+;; it expects its argument to be a list of FAT32 names, which means there is
+;; not much hope for formulating a particularly coherent relation between this
+;; and the friendly command line programs basename(1)/dirname(1).
+
+;; From the common man page basename(3)/dirname(3):
+;; --
+;; If  path  does  not contain a slash, dirname() returns the string "." while
+;; basename() returns a copy of path.  If path is the string  "/",  then  both
+;; dirname()  and basename() return the string "/".  If path is a NULL pointer
+;; or points to an empty string, then both dirname() and basename() return the
+;; string ".".
+;; --
+;; Of course, an empty list means something went wrong with the parsing code,
+;; because even in the case of an empty path string, (list "") should be passed
+;; to these functions. Still, we do the default thing, because neither of these
+;; functions sets errno.
+
+;; Also, an empty string right in the beginning indicates that the path began
+;; with a "/". While not documented properly in the man page, for a path such
+;; as "/home" or "/tmp", the dirname will be "/".
+(defund
+  m1-basename-dirname-helper (path)
+  (declare (xargs :guard (fat32-filename-list-p path)
+                  :guard-hints (("Goal" :in-theory (disable
+                                                    make-list-ac-removal)))
+                  :guard-debug t))
+  (b*
+      (;; Under the assumption that all pathnames begin with a /, this really
+       ;; is the case where there's a / and nothing else.
+       ((when (atom path))
+        (mv *empty-fat32-name* nil))
+       ((when (atom (cdr path)))
+        (mv
+         (fat32-filename-fix (car path))
+         nil))
+       ((mv tail-basename tail-dirname)
+        (m1-basename-dirname-helper (cdr path))))
+    (mv tail-basename
+        (list* (fat32-filename-fix (car path))
+               tail-dirname))))
+
+(defthm
+  m1-basename-dirname-helper-correctness-1
+  (mv-let (basename dirname)
+    (m1-basename-dirname-helper path)
+    (and (fat32-filename-p basename)
+         (fat32-filename-list-p dirname)))
+  :hints
+  (("goal" :induct (m1-basename-dirname-helper path)
+    :in-theory (enable m1-basename-dirname-helper)))
+  :rule-classes
+  (:rewrite
+   (:type-prescription
+    :corollary
+    (stringp (mv-nth 0 (m1-basename-dirname-helper path))))
+   (:type-prescription
+    :corollary
+    (true-listp (mv-nth 1 (m1-basename-dirname-helper path))))))
+
+(defun m1-basename (path)
+  (declare (xargs :guard (fat32-filename-list-p path)))
+  (mv-let (basename dirname)
+    (m1-basename-dirname-helper path)
+    (declare (ignore dirname))
+    basename))
+
+(defun m1-dirname (path)
+  (declare (xargs :guard (fat32-filename-list-p path)))
+  (mv-let (basename dirname)
+    (m1-basename-dirname-helper path)
+    (declare (ignore basename))
+    dirname))
+
+;; This used to be guard verified, and then we brought in the
+;; fat32-filename-list-p predicate and made everything complicated. Let's let
+;; the system calls remain guard-unverified until we can test some more and
+;; demonstrate that they work. That should give us enough time to figure out
+;; the point at which we want to figure out the correct level of abstraction to
+;; clean up all the weird pathnames.
+(defun m1-lstat (fs pathname)
+  (declare (xargs :guard (and (m1-file-alist-p fs)
+                              (fat32-filename-list-p pathname))))
+  (b*
+      (((mv file errno)
+        (find-file-by-pathname fs pathname))
+       ((when (not (equal errno 0)))
+        (mv (make-struct-stat) -1 errno)))
+    (mv
+       (make-struct-stat
+        :st_size (dir-ent-file-size
+                  (m1-file->dir-ent file)))
+       0 0)))
+
+(defun m1-open (pathname fs fd-table file-table)
+  (declare (xargs :guard (and (m1-file-alist-p fs)
+                              (fat32-filename-list-p pathname)
+                              (fd-table-p fd-table)
+                              (file-table-p file-table))))
+  (b*
+      ((fd-table (fd-table-fix fd-table))
+       (file-table (file-table-fix file-table))
+       ((mv & errno)
+        (find-file-by-pathname fs pathname))
+       ((unless (equal errno 0))
+        (mv fd-table file-table -1 errno))
+       (file-table-index
+        (find-new-index (strip-cars file-table)))
+       (fd-table-index
+        (find-new-index (strip-cars fd-table))))
+    (mv
+     (cons
+      (cons fd-table-index file-table-index)
+      fd-table)
+     (cons
+      (cons file-table-index (make-file-table-element :pos 0 :fid pathname))
+      file-table)
+     fd-table-index 0)))
+
+(defthm m1-open-correctness-1
+  (b*
+      (((mv fd-table file-table & &) (m1-open pathname fs fd-table file-table)))
+    (and
+     (fd-table-p fd-table)
+     (file-table-p file-table))))
+
+(defthm
+  m1-pread-guard-lemma-1
+  (implies
+   (and (file-table-p file-table)
+        (consp (assoc-equal x file-table)))
+   (file-table-element-p (cdr (assoc-equal x file-table)))))
+
+;; Per the man page pread(2), this should not change the offset of the file
+;; descriptor in the file table. Thus, there's no need for the file table to be
+;; an argument.
+(defun
+  m1-pread
+  (fd count offset fs fd-table file-table)
+  (declare (xargs :guard (and (natp fd)
+                              (natp count)
+                              (natp offset)
+                              (fd-table-p fd-table)
+                              (file-table-p file-table)
+                              (m1-file-alist-p fs))
+                  :guard-debug t))
+  (b*
+      ((fd-table-entry (assoc-equal fd fd-table))
+       ((unless (consp fd-table-entry))
+        (mv "" -1 *ebadf*))
+       (file-table-entry (assoc-equal (cdr fd-table-entry)
+                                      file-table))
+       ((unless (consp file-table-entry))
+        (mv "" -1 *ebadf*))
+       (pathname (file-table-element->fid (cdr file-table-entry)))
+       ((mv file error-code)
+        (find-file-by-pathname fs pathname))
+       ((unless (and (equal error-code 0)
+                     (m1-regular-file-p file)))
+        (mv "" -1 error-code))
+       (new-offset (min (+ offset count)
+                        (length (m1-file->contents file))))
+       (buf (subseq (m1-file->contents file)
+                    (min offset
+                         (length (m1-file->contents file)))
+                    new-offset)))
+    (mv buf (length buf) 0)))
+
+(defthm
+  m1-pread-correctness-1
+  (mv-let (buf ret error-code)
+    (m1-pread fd count offset fs fd-table file-table)
+    (and (stringp buf)
+         (integerp ret)
+         (integerp error-code)
+         (implies (>= ret 0)
+                  (equal (length buf) ret)))))
+
+(defun
+  m1-pwrite
+  (fd buf offset fs fd-table file-table)
+  (declare (xargs :guard (and (natp fd)
+                              (stringp buf)
+                              (natp offset)
+                              (fd-table-p fd-table)
+                              (file-table-p file-table)
+                              (m1-file-alist-p fs))
+                  :guard-debug t
+                  :guard-hints (("Goal" :in-theory (enable len-of-insert-text))
+                                ("Subgoal 2'" :in-theory (disable
+                                                          consp-assoc-equal)
+                                 :use (:instance consp-assoc-equal
+                                                 (name (CDR (CAR FD-TABLE)))
+                                                 (l
+                                                  FILE-TABLE))))))
+  (b*
+      ((fd-table-entry (assoc-equal fd fd-table))
+       (fs (m1-file-alist-fix fs))
+       ((unless (consp fd-table-entry))
+        (mv fs -1 *ebadf*))
+       (file-table-entry (assoc-equal (cdr fd-table-entry)
+                                      file-table))
+       ((unless (consp file-table-entry))
+        (mv fs -1 *ebadf*))
+       (pathname (file-table-element->fid (cdr file-table-entry)))
+       ((mv file error-code)
+        (find-file-by-pathname fs pathname))
+       ((mv oldtext dir-ent)
+        (if (and (equal error-code 0)
+                 (m1-regular-file-p file))
+            (mv (coerce (m1-file->contents file) 'list)
+                (m1-file->dir-ent file))
+            (mv nil (dir-ent-fix nil))))
+       ((unless (unsigned-byte-p 32 (+ OFFSET (length BUF))))
+        (mv fs -1 *enospc*))
+       (file
+        (make-m1-file
+         :dir-ent dir-ent
+         :contents (coerce (insert-text oldtext offset buf)
+                           'string)))
+       ((mv fs error-code)
+        (place-file-by-pathname fs pathname file)))
+    (mv fs (if (equal error-code 0) 0 -1)
+        error-code)))
+
+(defun
+    m1-mkdir (fs pathname)
+  (declare
+   (xargs
+    :guard (and (m1-file-alist-p fs)
+                (fat32-filename-list-p pathname))
+    :guard-hints
+    (("goal"
+      :in-theory
+      (disable
+       (:rewrite m1-basename-dirname-helper-correctness-1))
+      :use
+      (:instance
+       (:rewrite m1-basename-dirname-helper-correctness-1)
+       (path pathname))))))
+  (b* ((dirname (m1-dirname pathname))
+       ;; Never pass relative pathnames to syscalls - make them always begin
+       ;; with "/".
+       ((mv parent-dir errno)
+        (find-file-by-pathname fs dirname))
+       ((unless (or (atom dirname)
+                    (and (equal errno 0)
+                         (m1-directory-file-p parent-dir))))
+        (mv fs -1 *enoent*))
+       ((mv & errno)
+        (find-file-by-pathname fs pathname))
+       ((unless (not (equal errno 0)))
+        (mv fs -1 *eexist*))
+       (basename (m1-basename pathname))
+       ((unless (equal (length basename) 11))
+        (mv fs -1 *enametoolong*))
+       (dir-ent
+        (DIR-ENT-INSTALL-DIRECTORY-BIT
+         (dir-ent-fix nil)
+         t))
+       (file (make-m1-file :dir-ent dir-ent
+                           :contents nil))
+       ((mv fs error-code)
+        (place-file-by-pathname fs pathname file))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code)))
+    (mv fs 0 0)))
+
+(defun
+  m1-mknod (fs pathname)
+  (declare (xargs :guard (and (m1-file-alist-p fs)
+                              (fat32-filename-list-p pathname))))
+  (b* ((dirname (m1-dirname pathname))
+       (basename (m1-basename pathname))
+       ((mv parent-dir errno)
+        (find-file-by-pathname fs dirname))
+       ((unless (or (atom dirname)
+                    (and (equal errno 0)
+                         (m1-directory-file-p parent-dir))))
+        (mv fs -1 *enoent*))
+       ((mv & errno)
+        (find-file-by-pathname fs pathname))
+       ((unless (not (equal errno 0)))
+        (mv fs -1 *eexist*))
+       ((unless (equal (length basename) 11))
+        (mv fs -1 *enametoolong*))
+       (dir-ent (dir-ent-set-filename (dir-ent-fix nil)
+                                      basename))
+       (file (make-m1-file :dir-ent dir-ent
+                           :contents nil))
+       ((mv fs error-code)
+        (place-file-by-pathname fs pathname file))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code)))
+    (mv fs 0 0)))
+
+(defthm
+  m1-unlink-guard-lemma-1
+  (implies (m1-file-p file)
+           (and
+            (true-listp (m1-file->dir-ent file))
+            (equal (len (m1-file->dir-ent file)) *ms-dir-ent-length*)
+            (unsigned-byte-listp 8 (m1-file->dir-ent file))))
+  :hints
+  (("goal" :in-theory (e/d (dir-ent-p)
+                           (dir-ent-p-of-m1-file->dir-ent))
+    :use (:instance dir-ent-p-of-m1-file->dir-ent
+                    (x file)))))
+
+;; The fat driver in Linux actually keeps the directory entries of files it is
+;; deleting, while removing links to their contents. Thus, in the special case
+;; where the last file is deleted from the root directory, the root directory
+;; will still occupy one cluster, which in turn contains one entry which
+;; points to the deleted file, with the filename's first character changed to
+;; #xe5, which signifies a deleted file, its file length changed to 0, and
+;; the first cluster changed to 0. This may even hold for other directories
+;; than root.
+
+;; This may be a place where co-simulation of statfs may have to be
+;; compromised... because, now, we delete the file from our tree representation
+;; and as a result we have a little more extra space than an implementation
+;; which simply marks the file as removed. The way forward, I think, is to
+;; delete the file from the tree, and make an m2-unlink that provably does the
+;; same thing as m1-unlink while actually just marking files as deleted.
+(defun
+    m1-unlink (fs pathname)
+  (declare
+   (xargs
+    :guard (and (m1-file-alist-p fs)
+                (fat32-filename-list-p pathname))))
+  (b* (((mv file error-code)
+        (find-file-by-pathname fs pathname))
+       ((unless (equal error-code 0)) (mv fs -1 *ENOENT*))
+       ((unless (m1-regular-file-p file)) (mv fs -1 *EISDIR*))
+       ((mv fs error-code)
+        (remove-file-by-pathname fs pathname))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code)))
+    (mv fs 0 0)))
+
+;; This is rather ad hoc - there is no such system call that I'm exactly aware
+;; of, but for now it beats making a recursive function at the application
+;; level.
+
+;; This may be a place where co-simulation of statfs has to be
+;; compromised... because, now, we delete the file from our tree representation
+;; and as a result we have a little more extra space than an implementation
+;; which simply marks the file as removed. The way forward, I think, is to
+;; delete the file from the tree, and make an m2-unlink that provably does the
+;; same thing as m1-unlink while actually just marking files as deleted.
+(defun
+    m1-unlink-recursive (fs pathname)
+  (declare
+   (xargs
+    :guard (and (m1-file-alist-p fs)
+                (fat32-filename-list-p pathname))))
+  (b* (((mv file error-code)
+        (find-file-by-pathname fs pathname))
+       ((unless (equal error-code 0)) (mv fs -1 *ENOENT*))
+       ((unless (m1-directory-file-p file)) (mv fs -1 *ENOTDIR*))
+       ((mv fs error-code)
+        (remove-file-by-pathname fs pathname))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code)))
+    (mv fs 0 0)))
+
+;; This may be a place where co-simulation of statfs may have to be
+;; compromised... because, now, we delete the file from our tree representation
+;; and as a result we have a little more extra space than an implementation
+;; which simply marks the file as removed. The way forward, I think, is to
+;; delete the file from the tree, and make an m2-unlink that provably does the
+;; same thing as m1-unlink while actually just marking files as deleted.
+(defun
+    m1-rmdir (fs pathname)
+  (declare
+   (xargs
+    :guard (and (m1-file-alist-p fs)
+                (fat32-filename-list-p pathname))))
+  (b* (((mv file error-code)
+        (find-file-by-pathname fs pathname))
+       ((unless (equal error-code 0)) (mv fs -1 *ENOENT*))
+       ((unless (m1-directory-file-p file)) (mv fs -1 *ENOTDIR*))
+       ((unless (atom (m1-file->contents file))) (mv fs -1 *EEXIST*))
+       ((mv fs error-code)
+        (remove-file-by-pathname fs pathname))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code)))
+    (mv fs 0 0)))
+
+(defun
+    m1-rename (fs oldpathname newpathname)
+  (declare
+   (xargs
+    :guard (and (m1-file-alist-p fs)
+                (fat32-filename-list-p oldpathname)
+                (fat32-filename-list-p newpathname))))
+  (b* (((mv file error-code)
+        (find-file-by-pathname fs oldpathname))
+       ((unless (equal error-code 0)) (mv fs -1 *ENOENT*))
+       ((mv fs error-code)
+        (remove-file-by-pathname fs oldpathname))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code))
+       (dirname (m1-dirname newpathname))
+       ((mv dir error-code)
+        (find-file-by-pathname fs dirname))
+       ((unless (and (equal error-code 0) (m1-directory-file-p dir)))
+        (mv fs -1 error-code))
+       ((mv fs error-code)
+        (place-file-by-pathname fs newpathname file))
+       ((unless (equal error-code 0))
+        (mv fs -1 error-code)))
+    (mv fs 0 0)))

--- a/books/projects/filesystems/set-indices.lisp
+++ b/books/projects/filesystems/set-indices.lisp
@@ -1,7 +1,3 @@
-; Copyright (C) 2017, Regents of the University of Texas
-; Written by Mihir Mehta
-; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
-
 (in-package "ACL2")
 
 (local (include-book "file-system-lemmas"))

--- a/books/projects/filesystems/test-stuff.lisp
+++ b/books/projects/filesystems/test-stuff.lisp
@@ -1,0 +1,144 @@
+(in-package "ACL2")
+
+(include-book "file-system-m2")
+(include-book "m1-syscalls")
+(include-book "centaur/getopt/top" :dir :system)
+
+(defoptions mkdir-opts
+  :parents (demo2)
+  :tag :demo2
+  ((parents    "no error if existing, make parent directories as needed"
+               booleanp
+               :rule-classes :type-prescription
+               :alias #\p)))
+
+(defun mkdir-list (fs name-list exit-status)
+  (b*
+      (((when (atom name-list))
+        (mv fs exit-status))
+       (fat32-pathname
+        (pathname-to-fat32-pathname (coerce (car name-list) 'list)))
+       ;; It doesn't really matter for these purposes what the errno is. We're
+       ;; not trying to match this program for its stderr output.
+       ((mv fs retval &)
+        (m1-mkdir fs fat32-pathname))
+       (exit-status (if (equal retval 0) exit-status 1)))
+    (mkdir-list fs (cdr name-list) exit-status)))
+
+(defoptions rm-opts
+  :parents (demo2)
+  :tag :demo2
+  ((recursive    "Recursively delete a directory"
+                 booleanp
+                 :rule-classes :type-prescription
+                 :alias #\r)))
+
+(defun rm-list (fs r name-list exit-status)
+  (b*
+      (((when (atom name-list))
+        (mv fs exit-status))
+       (fat32-pathname
+        (pathname-to-fat32-pathname (coerce (car name-list) 'list)))
+       ;; It doesn't really matter for these purposes what the errno is. We're
+       ;; not trying to match this program for its stderr output.
+       ((mv fs retval &)
+        (if r
+            (m1-unlink-recursive fs fat32-pathname)
+          (m1-unlink fs fat32-pathname)))
+       (exit-status (if (equal retval 0) exit-status 1)))
+    (rm-list fs r (cdr name-list) exit-status)))
+
+(defoptions rmdir-opts
+  :parents (demo2)
+  :tag :demo2
+  ((parents    "no error if existing, make parent directories as needed"
+               booleanp
+               :rule-classes :type-prescription
+               :alias #\p)))
+
+(defun rmdir-list (fs name-list exit-status)
+  (b*
+      (((when (atom name-list))
+        (mv fs exit-status))
+       (fat32-pathname
+        (pathname-to-fat32-pathname (coerce (car name-list) 'list)))
+       ;; It doesn't really matter for these purposes what the errno is. We're
+       ;; not trying to match this program for its stderr output.
+       ((mv fs retval &)
+        (m1-rmdir fs fat32-pathname))
+       (exit-status (if (equal retval 0) exit-status 1)))
+    (rmdir-list fs (cdr name-list) exit-status)))
+
+(defoptions wc-opts
+  :parents (demo2)
+  :tag :demo2
+
+  ((bytes    "Count bytes"
+             booleanp
+             :rule-classes :type-prescription
+             :alias #\c)
+
+   (lines "Count lines"
+          booleanp
+          :rule-classes :type-prescription
+          :alias #\l)
+
+   (words "Count words"
+           booleanp
+           :rule-classes :type-prescription
+           :alias #\w)))
+
+(defun wc-helper (text nl nw nc beginning-of-word-p pos)
+  (declare (xargs :measure (nfix (- (length text) pos))))
+  (if
+      (zp (- (length text) pos))
+      (mv nl nw nc)
+    (b*
+        ((c (char text pos))
+         (nc (+ nc 1))
+         (nl (if (equal c #\newline) (+ nl 1) nl))
+         ((mv beginning-of-word-p nw)
+          (if (or (equal c #\space) (equal c #\newline) (equal c #\tab))
+              (mv t nw)
+            (if beginning-of-word-p
+                (mv nil (+ nw 1))
+              (mv beginning-of-word-p nw)))))
+      (wc-helper text nl nw nc beginning-of-word-p (+ pos 1)))))
+
+(defun compare-disks (image-path1 image-path2 fat32-in-memory state)
+  (declare (xargs :stobjs (fat32-in-memory state)
+                  :guard-debug t
+                  :guard (and (fat32-in-memoryp fat32-in-memory)
+                              (stringp image-path1)
+                              (stringp image-path2))
+                  :guard-hints (("Goal" :in-theory (disable
+                                                    read-file-into-string2)) )
+                  :otf-flg t))
+  (b*
+    (((mv fat32-in-memory error-code1)
+      (disk-image-to-fat32-in-memory
+       fat32-in-memory image-path1 state))
+     ((mv fs-ref error-code2)
+      (if
+          (not (equal error-code1 0))
+          (mv nil *EIO*)
+        (fat32-in-memory-to-m1-fs fat32-in-memory)))
+     ((mv fat32-in-memory error-code3)
+      (disk-image-to-fat32-in-memory
+       fat32-in-memory image-path2 state))
+     ((mv fs error-code4)
+      (if
+          (or (not (equal error-code1 0)) (not (equal error-code3 0)))
+          (mv nil *EIO*)
+        (fat32-in-memory-to-m1-fs fat32-in-memory)))
+     ((unless (or (equal error-code1 0) (equal error-code3 0)))
+      (mv (good-bye 0) fat32-in-memory))
+     ((unless (and (equal error-code1 0) (equal error-code3 0)))
+      (mv (good-bye 1) fat32-in-memory))
+     ((unless (or (equal error-code2 0) (equal error-code4 0)))
+      (mv (good-bye 0) fat32-in-memory))
+     ((unless (and (equal error-code2 0) (equal error-code4 0)))
+      (mv (good-bye 1) fat32-in-memory))
+     ((unless (m1-dir-equiv fs-ref fs))
+      (mv (good-bye 1) fat32-in-memory)))
+  (mv (good-bye 0) fat32-in-memory)))

--- a/books/projects/filesystems/test/Makefile
+++ b/books/projects/filesystems/test/Makefile
@@ -1,29 +1,66 @@
-test: test-cp-replicant-1 test-cp-replicant-2 test-cp-replicant-3 \
-test-cp-replicant-4 test-mkfs-replicant-1 test-mkfs-replicant-2 \
-test-mkfs-replicant-3
+# test-mkfs-replicant-3 was always problematic; it's now removed
+# because our model has finally become strict enough to reject it.
+#
+# test-stat-replicant-1 and test-stat-replicant-2 are also removed,
+# for reasons explained in a comment below.
+TEST:= test-cp-replicant-1 test-cp-replicant-2 test-cp-replicant-3 \
+test-cp-replicant-4 mtools-test-cp-replicant-2 \
+test-mkfs-replicant-1 test-mkfs-replicant-2 \
+test-wc-replicant-1 test-wc-replicant-2 test-wc-replicant-3 \
+test-rm-replicant-1 test-rm-replicant-2 test-rm-replicant-3 \
+test-rm-replicant-4 mtools-test-rm-replicant-1 \
+mtools-test-rm-replicant-2 \
+test-unlink-replicant-1 test-unlink-replicant-2 \
+test-unlink-replicant-3 \
+test-mkdir-replicant-1 test-mkdir-replicant-2 \
+mtools-test-mkdir-replicant-1 \
+test-rmdir-replicant-1 test-rmdir-replicant-2 \
+mtools-test-rmdir-replicant-1 \
+test-mv-replicant-1 mtools-test-mv-replicant-1 \
+mtools-test-mv-replicant-2
 
-.PHONY: clean-mountpoint test test-cp-replicant-1 \
-test-cp-replicant-2 test-cp-replicant-3 test-cp-replicant-4 \
-test-mkfs-replicant-1 test-mkfs-replicant-2 test-mkfs-replicant-3
+test: $(TEST)
+
+.PHONY: clean-mountpoint test $(TEST)
 
 .PHONY: debug-create-dir-and-file debug-create-dir debug-do-nothing \
 debug-create-dir-copy-file
 
+.PHONY: mtools-read-write-test-70MB mtools-read-write-test-140MB \
+mtools-read-write-test-210MB mtools-read-write-test-280MB \
+mtools-read-write-test-560MB mtools-read-write-test-1120MB
+
+# FUSEPOINT and BBFS are commented below because they refer to Joseph
+# Pfeiffer's pedagogical Big Brother Filesystem, which I used in some
+# of the tests. For almost every test, they only helped log the
+# syscalls and their return values without affecting the course of the
+# test; however, the stat tests do rely on them because without the
+# interposition of the FUSE layer, the id value in the struct statfs
+# can be completely arbitrary depending on mount time details which
+# our stat implementation has no access to. When FUSE is interposed,
+# however, a 0 value is assigned to id, which is hard-coded for the
+# stat tests to make them work. They can be run by downloading and
+# compiling BBFS and noting the path to the executable in the BBFS
+# variable, below.
 DISK=disk1.raw
 SIZE=70000
 MOUNTPOINT=mount1
+# FUSEPOINT=mount2
+# BBFS=$(HOME)/src/bbfs/fuse-tutorial-2018-02-04/src/bbfs
 UID=$(shell id -u)
 GID=$(shell id -g)
+MTOOLSRC=$(shell pwd)/.mtoolsrc
 
 clean-mountpoint:
 	rm -rf $(MOUNTPOINT)
 
-clean-fusepoint:
-	rm -rf  $(MOUNTPOINT)
-
 $(MOUNTPOINT):
 	rm -rf $(MOUNTPOINT)
 	mkdir -p $(MOUNTPOINT)
+
+# $(FUSEPOINT):
+# 	rm -rf $(FUSEPOINT)
+# 	mkdir -p $(FUSEPOINT)
 
 test-cp-replicant-1: cp-ref-output-1.txt cp-output-1.txt
 	diff -u -i cp-ref-output-1.txt cp-output-1.txt
@@ -37,6 +74,9 @@ test-cp-replicant-3: cp-ref-output-3.txt cp-output-3.txt
 test-cp-replicant-4: cp-ref-output-4.txt cp-output-4.txt
 	diff -u -i cp-ref-output-4.txt cp-output-4.txt
 
+mtools-test-cp-replicant-2: mtools-cp-ref-output-2.txt mtools-cp-output-2.txt
+	diff -u -i mtools-cp-ref-output-2.txt mtools-cp-output-2.txt
+
 test-cp-replicant-5: cp-ref-output-5.txt cp-output-5.txt
 	diff -u -i cp-ref-output-5.txt cp-output-5.txt
 
@@ -49,70 +89,175 @@ test-mkfs-replicant-2: mkfs-ref-output-2.txt mkfs-output-2.txt
 test-mkfs-replicant-3: mkfs-ref-output-3.txt mkfs-output-3.txt
 	diff -u -i mkfs-ref-output-3.txt mkfs-output-3.txt
 
+test-wc-replicant-1: wc-ref-output-1.txt wc-output-1.txt
+	diff -u -i wc-ref-output-1.txt wc-output-1.txt
+
+test-wc-replicant-2: wc-ref-output-2.txt wc-output-2.txt
+	diff -u -i wc-ref-output-2.txt wc-output-2.txt
+
+test-wc-replicant-3: wc-ref-output-3.txt wc-output-3.txt
+	diff -u -i wc-ref-output-3.txt wc-output-3.txt
+
+test-stat-replicant-1: stat-ref-output-1.txt stat-output-1.txt
+	diff -u -i stat-ref-output-1.txt stat-output-1.txt
+
+test-stat-replicant-2: stat-ref-output-2.txt stat-output-2.txt
+	diff -u -i stat-ref-output-2.txt stat-output-2.txt
+
+test-rm-replicant-1: rm-output-1.raw rm-ref-output-1.raw
+	env DISK=$(DISK) REF_INPUT="rm-ref-output-1.raw" \
+	INPUT="rm-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+test-rm-replicant-2: rm-output-2.raw rm-ref-output-2.raw
+	env DISK=$(DISK) REF_INPUT="rm-ref-output-2.raw" \
+	INPUT="rm-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+test-rm-replicant-3: rm-output-3.raw rm-ref-output-3.raw
+	env DISK=$(DISK) REF_INPUT="rm-ref-output-3.raw" \
+	INPUT="rm-output-3.raw" $(ACL2) -- < compare-disks.lisp
+
+test-rm-replicant-4: rm-output-4.raw rm-ref-output-4.raw
+	env DISK=$(DISK) REF_INPUT="rm-ref-output-4.raw" \
+	INPUT="rm-output-4.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-rm-replicant-1: mtools-rm-ref-output-1.raw mtools-rm-output-1.raw
+	env DISK=$(DISK) REF_INPUT="mtools-rm-ref-output-1.raw" \
+	INPUT="mtools-rm-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-rm-replicant-2: mtools-rm-ref-output-2.raw mtools-rm-output-2.raw
+	env DISK=$(DISK) REF_INPUT="mtools-rm-ref-output-2.raw" \
+	INPUT="mtools-rm-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+test-unlink-replicant-1: unlink-output-1.raw unlink-ref-output-1.raw
+	env DISK=$(DISK) REF_INPUT="unlink-ref-output-1.raw" \
+	INPUT="unlink-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+test-unlink-replicant-2: unlink-output-2.raw unlink-ref-output-2.raw
+	env DISK=$(DISK) REF_INPUT="unlink-ref-output-2.raw" \
+	INPUT="unlink-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+test-unlink-replicant-3: unlink-output-3.raw unlink-ref-output-3.raw
+	env DISK=$(DISK) REF_INPUT="unlink-ref-output-3.raw" \
+	INPUT="unlink-output-3.raw" $(ACL2) -- < compare-disks.lisp
+
+test-mkdir-replicant-1: mkdir-output-1.raw mkdir-ref-output-1.raw
+	env DISK=$(DISK) REF_INPUT="mkdir-ref-output-1.raw" \
+	INPUT="mkdir-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+test-mkdir-replicant-2: mkdir-output-2.raw mkdir-ref-output-2.raw
+	env DISK=$(DISK) REF_INPUT="mkdir-ref-output-2.raw" \
+	INPUT="mkdir-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-mkdir-replicant-1: mtools-mkdir-ref-output-1.raw mtools-mkdir-output-1.raw
+	env DISK=$(DISK) REF_INPUT="mtools-mkdir-ref-output-1.raw" \
+	INPUT="mtools-mkdir-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-mkdir-replicant-2: mtools-mkdir-ref-output-2.raw mtools-mkdir-output-2.raw
+	env DISK=$(DISK) REF_INPUT="mtools-mkdir-ref-output-2.raw" \
+	INPUT="mtools-mkdir-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+test-rmdir-replicant-1: rmdir-output-1.raw rmdir-ref-output-1.raw
+	env DISK=$(DISK) REF_INPUT="rmdir-ref-output-1.raw" \
+	INPUT="rmdir-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+test-rmdir-replicant-2: rmdir-output-2.raw rmdir-ref-output-2.raw
+	env DISK=$(DISK) REF_INPUT="rmdir-ref-output-2.raw" \
+	INPUT="rmdir-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-rmdir-replicant-1: mtools-rmdir-ref-output-1.raw mtools-rmdir-output-1.raw
+	env DISK=$(DISK) REF_INPUT="mtools-rmdir-ref-output-1.raw" \
+	INPUT="mtools-rmdir-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-rmdir-replicant-2: mtools-rmdir-ref-output-2.raw mtools-rmdir-output-2.raw
+	env DISK=$(DISK) REF_INPUT="mtools-rmdir-ref-output-2.raw" \
+	INPUT="mtools-rmdir-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
+test-mv-replicant-1: mv-output-1.raw mv-ref-output-1.raw
+	env DISK=$(DISK) REF_INPUT="mv-ref-output-1.raw" \
+	INPUT="mv-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-mv-replicant-1: mtools-mv-output-1.raw mtools-mv-ref-output-1.raw
+	env DISK=$(DISK) REF_INPUT="mtools-mv-ref-output-1.raw" \
+	INPUT="mtools-mv-output-1.raw" $(ACL2) -- < compare-disks.lisp
+
+mtools-test-mv-replicant-2: mtools-mv-ref-output-2.raw mtools-mv-output-2.raw
+	env DISK=$(DISK) REF_INPUT="mtools-mv-ref-output-2.raw" \
+	INPUT="mtools-mv-output-2.raw" $(ACL2) -- < compare-disks.lisp
+
 cp-ref-output-1.txt cp-output-1.txt: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	echo "four" >  $(MOUNTPOINT)/vmlinuz
-	cat  $(MOUNTPOINT)/vmlinuz > cp-ref-output-1.txt
+	echo "four" > $(MOUNTPOINT)/vmlinuz
+	cat $(MOUNTPOINT)/vmlinuz > cp-ref-output-1.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	env DISK=$(DISK) CP_OUTPUT="cp-output-1.txt" \
-	CP_INPUT="VMLINUZ    " $(ACL2) < cp-replicant.lisp
+	CP_INPUT="/vmlinuz" $(ACL2) < cp-replicant.lisp
 
 cp-ref-output-2.txt cp-output-2.txt: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	cp input-1204-bytes.txt  $(MOUNTPOINT)/vmlinuz
-	cat  $(MOUNTPOINT)/vmlinuz > cp-ref-output-2.txt
+	cp input-1204-bytes.txt $(MOUNTPOINT)/vmlinuz
+	cat $(MOUNTPOINT)/vmlinuz > cp-ref-output-2.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	env DISK=$(DISK) CP_OUTPUT="cp-output-2.txt" \
-	CP_INPUT="VMLINUZ    " $(ACL2) < cp-replicant.lisp
+	CP_INPUT="/vmlinuz" $(ACL2) < cp-replicant.lisp
 
 cp-ref-output-3.txt cp-output-3.txt: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	cp input-1204-bytes.txt  $(MOUNTPOINT)/vmlinuz
-	cp input-4623-bytes.txt  $(MOUNTPOINT)/initrd.img
-	cat  $(MOUNTPOINT)/initrd.img > cp-ref-output-3.txt
+	cp input-1204-bytes.txt $(MOUNTPOINT)/vmlinuz
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	cat $(MOUNTPOINT)/initrd.img > cp-ref-output-3.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	env DISK=$(DISK) CP_OUTPUT="cp-output-3.txt" \
-	CP_INPUT="INITRD  IMG" $(ACL2) < cp-replicant.lisp
+	CP_INPUT="/initrd.img" $(ACL2) < cp-replicant.lisp
 
 cp-ref-output-4.txt cp-output-4.txt: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
 	for i1 in $(shell seq 1 32); do \
-		cp input-1204-bytes.txt  $(MOUNTPOINT)/initrd$$i1.img; \
+		cp input-1204-bytes.txt $(MOUNTPOINT)/initrd$$i1.img; \
 	done
-	cp input-4623-bytes.txt  $(MOUNTPOINT)/initrd.img
-	cat  $(MOUNTPOINT)/initrd.img > cp-ref-output-4.txt
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	cat $(MOUNTPOINT)/initrd.img > cp-ref-output-4.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	env DISK=$(DISK) CP_OUTPUT="cp-output-4.txt" \
-	CP_INPUT="INITRD  IMG" $(ACL2) < cp-replicant.lisp
+	CP_INPUT="/initrd.img" $(ACL2) < cp-replicant.lisp
 
 cp-ref-output-5.txt cp-output-5.txt: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	cp input-1204-bytes.txt  $(MOUNTPOINT)/initrd.img
-	sync  $(MOUNTPOINT)/initrd.img
-	rm  $(MOUNTPOINT)/initrd.img
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	sync $(MOUNTPOINT)/initrd.img
+	rm $(MOUNTPOINT)/initrd.img
 	for i1 in $(shell seq 1 32); do \
-		cp input-1204-bytes.txt  $(MOUNTPOINT)/initrd$$i1.img; \
+		cp input-1204-bytes.txt $(MOUNTPOINT)/initrd$$i1.img; \
 	done
-	cp input-4623-bytes.txt  $(MOUNTPOINT)/initrd.img
-	cat  $(MOUNTPOINT)/initrd.img > cp-ref-output-5.txt
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	cat $(MOUNTPOINT)/initrd.img > cp-ref-output-5.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	env DISK=$(DISK) CP_OUTPUT="cp-output-5.txt" \
-	CP_INPUT="INITRD  IMG" $(ACL2) < cp-replicant.lisp
+	CP_INPUT="/initrd.img" $(ACL2) < cp-replicant.lisp
+
+mtools-cp-ref-output-2.txt mtools-cp-output-2.txt: cp-replicant.lisp
+	rm -f $(DISK) mtools-cp-ref-output-2.txt
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env MTOOLSRC=$(MTOOLSRC) mcopy c:/vmlinuz mtools-cp-ref-output-2.txt
+	env DISK=$(DISK) CP_OUTPUT="mtools-cp-output-2.txt" \
+	CP_INPUT="/vmlinuz" $(ACL2) < cp-replicant.lisp
 
 mkfs-ref-output-1.txt mkfs-output-1.txt: $(MOUNTPOINT) \
 mkfs.fat-3.0.28-replicant.lisp
@@ -137,6 +282,352 @@ mkfs.fat-3.0.28-replicant.lisp
 	env DISK=$(DISK) MKFS_OUTPUT="mkfs-output-3.txt" $(ACL2) < \
 	mkfs.fat-3.0.28-replicant.lisp
 
+wc-ref-output-1.txt wc-output-1.txt: $(MOUNTPOINT) wc-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	wc -c < $(MOUNTPOINT)/initrd.img > wc-ref-output-1.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) WC_OUTPUT="wc-output-1.txt" \
+	WC_INPUT="/initrd.img" $(ACL2) -- -c < wc-replicant.lisp
+
+wc-ref-output-2.txt wc-output-2.txt: $(MOUNTPOINT) wc-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	wc -l < $(MOUNTPOINT)/initrd.img > wc-ref-output-2.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) WC_OUTPUT="wc-output-2.txt" \
+	WC_INPUT="/initrd.img" $(ACL2) -- -l < wc-replicant.lisp
+
+wc-ref-output-3.txt wc-output-3.txt: $(MOUNTPOINT) wc-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	wc -w < $(MOUNTPOINT)/initrd.img > wc-ref-output-3.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) WC_OUTPUT="wc-output-3.txt" \
+	WC_INPUT="/initrd.img" $(ACL2) -- -w < wc-replicant.lisp
+
+# stat-ref-output-1.txt stat-output-1.txt: $(MOUNTPOINT) $(FUSEPOINT) stat-replicant.lisp
+# 	rm -f $(DISK)
+# 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+# 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+# 	$(BBFS) $(MOUNTPOINT) $(FUSEPOINT)
+# 	cp input-4623-bytes.txt $(FUSEPOINT)/initrd.img
+# 	cd $(FUSEPOINT); stat -f initrd.img > ../stat-ref-output-1.txt; cd -
+# 	sleep 1
+# 	fusermount -u $(FUSEPOINT)
+# 	sudo umount $(MOUNTPOINT)
+# 	env DISK=$(DISK) STAT_OUTPUT="stat-output-1.txt" \
+# 	STAT_INPUT="initrd.img" $(ACL2) -- -f < stat-replicant.lisp
+
+# stat-ref-output-2.txt stat-output-2.txt: $(MOUNTPOINT) $(FUSEPOINT) stat-replicant.lisp
+# 	rm -f $(DISK)
+# 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+# 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+# 	$(BBFS) $(MOUNTPOINT) $(FUSEPOINT)
+# 	for i1 in $(shell seq 1 32); do \
+# 		cp input-1204-bytes.txt $(FUSEPOINT)/initrd$$i1.img; \
+# 	done
+# 	cp input-4623-bytes.txt $(FUSEPOINT)/initrd.img
+# 	cd $(FUSEPOINT); stat -f initrd.img > ../stat-ref-output-2.txt; cd -
+# 	sleep 1
+# 	fusermount -u $(FUSEPOINT)
+# 	sudo umount $(MOUNTPOINT)
+# 	env DISK=$(DISK) STAT_OUTPUT="stat-output-2.txt" \
+# 	STAT_INPUT="initrd.img" $(ACL2) -- -f < stat-replicant.lisp
+
+rm-ref-output-1.raw rm-output-1.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) rm-ref-output-1.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos rm-ref-output-1.raw $(MOUNTPOINT)
+	rm $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="rm-output-1.raw" \
+	$(ACL2) -- "/initrd.img" \
+	< rm-replicant.lisp
+
+rm-ref-output-2.raw rm-output-2.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	for i1 in $(shell seq 1 32); do \
+		cp input-1204-bytes.txt $(MOUNTPOINT)/initrd$$i1.img; \
+	done
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) rm-ref-output-2.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos rm-ref-output-2.raw $(MOUNTPOINT)
+	rm $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="rm-output-2.raw" \
+	$(ACL2) -- "/initrd.img" \
+	< rm-replicant.lisp
+
+rm-ref-output-3.raw rm-output-3.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	mkdir $(MOUNTPOINT)/tmp
+	cp input-1204-bytes.txt $(MOUNTPOINT)/tmp/file.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) rm-ref-output-3.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos rm-ref-output-3.raw $(MOUNTPOINT)
+	rm $(MOUNTPOINT)/tmp/file.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="rm-output-3.raw" \
+	$(ACL2) -- "/tmp/file.txt" \
+	< rm-replicant.lisp
+
+rm-ref-output-4.raw rm-output-4.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	mkdir $(MOUNTPOINT)/tmp
+	cp input-1204-bytes.txt $(MOUNTPOINT)/tmp/file.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) rm-ref-output-4.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos rm-ref-output-4.raw $(MOUNTPOINT)
+	rm -r $(MOUNTPOINT)/tmp
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="rm-output-4.raw" \
+	$(ACL2) -- -r "/tmp" \
+	< rm-replicant.lisp
+
+mtools-rm-ref-output-1.raw mtools-rm-output-1.raw: rm-replicant.lisp
+	rm -f $(DISK) mtools-rm-ref-output-1.raw
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	cp $(DISK) mtools-rm-output-1.raw
+	env MTOOLSRC=$(MTOOLSRC) mdel c:/vmlinuz
+	cp $(DISK) mtools-rm-ref-output-1.raw
+	env DISK="mtools-rm-output-1.raw" RM_OUTPUT="mtools-rm-output-1.raw" \
+	$(ACL2) -- "/vmlinuz" < rm-replicant.lisp
+
+mtools-rm-ref-output-2.raw mtools-rm-output-2.raw: rm-replicant.lisp
+	rm -f $(DISK) mtools-rm-ref-output-2.raw
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env MTOOLSRC=$(MTOOLSRC) mmd c:/tmp
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/tmp/file.txt
+	cp $(DISK) mtools-rm-output-2.raw
+	env MTOOLSRC=$(MTOOLSRC) mdeltree c:/tmp
+	cp $(DISK) mtools-rm-ref-output-2.raw
+	env DISK="mtools-rm-output-2.raw" RM_OUTPUT="mtools-rm-output-2.raw" \
+	$(ACL2) -- -r "/tmp" < rm-replicant.lisp
+
+unlink-ref-output-1.raw unlink-output-1.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) unlink-ref-output-1.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos unlink-ref-output-1.raw $(MOUNTPOINT)
+	unlink $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="unlink-output-1.raw" \
+	$(ACL2) -- "/initrd.img" \
+	< rm-replicant.lisp
+
+unlink-ref-output-2.raw unlink-output-2.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	for i1 in $(shell seq 1 32); do \
+		cp input-1204-bytes.txt $(MOUNTPOINT)/initrd$$i1.img; \
+	done
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) unlink-ref-output-2.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos unlink-ref-output-2.raw $(MOUNTPOINT)
+	unlink $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="unlink-output-2.raw" \
+	$(ACL2) -- "/initrd.img" \
+	< rm-replicant.lisp
+
+unlink-ref-output-3.raw unlink-output-3.raw: $(MOUNTPOINT) rm-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	mkdir $(MOUNTPOINT)/tmp
+	cp input-1204-bytes.txt $(MOUNTPOINT)/tmp/file.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) unlink-ref-output-3.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos unlink-ref-output-3.raw $(MOUNTPOINT)
+	unlink $(MOUNTPOINT)/tmp/file.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RM_OUTPUT="unlink-output-3.raw" \
+	$(ACL2) -- "/tmp/file.txt" \
+	< rm-replicant.lisp
+
+mkdir-ref-output-1.raw mkdir-output-1.raw: $(MOUNTPOINT) mkdir-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) mkdir-ref-output-1.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos mkdir-ref-output-1.raw $(MOUNTPOINT)
+	mkdir $(MOUNTPOINT)/dir1
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) MKDIR_OUTPUT="mkdir-output-1.raw" \
+	$(ACL2) -- "/dir1" < mkdir-replicant.lisp
+
+mkdir-ref-output-2.raw mkdir-output-2.raw: $(MOUNTPOINT) mkdir-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	mkdir $(MOUNTPOINT)/dir1
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) mkdir-ref-output-2.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos mkdir-ref-output-2.raw $(MOUNTPOINT)
+	mkdir $(MOUNTPOINT)/dir1/dir2
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) MKDIR_OUTPUT="mkdir-output-2.raw" \
+	$(ACL2) -- "/dir1/dir2" < mkdir-replicant.lisp
+
+mtools-mkdir-ref-output-1.raw mtools-mkdir-output-1.raw: mkdir-replicant.lisp
+	rm -f $(DISK) mtools-mkdir-ref-output-1.raw
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	cp $(DISK) mtools-mkdir-output-1.raw
+	env MTOOLSRC=$(MTOOLSRC) mmd c:/tmp
+	cp $(DISK) mtools-mkdir-ref-output-1.raw
+	env DISK="mtools-mkdir-output-1.raw" MKDIR_OUTPUT="mtools-mkdir-output-1.raw" \
+	$(ACL2) -- "/tmp" \
+	< mkdir-replicant.lisp
+
+rmdir-ref-output-1.raw rmdir-output-1.raw: $(MOUNTPOINT) rmdir-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-4623-bytes.txt $(MOUNTPOINT)/initrd.img
+	mkdir $(MOUNTPOINT)/dir1
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) rmdir-ref-output-1.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos rmdir-ref-output-1.raw $(MOUNTPOINT)
+	rmdir $(MOUNTPOINT)/dir1
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RMDIR_OUTPUT="rmdir-output-1.raw" \
+	$(ACL2) -- "/dir1" < rmdir-replicant.lisp
+
+rmdir-ref-output-2.raw rmdir-output-2.raw: $(MOUNTPOINT) rmdir-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	mkdir -p $(MOUNTPOINT)/dir1/dir2
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) rmdir-ref-output-2.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos rmdir-ref-output-2.raw $(MOUNTPOINT)
+	rmdir $(MOUNTPOINT)/dir1/dir2
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) RMDIR_OUTPUT="rmdir-output-2.raw" \
+	$(ACL2) -- "/dir1/dir2" < rmdir-replicant.lisp
+
+mtools-rmdir-ref-output-1.raw mtools-rmdir-output-1.raw: rmdir-replicant.lisp
+	rm -f $(DISK) mtools-rmdir-ref-output-1.raw
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env MTOOLSRC=$(MTOOLSRC) mmd c:/tmp
+	cp $(DISK) mtools-rmdir-output-1.raw
+	env MTOOLSRC=$(MTOOLSRC) mrd c:/tmp
+	cp $(DISK) mtools-rmdir-ref-output-1.raw
+	env DISK="mtools-rmdir-output-1.raw" RMDIR_OUTPUT="mtools-rmdir-output-1.raw" \
+	$(ACL2) -- "/tmp" \
+	< rmdir-replicant.lisp
+
+mv-ref-output-1.raw mv-output-1.raw: $(MOUNTPOINT) mv-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	cp input-1204-bytes.txt $(MOUNTPOINT)/initrd.img
+	mkdir $(MOUNTPOINT)/tmp
+	cp input-1204-bytes.txt $(MOUNTPOINT)/tmp/file1.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	cp $(DISK) mv-ref-output-1.raw
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos mv-ref-output-1.raw $(MOUNTPOINT)
+	mv $(MOUNTPOINT)/tmp/file1.txt $(MOUNTPOINT)/tmp/file2.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	env DISK=$(DISK) MV_OUTPUT="mv-output-1.raw" \
+	$(ACL2) -- "/tmp/file1.txt" "/tmp/file2.txt" \
+	< mv-replicant.lisp
+
+mtools-mv-ref-output-1.raw mtools-mv-output-1.raw: mv-replicant.lisp
+	rm -f $(DISK) mtools-mv-ref-output-1.raw
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env MTOOLSRC=$(MTOOLSRC) mmd c:/tmp
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/tmp/file1.txt
+	cp $(DISK) mtools-mv-output-1.raw
+	env MTOOLSRC=$(MTOOLSRC) mmove c:/tmp/file1.txt c:/tmp/file2.txt
+	cp $(DISK) mtools-mv-ref-output-1.raw
+	env DISK="mtools-mv-output-1.raw" MV_OUTPUT="mtools-mv-output-1.raw" \
+	$(ACL2) -- "/tmp/file1.txt" "/tmp/file2.txt" < mv-replicant.lisp
+
+mtools-mv-ref-output-2.raw mtools-mv-output-2.raw: mv-replicant.lisp
+	rm -f $(DISK) mtools-mv-ref-output-2.raw
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env MTOOLSRC=$(MTOOLSRC) mmd c:/tmp
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/tmp/file1.txt
+	cp $(DISK) mtools-mv-output-2.raw
+	env MTOOLSRC=$(MTOOLSRC) mren c:/tmp/file1.txt c:/tmp/file2.txt
+	cp $(DISK) mtools-mv-ref-output-2.raw
+	env DISK="mtools-mv-output-2.raw" MV_OUTPUT="mtools-mv-output-2.raw" \
+	$(ACL2) -- "/tmp/file1.txt" "/tmp/file2.txt" < mv-replicant.lisp
+
 debug-do-nothing: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
@@ -149,7 +640,7 @@ debug-create-dir: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	mkdir  $(MOUNTPOINT)/tmp
+	mkdir $(MOUNTPOINT)/tmp
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	true
@@ -158,8 +649,8 @@ debug-create-dir-and-file: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	mkdir  $(MOUNTPOINT)/tmp
-	touch  $(MOUNTPOINT)/tmp/ticket1.txt
+	mkdir $(MOUNTPOINT)/tmp
+	touch $(MOUNTPOINT)/tmp/ticket1.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	true
@@ -168,9 +659,103 @@ debug-create-dir-copy-file: $(MOUNTPOINT) cp-replicant.lisp
 	rm -f $(DISK)
 	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
 	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
-	mkdir  $(MOUNTPOINT)/tmp
-	touch  $(MOUNTPOINT)/tmp/ticket1.txt
-	cp  $(MOUNTPOINT)/tmp/ticket1.txt  $(MOUNTPOINT)/tmp/ticket2.txt
+	mkdir $(MOUNTPOINT)/tmp
+	touch $(MOUNTPOINT)/tmp/ticket1.txt
+	cp $(MOUNTPOINT)/tmp/ticket1.txt $(MOUNTPOINT)/tmp/ticket2.txt
 	sleep 1
 	sudo umount $(MOUNTPOINT)
 	true
+
+debug-create-dir-and-file-rm: $(MOUNTPOINT) cp-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	mkdir $(MOUNTPOINT)/tmp
+	touch $(MOUNTPOINT)/tmp/ticket1.txt
+	sync $(MOUNTPOINT)/tmp/ticket1.txt
+	rm $(MOUNTPOINT)/tmp/ticket1.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	true
+
+debug-create-dir-and-file-mv: $(MOUNTPOINT) cp-replicant.lisp
+	rm -f $(DISK)
+	mkfs.fat -C -v -F 32 -s 2 $(DISK) $(SIZE)
+	sudo mount -o loop,uid=$(UID),gid=$(GID) -t msdos $(DISK) $(MOUNTPOINT)
+	mkdir $(MOUNTPOINT)/tmp
+	touch $(MOUNTPOINT)/tmp/ticket1.txt
+	sync $(MOUNTPOINT)/tmp/ticket1.txt
+	mv $(MOUNTPOINT)/tmp/ticket1.txt $(MOUNTPOINT)/tmp/ticket2.txt
+	sleep 1
+	sudo umount $(MOUNTPOINT)
+	true
+
+# The following test creates a 70 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-70MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=17920
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 140000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp
+
+# The following test creates a 140 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-140MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=35840
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 280000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp
+
+# The following test creates a 210 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-210MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=53760
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 420000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp
+
+# The following test creates a 280 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-280MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=71680
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 560000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp
+
+# The following test creates a 560 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-560MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=143360
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 1120000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp
+
+# The following test creates a 1120 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-1120MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=286720
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 2240000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp
+
+# The following test creates a 1680 MB disk image, copies a file to the
+# root directory, reads it in ACL2, then writes it back without change.
+mtools-read-write-test-1680MB: read-disk-image-write-disk-image.lisp
+	rm -f $(DISK)
+	dd if=/dev/zero of=$(DISK) bs=4096 count=430080
+	env MTOOLSRC=$(MTOOLSRC) mformat -T 3360000 -h 64 -s 32 -S \
+	2 -F -c 2 c:
+	env MTOOLSRC=$(MTOOLSRC) mcopy input-1204-bytes.txt c:/vmlinuz
+	env DISK=$(DISK) $(ACL2) -- < read-disk-image-write-disk-image.lisp

--- a/books/projects/filesystems/test/cp-replicant.lisp
+++ b/books/projects/filesystems/test/cp-replicant.lisp
@@ -1,39 +1,10 @@
-(include-book "../file-system-m2")
-
-(defun
-    get-dir-ent-contents
-    (fat32-in-memory dir-ent)
-  (declare (xargs :stobjs (fat32-in-memory)
-                  :verify-guards nil))
-  (b*
-      ((first-cluster (dir-ent-first-cluster dir-ent))
-       (file-size (dir-ent-file-size dir-ent)))
-    (get-clusterchain-contents
-     fat32-in-memory (fat32-entry-mask first-cluster) file-size)))
-
-(defun get-dir-ent-matching-name
-    (dir-contents str)
-  (declare (xargs :verify-guards nil
-                  :measure (len dir-contents)))
-  (if
-      (atom dir-contents)
-      nil
-    (let*
-        ((dir-ent (take *ms-dir-ent-length* dir-contents)))
-      (if
-          (and
-           (not (equal (nth 0 dir-ent) #xe5))
-           (equal str (nats=>string (subseq dir-ent 0 11))))
-          dir-ent
-        (get-dir-ent-matching-name
-         (nthcdr *ms-dir-ent-length* dir-contents)
-         str)))))
+(include-book "../test-stuff")
 
 (b*
     (((mv & val state)
       (getenv$ "DISK" state))
      ((mv fat32-in-memory &)
-      (slurp-disk-image
+      (disk-image-to-fat32-in-memory
        fat32-in-memory val state))
      ((mv & val state)
       (getenv$ "CP_OUTPUT" state))
@@ -41,27 +12,24 @@
       (open-output-channel val :character state))
      ((mv & val state)
       (getenv$ "CP_INPUT" state))
-     ((mv dir-clusterchain error-code)
-      (get-clusterchain
-       fat32-in-memory 2 2097152))
+     (fat32-pathname (pathname-to-fat32-pathname (coerce val 'list)))
+     ((mv fs &)
+      (fat32-in-memory-to-m1-fs fat32-in-memory))
+     ((mv val error-code &)
+      (m1-lstat fs fat32-pathname))
      ((unless (equal error-code 0))
-       (mv fat32-in-memory state))
-     (dir-contents
-      (get-contents-from-clusterchain
-       fat32-in-memory dir-clusterchain 2097152))
-     ((mv contents error-code)
-      (get-dir-ent-contents
-       fat32-in-memory
-       (get-dir-ent-matching-name
-        dir-contents val)))
+      (mv fat32-in-memory state))
+     (file-length (struct-stat->st_size val))
+     ((mv fd-table file-table fd &)
+      (m1-open fat32-pathname fs nil nil))
+     ((mv file-text file-read-length &)
+      (m1-pread
+       fd file-length 0 fs fd-table file-table))
+     ((unless (equal file-read-length file-length))
+      (mv fat32-in-memory state))
      (state
-      (if
-          (not (equal error-code 0))
-          state
-        (princ$
-         (nats=>string
-          contents)
-         channel state)))
-     (state
-      (close-output-channel channel state)))
+      (princ$
+       file-text
+       channel state))
+     (state (close-output-channel channel state)))
   (mv fat32-in-memory state))

--- a/books/projects/filesystems/test/mv-replicant.lisp
+++ b/books/projects/filesystems/test/mv-replicant.lisp
@@ -4,11 +4,8 @@
 (b*
     (((mv argv state)
       (oslib::argv))
-     ((mv errmsg opts extra-args) (parse-mkdir-opts argv))
-     ;; Either a parsing error, or no files provided on the command line.
-     ((when (or errmsg (atom extra-args)))
+     ((unless (>= (len argv) 2))
       (mv (good-bye 1) fat32-in-memory state))
-     ((mkdir-opts opts) opts)
      ((mv & val state)
       (getenv$ "DISK" state))
      ((mv fat32-in-memory &)
@@ -16,15 +13,14 @@
        fat32-in-memory val state))
      ((mv fs &)
       (fat32-in-memory-to-m1-fs fat32-in-memory))
-     ((mv fs exit-status)
-      ;; The -p option to mkdir is not yet supported.
-      (if opts.parents
-          (mv fs -1)
-        (mkdir-list fs extra-args 0)))
+     (oldpathname (pathname-to-fat32-pathname (coerce (nth 0 argv) 'list)))
+     (newpathname (pathname-to-fat32-pathname (coerce (nth 1 argv) 'list)))
+     ((mv fs exit-status &)
+      (m1-rename fs oldpathname newpathname))
      ((mv fat32-in-memory &)
       (m1-fs-to-fat32-in-memory fat32-in-memory fs))
      ((mv & val state)
-      (getenv$ "MKDIR_OUTPUT" state))
+      (getenv$ "MV_OUTPUT" state))
      (state
       (fat32-in-memory-to-disk-image
        fat32-in-memory val state)))

--- a/books/projects/filesystems/test/rm-replicant.lisp
+++ b/books/projects/filesystems/test/rm-replicant.lisp
@@ -1,44 +1,31 @@
-(include-book "../file-system-m2")
-(include-book "centaur/getopt/top" :dir :system)
+(include-book "../test-stuff")
 (include-book "oslib/argv" :dir :system)
 
-(defoptions rm-opts
-  :parents (demo2)
-  :tag :demo2
-
-  ((recursive    "Recursively delete a directory"
-                 booleanp
-                 :rule-classes :type-prescription
-                 :alias #\r)))
-
 (b*
-    (((mv & val state)
+    (((mv argv state)
+      (oslib::argv))
+     ((mv errmsg opts extra-args) (parse-rm-opts argv))
+     ;; Either a parsing error, or no files provided on the command line.
+     ((when (or errmsg (atom extra-args)))
+      (mv (good-bye 1) fat32-in-memory state))
+     ((rm-opts opts) opts)
+     ((mv & val state)
       (getenv$ "DISK" state))
      ((mv fat32-in-memory &)
       (disk-image-to-fat32-in-memory
        fat32-in-memory val state))
-     ((mv & val state)
-      (getenv$ "RM_OUTPUT" state))
-     ((mv channel state)
-       (open-output-channel val :character state))
-     ((mv & val state)
-      (getenv$ "RM_INPUT" state))
-     (fat32-pathname (pathname-to-fat32-pathname (coerce val 'list)))
      ((mv fs &)
       (fat32-in-memory-to-m1-fs fat32-in-memory))
-     ((mv & error-code &)
-      (m1-lstat fs fat32-pathname))
-     ((unless (equal error-code 0))
-      (mv fat32-in-memory state))
-     ((mv fs & &)
-      (m1-unlink fs fat32-pathname))
+     ((mv fs exit-status)
+      (if
+          opts.recursive
+          (rm-list fs t extra-args 0)
+        (rm-list fs nil extra-args 0)))
      ((mv fat32-in-memory &)
       (m1-fs-to-fat32-in-memory fat32-in-memory fs))
-     ;; ((mv errmsg opts ?extra-args) (parse-rm-opts argv))
+     ((mv & val state)
+      (getenv$ "RM_OUTPUT" state))
      (state
-      (princ$
-       (fat32-in-memory-to-string fat32-in-memory)
-       channel state))
-     (state
-      (close-output-channel channel state)))
-  (mv fat32-in-memory state))
+      (fat32-in-memory-to-disk-image
+       fat32-in-memory val state)))
+  (mv (good-bye exit-status) fat32-in-memory state))

--- a/books/projects/filesystems/test/rmdir-replicant.lisp
+++ b/books/projects/filesystems/test/rmdir-replicant.lisp
@@ -4,11 +4,11 @@
 (b*
     (((mv argv state)
       (oslib::argv))
-     ((mv errmsg opts extra-args) (parse-mkdir-opts argv))
+     ((mv errmsg opts extra-args) (parse-rmdir-opts argv))
      ;; Either a parsing error, or no files provided on the command line.
      ((when (or errmsg (atom extra-args)))
       (mv (good-bye 1) fat32-in-memory state))
-     ((mkdir-opts opts) opts)
+     ((rmdir-opts opts) opts)
      ((mv & val state)
       (getenv$ "DISK" state))
      ((mv fat32-in-memory &)
@@ -17,14 +17,14 @@
      ((mv fs &)
       (fat32-in-memory-to-m1-fs fat32-in-memory))
      ((mv fs exit-status)
-      ;; The -p option to mkdir is not yet supported.
+      ;; The -p option to rmdir is not yet supported.
       (if opts.parents
           (mv fs -1)
-        (mkdir-list fs extra-args 0)))
+        (rmdir-list fs extra-args 0)))
      ((mv fat32-in-memory &)
       (m1-fs-to-fat32-in-memory fat32-in-memory fs))
      ((mv & val state)
-      (getenv$ "MKDIR_OUTPUT" state))
+      (getenv$ "RMDIR_OUTPUT" state))
      (state
       (fat32-in-memory-to-disk-image
        fat32-in-memory val state)))

--- a/books/projects/filesystems/test/wc-replicant.lisp
+++ b/books/projects/filesystems/test/wc-replicant.lisp
@@ -1,42 +1,5 @@
-(include-book "../file-system-m2")
-(include-book "centaur/getopt/top" :dir :system)
+(include-book "../test-stuff")
 (include-book "oslib/argv" :dir :system)
-
-(defoptions wc-opts
-  :parents (demo2)
-  :tag :demo2
-
-  ((bytes    "Count bytes"
-             booleanp
-             :rule-classes :type-prescription
-             :alias #\c)
-
-   (lines "Count lines"
-          booleanp
-          :rule-classes :type-prescription
-          :alias #\l)
-
-   (words "Count words"
-           booleanp
-           :rule-classes :type-prescription
-           :alias #\w)))
-
-(defun wc-helper (text nl nw nc beginning-of-word-p pos)
-  (declare (xargs :measure (nfix (- (length text) pos))))
-  (if
-      (zp (- (length text) pos))
-      (mv nl nw nc)
-    (b*
-        ((c (char text pos))
-         (nc (+ nc 1))
-         (nl (if (equal c #\newline) (+ nl 1) nl))
-         ((mv beginning-of-word-p nw)
-          (if (or (equal c #\space) (equal c #\newline) (equal c #\tab))
-              (mv t nw)
-            (if beginning-of-word-p
-                (mv nil (+ nw 1))
-              (mv beginning-of-word-p nw)))))
-      (wc-helper text nl nw nc beginning-of-word-p (+ pos 1)))))
 
 (b*
     (((mv & val state)

--- a/books/std/io/base.lisp
+++ b/books/std/io/base.lisp
@@ -715,15 +715,25 @@ foo
   (defthm
     stringp-of-read-file-into-string1
     (implies
-     (and
-      (symbolp channel)
-      (open-input-channel-p channel
-                            :character state)
-      (state-p state)
-      (not (null (mv-nth 0
-                         (read-file-into-string1 channel state ans bound)))))
-     (stringp (mv-nth 0
-                      (read-file-into-string1 channel state ans bound)))))
+     (not
+      (null
+       (mv-nth 0
+               (read-file-into-string1 channel state ans bound))))
+     (stringp
+      (mv-nth 0
+              (read-file-into-string1 channel state ans bound))))
+    :rule-classes
+    (:rewrite
+     (:type-prescription
+      :corollary
+      (or
+       (null
+        (mv-nth 0
+                (read-file-into-string1 channel state ans bound)))
+       (stringp
+        (mv-nth
+         0
+         (read-file-into-string1 channel state ans bound)))))))
 
   (defthm
     state-p1-of-read-file-into-string1

--- a/books/std/io/base.lisp
+++ b/books/std/io/base.lisp
@@ -705,7 +705,35 @@ foo
                      state))
      :hints(("Goal" :in-theory (e/d (read-object state-p1)))))))
 
+(defsection std/io/read-file-into-string
+  :parents (std/io read-file-into-string)
 
+  :long "<p>See @(see read-file-into-string).</p>"
+
+  (local (in-theory (disable read-char$ open-input-channel-p1)))
+
+  (defthm
+    stringp-of-read-file-into-string1
+    (implies
+     (and
+      (symbolp channel)
+      (open-input-channel-p channel
+                            :character state)
+      (state-p state)
+      (not (null (mv-nth 0
+                         (read-file-into-string1 channel state ans bound)))))
+     (stringp (mv-nth 0
+                      (read-file-into-string1 channel state ans bound)))))
+
+  (defthm
+    state-p1-of-read-file-into-string1
+    (implies
+     (and (symbolp channel)
+          (open-input-channel-p channel
+                                :character state)
+          (state-p state))
+     (state-p1 (mv-nth 1
+                       (read-file-into-string1 channel state ans bound))))))
 
 ; -----------------------------------------------------------------------------
 ;


### PR DESCRIPTION
I'm not sure who should review the books/std/io/base.lisp changes, but I think it would suffice for @ericsmithkestrel to do so, since he responded to my question on Slack. I decided to follow the (apparent) convention that lemmas about built-in I/O functions go in the base.lisp file while community-defined functions each get their own file in that directory.