### PR TITLE
[Std/alists] Add some theorems about REMOVE-ASSOC-EQUAL.

### DIFF
--- a/books/centaur/misc/sparsemap-impl.lisp
+++ b/books/centaur/misc/sparsemap-impl.lisp
@@ -2172,7 +2172,8 @@
                                                                                    x))))
                            (if (assoc k x)
                                (1- (len (remove-duplicates-equal (strip-cars x))))
-                             (len (remove-duplicates-equal (strip-cars x))))))))
+                             (len (remove-duplicates-equal (strip-cars x))))))
+           :hints (("Goal" :in-theory (enable remove-assoc-equal)))))
 
   (local (defthm not-alist-equiv-when-lookup-unequal
            (implies (and (alistp x) (alistp y)

--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -411,6 +411,9 @@
  <p>Added a function @(tsee remove-assocs), moved from
  @('[books]/kestrel/utilities/').</p>
 
+ <p>Added some theorems about @(tsee remove-assoc-equal), moved from
+ @('[books]/kestrel/utilities/').</p>
+
  <h4>@(csee std/basic)</h4>
 
  <p>Added a recognizer @(tsee bytep) for ``standard'' (i.e. unsigned 8-bit)

--- a/books/kestrel/utilities/alists/remove-assoc-theorems.lisp
+++ b/books/kestrel/utilities/alists/remove-assoc-theorems.lisp
@@ -1,38 +1,5 @@
-; Alist Utilities -- Theorems about REMOVE-ASSOC-EQUAL
-;
-; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
-;
-; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
-;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; This file is a temporary redirection wrapper.
 
 (in-package "ACL2")
 
-(include-book "xdoc/top" :dir :system)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defsection remove-assoc-equal-theorems
-  :parents (alist-utilities remove-assoc)
-  :short "Some theorems about the built-in function @(tsee remove-assoc)."
-
-  (defthm alistp-of-remove-assoc-equal
-    (implies (alistp x)
-             (alistp (remove-assoc-equal a x))))
-
-  (defthm acl2-count-of-remove-assoc-equal-upper-bound
-    (<= (acl2-count (remove-assoc-equal a x))
-        (acl2-count x))
-    :rule-classes :linear)
-
-  (defthm symbol-alistp-of-remove-assoc-equal
-    (implies (symbol-alistp x)
-             (symbol-alistp (remove-assoc-equal a x))))
-
-  (defthm eqlable-alistp-of-remove-assoc-equal
-    (implies (eqlable-alistp x)
-             (eqlable-alistp (remove-assoc-equal a x)))))
-
-(in-theory (disable remove-assoc-equal))
+(include-book "std/alists/remove-assoc-equal" :dir :system)

--- a/books/std/alists/remove-assoc-equal.lisp
+++ b/books/std/alists/remove-assoc-equal.lisp
@@ -4,7 +4,8 @@
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Main Author: Alessandro Coglio (coglio@kestrel.edu)
+; Contributing Author: Mihir Mehta (mihir@cs.utexas.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -34,7 +35,11 @@
 
   (defthm eqlable-alistp-of-remove-assoc-equal
     (implies (eqlable-alistp x)
-             (eqlable-alistp (remove-assoc-equal a x)))))
+             (eqlable-alistp (remove-assoc-equal a x))))
+
+  (defthm strip-cars-of-remove-assoc-equal
+    (equal (strip-cars (remove-assoc-equal a x))
+           (remove-equal a (strip-cars x)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/std/alists/remove-assoc-equal.lisp
+++ b/books/std/alists/remove-assoc-equal.lisp
@@ -1,0 +1,41 @@
+; Standard Association Lists Library
+;
+; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Alessandro Coglio (coglio@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "ACL2")
+
+(include-book "xdoc/top" :dir :system)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defsection std/alists/remove-assoc-equal
+  :parents (std/alists remove-assoc)
+  :short "Theorems about @(tsee remove-assoc-equal)
+          in the @(see std/alists) library."
+
+  (defthm alistp-of-remove-assoc-equal
+    (implies (alistp x)
+             (alistp (remove-assoc-equal a x))))
+
+  (defthm acl2-count-of-remove-assoc-equal-upper-bound
+    (<= (acl2-count (remove-assoc-equal a x))
+        (acl2-count x))
+    :rule-classes :linear)
+
+  (defthm symbol-alistp-of-remove-assoc-equal
+    (implies (symbol-alistp x)
+             (symbol-alistp (remove-assoc-equal a x))))
+
+  (defthm eqlable-alistp-of-remove-assoc-equal
+    (implies (eqlable-alistp x)
+             (eqlable-alistp (remove-assoc-equal a x)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-theory (disable remove-assoc-equal))

--- a/books/std/alists/top.lisp
+++ b/books/std/alists/top.lisp
@@ -56,6 +56,7 @@
 (include-book "strip-cdrs")
 (include-book "pairlis")
 (include-book "remove-assocs")
+(include-book "remove-assoc-equal")
 
 (include-book "alist-defuns")
 


### PR DESCRIPTION
Since this affects Std, I'm making a PR instead of pushing directly. Unless there are objections, I'll merge in 1-2 days. Since I had to make a small change to one of @solswords 's files (see below), it would be great if he could have a quick look at that file.


The function is disabled at the end of the file, after the theorems are proved.

Adjust an existing proof, which apparently relies on the function to be enabled
after including Std/alists, by enabling the function in the hints. Perhaps this
can be avoided by adding more theorems to the newly added Std/alists file on
REMOVE-ASSOC-EQUAL.
