### PR TITLE
Use env var for startjob in jenkins multi script

### DIFF
--- a/books/build/jenkins/build-multi.sh
+++ b/books/build/jenkins/build-multi.sh
@@ -40,7 +40,7 @@ fi
 
 LISP=`which $LISP`
 echo "Using LISP = $LISP"
-echo "Using STARTJOB = `which startjob`"
+echo "Using STARTJOB = $STARTJOB"
 #echo "Using ACL2_HONS = $ACL2_HONS"
 echo "Using ACL2_PAR  = $ACL2_PAR"
 echo "Using ACL2_REAL    = $ACL2_REAL"
@@ -85,14 +85,14 @@ echo "Making ACL2(${ACL2_SUFFIX})"
 # need to use single-quote to prevent interpolation of the double
 # quotes in the calling shell.  If your startjob is just a wrapper for
 # bash, you'll want to use $* to pass in the arguments to startjob
-startjob -c "make acl2${ACL2_SUFFIX} -f books/build/jenkins/Makefile LISP=$LISP &> make.log" \
+$STARTJOB -c "make acl2${ACL2_SUFFIX} -f books/build/jenkins/Makefile LISP=$LISP &> make.log" \
   --name "J_${LISP}_ACL2${ACL2_SUFFIX}" \
   --limits "pmem=4gb,nodes=1:ppn=1,walltime=10:00"
 
 echo "Building the books."
 cd books
  # inherit USE_QUICKLISP for the following make call
-startjob -c "nice -n 19 time make $TARGET ACL2=$WORKSPACE/saved_acl2$ACL2_SUFFIX -j $BOOK_PARALLELISM_LEVEL $MAKEOPTS"
+$STARTJOB -c "nice -n 19 time make $TARGET ACL2=$WORKSPACE/saved_acl2$ACL2_SUFFIX -j $BOOK_PARALLELISM_LEVEL $MAKEOPTS"
 
 echo "Build was successful."
 


### PR DESCRIPTION
Use environment variable for startjob in jenkin's multiple lisp script.