### PR TITLE
[Std/lists] Remove TAKE-REDEFINITION and TAKE-INDUCTION.

### DIFF
--- a/books/acl2s/base-theory.lisp
+++ b/books/acl2s/base-theory.lisp
@@ -64,7 +64,7 @@
 (sig acl2::rev ((alistof :a :b)) => (alistof :a :b)
      :suffix alistof)
 
-(sig nth (nat (listof :a)) => :a 
+(sig nth (nat (listof :a)) => :a
      :satisfies (< x1 (len x2)))
 ; PETE: I added and removed the sig below because it caused the
 ; theorem prover to get super slow.
@@ -100,6 +100,7 @@
 (sig first-n-ac (nat (alistof :a :b) (alistof :a :b)) => (alistof :a :b)
      :satisfies (< x1 (len x2))
      :suffix alistof)
+(local (in-theory (enable take)))
 (sig take (nat (listof :a)) => (listof :a)
      :satisfies (<= x1 (len x2))
      :hints (("Goal" :cases ((equal x1 (len x2))))))
@@ -107,6 +108,7 @@
      :satisfies (<= x1 (len x2))
      :suffix alistof
      :hints (("Goal" :cases ((equal x1 (len x2))))))
+(local (in-theory (disable take)))
 (sig subseq-list ((listof :a) nat nat) => (listof :a)
      :satisfies (and (<= x3 (len x1)) (<= x2 x3)))
 (sig subseq-list ((alistof :a :b) nat nat) => (alistof :a :b)
@@ -137,15 +139,15 @@ Decided to leave out for now because
   "rtl/rel11/lib/top" :dir :system)
 (in-theory
  (disable
-  acl2::|(mod (+ x y) z) where (<= 0 z)| acl2::|(mod (+ x (- (mod a b))) y)| 
+  acl2::|(mod (+ x y) z) where (<= 0 z)| acl2::|(mod (+ x (- (mod a b))) y)|
   acl2::|(mod (mod x y) z)| acl2::|(mod (+ x (mod a b)) y)| acl2::cancel-mod-+
-  acl2::mod-cancel-*-const acl2::simplify-products-gather-exponents-equal 
+  acl2::mod-cancel-*-const acl2::simplify-products-gather-exponents-equal
   acl2::simplify-products-gather-exponents-<
   acl2::cancel-mod-+ acl2::reduce-additive-constant-< acl2::|(floor x 2)|
   acl2::|(equal x (if a b c))| acl2::|(equal (if a b c) x)|))
 |#
 
-#| 
+#|
 
 PETE: See if there is a way to get rid of these rules.
 
@@ -153,7 +155,7 @@ PETE: See if there is a way to get rid of these rules.
 
 #|
 
-Experimenting with arithmetic. 
+Experimenting with arithmetic.
 Here is what we had before experimentation.
 
 (defthm natp-implies-acl2-numberp
@@ -206,7 +208,7 @@ neg: non-pos-integer, neg-rational
 pos: nat, pos-rational
 non-neg-integer (rewrites to nat)
 nat: integer
-non-pos-integer: integer 
+non-pos-integer: integer
 odd:     (not recognizer)
 even:    (not recognizer)
 z:       (not recognizer)
@@ -226,7 +228,7 @@ acl2-number
 
 We also want disjoint theorems
 
-neg: nat, 
+neg: nat,
 pos: non-pos-integer
 odd: even (don't need as it follows from definition of odd)
 integer: ratio
@@ -244,7 +246,7 @@ subtype and disjoint forms, so see base.lisp in defdata.
 
 #|
 
-These rules cause problems. Better to 
+These rules cause problems. Better to
 use the rules below.
 
 (defthm negp-expand-+
@@ -405,13 +407,13 @@ End of new version.
 |#
 
 (defthm numerator-1-decreases
-  (implies (rationalp n) 
+  (implies (rationalp n)
            (< (numerator (- n 1))
               (numerator n)))
-  :hints (("goal" 
-           :use ((:instance ACL2::|(* r (denominator r))| 
+  :hints (("goal"
+           :use ((:instance ACL2::|(* r (denominator r))|
                             (acl2::r n))
-                 (:instance ACL2::|(* r (denominator r))| 
+                 (:instance ACL2::|(* r (denominator r))|
                             (acl2::r (- n 1)))
                  )
            :in-theory (disable ACL2::|(* r (denominator r))|)))
@@ -430,8 +432,8 @@ End of new version.
            (< (numerator (+ (- n) r))
               (numerator r)))
   :hints (("goal" :induct (posp-ind n))
-          ("subgoal *1/2.2" 
-           :use ((:instance numerator-1-decreases 
+          ("subgoal *1/2.2"
+           :use ((:instance numerator-1-decreases
                             (n (+ r (- n) 1))))))
   :rule-classes ((:linear) (:rewrite)))
 

--- a/books/centaur/4v-sexpr/g-sexpr-eval.lisp
+++ b/books/centaur/4v-sexpr/g-sexpr-eval.lisp
@@ -522,7 +522,7 @@
      (implies (true-list-listp x)
               (equal (take-lists (len-of-each x) (append-lists x))
                      x))
-     :hints(("Goal" :in-theory (enable take-redefinition))))
+     :hints(("Goal" :in-theory (enable take))))
 
    (defthm 4v-sexpr-eval-list-of-append
      (equal (4v-sexpr-eval-list (append a b) env)

--- a/books/centaur/acre/match.lisp
+++ b/books/centaur/acre/match.lisp
@@ -241,7 +241,7 @@
                           (:instance append-of-undup-under-undup-equiv-1
                            (x a-equiv) (y b)))
              :in-theory (disable append-of-undup-under-undup-equiv-1))))
-             
+
   (defcong undup-equiv undup-equiv (append a b) 2)
   (defcong undup-equiv undup-equiv (append a b) 2)
 
@@ -427,7 +427,7 @@
     (iff (matchstatelist-indices-gte n (matches-add-backref name start x))
          (matchstatelist-indices-gte n x))
     :hints(("Goal" :in-theory (enable matchstatelist-indices-gte))))
-  
+
   (defthm matchstatelist-indices-lte-of-add-backref
     (iff (matchstatelist-indices-lte n (matches-add-backref name start x))
          (matchstatelist-indices-lte n x))
@@ -469,7 +469,7 @@
     (implies (<= (nfix idx) (matchstatelist-min-index x))
              (matchstatelist-indices-gte idx x))
     :hints(("Goal" :in-theory (enable matchstatelist-indices-gte)))))
-      
+
 
 
 (define matchstate-measure ((x stringp)
@@ -540,7 +540,7 @@
   ;;            (equal (matchstatelist-measure x (remove k y))
   ;;                   (matchstatelist-measure x y))))
 
-  
+
   (local (defthm undup-of-remove-rev
            (equal (undup (remove k x))
                   (remove k (undup x)))))
@@ -556,7 +556,7 @@
                 '(:cases ((< (matchstate-measure x (car sts)) (matchstatelist-measure x (cdr sts)))
                           (< (matchstatelist-measure x (cdr sts)) (matchstate-measure x (car sts))))))))
 
-  
+
 
   (defcong undup-equiv equal (matchstatelist-measure x sts) 2
     :hints (("goal" :use ((:instance matchstatelist-measure-of-undup)
@@ -680,7 +680,7 @@
     (implies (and (backref-alist-in-bounds x str)
                   (cdr (assoc name x)))
              (backref-in-bounds (cdr (assoc name x)) str))))
-                  
+
 (define matchstate-in-bounds ((st matchstate-p) (str stringp))
   (b* (((matchstate st)))
     (and (<= (matchstate->index st) (strlen str))
@@ -794,7 +794,7 @@
                       ((unless (< st.index (strlen x))) nil))
                    (and (xor (match-charset pat.chars 0 (char x st.index) mode) pat.negp)
                         (list (change-matchstate st :index (+ 1 st.index)))))
-                     
+
 
         :start (and (eql st.index 0)
                     (list st))
@@ -804,7 +804,7 @@
 
         :group (b* ((rec-matches (match-regex-rec pat.pat x st mode)))
                  (matches-add-backref pat.index st.index rec-matches))
-        
+
         :backref (b* ((backref (cdr (assoc-equal pat.index st.backrefs)))
                       ((unless backref) nil)
                       ((backref backref))
@@ -818,7 +818,7 @@
 
         :reverse-pref (b* ((rec-matches (match-regex-rec pat.pat x st mode)))
                         (rev rec-matches))
-        
+
         :no-backtrack (b* ((rec-matches (match-regex-rec pat.pat x st mode)))
                         (and (consp rec-matches)
                              (list (car rec-matches))))
@@ -897,8 +897,8 @@
         nil
       (append (match-regex-rec pat x (car sts) mode)
               (match-regex-sts-rec pat x (cdr sts) mode))))
-  
-  
+
+
   (define match-repeat-sts-minimum-rec ((min natp)
                                         (pat regex-p)
                                         (x stringp)
@@ -994,7 +994,7 @@
          ;; allow a single zero-length match for the last one
          (last-matches (match-regex-sts-rec pat x matches mode)))
       (undup (append last-matches matches)))
-         
+
     ;; (b* ((max (maybe-natp-fix max))
     ;;      (min (lnfix min))
     ;;      (base-matches (and (eql min 0) (list (matchstate-fix st))))
@@ -1019,7 +1019,7 @@
           `(defconst *match-regex-fns*
              ',(remove 'match-repeat-sts-rec-exec
                        (acl2::getpropc 'match-regex-rec 'acl2::recursivep nil (w state))))))
-  
+
   (local (make-event `(in-theory (disable . ,*match-regex-fns*))))
 
   (local (defun match-regex-mr-fns (name body-when-takes-st body-when-takes-sts hints rule-classes fns wrld)
@@ -1235,7 +1235,7 @@
       :fn match-repeat-rec)
     :hints (("goal" :do-not-induct t))
     :skip-others t)
-  
+
 
 
 
@@ -1387,7 +1387,7 @@
                       (match-regex-sts-nonzero-rec pat x nil mode)
                       (:free (a b)
                        (match-regex-sts-nonzero-rec pat x (cons a b) mode)))))))
-                    
+
   (local (defthm match-regex-sts-nonzero-rec-of-remove
            (EQUAL
             (SET-DIFFERENCE-EQUAL
@@ -1471,7 +1471,7 @@
     :fn match-repeat-sts-rec)
     :skip-others t)
 
-  
+
   (defcong undup-equiv undup-equiv (match-repeat-sts-rec max pat x sts mode) 4
     :hints (("goal" :use ((:instance match-repeat-sts-rec-of-undup)
                           (:instance match-repeat-sts-rec-of-undup
@@ -1532,7 +1532,7 @@
   :returns (substr stringp :rule-classes :type-prescription)
   (b* (((backref x)))
     (subseq (lstrfix str) x.loc (+ x.loc x.len))))
-  
+
 (define maybe-backref-in-bounds ((x maybe-backref-p) (str stringp))
   (or (not x) (backref-in-bounds x str))
   ///
@@ -1712,7 +1712,7 @@
        (cons `(,var (,fn ,name ,matchresult))
               (captures-bindings (cdr args) (+ 1 index) matchresult !)))
       (& (er hard? 'captures-bindings "Bad capture element: ~x0" arg)))))
-                  
+
 (acl2::def-b*-binder captures
   :body
   (b* ((args acl2::args)
@@ -1744,8 +1744,8 @@
        (cons `(,var (,fn ,name ,matchresult))
               (named-captures-bindings (cdr args) matchresult !)))
       (& (er hard? 'named-captures-bindings "Bad capture element: ~x0" arg)))))
-                  
-    
+
+
 
 (acl2::def-b*-binder named-captures
   :body
@@ -1795,7 +1795,7 @@
                 (and (<= (len a) (len c))
                      (equal (take (len a) c) (list-fix a))
                      (equal (nthcdr (len a) c) b)))
-           :hints(("Goal" :in-theory (enable append acl2::take-redefinition nthcdr len list-fix
+           :hints(("Goal" :in-theory (enable append acl2::take nthcdr len list-fix
                                              equal-cons-strong)
                    :induct (eoa-ind a c)))))
 
@@ -1808,7 +1808,7 @@
                 (and (<= (len a) (len c))
                      (str::icharlisteqv (take (len a) c) (list-fix a))
                      (str::icharlisteqv (nthcdr (len a) c) b)))
-           :hints(("Goal" :in-theory (enable append acl2::take-redefinition nthcdr len list-fix
+           :hints(("Goal" :in-theory (enable append acl2::take nthcdr len list-fix
                                              icharlisteqv-cons-strong)
                    :induct (eoa-ind a c)))))
 
@@ -1834,7 +1834,8 @@
   (local (defthm character-listp-of-take
            (implies (and (character-listp x)
                          (<= (nfix n) (len x)))
-                    (character-listp (take n x)))))
+                    (character-listp (take n x)))
+           :hints (("Goal" :in-theory (enable take)))))
 
   (local (defthm character-listp-of-nthcdr
            (implies (character-listp x)
@@ -1856,7 +1857,7 @@
                   (and (<= (nfix n) (nfix m))
                        (take (- (nfix m) (nfix n))
                              (nthcdr n x))))
-           :hints(("Goal" :in-theory (enable nthcdr)
+           :hints(("Goal" :in-theory (enable nthcdr take)
                    :induct (nthcdr-of-take-ind n m x))
                   (and stable-under-simplificationp
                        '(:in-theory (enable nfix))))))
@@ -1864,7 +1865,7 @@
   (local (defthm nthcdr-of-nthcdr
            (equal (nthcdr n (nthcdr m x))
                   (nthcdr (+ (nfix n) (nfix m)) x))))
-  
+
   (defthm match-exact-of-cat
     (Equal (match-exact (concatenate 'string x y) str index mode)
            (let ((x-index (match-exact x str index mode)))
@@ -1892,7 +1893,7 @@
 
    ;; (defmacro def-regex-simp (fn pat)
    ;;   `(make-event (def-regex-simp-fn ',fn ',pat state)))
-     
+
 
    ;; (def-regex-simp match-regex-rec (regex-exact str))
    ;; (def-regex-simp match-regex-rec (regex-concat lst))
@@ -1946,7 +1947,7 @@
     '(acl2::defopen match-concat-sts-rec-of-nil (match-concat-sts-rec x str nil mode)
        :hint (:expand ((match-concat-sts-rec x str nil mode)))))
 
-   
+
    (make-event
     '(acl2::defopen match-regex-sts-rec-of-nil (match-regex-sts-rec x str nil mode)
        :hint (:expand ((match-regex-sts-rec x str nil mode)))))

--- a/books/centaur/aignet/eval.lisp
+++ b/books/centaur/aignet/eval.lisp
@@ -320,7 +320,7 @@ literal:</p>
               (fanin-count aignet)
               (len (aignet-invals->vals invals vals aignet))))
     :rule-classes :linear)
-  
+
   (fty::deffixequiv aignet-invals->vals-iter :args ((aignet aignet)))
   (fty::deffixequiv aignet-invals->vals$inline :args ((aignet aignet)))
 
@@ -746,7 +746,7 @@ literal:</p>
              :expand ((:free (invals regvals)
                        (id-eval id invals regvals orig))))))
 
-  ;; (local (in-theory (disable acl2::take-redefinition)))
+  ;; (local (in-theory (disable acl2::take)))
 
   (defun set-prefix (n first second)
     (declare (xargs :guard (and (true-listp first)
@@ -905,7 +905,7 @@ literal:</p>
     (implies (< (nfix n) (num-fanins aignet))
              (equal (nth n new-vals)
                     (id-eval n invals regvals aignet)))))
-  
+
 
 
 
@@ -977,12 +977,12 @@ literal:</p>
              (bit-list-fix bitarr))
       :hints (("goal" :do-not-induct t)
               (acl2::equal-by-nths-hint)))))
-         
+
 
 
 (defsection aignet-sim-frames
 
-  
+
 
   (local (defthm bit-listp-of-update-nth
            (implies (and (bit-listp x)
@@ -1111,7 +1111,7 @@ literal:</p>
     :index n
     :last (num-regs aignet))
 
-  
+
   (defthm aignet-vals->nxstvals-iter-preserves-size
     (implies (and (<= (num-regs aignet) (len regvals))
                   (<= (nfix n) (num-regs aignet)))
@@ -1189,9 +1189,3 @@ literal:</p>
     (defthm len-of-aignet-sim-frames
       (equal (len (aignet-sim-frames vals frames initsts aignet))
              (num-fanins aignet)))))
-
-
-
-         
-
-

--- a/books/centaur/aignet/from-hons-aig.lisp
+++ b/books/centaur/aignet/from-hons-aig.lisp
@@ -109,7 +109,7 @@
                     (append (take n bitarr)
                             (env-to-bitarr vars env)
                             (nthcdr (+ (nfix n) (len vars)) bitarr))))
-    :hints(("Goal" :in-theory (e/d (env-to-bitarr) (acl2::take-redefinition nthcdr (force)))))))
+    :hints(("Goal" :in-theory (e/d (env-to-bitarr) (acl2::take nthcdr (force)))))))
 
 (local (defthm nthcdr-of-length
          (implies (and (true-listp x)
@@ -1300,7 +1300,7 @@
 ;;   (local (in-theory (enable first-n-rev-alist-keys
 ;;                             set-difference$)))
 ;;   (local (include-book "centaur/misc/lists" :dir :system))
-;;   (local (in-theory (disable acl2::take-redefinition)))
+;;   (local (in-theory (disable acl2::take)))
 
 ;;   (defthm first-n-rev-def
 ;;     (implies (and (alistp alist)
@@ -3140,7 +3140,7 @@
                             (nthcdr (+ (nfix n) (len envs)) (stobjs::2darr->rows frames)))))
     :hints(("Goal" :in-theory (e/d (envs-to-bitarrs
                                     env-to-frame-is-update-nth)
-                                   (acl2::take-redefinition nthcdr (force))))))
+                                   (acl2::take nthcdr (force))))))
 
   (std::defret aig-envs-to-aignet-frames-aux-lookup
     (implies (equal (len vars) (frames-ncols frames))

--- a/books/centaur/aignet/mark-impls.lisp
+++ b/books/centaur/aignet/mark-impls.lisp
@@ -206,7 +206,7 @@
   ;;                                        (nth (logtail 5 bitidx) (nth *eba$c->bitsi* eba$c)))))))
   ;;   :hints (("goal" :use eba$c-set-bits-in-bounds-necc)))
 
-  
+
 
   (stobjs::def-updater-independence-thm eba$c-set-bits-in-bounds-updater-independence
     (implies (and (eba$c-set-bits-in-bounds old)
@@ -247,11 +247,11 @@
                           (idx (eba$c-last-bits-in-bounds-witness new))))
                    :in-theory (disable eba$c-last-bits-in-bounds-necc))))))
 
-    
-             
-                  
 
-  
+
+
+
+
 
 (local (in-theory (disable unsigned-byte-p signed-byte-p)))
 
@@ -351,7 +351,7 @@
             :use ((:instance logapp-of-loghead-logtail)
                   (:instance logapp-of-loghead-logtail
                    (x y)))))))
-                         
+
 
 (local
  (defthm loghead-less-when-logtail-equal
@@ -410,7 +410,7 @@
   :split-types t
   :returns (new-eba$c)
   :inline t
-  (mbe :logic 
+  (mbe :logic
        (b* ((word-idx (ash (lnfix n) -5))
             (bit-idx (logand #x1f (lnfix n))))
          (eba$c-set-bit$ word-idx bit-idx eba$c))
@@ -440,7 +440,7 @@
              (eba$c-set-bits-invar new-eba$c))
     :hints(("Goal" :in-theory (e/d (eba$c-set-bits-invar)
                                    (;; eba$c-set-bit
-                                    acl2::take-redefinition))
+                                    acl2::take))
             :use ((:instance logtail-monotonic
                            (x (nfix n)) (y (eba$c->length eba$c)) (n 5))))
            (and stable-under-simplificationp
@@ -453,7 +453,7 @@
   ;;            (eba$c-set-bits-in-words new-eba$c))
   ;;   :hints (("goal" :use ((:instance logtail-monotonic
   ;;                          (x (nfix n)) (y (eba$c->length eba$c)) (n 5)))
-  ;;            :in-theory (disable acl2::take-redefinition))
+  ;;            :in-theory (disable acl2::take))
   ;;           (and stable-under-simplificationp
   ;;                `(:expand (,(car (last clause)))))))
 
@@ -470,7 +470,7 @@
                     (len (nth *eba$c->bitsi* eba$c))))
     :hints (("goal" :use ((:instance logtail-monotonic
                            (x (nfix n)) (y (eba$c->length eba$c)) (n 5)))
-             :in-theory (disable acl2::take-redefinition
+             :in-theory (disable acl2::take
                                  logtail-monotonic))))
 
   (defret eba$c-set-bit-wordcount-incr
@@ -576,7 +576,7 @@
              (eba$c-set-bits-invar new-eba$c))
     :hints(("Goal" :in-theory (e/d (eba$c-set-bits-invar)
                                    (;; eba$c-clear-bit
-                                    acl2::take-redefinition))
+                                    acl2::take))
             :use ((:instance logtail-monotonic
                    (x (nfix n)) (y (eba$c->length eba$c)) (n 5))))
            (and stable-under-simplificationp
@@ -589,7 +589,7 @@
   ;;            (eba$c-set-bits-in-words new-eba$c))
   ;;   :hints (("goal" :use ((:instance logtail-monotonic
   ;;                          (x (nfix n)) (y (eba$c->length eba$c)) (n 5)))
-  ;;            :in-theory (disable acl2::take-redefinition))
+  ;;            :in-theory (disable acl2::take))
   ;;           (and stable-under-simplificationp
   ;;                `(:expand (,(car (last clause)))))))
 
@@ -605,7 +605,7 @@
                     (len (nth *eba$c->bitsi* eba$c))))
     :hints (("goal" :use ((:instance logtail-monotonic
                            (x (nfix n)) (y (eba$c->length eba$c)) (n 5)))
-             :in-theory (disable acl2::take-redefinition))))
+             :in-theory (disable acl2::take))))
 
   (defret eba$c-clear-bit-preserves-wordcount
     (equal (nth *eba$c->wordcount* new-eba$c)
@@ -735,7 +735,7 @@
            (implies (not (logbitp k (nfix (nth idx (nth *eba$c->bitsi* eba$c)))))
                     (not (logbitp k (nfix (nth idx (nth *eba$c->bitsi* new-eba$c))))))))
 
-  
+
   (defret eba$c-clear-words-preserves-set-bits-in-bounds
     (implies (eba$c-set-bits-in-bounds eba$c)
              (eba$c-set-bits-in-bounds new-eba$c))
@@ -836,7 +836,7 @@
                                     ACL2::INEQUALITY-WITH-NFIX-HYP-2))
                    :use ((:instance eba$c-set-bits-in-bounds-necc
                           (idx (eba$c-set-bits-in-bounds-witness new-eba$c))))))))
-  
+
   (defret eba$c-clear-all-preserves-last-bits-in-bounds
     (implies (eba$c-last-bits-in-bounds eba$c)
              (eba$c-last-bits-in-bounds new-eba$c))
@@ -855,7 +855,7 @@
               (< (ash (eba$c->length eba$c) -5) (eba$c->bits-length eba$c))
               (<= (ash (eba$c->length eba$c) -7) (eba$c->wordlist-length eba$c)))
   :returns (new-eba$c)
-  (b* ((eba$c (if (< (the (unsigned-byte 32) 
+  (b* ((eba$c (if (< (the (unsigned-byte 32)
                           (lnfix (eba$c->wordcount eba$c)))
                      (the (unsigned-byte 32)
                           (ash (the (unsigned-byte 32)
@@ -904,7 +904,7 @@
                 `(:expand (,(car (last clause)))
                   :cases ((<= (nfix (eba$c-set-bits-in-words-witness (eba$c-clear eba$c)))
                               (logtail 5 (nfix (eba$c->length eba$c)))))))))
-  
+
   (defret eba$c-clear-preserves-set-bits-in-bounds
     (implies (eba$c-set-bits-in-bounds eba$c)
              (eba$c-set-bits-in-bounds new-eba$c)))
@@ -954,7 +954,7 @@
                  (eba$c-resize$ n eba$c)
                (ec-call (eba$c-resize$ n eba$c))))
   ///
-  
+
   (defret eba$c-resize-effect
     (implies (and (eba$c-set-bits-invar eba$c)
                   (eba$c-set-bits-in-bounds eba$c))
@@ -992,7 +992,7 @@
   (defret eba$c-resize-bits-length
     (equal (len (nth *eba$c->bitsi* new-eba$c))
            (+ 1 (logtail 5 (nfix n)))))
-  
+
   (defret eba$c-resize-wordlist-length
     (equal (len (nth *eba$c->wordlisti* new-eba$c))
            (logtail 7 (nfix n))))
@@ -1039,7 +1039,7 @@
             (bit-idx (logand #x1f (lnfix n))))
          (logbit (the (unsigned-byte 5) bit-idx)
                  (the (unsigned-byte 32) (lnfix (eba$c->bitsi word-idx eba$c)))))
-       :exec 
+       :exec
        (b* (((the (unsigned-byte 27) word-idx)
              (the (unsigned-byte 27)
                   (ash (the (unsigned-byte 32) n) -5)))
@@ -1182,7 +1182,7 @@
                    (update-eba$c->length (lnfix n) eba$c)
                  (ec-call (update-eba$c->length (lnfix n) eba$c)))))
   ///
-  
+
   (defret eba$c-grow-effect
     (implies (<= (nfix (eba$c->length eba$c)) (nfix n))
              (nat-equiv (nth idx (nth *eba$c->bitsi* new-eba$c))
@@ -1219,7 +1219,7 @@
     (nat-equiv (nth idx (nth *eba$c->wordlisti* new-eba$c))
                (nth idx (nth *eba$c->wordlisti* eba$c))))
 
-  
+
 
   (local (defret nth-wordlist-of-eba$c-grow-under-equal
            (implies (case-split (< (nfix idx) (len (nth *eba$c->wordlisti* eba$c))))
@@ -1253,7 +1253,7 @@
   (local (defret wordlist-len-increasing-of-eba$c-grow
            (<= (len (nth *eba$c->wordlisti* eba$c)) (len (nth *eba$c->wordlisti* new-eba$c)))
            :rule-classes :linear))
-           
+
 
   (local (in-theory (disable ACL2::TAKE-OF-TOO-MANY)))
 
@@ -1359,17 +1359,17 @@
     (<= (logtail 7 (nfix n)) (len (nth *eba$c->wordlisti* new-eba$c)))
     :rule-classes :linear))
 
-  
+
 
 (define eba$ap (eba$a)
   :enabled t
   (true-listp eba$a))
-   
+
 (define eba$a-length (eba$a)
   :guard t
   :enabled t
   (len eba$a))
-       
+
 
 (define eba$a-set-bit ((n natp) eba$a)
   :guard (< n (eba$a-length eba$a))
@@ -1399,7 +1399,7 @@
   :guard (<= (eba$a-length eba$a) n)
   :enabled t
   (resize-list eba$a n 0))
- 
+
 (define create-eba$a ()
   :enabled t
   nil)
@@ -1407,7 +1407,7 @@
 
 
 (defsection eba
-  
+
   (local (defun-sk eba-bits-corr (eba$c eba$a)
            (forall idx
                    (implies (< (nfix idx) (len eba$a))
@@ -1508,4 +1508,3 @@
               (eba-grow :exec eba$c-grow$inline :logic eba$a-grow :protect t)))
 
   )
-

--- a/books/centaur/clex/sin.lisp
+++ b/books/centaur/clex/sin.lisp
@@ -316,7 +316,7 @@ than to use this in a loop.</p>"
                      (nfix line)))
            :hints(("Goal" :in-theory (enable line-after-nthcdr
                                              count-newlines
-                                             acl2::take-redefinition)))))
+                                             acl2::take)))))
 
   (local (defthmd l0
            (implies (equal new-line (line-after-nthcdr n x line))
@@ -548,4 +548,3 @@ the implementation.</p>"
                       :exec  sin$c-find)
 
             ))
-

--- a/books/centaur/esim/vltoe/emodwire.lisp
+++ b/books/centaur/esim/vltoe/emodwire.lisp
@@ -1236,7 +1236,7 @@ index of @('|reset|') is @('nil').</p>"
                  :hints(("Goal"
                          :induct (my-induct n x)
                          :in-theory (enable vl-emodwire-encoding-valid-p
-                                            acl2::take-redefinition)))))
+                                            acl2::take)))))
 
         (defthm f2
           (implies (vl-emodwire-p x)

--- a/books/centaur/gl/run-gified-cp.lisp
+++ b/books/centaur/gl/run-gified-cp.lisp
@@ -575,7 +575,7 @@
  (defthm run-gified-ev-lst-take
    (equal (run-gified-ev-lst (acl2::take n x) a)
           (acl2::take n (run-gified-ev-lst x a)))
-   :hints(("Goal" :in-theory (enable acl2::take-redefinition)))))
+   :hints(("Goal" :in-theory (enable acl2::take)))))
 
 (local
  (defthm list-fix-run-gified-ev-lst
@@ -1063,7 +1063,7 @@
    (defthm gobj-listp-take
      (implies (gobj-listp gobj)
               (gobj-listp (acl2::take n gobj)))
-     :hints(("Goal" :in-theory (enable gobj-listp acl2::take-redefinition
+     :hints(("Goal" :in-theory (enable gobj-listp acl2::take
                                        acl2::replicate))))
 
    (defun count-down2-cdr (n m l)
@@ -1076,7 +1076,7 @@
                    (< (nfix n) (nfix m)))
               (gobj-listp (acl2::take n gobj)))
      :hints (("goal" :induct (count-down2-cdr m n gobj)
-              :in-theory (enable gobj-listp acl2::take-redefinition nfix))))
+              :in-theory (enable gobj-listp acl2::take nfix))))
 
    ;; (Defthm gobjectp-nth-when-gobj-listp-take
    ;;   (implies (and (gobj-listp (acl2::take m x))
@@ -1190,7 +1190,7 @@
                                          n formals actuals) a)
                      (acl2::take (len formals)
                                         (nthcdr n (run-gified-ev actuals a)))))
-     :hints(("Goal" :in-theory (enable nth nthcdr acl2::take-redefinition))))
+     :hints(("Goal" :in-theory (enable nth nthcdr acl2::take))))
 
 
 
@@ -1235,7 +1235,7 @@
                       nil)))
      :hints(("Goal"
              :induct t
-             :in-theory (enable acl2::take-redefinition)
+             :in-theory (enable acl2::take)
              :expand ((:free (a b c)
                              (acl2::ev-apply-arglist-on-result
                               n a b c))))
@@ -1257,7 +1257,7 @@
                         (len formals)
                         (nthcdr idx (run-gified-ev varname a)))))
        :hints(("Goal" :in-theory (enable my-equal-of-cons
-                                         acl2::take-redefinition
+                                         acl2::take
                                          nths-matching-formalsp))))
 
      (defthmd nths-matching-formalsp-make-nths-matching-formals-ev1
@@ -1359,7 +1359,7 @@
 
    (local
     (in-theory (disable
-                        cheap-default-car cheap-default-cdr acl2::take-redefinition
+                        cheap-default-car cheap-default-cdr acl2::take
                         ev-quote-clause-correct-for-run-gified-ev
                         ev-lookup-var-clause-correct-for-run-gified-ev
                         nth-when-len-smaller

--- a/books/centaur/gl/shape-spec.lisp
+++ b/books/centaur/gl/shape-spec.lisp
@@ -782,7 +782,7 @@
          :hints(("Goal" :in-theory (enable shape-spec-obj-in-range-iff)))))
 
 
-         
+
 
 (local
  (encapsulate nil
@@ -1714,7 +1714,7 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
   (defthm ev-of-make-nth-terms
     (equal (sspec-geval-ev-lst (make-nth-terms x start n) a)
            (take n (nthcdr start (sspec-geval-ev x a))))
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition
+    :hints(("Goal" :in-theory (enable acl2::take
                                       nthcdr))))
 
   (defthm len-of-make-nth-terms
@@ -2280,7 +2280,7 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
                   (no-duplicatesp (shape-spec-indices x)))
              (no-duplicatesp (g-integer->bits x)))
     :hints (("goal" :expand ((shape-spec-indices x))))))
-                  
+
 
 (defines shape-spec-env-term
   (define shape-spec-env-term ((x shape-specp)
@@ -2353,7 +2353,7 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
                        (car (sspec-geval-ev (shape-spec-env-term x obj-term) a)))
                       (shape-spec-indices x)))
       :hints ('(:expand ((shape-spec-env-term x obj-term)
-                         (shape-spec-indices x)))) 
+                         (shape-spec-indices x))))
       :flag ss)
     (defthm indices-of-shape-spec-env-term-iff
       (implies (shape-specp x)
@@ -2361,7 +2361,7 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
                        (car (sspec-geval-ev (shape-spec-env-term-iff x obj-term) a)))
                       (shape-spec-indices x)))
       :hints ('(:expand ((shape-spec-env-term-iff x obj-term)
-                         (shape-spec-indices x)))) 
+                         (shape-spec-indices x))))
       :flag iff)
     (defthm indices-of-shape-spec-list-env-term
       (implies (shape-spec-listp x)
@@ -2380,7 +2380,7 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
                        (cdr (sspec-geval-ev (shape-spec-env-term x obj-term) a)))
                       (shape-spec-vars x)))
       :hints ('(:expand ((shape-spec-env-term x obj-term)
-                         (shape-spec-vars x)))) 
+                         (shape-spec-vars x))))
       :flag ss)
     (defthm vars-of-shape-spec-env-term-iff
       (implies (shape-specp x)
@@ -2388,7 +2388,7 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
                        (cdr (sspec-geval-ev (shape-spec-env-term-iff x obj-term) a)))
                       (shape-spec-vars x)))
       :hints ('(:expand ((shape-spec-env-term-iff x obj-term)
-                         (shape-spec-vars x)))) 
+                         (shape-spec-vars x))))
       :flag iff)
     (defthm vars-of-shape-spec-list-env-term
       (implies (shape-spec-listp x)
@@ -2636,4 +2636,3 @@ for (e.g.)  adding rules to the coverage strategy are likely to change.</p>")
 
 
   )
-

--- a/books/centaur/glmc/bfr-mcheck-abc.lisp
+++ b/books/centaur/glmc/bfr-mcheck-abc.lisp
@@ -127,7 +127,7 @@
                                           (acl2::update-nth-when-atom
                                            acl2::update-nth-when-zp
                                            (aignet::bits-to-bools)))))))
-  
+
   (local (std::defret aignet-bitarr-to-aig-env-of-aig-env-to-bitarr-gen
            (implies (equal (len vars1) (nfix n))
                     (equal (aignet::aignet-bitarr-to-aig-env (append vars1 vars) (aig-env-to-bitarr n vars env bitarr))
@@ -141,7 +141,7 @@
                                             acl2::take-of-too-many
                                             acl2::take-of-zero
                                             acl2::car-of-take
-                                            acl2::take-redefinition))
+                                            acl2::take))
                    :induct (aignet-bitarr-to-aig-env-of-aig-env-to-bitarr-ind n vars vars1 env bitarr)
                    :expand ((aig-env-to-bitarr n vars env bitarr)))
                   (and stable-under-simplificationp
@@ -153,7 +153,7 @@
     :hints (("goal" :use ((:instance aignet-bitarr-to-aig-env-of-aig-env-to-bitarr-gen
                            (vars1 nil) (n 0)))
              :in-theory (disable aignet-bitarr-to-aig-env-of-aig-env-to-bitarr-gen)))))
-    
+
 (local (defthm aig-var-listp-of-keys-when-bfr-updates-p
          (implies (and (bfr-updates-p x)
                        (bfr-mode))
@@ -184,7 +184,7 @@
            :in-theory (enable aignet::aig-fsm-frame-nextst))))
 
 
-                  
+
 (define aig-mcheck-to-aignet (prop
                               (updates bfr-updates-p)
                               init-st
@@ -244,7 +244,7 @@
 
 
 
-  
+
 (defthm bfr-updates-p-of-fast-alist-clean
   (implies (bfr-updates-p x)
            (bfr-updates-p (fast-alist-clean x)))
@@ -441,7 +441,7 @@
                                    (bfr-eval-updates alist env)))
            :hints(("Goal" :in-theory (enable bfr-env-equiv bfr-lookup bfr-eval)))))
 
-  (local (defthmd aig-env-extract-when-bfr-env-equiv         
+  (local (defthmd aig-env-extract-when-bfr-env-equiv
            (implies (and (bfr-mode)
                          (bfr-env-equiv a b)
                          (acl2::aig-var-listp keys))
@@ -491,7 +491,7 @@
            :hints (("goal" :use ((:instance aig-fsm-run-when-bfr-env-equiv
                                   (a (bfr-eval-updates (fast-alist-clean alist) env))
                                   (b (bfr-eval-updates alist env))))))))
-  
+
 
 
   (define bfr-mcrun-fail-cycle (prop (updates bfr-updates-p) curr-st ins)
@@ -671,12 +671,10 @@
     :hints (("goal" :cases ((consp ins))
              :use bfrmc-set-initst-pred-vars-bounded
              :in-theory (disable bfrmc-set-initst-pred-vars-bounded)))))
-             
+
 
 
 (local (defattach bfr-mcheck bfr-mcheck-abc-simple))
 
 (defmacro bfr-mcheck-use-abc-simple ()
   '(defattach bfr-mcheck bfr-mcheck-abc-simple))
-
-

--- a/books/centaur/misc/smm-impl.lisp
+++ b/books/centaur/misc/smm-impl.lisp
@@ -252,7 +252,7 @@
 
 (defsection smme-mem-accessors
 
-  
+
   (defthm smme-memp-is-u32-listp
     (equal (smme-memp x)
            (u32-listp x)))
@@ -430,7 +430,7 @@
              (smme-wfp new))
     :hints(("Goal" :in-theory (enable ;; smme-sizes-okp
                                       stobjs::nth-when-range-nat-equiv))))
-                  
+
   ;; (defthm smme-wfp-of-update-smme-memi
   ;;   (implies (smme-wfp smme)
   ;;            (smme-wfp (update-smme-memi i v smme))))
@@ -627,7 +627,7 @@
              :in-theory (disable smme-wfp-implies-blockstarts-monotonic)
              :cases ((< (nfix m) (nfix n))
                      (< (nfix n) (nfix m))))))
-  
+
   (defthm smme-addrs-with-different-i
     (implies (not (equal (nfix i1) (nfix i2)))
              (not (equal (smme-addr n i1 smme)
@@ -944,7 +944,7 @@
   ;;            (smme-wfp (smme-maybe-grow-mem n smme)))
   ;;   :hints(("Goal" :in-theory (disable smme-maybe-grow-mem))))
   )
-             
+
 
 
 ;; (defthm blocksize-of-smme-maybe-grow-sizes
@@ -1234,7 +1234,7 @@
     (implies (< (nfix n) (smme-block-start (smme-nblocks smme) smme))
              (nat-equiv (nth n (nth *smme-memi* new-smme))
                         (nth n (nth *smme-memi* smme)))))
-  
+
   (defret new-block-start-of-smme-addblock
     (implies (equal (smme-nblocks smme1) (smme-nblocks smme))
              (equal (smme-block-start (+ 1 (smme-nblocks smme1)) new-smme)
@@ -1391,7 +1391,7 @@
                   (< 0 (smme-nblocks smme)))
              (nat-equiv (nth n (nth *smme-memi* new-smme))
                         (nth n (nth *smme-memi* smme)))))
-  
+
   (defret new-block-start-of-smme-resize-last
     (implies (equal (smme-nblocks smme1) (smme-nblocks smme))
              (equal (smme-block-start (smme-nblocks smme1) new-smme)
@@ -1996,7 +1996,7 @@
            (equal (smml-block-start n (take n x))
                   (smml-block-start n x)))
   :hints (("goal" :induct t
-           :in-theory (disable smml-block-start-alt)
+           :in-theory (e/d (take) (smml-block-start-alt))
            :expand ((:free (x) (smml-block-start n x))))))
 
 (defthm smml-fast-read-of-take
@@ -2007,7 +2007,7 @@
   :hints(("Goal" :in-theory (e/d () (smml-block-start-alt)))))
 
 ;; (defthm smml-fast-read-of-take
-;;   (implies (< (nfix n) (smml-block-start 
+;;   (implies (< (nfix n) (smml-block-start
 
 
 (defthm u32-listp-of-repeat
@@ -2018,7 +2018,7 @@
 (defthm u32-list-listp-take
   (implies (u32-list-listp x)
            (u32-list-listp (take n x)))
-  :hints(("Goal" :in-theory (disable take-of-too-many take-when-atom))))
+  :hints(("Goal" :in-theory (e/d (take) (take-of-too-many take-when-atom)))))
 
 (local (defthm len-equal-0
          (equal (equal (len x) 0) (atom x))))

--- a/books/centaur/misc/tailrec.lisp
+++ b/books/centaur/misc/tailrec.lisp
@@ -682,7 +682,7 @@
         (implies (and (natp start) (natp n))
                  (equal (partial-ev-lst (get-mv-nths start n term) al)
                         (take n (nthcdr start (partial-ev term al)))))
-        :hints(("Goal" :in-theory (enable take-redefinition nthcdr)
+        :hints(("Goal" :in-theory (enable take nthcdr)
                 :induct (get-mv-nths start n term)
                 :expand ((:free (x) (nthcdr (+ 1 start) x))))))))
 
@@ -1843,9 +1843,3 @@
              (otherwise (prog2$ (cw "bad instruction: ~x0~%" (car instr))
                                 sta))))))
      :diverge (mk-sta))))
-
-
-
-
-
-

--- a/books/centaur/misc/tarjan.lisp
+++ b/books/centaur/misc/tarjan.lisp
@@ -86,7 +86,7 @@
          :rule-classes :linear))
 
 
- 
+
 (defines tarjan-sccs
   :flag-local nil
   (define tarjan-sccs (x
@@ -302,7 +302,7 @@
                     :in-theory (e/d ()
                                     (tarjan-sccs-list-extend-preorder))))
            :fn tarjan-sccs-list))
-  
+
 
   (std::defret-mutual tarjan-sccs-preserve-stack-subset-of-preorder
     (defret tarjan-sccs-preserve-stack-subset-of-preorder
@@ -634,7 +634,7 @@
     (implies (graph-reachable-through-unvisited-p x y preorder)
              (let ((path (graph-reachable-through-unvisited-canonical-witness x y preorder)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (equal (car (last path)) y)
                     (not (intersectp-equal path preorder)))))
@@ -684,7 +684,7 @@
     :predicate (graph-reachable-through-unvisited-p x y preorder)
     :expr (let ((path (graph-reachable-through-unvisited-canonical-witness x y preorder)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (equal (car (last path)) y)
                     (not (intersectp path preorder))
@@ -700,7 +700,7 @@
              (iff (graph-reachable-through-unvisited-p x y preorder)
                   (let ((path (graph-reachable-through-unvisited-canonical-witness x y preorder)))
                     (and (consp path)
-                         (graph-path-p path) 
+                         (graph-path-p path)
                          (equal (car path) x)
                          (equal (car (last path)) y)
                          (not (intersectp-equal path preorder))
@@ -781,7 +781,7 @@
              `'(:use ((:instance no-duplicatesp-of-graph-reachable-through-unvisited-canonical-witness))
                 :expand ((no-duplicatesp ,(hq x-y)))
                 :in-theory (disable no-duplicatesp-of-graph-reachable-through-unvisited-canonical-witness)))))
-                           
+
 
   (defthm graph-reachable-through-unvisited-implies-reachable-for-some-successor
     (implies (and (graph-reachable-through-unvisited-p x y preorder)
@@ -837,7 +837,7 @@
     :predicate (graph-reachable-through-unvisited-for-some-x x y preorder)
     :expr (let ((path (graph-reachable-through-unvisited-for-some-x-witness x y preorder)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (member (car path) x)
                     (equal (car (last path)) y)
                     (not (intersectp path preorder))
@@ -919,7 +919,7 @@
                     (path (graph-reachable-through-unvisited-p-witness z y new-preorder))))))
     :rule-classes ((:rewrite :match-free :all)))
 
-  
+
 
   (local (defun reachable-through-unvisited-by-member-cond-2-hint (x y z preorder new-preorder)
            ;; Hyp assumes z reaches y in preorder.
@@ -949,7 +949,7 @@
              `'(:use ((:instance graph-reachable-through-unvisited-p-suff
                        (path ,(hq x-y)) (visited preorder)))
                 :in-theory (disable graph-reachable-through-unvisited-p-suff)))))
-                                    
+
 
   ;; This is the hard direction: if y is not reachable-through-unvisited from
   ;; x, then it remains reachable from z (if it was before) after adding the
@@ -1064,7 +1064,7 @@
                           (simple-generalize-cp
                            clause '((,witness . witness))))))))
     :fn tarjan-sccs-list))
-              
+
 
 
 
@@ -1184,7 +1184,7 @@
     (implies (graph-reachable-through-unvisited-but-last-p x y preorder)
              (let ((path (graph-reachable-through-unvisited-but-last-canonical-witness x y preorder)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (equal (car (last path)) y)
                     (not (intersectp-equal (butlast path 1) preorder)))))
@@ -1230,15 +1230,15 @@
                              (graph-reachable-through-unvisited-but-last-implies-canonical-witness
                               graph-reachable-through-unvisited-but-last-canonical-witness)))))
 
-  
 
-  
+
+
 
   (defwitness graph-reachable-through-unvisited-but-last-witness
     :predicate (graph-reachable-through-unvisited-but-last-p x y preorder)
     :expr (let ((path (graph-reachable-through-unvisited-but-last-canonical-witness x y preorder)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (equal (car (last path)) y)
                     (not (intersectp (butlast path 1) preorder))
@@ -1254,7 +1254,7 @@
              (iff (graph-reachable-through-unvisited-but-last-p x y preorder)
                   (let ((path (graph-reachable-through-unvisited-but-last-canonical-witness x y preorder)))
                     (and (consp path)
-                         (graph-path-p path) 
+                         (graph-path-p path)
                          (equal (car path) x)
                          (equal (car (last path)) y)
                          (not (intersectp-equal (butlast path 1) preorder))
@@ -1269,14 +1269,14 @@
   ;;   (implies (graph-reachable-through-unvisited-p x y preorder)
   ;;            (let ((path (graph-reachable-through-unvisited-but-last-canonical-witness x y preorder)))
   ;;              (and (consp path)
-  ;;                   (graph-path-p path) 
+  ;;                   (graph-path-p path)
   ;;                   (equal (car path) x)
   ;;                   (equal (car (last path)) y)
   ;;                   (not (intersectp-equal (butlast path 1) preorder)))))
   ;;   :hints (("goal" :use graph-reachable-through-unvisited-but-last-implies-canonical-witness
   ;;            :in-theory (disable graph-reachable-through-unvisited-but-last-implies-canonical-witness))))
 
-  
+
   (local (defthm no-intersectp-of-cdr
            (implies (not (intersectp x y))
                     (not (intersectp (cdr x) y)))
@@ -1319,7 +1319,7 @@
   (local (in-theory (disable graph-reachable-through-unvisited-but-last-canonical-witness)))
 
 
-  
+
 
   ;; (local (defun reachable-after-visiting-x-witness (x y z preorder new-preorder)
   ;;          ;; returns: flag, path
@@ -1422,7 +1422,7 @@
   (local (defthm graph-reachable-through-unvisited-but-last-of-append-last-1
            (implies (graph-reachable-through-unvisited-p x y preorder)
                     (graph-reachable-through-unvisited-but-last-p x y (append preorder (list y))))
-           :hints (("goal" 
+           :hints (("goal"
                     :use (;;(:instance graph-reachable-through-unvisited-implies-canonical-witness)
                           (:instance graph-reachable-through-unvisited-but-last-p-suff
                            (visited (append preorder (list y)))
@@ -1442,7 +1442,7 @@
            (implies (and (graph-reachable-through-unvisited-but-last-p x y (append preorder (list y)))
                          (not (member y preorder)))
                     (graph-reachable-through-unvisited-p x y preorder))
-           :hints (("goal" 
+           :hints (("goal"
                     :use ((:instance graph-reachable-through-unvisited-but-last-implies-canonical-witness
                            (preorder (append preorder (list y))))
                           (:instance graph-reachable-through-unvisited-p-suff
@@ -1519,7 +1519,7 @@
                              (stack true-listp)
                              (preorder true-listp))
   :guard (subsetp-equal stack preorder)
-  :returns (lowlink-node) 
+  :returns (lowlink-node)
   :prepwork ((local (defthm index-of-rationalp-when-member
                       (implies (member k x)
                                (rationalp (index-of k x))))))
@@ -1766,7 +1766,7 @@
     :otf-flg t
     :rule-classes ((:rewrite :match-free :all)))
 
-  
+
   (defthm tarjan-node-reaches-stack-of-extension-when-stack-not-reachable
     (let ((some-node (tarjan-lowlink-node node stack preorder)))
       (implies (and (tarjan-preorder-member-cond x preorder new-preorder)
@@ -1871,7 +1871,7 @@
     :predicate (tarjan-node-reaches-stack x stack preorder)
     :expr (let ((path (tarjan-node-stack-path x stack preorder)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (member (car (last path)) stack)
                     (not (intersectp (butlast path 1) preorder))
@@ -1886,8 +1886,8 @@
     (implies (tarjan-node-reaches-stack node stack preorder)
              (equal (car (last path))
                     (tarjan-lowlink-node node stack preorder)))))
-  
-          
+
+
 
 (define prefix-path-to (x (path true-listp))
   :guard (member-equal x path)
@@ -1991,7 +1991,7 @@
                     :in-theory (enable tarjan-node-reaches-stack-of-add-x-no-witness))
                    (witness :ruleset stack-reachable-through-node-stack-path))))
 
-                
+
 
   (local (defthm tarjan-node-reaches-stack-of-add-x-no
            (implies (and (tarjan-node-reaches-stack x stack preorder)
@@ -2017,7 +2017,7 @@
            (not (member x (butlast (prefix-path-to x path) 1)))
            :hints(("Goal" :in-theory (enable prefix-path-to
                                              butlast-redefinition len)))))
-  
+
 
   (local (defthm not-mebmer-of-butlast
            (implies (not (member x path))
@@ -2062,7 +2062,7 @@
 
 
 
-  
+
 (local (in-theory (disable min)))
 
 (define tarjan-lowlink-spec ((node)
@@ -2141,7 +2141,7 @@
                            (index-of k a)))
            :hints(("Goal" :in-theory (enable index-of prefixp)))))
 
-  
+
 
   (defthm tarjan-lowlink-spec-of-extension-when-lowlink-is-less
     (implies (and (tarjan-preorder-member-cond x preorder new-preorder)
@@ -2210,8 +2210,8 @@
                     (not (equal node (tarjan-lowlink-node node stack preorder))))
            :hints (("goal" :use tarjan-lowlink-node-exists-when-node-reaches-stack
                     :in-theory (disable tarjan-lowlink-node-exists-when-node-reaches-stack)))))
-  
-  
+
+
 
   (defret tarjan-lowlink-successor-is-a-successor
     (implies (and (tarjan-node-reaches-stack node stack preorder)
@@ -2232,8 +2232,8 @@
   (local (use-trivial-ancestors-check))
   ;; (local (defun tarjan-lowlink-successor-reaches-lowlink-node-witness (node stack preorder)
   ;;          (b* ((node-stack-path (tarjan-node-stack-path node stack preorder)))
-             
-  
+
+
   (defret tarjan-lowlink-successor-reaches-lowlink-node
     (implies (and (tarjan-node-reaches-stack node stack preorder)
                   (not (member node stack)))
@@ -2249,7 +2249,7 @@
                              (graph-reachable-through-unvisited-but-last-p-suff
                               butlast-redefinition)))))
 
-  
+
 
   (defret tarjan-node-reaches-stack-of-tarjan-lowlink-successor
     (implies (and (tarjan-node-reaches-stack node stack preorder)
@@ -2406,7 +2406,7 @@
                               tarjan-lowlink-successor
                               butlast-redefinition
                               (force))))
-            
+
             (and stable-under-simplificationp
                  '(:use ((:instance tarjan-lowlink-node-exists-when-node-reaches-stack
                           (node successor)
@@ -2417,7 +2417,7 @@
                                        (force))))
             ))
 
-    
+
   (defret tarjan-lowlink-spec-of-tarjan-lowlink-successor-extended
     (implies (and (tarjan-node-reaches-stack node stack preorder)
                   (not (member node stack))
@@ -2428,7 +2428,7 @@
     :hints(("Goal" :in-theory (e/d (tarjan-lowlink-spec)
                                    (tarjan-lowlink-successor)))))
 
-  
+
   (defret tarjan-lowlink-successor-minimizes-lowlink-lemma
     (implies (and (tarjan-node-reaches-stack node stack preorder)
                   (not (member node stack))
@@ -2466,8 +2466,8 @@
                   :in-theory (disable tarjan-lowlink-successor
                                       tarjan-lowlink-node-exists-when-node-reaches-stack)))))
 
-  
-  
+
+
   (local (defret tarjan-lowlink-node-exists-when-node-reaches-stack-superset
            (implies (and (tarjan-node-reaches-stack node stack preorder)
                          (subsetp stack stack2))
@@ -2486,7 +2486,7 @@
                                    (index-of-append))
             :do-not-induct t)))
 
-  
+
   (defthm tarjan-lowlink-node-of-successor-when-node-does-not-reach-stack
     (implies (and (not (tarjan-node-reaches-stack node stack preorder))
                   (not (member node preorder))
@@ -2613,7 +2613,7 @@
             :do-not-induct t)
            (and stable-under-simplificationp
                 '(:in-theory (enable tarjan-lowlink-spec))))))
-    
+
 (define prefix-path-to-blocked ((preorder true-listp) (path true-listp))
   :returns (prefix)
   (if (atom path)
@@ -2748,7 +2748,7 @@
 
 
 
-  ;; Similarly, if y.lowlink' < x.lowlink, then y.lowlink must exist because 
+  ;; Similarly, if y.lowlink' < x.lowlink, then y.lowlink must exist because
   ;; it can reach any stack node that y' can.
 
   ;; This gets rid of three of the above cases, leaving 6:
@@ -2766,7 +2766,7 @@
   ;; y.lowlink < y.lowlink' <= x.lowlink
   ;; y.lowlink < x.lowlink <= y.lowlink'
   ;; y.lowlink < x.lowlink and ! y.lowlink'
-  
+
 
   ;; The crux of these is that the new-preorder is extended with nodes
   ;; reachable through unvisited paths from x. Thus for any path that y could
@@ -2825,7 +2825,7 @@
   ;;                               (:instance tarjan-lowlink-min-associative
   ;;                                (x x) (y y) (z lst)))))))
 
-  
+
   (local (defthm min-special
            (implies (and (equal (min x lst1)
                                 (min x lst))
@@ -2837,7 +2837,7 @@
                            t))
            :hints(("Goal" :in-theory (enable min)))))
 
-  
+
 
   (local (defthm len-when-prefixp
            (implies (prefixp a b)
@@ -2872,7 +2872,7 @@
                          (member (car (last x)) y)))
            :hints(("Goal" :in-theory (enable intersectp last)))))
 
-  
+
   (local (defthmd butlast-of-cdr
            (implies (< (nfix n) (len x))
                     (equal (butlast (cdr x) n)
@@ -2905,7 +2905,7 @@
              `'(:use ((:instance tarjan-node-reaches-stack-by-path
                        (node ,(hq y)) (path ,(hq path))))))))
 
-  
+
   (local (defthm tarjan-node-reaches-stack-of-member-cond-extension-no
            (implies (and (subsetp preorder new-preorder)
                          (tarjan-stack-member-cond x stack preorder new-stack)
@@ -2925,14 +2925,14 @@
            (implies (member (car (last path)) preorder)
                     (member (car (last (prefix-path-to-blocked preorder path))) preorder))
            :hints(("Goal" :in-theory (enable prefix-path-to-blocked last)))))
-  
+
   (local (defthm prefix-path-to-blocked-when-butlast-not-intersecting-preorder
            (implies (and (member (car (last (prefix-path-to-blocked other-preorder path))) preorder)
                          (not (intersectp (butlast path 1) preorder)))
                     (equal (prefix-path-to-blocked other-preorder path)
                            (list-fix path)))
            :hints(("Goal" :in-theory (enable last prefix-path-to-blocked intersectp list-fix)))))
-  
+
   (local (defthm intersectp-of-butlast-of-member
            (implies (not (intersectp (butlast x n) y))
                     (not (intersectp (butlast (member k x) n) y)))
@@ -2993,7 +2993,7 @@
              (iff (tarjan-node-reaches-stack y new-stack new-preorder)
                   (tarjan-node-reaches-stack y stack preorder))))
 
-  
+
   (local (defun tarjan-node-reaches-stack-of-member-cond-list-extension-no-hint
            (x y stack preorder new-stack new-preorder)
            (declare (ignorable x))
@@ -3016,7 +3016,7 @@
              `'(:use ((:instance tarjan-node-reaches-stack-by-path
                        (node ,(hq y)) (path ,(hq path))))))))
 
-  
+
   (local (defthm tarjan-node-reaches-stack-of-member-cond-list-extension-no
            (implies (and (subsetp preorder new-preorder)
                          (tarjan-stack-member-cond-list x stack preorder new-stack)
@@ -3031,7 +3031,7 @@
                    (use-termhint (tarjan-node-reaches-stack-of-member-cond-list-extension-no-hint
                                   x y stack preorder new-stack new-preorder)))))
 
-  
+
 
 
   (local (defthm tarjan-node-reaches-stack-of-member-cond-list-extension-yes
@@ -3053,7 +3053,7 @@
                     :do-not-induct t))
            :otf-flg t))
 
-  
+
   (local (defthm subsetp-by-preorder-member-cond-list
            (implies (tarjan-preorder-member-cond-list x preorder new-preorder)
                     (subsetp preorder new-preorder))
@@ -3160,7 +3160,7 @@
                    '(:expand ((graph-reachable-through-unvisited-for-some-x x witness preorder)))))
       :fn tarjan-sccs-list)
     :otf-flg t)
-                    
+
 )
 
 
@@ -3349,7 +3349,7 @@
              `'(:use ,use-hints
                 :in-theory (disable tarjan-preorder-member-cond-necc
                                     scc-in-preorder-p-necc)))))
-  
+
 
 
   (local (defthmd scc-in-preorder-p-preserved-by-extension-lemma1
@@ -3396,7 +3396,7 @@
   (local
    (defthm scc-in-preorder-p-preserved-by-extension
      ;; ->: If a, b are members of scc, show that a reaches b in new-preorder:
-     ;; Get the path from a to b in the 
+     ;; Get the path from a to b in the
      (implies (and (tarjan-preorder-member-cond x preorder new-preorder)
                    (scc-in-preorder-p scc preorder)
                    (not (graph-reachable-through-unvisited-p x (car scc) preorder)))
@@ -3420,7 +3420,7 @@
            :hints (("goal" :use ((:instance scc-in-preorder-p-necc
                                   (x a) (y b) (preorder new-preorder)))
                     :in-theory (disable scc-in-preorder-p-necc)))))
-  
+
   (local (defun not-scc-in-preorder-lemma-hint (x a preorder new-preorder scc)
                  (b* (;; ((unless (graph-reachable-through-unvisited-p x a preorder))
                       ;;  ;; reachability is preserved by reachable-through-unvisited-by-member-cond-2.
@@ -3442,7 +3442,7 @@
                          (scc-in-preorder-p scc new-preorder))
                     (graph-reachable-through-unvisited-p x (car scc) preorder))
            :hints ((use-termhint (not-scc-in-preorder-lemma-hint x a preorder new-preorder scc)))))
-           
+
   (defthmd not-scc-in-preorder-p-when-member-in-common-with-preorder
     (implies (and (member x scc)
                   (member x preorder))
@@ -3514,16 +3514,16 @@
              `'(:use ((:instance scc-in-preorder-p-necc
                        (preorder new-preorder)
                        (x ,(hq a)) (y ,(hq b))))))))
-  
+
   (local (in-theory (disable NOT-GRAPH-REACHABLE-THROUGH-UNVISITED-P-WHEN-MEMBER-LAST
                              NOT-GRAPH-REACHABLE-THROUGH-UNVISITED-P-WHEN-MEMBER-first
                              ;; reachable-through-unvisited-by-member-cond-1
                              tarjan-preorder-member-cond-necc)))
-                         
+
 
   (defthm not-scc-in-preorder-p-preserved-by-extension
     ;; ->: If a, b are members of scc, show that a reaches b in new-preorder:
-    ;; Get the path from a to b in the 
+    ;; Get the path from a to b in the
     (implies (and (tarjan-preorder-member-cond x preorder new-preorder)
                   (not (scc-in-preorder-p scc preorder)))
              (not (scc-in-preorder-p scc new-preorder)))
@@ -3554,7 +3554,7 @@
              `'(:use ((:instance graph-reachable-through-unvisited-p-suff
                        (x ,(hq a)) (y ,(hq x)) (visited ,(hq preorder))
                        (path ,(hq (prefix-path-to x a-b)))))))))
-                
+
 
   (defthmd graph-reachable-through-unvisited-if-not-blocked-by-reachable
     (implies (and (graph-reachable-through-unvisited-p a b preorder)
@@ -3577,7 +3577,7 @@
              `'(:use ((:instance graph-reachable-through-unvisited-p-suff
                        (x ,(hq x)) (y ,(hq b)) (visited ,(hq preorder))
                        (path ,(hq (member x a-b)))))))))
-                
+
 
   (defthmd graph-reachable-through-unvisited-if-not-blocked-by-reaching
     (implies (and (graph-reachable-through-unvisited-p a b preorder)
@@ -3624,7 +3624,7 @@
              ;; transitivity
              nil)))
 
-                
+
   ;;               ;; ((mv a b) (scc-in-preorder-p-witness scc preorder))
   ;;               ;; ((unless (member b preorder))
   ;;               ;;  ;; do we have to do anything?
@@ -3641,7 +3641,7 @@
     :otf-flg t)
   )
 
-  
+
 
 (define scc-reachable-from-node (scc node stack preorder)
   :verify-guards nil
@@ -3717,11 +3717,11 @@
   ;;                             (graph-reachable-through-unvisited-p x (car scc) new-preorder)))
   ;;                '(:use ((:instance tarjan-sccs-produces-reachable-sccs-cond-necc))))
   ;;               ((when (graph-reachable-through-unvisited-p x (car scc) preorder))
-                 
+
   ;;               ((unless (scc-in-preorder-p scc preorder))
   ;;                '(:use scc-in-preorder-p-of-extension-iff-previous))
-                
-           
+
+
 
   ;; (defthm tarjan-sccs-produces-reachable-sccs-cond-of-extended-stack-lemma
   ;;   (implies (and (tarjan-sccs-produces-reachable-sccs-cond x new-stack new-preorder sccs)
@@ -3734,9 +3734,9 @@
   ;;                          (graph-reachable-through-unvisited-p x (car scc) preorder)
   ;;                          (not (tarjan-node-reaches-stack (car scc) stack preorder)))))
   ;;   :hints(("Goal" :in-theory (disable tarjan-sccs-produces-reachable-sccs-cond-necc)
-            
-    
-    
+
+
+
 
 
   ;; (defthm tarjan-sccs-produces-reachable-sccs-cond-of-extended-stack
@@ -3762,7 +3762,7 @@
   ;;                         (stack new-stack) (preorder new-preorder)
   ;;                         (scc witness)))
   ;;                  :in-theory (disable tarjan-sccs-produces-reachable-sccs-cond-necc))))))
-                  
+
 
 (defsection tarjan-sccs-list-produces-reachable-sccs-cond
   (defun-sk tarjan-sccs-list-produces-reachable-sccs-cond (x stack preorder sccs)
@@ -3838,7 +3838,7 @@
   ;;          :hints(("Goal" :in-theory (enable graph-reachable-through-unvisited-for-some-x)))
   ;;          :rule-classes ((:rewrite :match-free :all))))
 
-  
+
 
   (defthm tarjan-sccs-list-produces-reachable-sccs-cond-of-extended-stack
     (implies (and (tarjan-sccs-list-produces-reachable-sccs-cond x new-stack new-preorder sccs)
@@ -3861,10 +3861,10 @@
                   (tarjan-sccs-list-produces-reachable-sccs-cond (cdr x) stack preorder sccs))
              (tarjan-sccs-list-produces-reachable-sccs-cond x stack preorder sccs)))
 
-  
 
 
-  
+
+
   ;; (local (defun tarjan-sccs-produces-reachable-sccs-cond-by-successors-hint
   ;;          (x stack preorder sccs)
   ;;          (b* ((scc (tarjan-sccs-produces-reachable-sccs-cond-witness
@@ -3880,7 +3880,7 @@
   ;;                `'(:use ((:instance tarjan-node-reaches-stack-when-reaches-other-node
   ;;                          (x ,(hq (car scc))) (y ,(hq x))))))
   ;;            nil)))
-                
+
 
   (defthm tarjan-sccs-produces-reachable-sccs-cond-by-successors
     (implies (and (tarjan-sccs-list-produces-reachable-sccs-cond
@@ -3954,7 +3954,7 @@
   ;;           ;;                x stack preorder sccs))
   ;;           )
   ;;   :otf-flg t)
-  
+
   )
 
 (defsection new-part-of-stack-is-scc
@@ -3975,7 +3975,7 @@
                     (<= (len a) (len b)))
            :hints(("Goal" :in-theory (enable suffixp)))
            :rule-classes (:rewrite :linear)))
-  
+
   (defthm take-difference-with-duplicate-free-suffix
     (implies (and (suffixp x y)
                   (no-duplicatesp y))
@@ -4035,7 +4035,7 @@
   (local (defthm not-tarjan-node-reaches-stack-of-cons-implies-not-reachable
            (implies (not (tarjan-node-reaches-stack y (cons x stack) (append preorder (list x))))
                     (not (graph-reachable-through-unvisited-p y x preorder)))
-           :hints (("goal" 
+           :hints (("goal"
                     :use ((:instance graph-reachable-through-unvisited-implies-canonical-witness
                            (x y) (y x))
                           (:instance tarjan-node-reaches-stack-by-path
@@ -4065,7 +4065,7 @@
              `'(:use ((:instance tarjan-node-reaches-stack-sufficient
                        (some-node ,(hq y-stack-node))
                        (node x)))))))
-                
+
 
   (local (defthm stack-nodes-reach-x
            ;; case where sccx and sccy are both in the scc,
@@ -4086,7 +4086,7 @@
            ;; When sccx and sccy are both members, they are both reachable from
            ;; (succs x) and therefore from x, and also both reach x, since they
            ;; reach (cons x stack) but not stack (or else x would reach stack
-           ;; through them.  Therefore they are both in an SCC from x. 
+           ;; through them.  Therefore they are both in an SCC from x.
            (implies (and (not (tarjan-node-reaches-stack x stack preorder))
                          (tarjan-stack-member-cond-list (graph-node-succs x)
                                                         (cons x stack)
@@ -4115,8 +4115,8 @@
                 )
              `'(:use ((:instance graph-reachable-through-unvisited-if-not-blocked-by-reachable
                        (a sccy) (b sccx)))))))
-                
-  
+
+
 
   (local (defthm take-difference-of-new-stack-is-scc-lemma-case2
            ;; When sccx is a member but y is not, then either sccy is in the
@@ -4173,7 +4173,7 @@
              (scc-in-preorder-p (take (+ (- (len stack)) (len new-stack)) new-stack)
                                 preorder))
     :hints (("goal" :do-not-induct t
-             :in-theory (disable take-redefinition len take-of-len-free member))
+             :in-theory (disable take len take-of-len-free member))
             (use-termhint (take-difference-of-new-stack-is-scc-hints x stack preorder new-stack)))
     :otf-flg t))
 
@@ -4219,7 +4219,7 @@
                          (no-duplicatesp y))
                     (not (member (car y) x)))
            :hints(("Goal" :in-theory (enable suffixp no-duplicatesp)))))
-                         
+
 
   (defthm tarjan-sccs-list-new-stack-car-reachable-from-x
     (implies (and (subsetp stack preorder)
@@ -4275,7 +4275,7 @@
              :in-theory (disable tarjan-node-reaches-stack-when-reaches-other-node)
              :do-not-induct t))
     :otf-flg t)
-             
+
   (local (in-theory (disable list-fix-of-cons)))
 
   (std::defret-mutual tarjan-sccs-produces-reachable-sccs
@@ -4373,10 +4373,10 @@
                                   (stack (cons x stack)) (x nodes)))
                     :in-theory (disable take-difference-is-set-difference
                                         tarjan-sccs-list-extend-stack)))))
-  
-  
 
-  
+
+
+
   (local (in-theory (disable list-fix-of-cons)))
 
   (local (defthm append-lists-of-append
@@ -4560,7 +4560,7 @@
     (implies (graph-reachable-p x y)
              (let ((path (graph-reachable-canonical-witness x y)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (equal (car (last path)) y))))
     :hints (("goal" :expand ((graph-reachable-p x y)))))
@@ -4600,7 +4600,7 @@
     :predicate (graph-reachable-p x y)
     :expr (let ((path (graph-reachable-canonical-witness x y)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (equal (car path) x)
                     (equal (car (last path)) y)
                     (no-duplicatesp path)))
@@ -4691,7 +4691,7 @@
     :predicate (graph-reachable-for-some-x x y)
     :expr (let ((path (graph-reachable-for-some-x-witness x y)))
                (and (consp path)
-                    (graph-path-p path) 
+                    (graph-path-p path)
                     (member (car path) x)
                     (equal (car (last path)) y)))
     :generalize (((graph-reachable-canonical-witness x y) . reachpath))
@@ -4711,7 +4711,7 @@
              (b* ((path (graph-reachable-canonical-witness x y)))
                `'(:use ((:instance graph-reachable-through-unvisited-p-suff
                          (x ,(hq x)) (y ,(hq y)) (visited nil) (path ,(hq path)))))))))
-  
+
   (defthm graph-reachable-through-unvisited-when-preorer-empty
     (iff (graph-reachable-through-unvisited-p x y nil)
          (graph-reachable-p x y))
@@ -4726,7 +4726,7 @@
              (b* ((path (graph-reachable-for-some-x-witness x y)))
                `'(:use ((:instance graph-reachable-through-unvisited-for-some-x-by-path
                          (x ,(hq x)) (y ,(hq y)) (preorder nil) (path ,(hq path)))))))))
-  
+
   (defthm graph-reachable-through-unvisited-for-some-x-when-preorder-empty
     (iff (graph-reachable-through-unvisited-for-some-x x y nil)
          (graph-reachable-for-some-x x y))

--- a/books/centaur/sv/mods/moddb.lisp
+++ b/books/centaur/sv/mods/moddb.lisp
@@ -80,7 +80,7 @@
                     (cons (car x) (take (1- n) (cdr x)))))
            :rule-classes ((:definition :controller-alist ((take t nil)))))
 
-         (in-theory (disable acl2::take-redefinition))))
+         (in-theory (disable acl2::take))))
 
 (local (defun count-down (idx min)
          (declare (xargS :measure (nfix (- (nfix idx) (nfix min)))))
@@ -581,7 +581,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
     (defthm elab-modinst-list-names-of-take
       (equal (elab-modinst-list-names (take n x))
              (namelist-fix (take n (elab-modinst-list-names x))))
-      :hints(("Goal" :in-theory (e/d (replicate)))))
+      :hints(("Goal" :in-theory (e/d (replicate take)))))
 
     (defthm len-of-elab-modinst-list-names
       (equal (len (elab-modinst-list-names x))
@@ -1102,7 +1102,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                            (and (member k x)
                                 (< (index-of k x)
                                    (nfix n)))))
-             :hints(("Goal" :in-theory (enable index-of)))))
+             :hints(("Goal" :in-theory (enable index-of take)))))
 
     (local (defthm member-when-nth
              (implies (and (equal k (nth n x))
@@ -1175,7 +1175,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                   :expand (,(car (last clause))))))
     :otf-flg t)
 
-  (local (in-theory (disable acl2::take-redefinition)))
+  (local (in-theory (disable acl2::take)))
 
   (defthm wirelist-fix-of-update-nth
     (implies (<= (nfix n) (len x))
@@ -1187,7 +1187,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
     (implies (<= (nfix n) (len x))
              (equal (wirelist-fix (take n x))
                     (take n (wirelist-fix x))))
-    :hints(("Goal" :in-theory (enable wirelist-fix))))
+    :hints(("Goal" :in-theory (enable wirelist-fix take))))
 
   (defthm nth-of-wirelist-fix
     (implies (< (nfix n) (len x))
@@ -1201,7 +1201,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                          (and (member k x)
                               (< (index-of k x)
                                  (nfix n)))))
-           :hints(("Goal" :in-theory (enable index-of)))))
+           :hints(("Goal" :in-theory (enable index-of take)))))
 
   (defthm elab-mod$c-add-wire-update
     (implies (elab-mod$c-wires-ok elab-mod$c)
@@ -1405,7 +1405,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                            (and (member k x)
                                 (< (index-of k x)
                                    (nfix n)))))
-             :hints(("Goal" :in-theory (enable index-of)))))
+             :hints(("Goal" :in-theory (enable index-of take)))))
 
     (local (defthm member-when-nth
              (implies (and (equal k (nth n x))
@@ -1483,7 +1483,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                (elab-modinst$c-copy elab-modinst$c elab-modinst$c2)
                elab-mod$c))
   ///
-  (local (in-theory (disable acl2::take-redefinition
+  (local (in-theory (disable acl2::take
                              elab-mod$c-modinsts-ok-implies-lookup-name)))
 
   (defthm elab-mod$c-modinsts-ok-of-elab-mod$c-add-inst
@@ -1947,7 +1947,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                              acl2::nth-when-too-large-cheap
                              len not member
                              acl2::take-of-len-free
-                             acl2::take-redefinition
+                             acl2::take
                              acl2::nth-when-atom
                              elab-modinst$cp)))
 
@@ -2059,7 +2059,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                            (and (index-of k x)
                                 (< (index-of k x) (nfix n))
                                 (index-of k x))))
-           :hints(("Goal" :in-theory (enable index-of len)))))
+           :hints(("Goal" :in-theory (enable index-of len take)))))
 
   (local (defthm len-when-equal-take
            (implies (equal x (take n y))
@@ -2104,7 +2104,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                          (and (member k x)
                               (< (index-of k x)
                                  (nfix n)))))
-           :hints(("Goal" :in-theory (enable index-of len)))))
+           :hints(("Goal" :in-theory (enable index-of len take)))))
 
 
   (defthm remove-duplicates-equal-when-no-duplicates-under-list-equiv
@@ -2284,7 +2284,8 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
     (defthm elab-mods->names-of-take
       (implies (<= (nfix n) (len elab-mods))
                (equal (elab-mods->names (take n elab-mods))
-                      (take n (elab-mods->names elab-mods)))))
+                      (take n (elab-mods->names elab-mods))))
+      :hints (("Goal" :in-theory (enable take))))
 
     (defthm len-of-elab-mods->names
       (equal (len (elab-mods->names x))
@@ -2343,14 +2344,15 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
   (fty::deffixcong elab-mod$a-equiv elab-modlist-equiv (replicate n d) d
     :hints(("Goal" :in-theory (enable replicate))))
   (fty::deffixcong elab-mod$a-equiv elab-modlist-equiv (resize-list lst n d) d)
-  (fty::deffixcong elab-modlist-equiv elab-modlist-equiv (take n x) x)
+  (fty::deffixcong elab-modlist-equiv elab-modlist-equiv (take n x) x
+    :hints (("Goal" :in-theory (enable take))
+            '(:expand (take n (elab-modlist-fix x)))))
   (fty::deffixcong elab-modlist-equiv elab-modlist-equiv (append x y) x)
   (fty::deffixcong elab-modlist-equiv elab-modlist-equiv (append x y) y)
   (fty::deffixcong elab-modlist-equiv elab-modlist-equiv (update-nth n v x) x
     :hints(("Goal" :in-theory (enable update-nth))))
   (fty::deffixcong elab-mod$a-equiv elab-modlist-equiv (update-nth n v x) v
     :hints(("Goal" :in-theory (enable update-nth))))
-
   (fty::deffixcong elab-mod$a-equiv modname-equiv (g :name x) x))
 
 (defsection moddb-stobj
@@ -2507,6 +2509,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
     (fty::deffixcong elab-modlist-norm-equiv elab-modlist-equiv
       (take n mods) mods
       :hints(("Goal" :in-theory (e/d (elab-modlist-norm
+                                      take
                                       my-open-take)
                                      (acl2::take-when-atom
 ; Matt K. mod 5/2016 (type-set bit for {1}):
@@ -2780,7 +2783,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                :in-theory (e/d ()
                                ((elab-mods->names)
                                 moddb-find-bad-index
-                                acl2::take-redefinition
+                                acl2::take
                                 acl2::take-of-len-free
                                 moddb-indices-ok-implies))))
       :otf-flg t)
@@ -2800,9 +2803,8 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
              (let ((name (modname-fix (g :name (nth n mods)))))
                (implies (< (nfix n) (nfix nmods))
                         (member name (elab-mods->names (take nmods mods)))))
-             :hints(("Goal" :in-theory (e/d (elab-mods->names my-open-take nth)
-                                            (acl2::take-redefinition
-                                             acl2::take-when-atom))))))
+             :hints(("Goal" :in-theory (e/d (elab-mods->names my-open-take nth take)
+                                            (acl2::take-when-atom))))))
 
     (local (defthm name-nth-index-name-take
              (let ((name (modname-fix (g :name (nth n mods)))))
@@ -2816,7 +2818,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                                             (acl2::integerp-of-index-of
                                              ;; ACL2::INDEX-OF-IFF-MEMBER
                                              acl2::take-when-atom
-                                             acl2::take-redefinition))
+                                             acl2::take))
                      :induct (ind2 n nmods mods)))))
 
     (local (defthmd equal-of-cons
@@ -3595,7 +3597,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
              (elab-modlist-equiv (take n (resize-list lst m d))
                                  (take n lst)))
     :hints (("goal" :induct (ind n m lst)
-             :in-theory (enable acl2::take-redefinition elab-mods->names))))
+             :in-theory (enable acl2::take elab-mods->names))))
 
 
   (defthm moddb-maybe-grow-under-moddb-norm-equiv
@@ -3695,9 +3697,9 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
     (local (defthm update-nth-of-take-length
              (equal (update-nth n v (take n x))
                     (take (+ 1 (nfix n)) (update-nth n v x)))
-             :hints(("Goal" :in-theory (e/d (acl2::take-redefinition update-nth))))))
+             :hints(("Goal" :in-theory (e/d (acl2::take update-nth))))))
 
-    (local (in-theory (disable acl2::take-redefinition
+    (local (in-theory (disable acl2::take
                                acl2::take-of-update-nth
                                acl2::take-after-update-nth)))
 
@@ -3712,7 +3714,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
                     (if (zp n)
                         nil
                       (cons (car x) (take (1- n) (cdr x)))))
-             :hints(("Goal" :in-theory (enable acl2::take-redefinition)))
+             :hints(("Goal" :in-theory (enable acl2::take)))
              :rule-classes ((:definition :controller-alist ((take t nil))))))
 
     (local (defun ind (n m mods)

--- a/books/centaur/sv/svex/symbolic.lisp
+++ b/books/centaur/sv/svex/symbolic.lisp
@@ -68,7 +68,7 @@
          (implies (equal (nfix n) (len x))
                   (equal (take n (append x y))
                          (list-fix x)))
-         :hints(("Goal" :in-theory (e/d (acl2::take-redefinition))
+         :hints(("Goal" :in-theory (e/d (acl2::take))
                  :induct (nthcdr n x)))))
 
 (local (in-theory (disable double-containment)))
@@ -821,7 +821,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                  (lognot (4vec->lower x)))))
 
 
-  
+
   (local
    (encapsulate nil
      (local (in-theory (disable* (:rules-of-class :linear :here)
@@ -1024,7 +1024,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                   (logbitp-reasoning))
            :otf-flg t))
 
-  
+
   (local (defthm 4vec-zero-ext-of-concat
            (implies (and (2vec-p w1) (2vec-p w2)
                          (<= 0 (2vec->val w1))
@@ -1150,7 +1150,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                              (equal lower-impl (aig-logapp-nss width lower-spec (list-fix lower-acc)))))))
      :rewrite :direct))
   (local (in-theory (disable svex-concat->a4vec-lower-acc-elim-correct)))
-  
+
   (local (std::defret-mutual svex-concat->a4vec-lower-acc-elim-lemma
            (defret svex-concat->a4vec-lower-acc-elim-lemma
              (svex-concat->a4vec-lower-acc-elim-correct x width env masks)
@@ -1237,18 +1237,18 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
            :hints(("Goal" :in-theory (enable 4vec-mask 4vec-zero-ext))
                   (logbitp-reasoning))))
 
-  
+
   (local (defthm 4vec-zero-ext-0
            (equal (4vec-zero-ext 0 x) 0)
            :hints(("Goal" :in-theory (enable 4vec-zero-ext)))))
 
-  
+
 
   ;; (local (Defthm 4vec-zero-ext-of-zp
   ;;                   (equal (4vec-zero-ext (2vec width) x) 0))
   ;;          :hints(("Goal" :in-theory (enable* 4vec-zero-ext
   ;;                                             ihsext-recursive-redefs))))
-  
+
   (local (defthm 4vec-concat-0
            (equal (4vec-concat width x 0)
                   (4vec-zero-ext width x))
@@ -1382,7 +1382,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                            (4vec-mask m2 b)))
            :hints(("Goal" :in-theory (enable 4vec-mask? 4vec-mask 4vec-bit? 3vec-bit? 4vmask-subsumes))
                   (logbitp-reasoning))))
-  
+
 
   ;; (local (defthm 4vec-zero-ext-to-concat
   ;;          (equal (4vec-zero-ext w x)
@@ -2556,7 +2556,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                     (4vec-mask mask2 val2))
     :templates (v)
     :instance-rulename svex-envs-mask-equiv-on-vars-instancing)
-  
+
   (local (defexample svex-envs-mask-equiv-on-vars-mask-look-example
            :pattern (svex-mask-lookup (svex-var var) masks)
            :templates (var)
@@ -2846,7 +2846,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                         `(:expand (,(car (last clause))
                                    (:free (acc)
                                     (svex-varmasks/env->aig-env-rec vars masks boolmasks env nextvar acc))))))))
-                   
+
   (defthm svex-varmasks/env->aig-env-accumulator-elim
     (implies (syntaxp (not (equal acc ''nil)))
              (equal (mv-nth 1 (svex-varmasks/env->aig-env-rec
@@ -3083,7 +3083,7 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
   (defthm svexlist-full-masks-p-of-nthcdr
     (implies (svexlist-full-masks-p x masks)
              (svexlist-full-masks-p (nthcdr n x) masks)))
-  
+
   (defthmd svexlist-full-masks-p-of-svexlist-mask-alist-lemma
     (implies (subsetp (svexlist-fix y) (svexlist-fix x))
              (svexlist-full-masks-p y (svexlist-mask-alist x)))
@@ -3106,8 +3106,8 @@ into @(see acl2::aig)s, to support symbolic simulation with @(see acl2::gl).")
                     (4veclist-fix 4vecs)))
     :hints(("Goal" :in-theory (enable 4veclist-mask svex-argmasks-lookup 4veclist-fix 4vec-mask)
             :induct (cdr2 x 4vecs)))))
-                    
-  
+
+
 
 (defsection general-correctness-theorems
   (local (defthm subsetp-intersection
@@ -3498,7 +3498,7 @@ except that we memoize the results and we use fast alist lookups."
 
   (defret len-of-<fn>
     (equal (len new-x) (len x))))
-  
+
 
 (define symbolic-params-x-out-cond ((symbolic-params alistp))
   ;; Only makes sense to x out unused variables if
@@ -3649,7 +3649,7 @@ obviously 2-vectors.</p>"
             (set-reasoning)
             (and stable-under-simplificationp
                  '(:cases ((member acl2::k0 (svexlist-vars x)))))))
-  
+
   (gl::def-gl-rewrite svexlist-eval-for-symbolic-redef
     (equal (svexlist-eval-for-symbolic x env symbolic-params)
            (svexlist-eval-gl x env symbolic-params))))
@@ -3673,7 +3673,7 @@ obviously 2-vectors.</p>"
 ;;       (gl::bool->sign (car v))
 ;;     (logcons (acl2::bool->bit (car v))
 ;;              (v2i-alt (cdr v)))))
-  
+
 
 (local (defthm v2i-of-aig-eval-list
          (equal (gl::v2i (aig-eval-list x env))
@@ -3686,8 +3686,8 @@ obviously 2-vectors.</p>"
 
 (define v2i-first-n ((n natp) (v true-listp))
   :returns (v2i (equal v2i (gl::v2i (take n v)))
-                :hints(("Goal" :in-theory (e/d (acl2::take-redefinition)
-                                               (take acl2::take-of-too-many))
+                :hints(("Goal" :in-theory (e/d (acl2::take)
+                                               (acl2::take-of-too-many))
                         :induct t)))
   :prepwork ((local (defthm v2i-of-singleton
                       (equal (gl::v2i (list x))
@@ -4015,7 +4015,7 @@ obviously 2-vectors.</p>"
                     (if (zp n)
                         (list x y)
                       (ind (1- n) (cdr x) (cdr y)))))
-           
+
            (defthm svex-eval-same-on-envs-of-nth-when-svexlist-eval-same-on-envs
              (implies (and (svexlist-eval-same-on-envs x y envs)
                            (< (nfix n) (len x)))
@@ -4082,7 +4082,7 @@ obviously 2-vectors.</p>"
                      :induct (ind x y envs1))))))
 
 
-  
+
   (local (defthm svexlist-eval-equiv-of-maybe-svexlist-rewrite-fixpoint
            (svexlist-eval-equiv (maybe-svexlist-rewrite-fixpoint x do-it) x)
            :hints(("Goal" :in-theory (enable svexlist-eval-equiv)))))
@@ -4168,7 +4168,7 @@ obviously 2-vectors.</p>"
                            (envs1 envs)))
              :in-theory (disable svexlist/env-list-eval-when-svexlistlist-eval-same-on-envs)
              :do-not-induct t))))
-  
+
 
 
 
@@ -4265,7 +4265,7 @@ bound in all environments.</p>"
                                   (x svexes) (symbolic-params params)))
                     :in-theory (disable svexlist/env-list-vars-for-symbolic-eval-sufficient))
                    (set-reasoning))))
-                                  
+
 
   (defthm svexlist/env-list-eval-gl-correct
     (equal (svexlist/env-list-eval-gl x envs symbolic-params)
@@ -4275,6 +4275,3 @@ bound in all environments.</p>"
   (gl::def-gl-rewrite svexlist/env-list-eval-for-symbolic-redef
     (equal (svexlist/env-list-eval x envs)
            (svexlist/env-list-eval-gl x envs nil))))
-
-
-

--- a/books/centaur/sv/svtv/decomp.lisp
+++ b/books/centaur/sv/svtv/decomp.lisp
@@ -2252,7 +2252,7 @@ trigger on any of the following:</p>
   (implies (and (svexlist-p x)
                 (<= (nfix n) (len x)))
            (svexlist-p (take n x)))
-  :hints(("Goal" :in-theory (enable acl2::take-redefinition
+  :hints(("Goal" :in-theory (enable acl2::take
                                     svexlist-p))))
 
 
@@ -2267,7 +2267,7 @@ trigger on any of the following:</p>
   (implies (<= (nfix n) (len x))
            (equal (svexlist-eval (take n x) env)
                   (take n (svexlist-eval x env))))
-  :hints(("Goal" :in-theory (enable svexlist-eval)
+  :hints(("Goal" :in-theory (enable svexlist-eval take)
           :induct (take n x)
           :expand ((svexlist-eval x env)))))
 

--- a/books/centaur/sv/svtv/expand.lisp
+++ b/books/centaur/sv/svtv/expand.lisp
@@ -138,7 +138,7 @@
 (define svtv-parse-path/select-aux ((dotted-parts string-listp)
                                     (orig-x stringp))
   :prepwork ((local (in-theory (disable (tau-system)
-                                        ;; acl2::take-redefinition
+                                        ;; acl2::take
                                         ;; acl2::take-of-len-free
                                         acl2::take-of-too-many
                                         subseq-list)))
@@ -428,6 +428,3 @@
                :entries xf.entries)
               svtv-ovs)
         (cons ov lhs-ovs))))
-
-
-

--- a/books/centaur/sv/svtv/fsm.lisp
+++ b/books/centaur/sv/svtv/fsm.lisp
@@ -69,7 +69,7 @@
 
 
 
-  
+
 (local (defthm alist-keys-of-svex-env-fix-of-svar-alist
          (implies (svar-alist-p x)
                   (equal (alist-keys (svex-env-fix x))
@@ -248,14 +248,14 @@
                                       svtv-fsm-step
                                       svtv-fsm-step-outs))))
 
-  
+
   (defthm consp-of-svtv-fsm-eval
     (equal (consp (svtv-fsm-eval ins prev-st x))
            (consp ins)))
 
 
 
-  
+
 
 
   (defun svtv-fsm-eval-is-svex-eval-unroll-multienv-ind (n ins prev-st x)
@@ -290,7 +290,7 @@
     (equal (svtv-fsm-eval ins (svex-env-reduce (svex-alist-keys (svtv->nextstate x)) prev-st) x)
            (svtv-fsm-eval ins prev-st x))
     :hints(("Goal" :in-theory (enable svtv-fsm-eval))))
-  
+
   (defthmd svtv-fsm-eval-is-svex-eval-unroll-multienv
     (implies (< (nfix n) (len ins))
              (equal (nth n (svtv-fsm-eval ins prev-st x))
@@ -329,7 +329,7 @@
                  '(:expand ((svtv-fsm-eval ins initst svtv))
                    :in-theory (enable svtv-fsm-step)))))
 
-  
+
 
   (local (defun svtv-fsm-eval-+-n-m-ind (n m ins prev-st x)
            (b* (((svtv x))
@@ -343,7 +343,7 @@
              (clear-memoize-table 'svex-eval)
              (fast-alist-free current-cycle-env)
              (svtv-fsm-eval-+-n-m-ind (1- n) (1- (nfix m)) (cdr ins) next-st x))))
-           
+
   (defthm lookup-in-fsm-eval-of-take
     (implies (and (< (nfix n) (len ins))
                   (< (nfix n) (nfix m)))
@@ -400,14 +400,14 @@
                                       svtv-fsm-step
                                       svtv-fsm-step-outs))))
 
-  
+
   (defthm consp-of-svtv-fsm-eval-states
     (equal (consp (svtv-fsm-eval-states ins prev-st x))
            (consp ins)))
 
 
 
-  
+
 
 
   (defun svtv-fsm-eval-states-is-svex-eval-unroll-multienv-ind (n ins prev-st x)
@@ -437,7 +437,7 @@
     (equal (svtv-fsm-eval-states ins (svex-env-extract (svex-alist-keys (svtv->nextstate x)) prev-st) x)
            (svtv-fsm-eval-states ins prev-st x))
     :hints(("Goal" :in-theory (enable svtv-fsm-eval-states))))
-  
+
   (defthmd svtv-fsm-eval-states-is-svex-eval-unroll-multienv
     (implies (< (nfix n) (len ins))
              (equal (nth n (svtv-fsm-eval-states ins prev-st x))
@@ -490,7 +490,7 @@
                       (:free (nextstate a b initst) (svex-unroll-state nextstate (cons a b) initst))
                       (:free (nextstate initst) (svex-unroll-state nextstate nil initst))))))
 
-  
+
 
   (local (defun svtv-fsm-eval-states-+-n-m-ind (n m ins prev-st x)
            (b* (((svtv x))
@@ -504,7 +504,7 @@
              (clear-memoize-table 'svex-eval)
              (fast-alist-free current-cycle-env)
              (svtv-fsm-eval-states-+-n-m-ind (1- n) (1- (nfix m)) (cdr ins) next-st x))))
-           
+
   (defthm lookup-in-fsm-eval-states-of-take
     (implies (and (< (nfix n) (len ins))
                   (< (nfix n) (nfix m)))
@@ -561,7 +561,7 @@
   (svex-envlist-extract signals (svtv-fsm-eval (take (len signals) ins) prev-st x))
 
   ///
-  
+
   ;; (defthm svtv-fsm-eval-of-take
   ;;   (implies (posp n)
   ;;            (equal (sv::svtv-fsm-eval (take n ins) initst svtv)
@@ -588,7 +588,7 @@
   (svex-envlist-extract signals (svtv-fsm-eval-states (take (len signals) ins) prev-st x))
 
   ///
-  
+
   ;; (defthm svtv-fsm-eval-of-take
   ;;   (implies (posp n)
   ;;            (equal (sv::svtv-fsm-eval (take n ins) initst svtv)
@@ -613,7 +613,7 @@
               (not (acl2::hons-dups-p (svex-alist-keys (svtv->nextstate svtv)))))
   (mv (svtv-fsm-run ins prev-st svtv out-signals)
       (svtv-fsm-run-states ins prev-st svtv state-signals)))
-  
+
 
 
 
@@ -650,7 +650,7 @@
           (svtv-fsm-run-spec (cdr signals) (1+ (lnfix cycle)) outs nextstate env)))
   ///
 
-  
+
   (local (defthm consp-by-len
            (implies (and (equal consp (posp (len x)))
                          (syntaxp (quotep consp)))
@@ -686,7 +686,7 @@
   ;;                   :use ((:instance svtv-fsm-eval-is-svex-eval-unroll-multienv
   ;;                          (n 0)))))))
 
-  
+
 
   (local (in-theory (enable SVEXLIST-EVAL-UNROLL-MULTIENV-IN-TERMS-OF-SVEX-UNROLL-STATE)))
 
@@ -772,7 +772,7 @@
                              (cons next-st (svtv-fsm-eval-states (cdr ins) next-st x)))))
            :hints(("Goal" :in-theory (enable svtv-fsm-eval-states)))))
 
-  (local (in-theory (disable ACL2::TAKE-REDEFINITION nthcdr)))
+  (local (in-theory (disable acl2::take nthcdr)))
 
   (local (defthm dumb
            (equal (+ a (- a) b)
@@ -989,7 +989,7 @@
     :hints (("goal" :use svtv-fsm-run-symbolic-svexlist->alists-of-append-alist-vals
              :in-theory (disable svtv-fsm-run-symbolic-svexlist->alists-of-append-alist-vals)
              :do-not-induct t)))
-  
+
   (local (defthmd nthcdr-of-append-less
            (implies (<= (nfix n) (len x))
                     (equal (nthcdr n (append x y))
@@ -1057,7 +1057,7 @@
                               :in-theory (e/d* (acl2::arith-equiv-forwarding)
                                                (nthcdr-of-len-append)))))))
   :guard (and (equal (alist-keys prev-st) (svex-alist-keys (svtv->nextstate x)))
-              (not (acl2::hons-dups-p (svex-alist-keys (svtv->nextstate x)))))  
+              (not (acl2::hons-dups-p (svex-alist-keys (svtv->nextstate x)))))
   (b* (((svtv x))
        ((when (and (atom out-signals) (atom state-signals)))
         (mv nil nil))
@@ -1086,7 +1086,7 @@
                     (equal (svex-envlist-extract keys x)
                            nil))
            :hints(("Goal" :in-theory (enable svex-envlist-extract)))))
-  
+
 
   (local (defthm svarlist-has-cycle-var-of-env-reduce
            (implies (not (svarlist-has-svex-cycle-var vars))
@@ -1121,7 +1121,3 @@
            (b* (((mv ?outs states) (svtv-fsm-run-outs-and-states-symbolic ins prev-st x :state-signals signals)))
              states))
     :hints(("Goal" :in-theory (enable svtv-fsm-run-outs-and-states)))))
-
-
-
-

--- a/books/centaur/sv/vl/expr.lisp
+++ b/books/centaur/sv/vl/expr.lisp
@@ -896,7 +896,7 @@ ignored.</p>"
     (implies (and (not err)
                   (not (member v (sv::svex-vars idx))))
              (not (member v (sv::svex-vars shift))))))
-               
+
 
 
 ;; #!sv
@@ -1331,7 +1331,7 @@ the way.</li>
                                       sv::svex-select->indices
                                       sv::svex-select-inner-var
                                       acl2::member-of-cons)))))
-                  
+
 
 
 (local (include-book "std/lists/nthcdr" :dir :system))
@@ -1394,7 +1394,7 @@ the way.</li>
              (local (in-theory (disable len-of-cdr
                                         acl2::take-of-len-free
                                         acl2::len-when-atom
-                                        acl2::take-redefinition
+                                        acl2::take
                                         acl2::nthcdr-when-zp
                                         acl2::subsetp-when-atom-left
                                         nthcdr)))
@@ -1425,7 +1425,7 @@ the way.</li>
        (decl-scopes (vl-elabscopes-traverse (rev decl.elabpath) scopes))
        (info (vl-elabscopes-item-info x.declname decl-scopes))
        (item (or info decl.item))
-       
+
        ((mv err paramval)
         (b* (((when (eq (tag item) :vl-vardecl))
               (b* (((vl-vardecl item)))
@@ -1500,7 +1500,7 @@ the way.</li>
   ;;          #!sv
   ;;          (implies (not (member v (svexlist-vars x)))
   ;;                   (not (member v (svexlist-vars (take n x)))))
-  ;;          :hints(("Goal" :in-theory (enable acl2::take-redefinition)))))
+  ;;          :hints(("Goal" :in-theory (enable acl2::take)))))
 
   ;; (local (defthm svexlist-vars-of-nthcdr
   ;;          #!sv
@@ -1944,7 +1944,7 @@ the way.</li>
           ;; Shift amounts need to be zero-extended -- right arg is always
           ;; treated as unsigned per SV spec 11.4.10.
           (:vl-binary-shr     (sv::svcall sv::rsh
-                                          ;; Weird case: 
+                                          ;; Weird case:
                                           (sv::svex-zerox right-size right)
                                           (sv::svex-zerox left-size left)))
           (:vl-binary-shl     (sv::svcall sv::lsh
@@ -2763,7 +2763,7 @@ the way.</li>
                     (equal (vl-funcall-args-to-ordered ports plainargs namedargs)
                            (vl-funcall-args-to-ordered ports nil namedargs)))
            :hints(("Goal" :in-theory (enable vl-funcall-args-to-ordered)))))
-                         
+
 
   (local (defthm funcall-args-to-ordered-is-args-to-ordered-alt
            (implies (and (no-duplicatesp (vl-portdecllist->names ports)))
@@ -2771,7 +2771,7 @@ the way.</li>
                            (args-to-ordered-alt ports namedargs)))
            :hints(("Goal" :in-theory (enable vl-portdecllist->names)
                    :induct (args-to-ordered-alt ports namedargs)))))
-           
+
   (local (defthm count-of-args-to-ordered
            (b* (((mv err args) (args-to-ordered-alt ports namedargs)))
              (implies (and (no-duplicatesp (vl-portdecllist->names ports))
@@ -3028,7 +3028,7 @@ a cons of two vttrees.</p>"
                   (vttree->warnings x.right)))
        :exec (rev (vttree->warnings-acc x nil nil)))
   ///
-  
+
 
   (local (defthm vl-warninglist-add-ctx-of-vl-warninglist-add-ctx
            (implies (case-split ctx1)
@@ -3075,7 +3075,7 @@ a cons of two vttrees.</p>"
            (list-fix (sv::constraintlist-fix constraints)))
     :hints(("Goal" :in-theory (enable constraintlist-add-ctx sv::constraintlist-fix
                                       sv::constraint-fix-redef)))))
-  
+
 
 (define vttree->constraints-acc ((x vttree-p)
                                  (context)
@@ -3240,10 +3240,10 @@ a cons of two vttrees.</p>"
              `((mv . ,(subst '__tmp__warnings 'vttree args)) . ,acl2::forms))
           (vttree (vttree-add-warnings __tmp__warnings vttree :ctx ,ctx)))
        ,acl2::rest-expr)))
-  
 
 
-  
+
+
 
 
 (defmacro vfatal (&rest args)
@@ -3278,7 +3278,7 @@ a cons of two vttrees.</p>"
   (defret constraints-of-vl-err->vfatal
     (equal (vttree->constraints new-vttree)
            (vttree->constraints vttree))))
-  
+
 
 (defines vl-expr-to-svex
   :ruler-extenders :all
@@ -3332,7 +3332,7 @@ a cons of two vttrees.</p>"
                              (append (sv::constraintlist-vars a)
                                      (sv::constraintlist-vars b)))
                       :hints(("Goal" :in-theory (enable sv::constraintlist-vars)))))
-             
+
              ;; (local (defthm and*-lhs
              ;;          (implies (and* x y)
              ;;                   x)
@@ -3441,7 +3441,7 @@ vector.</p>"
              ((wvmv vttree size) (vl-datatype-size-warn ftype x nil)))
           (mv vttree
               svex ftype size))
-        
+
         :vl-stream
         (b* (((mv vttree svex size)
               (vl-streaming-concat-to-svex x ss scopes)))
@@ -4381,7 +4381,7 @@ functions can assume all bits of it are good.</p>"
          (vttree nil)
          (opacity (vl-expr-opacity x))
          (packedp (vl-datatype-packedp type))
-         ((when (and packedp 
+         ((when (and packedp
                      (not (eq opacity :special))
                      (not (vl-expr-case x :vl-pattern))
                      ;; note: qmark might have a pattern inside it
@@ -4399,7 +4399,7 @@ functions can assume all bits of it are good.</p>"
                     nil
                     (svex-x)))
                ((vmv vttree svex ?rhs-size) (vl-expr-to-svex-selfdet x size ss scopes))
-               
+
                ;; ((vmv vttree) (vl-maybe-warn-about-implicit-truncation lhs size x rhs-size ss))
                ((mv & x-selfsize) (vl-expr-selfsize x ss scopes))
                ((unless x-selfsize)
@@ -4934,7 +4934,7 @@ functions can assume all bits of it are good.</p>"
       (mv vttree (cons first rest)
           (cons size1 rest-sizes))))
   ///
-  
+
   (local
    (make-event
     `(in-theory (disable . ,(flag::get-clique-members 'vl-expr-to-svex-vector (w state))))))

--- a/books/centaur/ubdds/param.lisp
+++ b/books/centaur/ubdds/param.lisp
@@ -525,7 +525,7 @@
                                  vars)
                   (bfix-list
                    (take n (nthcdr start vars)))))
-  :hints(("Goal" :in-theory (enable take-redefinition))))
+  :hints(("Goal" :in-theory (enable take))))
 
 (defthm ubdd-listp-make-list-ac
   (equal (ubdd-listp (make-list-ac n nil acc))

--- a/books/centaur/vl/expr.lisp
+++ b/books/centaur/vl/expr.lisp
@@ -2290,14 +2290,14 @@ unnamed (plain) arguments followed by some named arguments.</p>"
                (vl-exprlist-fix (take n x))
              (append (vl-exprlist-fix x)
                      (replicate (- (nfix n) (len x)) nil))))
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable acl2::take))))
 
   (defcong vl-exprlist-equiv vl-exprlist-equiv (list-fix x) 1)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (append x y) 1)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (append x y) 2)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (rev x) 1)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (take n x) 2
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable acl2::take))))
   (defcong vl-exprlist-equiv vl-exprlist-equiv (nthcdr n x) 2))
 
 

--- a/books/centaur/vl/lint/lucid.lisp
+++ b/books/centaur/vl/lint/lucid.lisp
@@ -2551,7 +2551,7 @@ created when we process their packages, etc.</p>"
                       (replicate (- (ifix k) (nfix (- (ifix b) (ifix a)))) nil))))
      :hints(("Goal"
              :induct (ind k a b)
-             :in-theory (enable acl2::take-redefinition ints-from repeat))
+             :in-theory (enable acl2::take ints-from repeat))
             (and stable-under-simplificationp
                  '(:in-theory (enable nfix repeat))))))
 

--- a/books/centaur/vl/mlib/fmt.lisp
+++ b/books/centaur/vl/mlib/fmt.lisp
@@ -367,7 +367,7 @@ formerly the \"location directive\" and printed a location.</p>")
               (<= (acl2-count (take n x))
                   (acl2-count x)))
      :hints (("goal" :induct (nth n x)
-              :in-theory (enable acl2::take-redefinition)))
+              :in-theory (enable acl2::take)))
      :rule-classes :linear))
   (defthm acl2-count-of-vl-fmt-pair-args
     (<= (acl2-count (strip-cdrs (vl-fmt-pair-args args)))

--- a/books/centaur/vl/mlib/stmt-tools.lisp
+++ b/books/centaur/vl/mlib/stmt-tools.lisp
@@ -470,7 +470,8 @@ directly part of the statement.</p>"
   (local (defthmd c3
            (implies (<= (nfix n) (len x))
                     (equal (append (take n x) (nthcdr n (list-fix x)))
-                           (list-fix x)))))
+                           (list-fix x)))
+           :hints (("Goal" :in-theory (enable take)))))
 
   (local (defthm c4
            (implies (<= (nfix n) (len x))
@@ -630,7 +631,8 @@ directly part of the statement.</p>"
   (defthm vl-stmtlist-fix-of-take
     (implies (<= (nfix n) (len x))
              (equal (vl-stmtlist-fix (take n x))
-                    (take n (vl-stmtlist-fix x)))))
+                    (take n (vl-stmtlist-fix x))))
+    :hints (("Goal" :in-theory (enable take))))
 
   (defthm vl-stmtlist-fix-of-nthcdr
     (equal (vl-stmtlist-fix (nthcdr n x))
@@ -933,6 +935,3 @@ process them.</p>"
   :inline t
   :enabled t
   (vl-stmt-case x :vl-timingstmt))
-
-
-

--- a/books/centaur/vl/util/echars.lisp
+++ b/books/centaur/vl/util/echars.lisp
@@ -465,7 +465,7 @@ the interface for constructing echars can be kept simple and bounds-free.</p>
   ;;   (implies (force (<= (nfix n) (len x)))
   ;;            (equal (vl-echarlist->chars (take n x))
   ;;                   (take n (vl-echarlist->chars x))))
-  ;;   :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+  ;;   :hints(("Goal" :in-theory (enable acl2::take))))
   )
 
 

--- a/books/centaur/vl/util/sum-nats.lisp
+++ b/books/centaur/vl/util/sum-nats.lisp
@@ -325,7 +325,7 @@ reasonable default we say the minimum of the empty list is @('0').</p>"
                       (replicate (- (nfix k) (nfix (- (nfix b) (nfix a)))) nil))))
      :hints(("Goal"
              :induct (ind k a b)
-             :in-theory (enable acl2::take-redefinition nats-from)))))
+             :in-theory (enable acl2::take nats-from)))))
 
 
   (encapsulate

--- a/books/centaur/vl2014/expr.lisp
+++ b/books/centaur/vl2014/expr.lisp
@@ -1342,8 +1342,7 @@ place; these annotations can be useful in error messages.</li>
               (implies (and (vl-exprlist-p x)
                             (< (nfix n) (len x)))
                        (vl-exprlist-p (take n x)))
-              :hints(("Goal" :in-theory (enable acl2::take-redefinition
-                                                acl2::take-induction)))))
+              :hints(("Goal" :in-theory (enable acl2::take)))))
      (local (defthm vl-exprlist-p-of-append-tmp
               (implies (and (vl-exprlist-p x)
                             (vl-exprlist-p y))
@@ -1810,14 +1809,14 @@ fairly easily solve the HIDEXPR problem.</p>"
                (vl-exprlist-fix (take n x))
              (append (vl-exprlist-fix x)
                      (replicate (- (nfix n) (len x)) nil))))
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable acl2::take))))
 
   (defcong vl-exprlist-equiv vl-exprlist-equiv (list-fix x) 1)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (append x y) 1)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (append x y) 2)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (rev x) 1)
   (defcong vl-exprlist-equiv vl-exprlist-equiv (take n x) 2
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable acl2::take))))
   (defcong vl-exprlist-equiv vl-exprlist-equiv (nthcdr n x) 2))
 
 

--- a/books/centaur/vl2014/mlib/stmt-tools.lisp
+++ b/books/centaur/vl2014/mlib/stmt-tools.lisp
@@ -447,7 +447,8 @@ directly part of the statement.</p>"
   (local (defthmd c3
            (implies (<= (nfix n) (len x))
                     (equal (append (take n x) (nthcdr n (list-fix x)))
-                           (list-fix x)))))
+                           (list-fix x)))
+           :hints (("Goal" :in-theory (enable take)))))
 
   (local (defthm c4
            (implies (<= (nfix n) (len x))
@@ -582,7 +583,8 @@ directly part of the statement.</p>"
   (defthm vl-stmtlist-fix-of-take
     (implies (<= (nfix n) (len x))
              (equal (vl-stmtlist-fix (take n x))
-                    (take n (vl-stmtlist-fix x)))))
+                    (take n (vl-stmtlist-fix x))))
+    :hints (("Goal" :in-theory (enable take))))
 
   (defthm vl-stmtlist-fix-of-nthcdr
     (equal (vl-stmtlist-fix (nthcdr n x))
@@ -875,6 +877,3 @@ process them.</p>"
   :inline t
   :enabled t
   (eq (vl-stmt-kind x) :vl-timingstmt))
-
-
-

--- a/books/centaur/vl2014/transforms/replicate-insts.lisp
+++ b/books/centaur/vl2014/transforms/replicate-insts.lisp
@@ -468,7 +468,7 @@ re-integrate it.</p>"
                          (<= n (len x)))
                     (all-equalp 1 (vl-exprlist->finalwidths (take n x))))
            :hints(("goal"
-                   :in-theory (e/d (acl2::take-redefinition)
+                   :in-theory (e/d (acl2::take)
                                    (all-equalp))))))
 
   (local (defthm c1
@@ -1271,4 +1271,3 @@ then we try to split it into a list of @('nil')-ranged, simple instances.  If
        (mods (vl-modulelist-replicate x.mods ss)))
     (vl-scopestacks-free)
     (change-vl-design x :mods mods)))
-

--- a/books/centaur/vl2014/util/echars.lisp
+++ b/books/centaur/vl2014/util/echars.lisp
@@ -490,7 +490,7 @@ the interface for constructing echars can be kept simple and bounds-free.</p>
   ;;   (implies (force (<= (nfix n) (len x)))
   ;;            (equal (vl-echarlist->chars (take n x))
   ;;                   (take n (vl-echarlist->chars x))))
-  ;;   :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+  ;;   :hints(("Goal" :in-theory (enable acl2::take))))
   )
 
 

--- a/books/centaur/vl2014/util/prefix-hash.lisp
+++ b/books/centaur/vl2014/util/prefix-hash.lisp
@@ -81,11 +81,11 @@
 
   (defthm prefixp-of-take-prefix-len-1
     (prefixp (take (prefix-len a b) a) a)
-    :hints(("Goal" :in-theory (enable prefixp acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable prefixp acl2::take))))
 
   (defthm prefixp-of-take-prefix-len-2
     (prefixp (take (prefix-len a b) a) b)
-    :hints(("Goal" :in-theory (enable prefixp acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable prefixp acl2::take))))
 
   (defthm prefix-len-of-take
     (implies (and (natp n)
@@ -94,7 +94,7 @@
                     (if (< (prefix-len a x) n)
                         (prefix-len a x)
                       n)))
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable acl2::take))))
 
   (defthm prefix-len-of-butlast
     ;; The hyp is ugly, but butlast has terrible behavior when N is not a natural
@@ -234,7 +234,7 @@
                          (true-listp p))
                     (equal (take (len p) x)
                            p))
-           :hints(("Goal" :in-theory (enable prefixp acl2::take-redefinition)))))
+           :hints(("Goal" :in-theory (enable prefixp acl2::take)))))
 
   (local (defthm l3
            (implies (and (prefixp p x)
@@ -336,5 +336,3 @@
                     (prefixp a key))
                (cons a (cons val (cdr (hons-assoc-equal a alist))))
              (hons-assoc-equal a alist)))))
-
-

--- a/books/centaur/vl2014/util/prefixp.lisp
+++ b/books/centaur/vl2014/util/prefixp.lisp
@@ -98,11 +98,11 @@
 
   (defthm prefixp-of-take-prefix-len-1
     (prefixp (take (prefix-len a b) a) a)
-    :hints(("Goal" :in-theory (enable prefixp acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable prefixp acl2::take))))
 
   (defthm prefixp-of-take-prefix-len-2
     (prefixp (take (prefix-len a b) a) b)
-    :hints(("Goal" :in-theory (enable prefixp acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable prefixp acl2::take))))
 
   (defthm prefix-len-of-take
     (implies (and (natp n)
@@ -111,7 +111,7 @@
                     (if (< (prefix-len a x) n)
                         (prefix-len a x)
                       n)))
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable acl2::take))))
 
   (defthm prefix-len-of-butlast
     ;; The hyp is ugly, but butlast has terrible behavior when N is not a natural
@@ -178,9 +178,3 @@
                   t))
   :hints(("Goal" :in-theory (enable recursive-butlast-1 prefixp)))
   :rule-classes ((:rewrite :backchain-limit-lst 0)))
-
-
-
-
-
-

--- a/books/centaur/vl2014/util/sum-nats.lisp
+++ b/books/centaur/vl2014/util/sum-nats.lisp
@@ -306,7 +306,7 @@ reasonable default we say the minimum of the empty list is @('0').</p>"
                       (replicate (- (nfix k) (nfix (- (nfix b) (nfix a)))) nil))))
      :hints(("Goal"
              :induct (ind k a b)
-             :in-theory (enable acl2::take-redefinition nats-from)))))
+             :in-theory (enable acl2::take nats-from)))))
 
 
   (encapsulate

--- a/books/clause-processors/bindinglist.lisp
+++ b/books/clause-processors/bindinglist.lisp
@@ -224,7 +224,7 @@
                                            (cons (car formals) deleted-formals)))
         ((member (car formals) deleted-formals)
          (lambda-remove-redundant-bindings (cdr formals) (cdr actuals) deleted-formals))
-        (t 
+        (t
          (b* (((mv rest-f rest-a)
                (lambda-remove-redundant-bindings (cdr formals) (cdr actuals) deleted-formals)))
            (mv (cons (car formals) rest-f)
@@ -406,7 +406,7 @@
            (not (intersectp (set-difference-eq a b) b))
            :hints(("Goal" :in-theory (enable intersectp)))))
 
-  
+
   (local (defun lambda-nest-to-bindinglist-correct-ind (x a)
            (b* (((when (or (atom x)
                            (eq (car x) 'quote)
@@ -436,7 +436,7 @@
 
 
 (local (include-book "std/lists/take" :dir :system))
-(local (in-theory (disable take-redefinition)))
+(local (in-theory (disable take)))
 
 (define bindinglist-free-vars ((x bindinglist-p))
   :verify-guards nil
@@ -490,7 +490,7 @@
                   (unify-ev-lst x a2)))
   :hints (("goal" :use ((:functional-instance base-ev-list-when-eval-alists-agree
                          (base-ev unify-ev) (base-ev-list unify-ev-lst))))))
-  
+
 
 
 
@@ -527,7 +527,7 @@
                   (equal (pairlis$ vars (unify-ev-lst vals a))
                          (pairlis$ vars (unify-ev-lst vals b))))
          :hints(("Goal" :induct (pairlis$ vars vals)
-                 :in-theory (enable pairlis$ acl2::take-redefinition simple-term-vars-lst)))))
+                 :in-theory (enable pairlis$ acl2::take simple-term-vars-lst)))))
 
 
 (defthm unify-ev-bindinglist-when-eval-alists-agree-on-free-vars
@@ -666,7 +666,7 @@
   (local (defthm pairlis$-of-unify-ev-lst-take
            (equal (pairlis$ vars (unify-ev-lst (take (len vars) vals) a))
                   (pairlis$ vars (unify-ev-lst vals a)))
-           :hints(("Goal" :in-theory (enable pairlis$ acl2::take-redefinition)
+           :hints(("Goal" :in-theory (enable pairlis$ acl2::take)
                    :induct (pairlis$ vars vals)))))
 
   (defret bindinglist-to-lambda-nest-correct
@@ -693,7 +693,7 @@
                          (vars (simple-term-vars ,(hq rest-body)))
                          (a1 ,(hq impl-alist))
                          (a2  ,(hq spec-alist))))))))))
-    
+
 
 (define bindinglist-to-lambda-nest-aux ((x bindinglist-p)
                                         (body pseudo-termp))
@@ -817,11 +817,3 @@
        '(value-triple :ok)
      (er hard? 'check-b*-binderst-to-bindinglist
          "Check failed!~%"))))
-
-
-
-                       
-                       
-       
-
-         

--- a/books/clause-processors/pseudo-term-fty.lisp
+++ b/books/clause-processors/pseudo-term-fty.lisp
@@ -107,7 +107,7 @@ of term and access the fields; see its documentation for examples.</p>
   ///
   (defthm symbol-listp-of-remove-non-symbols
     (symbol-listp (remove-non-symbols x)))
-  
+
   (defthm remove-non-symbols-when-symbol-listp
     (implies (symbol-listp x)
              (equal (remove-non-symbols x) x))))
@@ -120,7 +120,7 @@ of term and access the fields; see its documentation for examples.</p>
               (remove-corresp-non-symbols (cdr x) (cdr y)))
       (remove-corresp-non-symbols (cdr x) (cdr y))))
   ///
-  
+
   (defthm pseudo-term-listp-of-remove-corresp-non-symbols
     (implies (pseudo-term-listp y)
              (pseudo-term-listp (remove-corresp-non-symbols x y))))
@@ -181,7 +181,7 @@ of term and access the fields; see its documentation for examples.</p>
 
   :flag-local nil
   ///
-  
+
   (local (in-theory (disable pseudo-term-fix
                              pseudo-term-list-fix)))
 
@@ -315,7 +315,7 @@ of term and access the fields; see its documentation for examples.</p>
          (true-list-fix x)))
 
 
-                             
+
 (defxdoc def-ev-pseudo-term-congruence
   :parents (pseudo-term-fty)
   :short "Prove that @(see pseudo-term-fix) is transparent to an evaluator and
@@ -453,7 +453,7 @@ introduced by it.</p>")
   (defthm pseudo-lambda-fix-when-pseudo-lambda-p
     (implies (pseudo-lambda-p x)
              (equal (pseudo-lambda-fix x) x)))
-  
+
   (fty::deffixtype pseudo-lambda :pred pseudo-lambda-p :fix pseudo-lambda-fix :equiv pseudo-lambda-equiv :define t))
 
 (define pseudo-lambda->formals ((x pseudo-lambda-p))
@@ -561,7 +561,7 @@ introduced by it.</p>")
     (implies (not (consp x))
              (equal (pseudo-fn-fix x)
                     (pseudo-fnsym-fix x))))
-  
+
   (fty::deffixtype pseudo-fn :pred pseudo-fn-p :fix pseudo-fn-fix :equiv pseudo-fn-equiv :define t))
 
 
@@ -673,7 +673,7 @@ introduced by it.</p>")
                                        pseudo-termp))))
   (pseudo-var-fix name)
   ///
-    
+
   (defthm kind-of-pseudo-term-var
     (equal (pseudo-term-kind (pseudo-term-var name)) :var))
 
@@ -781,7 +781,7 @@ introduced by it.</p>")
     :hints(("Goal" :in-theory (enable pseudo-term-fncall->fn
                                       pseudo-term-kind)
             :expand ((:free (a b) (pseudo-term-fix (cons a b)))))))
-  
+
   ;; this is kind of a yucky way to do it but it will work without having to
   ;; prove a whole new list of theorems for each evaluator
   (defthm base-ev-of-pseudo-term-fncall
@@ -998,7 +998,7 @@ introduced by it.</p>")
     :hints(("Goal" :in-theory (enable pseudo-term-lambda->body
                                       pseudo-lambda)
             :expand ((:free (a b) (pseudo-term-fix (cons a b)))))))
-  
+
   (defthm base-ev-of-pseudo-term-lambda
     (equal (base-ev (pseudo-term-lambda formals body args) a)
            (base-ev body (pairlis$ formals (base-ev-list args a))))
@@ -1108,7 +1108,7 @@ introduced by it.</p>")
 (local (defthm pseudo-term-listp-of-take
          (implies (pseudo-term-listp x)
                   (pseudo-term-listp (take n x)))
-         :hints(("Goal" :in-theory (enable take-redefinition)))))
+         :hints(("Goal" :in-theory (enable take)))))
 
 (define pseudo-fn-args-fix ((fn pseudo-fn-p)
                             (args pseudo-term-listp))
@@ -1140,7 +1140,7 @@ introduced by it.</p>")
                                            pseudo-lambda-p
                                            pseudo-fn-args-p-when-consp
                                            pseudo-term-fncall)))
-  
+
   (mbe :logic
        (if (consp fn)
            (pseudo-term-lambda (pseudo-lambda->formals fn)
@@ -1192,7 +1192,7 @@ introduced by it.</p>")
                         '((fn   . pseudo-term-call->fn)
                           (args . pseudo-term-call->args))
                         args forms rest-expr)))
-           
+
 (define pseudo-term-const->val ((x pseudo-termp))
   :parents (pseudo-term-quote
             pseudo-term-null)
@@ -1295,7 +1295,7 @@ all the cases and all the accessors that can be used in each case.</p>
                 (pseudo-term-count x)))
     :hints (("goal" :expand ((pseudo-term-count x))))
     :rule-classes :linear)
-  
+
   (defthm pseudo-term-list-count-of-pseudo-term-call->args
     (implies (member (pseudo-term-kind x) '(:fncall :lambda))
              (< (pseudo-term-list-count (pseudo-term-call->args x))

--- a/books/defsort/generic.lisp
+++ b/books/defsort/generic.lisp
@@ -40,7 +40,7 @@
 (local (include-book "std/lists/equiv" :dir :system))
 (local (include-book "std/lists/no-duplicatesp" :dir :system))
 (local (include-book "ihs/ihs-lemmas" :dir :system))
-(local (in-theory (disable floor mod take-redefinition nthcdr)))
+(local (in-theory (disable floor mod take nthcdr)))
 
 (defthmd comparable-mergesort-admission-nthcdr
   (implies (consp (cdr x))
@@ -133,7 +133,7 @@
                    (force (<= (nfix n) (len x))))
               (comparable-listp (take n x)))
      :hints(("Goal"
-             :in-theory (enable take-redefinition)
+             :in-theory (enable take)
              :induct (take n x))))
 
    (defthm comparable-listp-of-nthcdr
@@ -413,7 +413,7 @@
 ;;                         (natp len2))
 ;;                    (equal (NTHCDR len1 (TAKE (+ len1 len2) X))
 ;;                           (TAKE len2 (NTHCDR len1 X))))
-;;           :hints(("Goal" :in-theory (e/d (take-redefinition nthcdr)
+;;           :hints(("Goal" :in-theory (e/d (take nthcdr)
 ;;                                          (open-small-nthcdr
 ;;                                           nthcdr-of-cdr))
 ;;                   :induct (nthcdr len1 x)))
@@ -589,7 +589,7 @@
             (equal (+ (duplicity a (nthcdr n x))
                       (duplicity a (take n x)))
                    (duplicity a x)))
-   :hints(("Goal" :in-theory (enable take-redefinition nthcdr)))))
+   :hints(("Goal" :in-theory (enable take nthcdr)))))
 
 (defthm duplicity-of-comparable-merge
   (equal (duplicity a (comparable-merge x y))
@@ -622,7 +622,7 @@
          (len x))
   :hints(("Goal" :in-theory (e/d ((:i comparable-mergesort)
                                   floor-bounded-by-/)
-                                 (take-redefinition nthcdr))
+                                 (take nthcdr))
           :induct (comparable-mergesort x)
           :expand ((comparable-mergesort x)))))
 
@@ -630,7 +630,7 @@
   (equal (consp (comparable-mergesort x))
          (consp x))
   :hints(("Goal" :in-theory (e/d ((:i comparable-mergesort))
-                                 (take-redefinition nthcdr))
+                                 (take nthcdr))
           :induct (comparable-mergesort x)
           :expand ((comparable-mergesort x)))))
 
@@ -675,7 +675,7 @@
                           (natp len2))
                      (equal (NTHCDR len1 (TAKE (+ len1 len2) X))
                             (TAKE len2 (NTHCDR len1 X))))
-            :hints(("Goal" :in-theory (e/d (take-redefinition nthcdr)
+            :hints(("Goal" :in-theory (e/d (take nthcdr)
                                            (open-small-nthcdr
                                             nthcdr-of-cdr))
                     :induct (nthcdr len1 x)))
@@ -1129,4 +1129,3 @@
                          (x (comparable-mergesort x))
                          (y (comparable-insertsort x))))
            :in-theory (disable compare-equiv-elts-of-unequal-lists))))
-

--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -448,10 +448,9 @@
  note-8-2) for details.</p>
 
  <p>The built-in function @(tsee take) has been redefined exactly along the
- lines suggested by the theorem @('take-redefinition') from
- @('\"books/std/lists/take.lisp\"').  @('Take-redefinition) itself has been
- left in place in order to minimize changes to existing books.  See @(see
- note-8-2) for details.</p>
+ lines suggested by the theorem @('take-redefinition') that was previously
+ introduced in @('\"books/std/lists/take.lisp\"').  This theorem has been now
+ removed.  See @(see note-8-2) for details.</p>
 
  <h4>@(csee std/util)</h4>
 

--- a/books/kestrel/bitcoin/bip39.lisp
+++ b/books/kestrel/bitcoin/bip39.lisp
@@ -149,7 +149,6 @@
     :enable (bip39-entropyp
              bip39-entropy-size-p
              bip39-entropy-fix)
-    :disable acl2::take-redefinition
     :prep-books ((include-book "arithmetic/top-with-meta" :dir :system)))
 
   (defruled values-of-len-of-bip39-entropy-to-word-indexes

--- a/books/kestrel/utilities/lists/prefixp-theorems.lisp
+++ b/books/kestrel/utilities/lists/prefixp-theorems.lisp
@@ -36,7 +36,7 @@
              (equal (take n x)
                     (take n y)))
     :rule-classes nil
-    :enable take-redefinition)
+    :enable take)
 
   (defrule prefixp-of-cdr-cdr
     (implies (and (prefixp x y)

--- a/books/misc/symbol-btree.lisp
+++ b/books/misc/symbol-btree.lisp
@@ -558,7 +558,7 @@ ACL2 !>
                              (take k (nthcdr n x)))
                      (take (+ n k) x)))
      :hints (("goal" :induct (take n x)
-              :in-theory (enable take-redefinition))))
+              :in-theory (enable take))))
 
    (defthm consp-nth-symbol-alist
      (implies (and (symbol-alistp x)

--- a/books/projects/async/arbitration/comp-interl.lisp
+++ b/books/projects/async/arbitration/comp-interl.lisp
@@ -830,7 +830,7 @@
                                len-nthcdr
                                append
                                take-of-too-many
-                               take-redefinition)))))
+                               take)))))
    ))
 
 (defthm booleanp-comp-interl2$in0-act
@@ -2010,7 +2010,7 @@
                                    append
                                    prepend-rec
                                    take-of-too-many
-                                   take-redefinition)))))
+                                   take)))))
 
 (defthmd comp-interl2$functionally-correct
   (b* ((extracted0-st (comp-interl2$extract0 st))
@@ -2153,5 +2153,3 @@
 ;;                      (comp-interl2$out-seq inputs-seq st data-size n)))))
 ;;        state)))
 ;;   )
-
-

--- a/books/projects/async/arbitration/comp-interl1.lisp
+++ b/books/projects/async/arbitration/comp-interl1.lisp
@@ -1995,7 +1995,7 @@
                                    append
                                    prepend-rec
                                    take-of-too-many
-                                   take-redefinition)))))
+                                   take)))))
 
 (defthmd comp-interl$functionally-correct
   (b* ((extracted0-st (comp-interl$extract0 st))
@@ -2049,8 +2049,3 @@
            :use comp-interl$dataflow-correct
            :in-theory (enable comp-interl$valid-st=>st-format
                               comp-interl$de-n))))
-
-
-
-
-

--- a/books/projects/async/arbitration/comp-interl2.lisp
+++ b/books/projects/async/arbitration/comp-interl2.lisp
@@ -1994,8 +1994,7 @@
                                    member
                                    append
                                    prepend-rec
-                                   take-of-too-many
-                                   take-redefinition)))))
+                                   take-of-too-many)))))
 
 (defthmd comp-interl$functionally-correct
   (b* ((extracted0-st (comp-interl$extract0 st))
@@ -2049,8 +2048,3 @@
            :use comp-interl$dataflow-correct
            :in-theory (enable comp-interl$valid-st=>st-format
                               comp-interl$de-n))))
-
-
-
-
-

--- a/books/projects/async/de.lisp
+++ b/books/projects/async/de.lisp
@@ -1350,8 +1350,6 @@
     str::istrprefixp$inline
     str::iprefixp-when-prefixp
     take
-    take-redefinition
     take-of-take-split
     take-of-too-many
     v-threefix))
-

--- a/books/projects/async/fifo/round-robin1.lisp
+++ b/books/projects/async/fifo/round-robin1.lisp
@@ -21,7 +21,7 @@
  (deftheory round-robin1$disabled-rules
    '(if*
      not
-     take-redefinition
+     take
      pairlis$
      strip-cars
      true-listp
@@ -1232,4 +1232,3 @@
 ;; The multi-step input-output relationship
 
 (in-out-stream-lemma round-robin1 :inv t)
-

--- a/books/projects/async/gcd/gcd-body3.lisp
+++ b/books/projects/async/gcd/gcd-body3.lisp
@@ -721,7 +721,7 @@
                                acl2::simplify-products-gather-exponents-<
                                acl2::len-when-prefixp
                                acl2::take-when-prefixp
-                               take-redefinition
+                               take
                                not
                                default-car
                                default-cdr
@@ -885,6 +885,3 @@
              :in-theory (enable gcd-body3$valid-st=>st-format
                                 gcd-body3$de-n))))
   )
-
-
-

--- a/books/projects/async/serial-adder/32-bit-serial-adder-old/32-bit-serial-adder.lisp
+++ b/books/projects/async/serial-adder/32-bit-serial-adder-old/32-bit-serial-adder.lisp
@@ -1212,7 +1212,7 @@
                                          async-adder$inv-st)
                                         (nth
                                          nthcdr
-                                         take-redefinition
+                                         take
                                          open-v-threefix
                                          car-cdr-elim))))))
 
@@ -1269,7 +1269,7 @@
                                          async-adder$inv-st)
                                         (nth
                                          nthcdr
-                                         take-redefinition
+                                         take
                                          open-v-threefix
                                          car-cdr-elim)))))))
 
@@ -1533,7 +1533,7 @@
                                          v-threefix-append)
                                         (nth
                                          nthcdr
-                                         take-redefinition
+                                         take
                                          append-v-threefix
                                          car-cdr-elim))))))
 
@@ -1591,7 +1591,7 @@
                                          v-threefix-append)
                                         (nth
                                          nthcdr
-                                         take-redefinition
+                                         take
                                          append-v-threefix
                                          car-cdr-elim)))))))
 
@@ -2852,4 +2852,3 @@
                               open-fv-serial-sum
                               open-fv-serial-carry
                               car-cdr-elim))))))
-

--- a/books/projects/async/serial-adder/32-bit-serial-adder-old/de.lisp
+++ b/books/projects/async/serial-adder/32-bit-serial-adder-old/de.lisp
@@ -1471,8 +1471,6 @@
     str::istrprefixp$inline
     str::iprefixp-when-prefixp
     take
-    take-redefinition
     take-of-take-split
     take-of-too-many
     v-threefix))
-

--- a/books/projects/async/serial-adder/serial-add.lisp
+++ b/books/projects/async/serial-adder/serial-add.lisp
@@ -29,7 +29,7 @@
      acl2::simplify-products-gather-exponents-<
      acl2::len-when-prefixp
      acl2::take-when-prefixp
-     take-redefinition
+     take
      not
      default-car
      default-cdr
@@ -1087,4 +1087,3 @@
              :in-theory (enable serial-add$valid-st=>st-format
                                 serial-add$de-n))))
   )
-

--- a/books/projects/async/serial-adder/serial-sub.lisp
+++ b/books/projects/async/serial-adder/serial-sub.lisp
@@ -29,7 +29,7 @@
      acl2::simplify-products-gather-exponents-<
      acl2::len-when-prefixp
      acl2::take-when-prefixp
-     take-redefinition
+     take
      not
      default-car
      default-cdr
@@ -1106,4 +1106,3 @@
              :in-theory (enable serial-sub$valid-st=>st-format
                                 serial-sub$de-n))))
   )
-

--- a/books/projects/filesystems/README.md
+++ b/books/projects/filesystems/README.md
@@ -4,8 +4,8 @@ details certain filesystem models and co-simulation tests applied to
 them; instructions for reviewing and executing these tests follow.
 
 Note: The books mentioned below were certified with a development
-snapshot of ACL2, dated 2019-04-17 and identified by commit hash
-d7e8dac3dd41c8b46281b5f26e09f108dbf995fb. The GNU/Linux programs
+snapshot of ACL2, dated 2019-05-02 and identified by commit hash
+4e079e4dc956bfb6301b29bba7f84db696a38186. The GNU/Linux programs
 mkfs.fat, diff, sudo, cp, mkdir, mv, rm, rmdir, stat, unlink, and wc
 are required in order to run the tests, as is the mtools suite of
 programs (version 4.0.18).

--- a/books/projects/filesystems/lofat.lisp
+++ b/books/projects/filesystems/lofat.lisp
@@ -1217,7 +1217,7 @@
 
 (encapsulate
   ()
-  
+
   (local
    (defthm
      update-data-region-alt-lemma-1
@@ -1289,7 +1289,7 @@
                                remember-that-time-with-update-nth
                                by-slice-you-mean-the-whole-cake-2
                                take-of-nthcdr)
-           (append take take-redefinition))
+           (append take))
       :induct (update-data-region fat32-in-memory str len)))))
 
 (defthm
@@ -3435,9 +3435,10 @@
           length (cluster-size fat32-in-memory)))
   :rule-classes :definition
   :hints
-  (("goal" :in-theory (enable get-clusterchain
-                              fati fat-length effective-fat nth
-                              get-clusterchain-alt-lemma-1))))
+  (("goal" :in-theory (e/d (get-clusterchain
+                            fati fat-length effective-fat nth
+                            get-clusterchain-alt-lemma-1)
+                           (take-when-atom)))))
 
 (encapsulate
   ()
@@ -3571,7 +3572,8 @@
   :hints
   (("goal" :in-theory
     (e/d (fat-length fati effective-fat
-                     nth get-clusterchain-contents)))))
+                     nth get-clusterchain-contents)
+         (take-when-atom)))))
 
 (defthm
   get-contents-from-clusterchain-of-update-data-regioni
@@ -3942,7 +3944,7 @@
     :in-theory
     (e/d (fat32-filename-p lofat-to-hifat-helper)
          (nth-of-string=>nats
-          natp-of-cluster-size take-redefinition))
+          natp-of-cluster-size take))
     :induct
     (lofat-to-hifat-helper fat32-in-memory
                                      dir-ent-list entry-limit)))
@@ -4001,7 +4003,7 @@
                            lofat-to-hifat-helper
                            useful-dir-ent-list-p)
          (nth-of-string=>nats natp-of-cluster-size
-                              take-redefinition))
+                              take))
     :induct (lofat-to-hifat-helper
              fat32-in-memory
              dir-ent-list entry-limit))))
@@ -5805,7 +5807,7 @@
                       (bpb_bytspersec fat32-in-memory))
                    90)
                 :initial-element (code-char 0)))))
-  
+
   :instructions ((:dive 1 2 1)
                  :x
                  :up (:rewrite str::explode-of-implode)
@@ -10759,7 +10761,7 @@
                        (:REWRITE NTH-WHEN-ATOM)
                        (:DEFINITION UPDATE-DATA-REGION)
                        (:REWRITE CONSP-OF-TAKE)
-                       (:DEFINITION TAKE-REDEFINITION)
+                       (:DEFINITION TAKE)
                        (:REWRITE
                         RESIZE-FAT-OF-FAT-LENGTH-WHEN-FAT32-IN-MEMORYP
                         . 2)

--- a/books/projects/fm9001/chip.lisp
+++ b/books/projects/fm9001/chip.lisp
@@ -1495,7 +1495,7 @@
                             bvp-is-true-listp
                             bvp-cvzbv
                             v-threefix-bvp
-                            take-redefinition
+                            take
                             f-gates=b-gates
                             open-v-threefix)))))
 

--- a/books/projects/fm9001/de.lisp
+++ b/books/projects/fm9001/de.lisp
@@ -262,7 +262,7 @@
     (vdd                    (list T))
     (vdd-parametric         (list T))
     (vss                    (list NIL))
-    
+
     (otherwise   nil)))
 
 (defun de-primp-apply (fn ins sts)
@@ -1555,7 +1555,6 @@
 
 (deftheory tv-disabled-rules
   '(take
-    take-redefinition
     take-of-take-split
     take-of-too-many
     take-of-len-free
@@ -1567,5 +1566,3 @@
     str::iprefixp-of-cons-left
     str::istrprefixp$inline
     str::iprefixp-when-prefixp))
-
-

--- a/books/projects/x86isa/machine/environment.lisp
+++ b/books/projects/x86isa/machine/environment.lisp
@@ -111,7 +111,7 @@
                     (natp n)
                     (<= n (len xs)))
                (byte-listp (take n xs)))
-      :hints (("Goal" :induct (ACL2::simpler-take-induction n x))))
+      :hints (("Goal" :in-theory (enable take))))
 
     (defthm byte-listp-read-n-bytes-from-string
       (implies (and (natp n)

--- a/books/projects/x86isa/proofs/wordCount/wc.lisp
+++ b/books/projects/x86isa/proofs/wordCount/wc.lisp
@@ -4357,7 +4357,7 @@
   :hints (("Goal" :in-theory (e/d* ()
                                    (word-state
                                     subset-p
-                                    (:definition acl2::take-redefinition)
+                                    (:definition acl2::take)
                                     (:rewrite acl2::car-nthcdr)
                                     (:definition nth)
                                     (:type-prescription file-descriptor-fieldp-implies-natp-offset)
@@ -5114,7 +5114,7 @@
                                     get-prefixes-opener-lemma-group-2-prefix
                                     get-prefixes-opener-lemma-group-3-prefix
                                     get-prefixes-opener-lemma-group-4-prefix
-                                    (:definition acl2::take-redefinition)
+                                    (:definition acl2::take)
                                     (:definition nth)
                                     (:type-prescription file-descriptor-fieldp-implies-natp-offset)
                                     (:rewrite acl2::take-of-too-many)

--- a/books/std/alists/alistp.lisp
+++ b/books/std/alists/alistp.lisp
@@ -113,7 +113,7 @@ Accordingly, you may not really need to reason about @('alistp') at all.</p>"
     (implies (alistp x)
              (equal (alistp (take n x))
                     (<= (nfix n) (len x))))
-    :hints(("Goal" :in-theory (enable take-redefinition))))
+    :hints(("Goal" :in-theory (enable take))))
 
   (defthm alistp-of-nthcdr
     (implies (alistp x)

--- a/books/std/io/take-bytes.lisp
+++ b/books/std/io/take-bytes.lisp
@@ -82,7 +82,7 @@ and also returns the updated state.</p>"
              (equal (mv-nth 0 (take-bytes n channel state))
                     (take n (mv-nth 0 (read-byte$-all channel state)))))
     :hints(("Goal"
-            :in-theory (enable take-redefinition read-byte$-all repeat)
+            :in-theory (enable take read-byte$-all repeat)
             :induct (take-bytes n channel state))))
 
   (defthm mv-nth1-of-take-bytes$

--- a/books/std/lists/all-equalp.lisp
+++ b/books/std/lists/all-equalp.lisp
@@ -129,10 +129,9 @@ consing.</p>
              (equal (all-equalp a (take n x))
                     (or (not a)
                         (<= (nfix n) (len x)))))
-    :hints(("Goal" :in-theory (enable take-redefinition))))
+    :hints(("Goal" :in-theory (enable take))))
 
   (defthm all-equalp-of-nthcdr
     (implies (all-equalp a x)
              (all-equalp a (nthcdr n x)))
     :hints(("Goal" :in-theory (enable nthcdr)))))
-

--- a/books/std/lists/butlast.lisp
+++ b/books/std/lists/butlast.lisp
@@ -36,7 +36,7 @@
 (include-book "abstract")
 (local (include-book "take"))
 
-(local (in-theory (enable take-redefinition)))
+(local (in-theory (enable take)))
 
 (defsection std/lists/butlast
   :parents (std/lists butlast)
@@ -73,4 +73,3 @@
   (def-listp-rule element-list-p-of-butlast
     (implies (element-list-p (double-rewrite x))
              (element-list-p (butlast x n)))))
-

--- a/books/std/lists/nats-equiv.lisp
+++ b/books/std/lists/nats-equiv.lisp
@@ -108,7 +108,7 @@
   (defcong nats-equiv nats-equiv (revappend x y) 2)
 
   (defcong nats-equiv nats-equiv (take n x) 2
-    :hints(("Goal" :in-theory (enable take-redefinition))))
+    :hints(("Goal" :in-theory (enable take))))
 
   (defcong nats-equiv nats-equiv (nthcdr n x) 2)
 
@@ -116,4 +116,3 @@
 
   (defcong nat-equiv nats-equiv (replicate n x) 2
     :hints(("Goal" :in-theory (enable replicate)))))
-

--- a/books/std/lists/prefixp.lisp
+++ b/books/std/lists/prefixp.lisp
@@ -115,7 +115,7 @@ the list @('y')."
   (defthm prefixp-of-take
     (equal (prefixp (take n x) x)
            (<= (nfix n) (len x)))
-    :hints(("Goal" :in-theory (enable acl2::take-redefinition))))
+    :hints(("Goal" :in-theory (enable take))))
 
   (defthm prefixp-reflexive
     (prefixp x x)

--- a/books/std/lists/subseq.lisp
+++ b/books/std/lists/subseq.lisp
@@ -85,7 +85,7 @@ ability to write nice rules about @('subseq-list').</p>
     (implies (natp n)
              (equal (subseq-list x n (len x))
                     (nthcdr n (list-fix x))))
-    :hints(("Goal" :in-theory (enable take-redefinition))))
+    :hints(("Goal" :in-theory (enable take))))
 
 ; We could strengthen the above rules by turning them into something like (take
 ; n (append x (repeat (- start) nil))) in the negative case, but that is

--- a/books/std/lists/take.lisp
+++ b/books/std/lists/take.lisp
@@ -29,62 +29,20 @@
 ;   DEALINGS IN THE SOFTWARE.
 ;
 ; Original author: Jared Davis <jared@kookamara.com>
+; Contributing author: Alessandro Coglio <coglio@kestrel.edu>
 ;
 ; take.lisp
 ; This file was originally part of the Unicode library.
 
 (in-package "ACL2")
+
 (include-book "list-fix")
 (include-book "equiv")
 (local (include-book "std/basic/inductions" :dir :system))
 
-(defun simpler-take-induction (n xs)
-  ;; Not generally meant to be used; only meant for take-induction
-  ;; and take-redefinition.
-  (if (zp n)
-      nil
-    (cons (car xs)
-          (simpler-take-induction (1- n) (cdr xs)))))
-
-
-(in-theory (disable (:definition take)))
-
 (defsection std/lists/take
   :parents (std/lists take)
   :short "Lemmas about @(see take) available in the @(see std/lists) library."
-
-  :long "<p>Through ACL2 Version 8.1, ACL2's built-in definition of @('take')
-was not especially good for reasoning since it was written in terms of the
-tail-recursive function @('first-n-ac').  We provided a much nicer @(see
-definition) rule:</p>
-
-  @(def take-redefinition)
-
-<p>This rule is is now essentially the built-in logical definition of @(tsee
-take), however, so this rule might no longer be necessary.  We also set up an
-analogous @(see induction) rule.</p>"
-
-  (encapsulate
-    ()
-    (local (in-theory (enable take)))
-
-    (local (defthm equivalence-lemma
-             (implies (true-listp acc)
-                      (equal (first-n-ac n xs acc)
-                             (revappend acc (simpler-take-induction n xs))))))
-
-    (defthm take-redefinition
-      (equal (take n x)
-             (if (zp n)
-                 nil
-               (cons (car x)
-                     (take (1- n) (cdr x)))))
-      :rule-classes ((:definition :controller-alist ((TAKE T NIL))))))
-
-  (defthm take-induction t
-    :rule-classes ((:induction
-                    :pattern (take n x)
-                    :scheme (simpler-take-induction n x))))
 
   (defthm consp-of-take
     (equal (consp (take n xs))

--- a/books/std/lists/top.lisp
+++ b/books/std/lists/top.lisp
@@ -85,7 +85,7 @@
                     revappend
                     no-duplicatesp-equal
                     make-character-list
-                    take-redefinition
+                    take
                     nthcdr
                     subseq-list
                     resize-list
@@ -193,5 +193,3 @@ rev), etc.</dd>
 <p>These rules allow for some very powerful equivalence-based reasoning.  When
 introducing new list-processing functions, it is generally a good idea to
 define the appropriate @(see congruence) rules for these relations.</p>")
-
-

--- a/books/std/strings/arithmetic.lisp
+++ b/books/std/strings/arithmetic.lisp
@@ -150,7 +150,7 @@
   (implies (character-listp x)
            (equal (character-listp (take n x))
                   (<= (nfix n) (len x))))
-  :hints(("Goal" :in-theory (enable take-redefinition))))
+  :hints(("Goal" :in-theory (enable take))))
 
 (defthm character-listp-of-rev
   (equal (character-listp (rev x))

--- a/books/std/strings/cat.lisp
+++ b/books/std/strings/cat.lisp
@@ -77,7 +77,7 @@ conses, where @('n') is the length of @('x').</p>"
                      (equal (append (take (- n 1) x) (cons (nth (- n 1) x) y))
                             (append (take n x) y)))
             :hints(("goal"
-                    :in-theory (enable acl2::take-redefinition)
+                    :in-theory (enable acl2::take)
                     :induct (take n x)))))
 
   (defthm append-chars-aux-correct
@@ -269,5 +269,3 @@ and reverse the result string.</p>"
 
   (defcong streqv equal (join x separator) 2)
   (defcong istreqv istreqv (join x separator) 2))
-
-

--- a/books/std/strings/firstn-chars.lisp
+++ b/books/std/strings/firstn-chars.lisp
@@ -33,7 +33,7 @@
 (local (include-book "arithmetic"))
 (local (include-book "std/lists/take" :dir :system))
 (local (include-book "std/lists/equiv" :dir :system))
-(local (in-theory (disable acl2::take-redefinition)))
+(local (in-theory (disable acl2::take)))
 
 (defsection firstn-chars
   :parents (substrings)

--- a/books/std/strings/strrange-equiv.lisp
+++ b/books/std/strings/strrange-equiv.lisp
@@ -88,7 +88,7 @@
   (local (include-book "std/lists/take" :dir :system))
   (local (include-book "std/lists/nthcdr" :dir :system))
 
-  (local (in-theory (disable nth nthcdr acl2::take-redefinition
+  (local (in-theory (disable nth nthcdr acl2::take
                              acl2::take-of-len-free nfix)))
 
   (local (defthm make-character-list-redef
@@ -110,7 +110,7 @@
                       (:free (x y) (nthcdr (+ 1 x) y)))
              :do-not-induct t)))
 
-  
+
   (defthmd strrange-equiv-equals-subseqs-equal
     (equal (strrange-equiv len x xidx y yidx)
            (equal (subseq (str-fix x) (nfix xidx) (+ (nfix len) (nfix xidx)))

--- a/books/std/util/deflist.lisp
+++ b/books/std/util/deflist.lisp
@@ -148,12 +148,12 @@
            (implies (and (member a (take n x))
                          (<= (nfix n) (len x)))
                     (member a x))
-           :hints(("Goal" :in-theory (enable acl2::take-redefinition)))))
+           :hints(("Goal" :in-theory (enable acl2::take)))))
 
   (local (defthm l1
            (implies (<= (nfix n) (len x))
                     (subsetp-equal (take n x) x))
-           :hints(("Goal" :in-theory (enable acl2::take-redefinition)))))
+           :hints(("Goal" :in-theory (enable acl2::take)))))
 
   (defthmd deflist-lemma-subsetp-of-butlast
     (subsetp-equal (butlast x n) x))
@@ -241,9 +241,7 @@
     acl2::default-<-1
     acl2::default-unary-minus
     acl2::unicity-of-0
-    acl2::take-redefinition
-    acl2::take-induction
-    acl2::simpler-take-induction
+    acl2::take
     acl2::list-fix-when-not-consp
     acl2::list-fix-when-true-listp
     acl2::list-fix-of-cons

--- a/books/unicode/read-utf8.lisp
+++ b/books/unicode/read-utf8.lisp
@@ -42,7 +42,7 @@
 
 (local (in-theory (disable signed-byte-p)))
 
-(local (in-theory (disable take-redefinition)))
+(local (in-theory (disable take)))
 
 (local (defthm signed-byte-p-resolver
          (implies (and (integerp n)
@@ -286,7 +286,7 @@
                                       acc)))
   :hints(("Goal"
           :in-theory (e/d (read-utf8-fast utf8=>ustring-fast
-                                          take-redefinition)
+                                          take)
                           (nthcdr-bytes-2
                            nthcdr-bytes-3
                            nthcdr-bytes-4))
@@ -303,7 +303,7 @@
 
 (encapsulate
   ()
-  (local (in-theory (enable take-redefinition)))
+  (local (in-theory (enable take)))
 
   (local (defthm terrible-lemma-1
            (implies (and (integerp x)

--- a/books/workshops/2018/mehta/file-system-m2.lisp
+++ b/books/workshops/2018/mehta/file-system-m2.lisp
@@ -1655,10 +1655,12 @@
                      (+ data-region-index len))
         ac)))
     :hints
-    (("goal" :in-theory (enable take-redefinition
-                                revappend-removal data-regioni))
+    (("goal" :in-theory (e/d (take
+                              revappend-removal data-regioni)
+                             (take-when-atom)))
      ("subgoal *1/2.4'''" :expand (repeat (+ -1 len) nil))
-     ("subgoal *1/2.1'''" :expand (repeat (+ -1 len) nil))))
+     ("subgoal *1/2.1'''" :expand (repeat (+ -1 len) nil))
+     ))
 
   (defthm
     get-dir-ent-helper-correctness-1


### PR DESCRIPTION
[I'm making a PR, instead of pushing directly, to give the community a chance to review, since this affect Std and indirectly many books.]

Now that the built-in definition of TAKE has been changed to be essentially like
TAKE-REDEFINITION in Std, there is no need for this rule to remain, which in
fact was slowing down some proofs. The companion rule TAKE-INDUCTION, an
induction rule based on TAKE-REDEFINITION, has also been removed, because it
should be now equivalent to the built-in induction rule generated by the new
definition of TAKE.

Several books had to be adapted to this change. Occurrences of TAKE-REDEFINITION
(e.g. in hints) have been replaced by TAKE. It was also necessary to enable TAKE
in several proofs that were otherwise failing. An :EXPAND hint also had to be
added to one proof, to force expansion of TAKE in the inductive case of the
proof. In a few places, it was necessary to enable or disable other TAKE-related
rules, such as TAKE-WHEN-ATOM.

While the changes to the books were minimal and all the proofs work, book
authors may want to double-check their files and perhaps tweak things.