### PR TITLE
Changing startjob from bash alias to env variable

### DIFF
--- a/books/build/jenkins/build-single.sh
+++ b/books/build/jenkins/build-single.sh
@@ -26,16 +26,16 @@ fi
 LISP=`which ccl`
 echo "Using LISP = $LISP"
 echo "Making TARGET   = $TARGET"
-echo "Using STARTJOB = `which startjob`"
+echo "Using STARTJOB = $STARTJOB"
 
 echo "Making ACL2"
-startjob -c "nice make acl2 -f books/build/jenkins/Makefile LISP=$LISP &> make.log" \
+$STARTJOB -c "nice make acl2 -f books/build/jenkins/Makefile LISP=$LISP &> make.log" \
   --name "J_CCL_ACL2" \
   --limits "pmem=4gb,nodes=1:ppn=1,walltime=10:00"
 
 echo "Building the books."
 cd books
-startjob -c "nice -n 5 make $TARGET ACL2=$WORKSPACE/saved_acl2 -j $BOOK_PARALLELISM_LEVEL $MAKEOPTS USE_QUICKLISP=1"
+$STARTJOB -c "nice -n 5 make $TARGET ACL2=$WORKSPACE/saved_acl2 -j $BOOK_PARALLELISM_LEVEL $MAKEOPTS USE_QUICKLISP=1"
 
 echo "Build was successful."
 


### PR DESCRIPTION
I don't know how the bash alias ever worked, but changing it to
an environment variable should do the trick.