### PR TITLE
Improve books makefile

### DIFF
--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -50,18 +50,19 @@
 #                 and other miscellaneous tools and macros.  Many users may
 #                 find "basic" to be a convenient starting place.
 #
-#   all           Certifies most books that are not horribly slow, including,
+#   regression    Certifies most books that are not horribly slow, including,
 #                 for instance, most of workshops, projects, the centaur
 #                 books, the jvm models, etc.  Usually, committers to
-#                 acl2-books should run "make all" first.
+#                 acl2-books should run "make regression" first.
 #
-#   almost-everything
-#                 An alias for "all"
-#
-#   everything    A very full build, including very slow books.  Most users
+#   regression-everything
+#                 A very full build, including very slow books.  Most users
 #                 will not want to use this target.  It is useful for, e.g.,
 #                 regression testing before releases.  Note that
-#                 EXCLUDED_PREFIXES may not work with the `everything' target.
+#                 EXCLUDED_PREFIXES may not work with the
+#                 `regression-everything' target.
+#
+#   all           alias for regression-everything
 #
 #   <dirname>     There are targets for many top-level directories, e.g., you
 #                 may run "make coi" to build everything in coi/ directory,
@@ -185,7 +186,7 @@ export ACL2
 .SUFFIXES:
 .SUFFIXES: .cert .lisp
 
-.PHONY: default basic all
+.PHONY: default basic regression
 
 # Keep this before any other target so that default will be the default target
 default: basic
@@ -422,9 +423,9 @@ ifneq ($(ACL2_HAS_REALS), )
 $(info Excluding non-ACL2(r) books: [$(CERT_PL_NON_ACL2R)])
 OK_CERTS := $(filter-out $(CERT_PL_NON_ACL2R), $(OK_CERTS))
 
-all: nonstd/workshops/1999/calculus/book/proof-outline.cert
-all: nonstd/workshops/1999/calculus/book/tree.cert
-all: nonstd/workshops/1999/calculus/book/tree/proof-outline
+regression: nonstd/workshops/1999/calculus/book/proof-outline.cert
+regression: nonstd/workshops/1999/calculus/book/tree.cert
+regression: nonstd/workshops/1999/calculus/book/tree/proof-outline
 
 # Some additional special instructions for generated ACL2(r)-only books.
 nonstd/workshops/1999/calculus/book/proof-outline.cert: nonstd/workshops/1999/calculus/book/tree.cert
@@ -528,6 +529,43 @@ OK_CERTS := $(filter-out $(CERT_PL_USES_QUICKLISP), $(OK_CERTS))
 endif
 
 
+# Books that currently don't certify (or don't certify on some
+# systems), and that we want to work around for the moment:
+BROKEN_BOOKS :=
+
+# The models/y86 books are a special case.  We prefer to include them
+# only with the "all" target, not the "regression" target, since they
+# have large memory requirements -- and then, only for certain host
+# Lisps.  Originally we handled them in a custom way, using old-style
+# Makefiles based on Makefile-generic rather than cert.pl, but then we
+# did not get the benefit of the cert.pl dependency analysis; for
+# example, if arithmetic-5/top.cert was out of date then "make" would
+# not rebuild the models/y86/ books as it should.  So we no longer
+# exclude them in the "egrep -v" command above, instead allowing
+# cert.pl to do its thing.
+
+ifneq ($(ACL2_HAS_HONS), )
+ifneq ($(filter CCL ALLEGRO SBCL, $(ACL2_HOST_LISP)), )
+
+# When the Lisp is not one of those mentioned on the line above, we
+# skip the models/y86/ books, even for the "all" target.  In
+# particular, we exclude GCL: in one ANSI GCL ACL2(h) regression,
+# certification runs were still proceeding after more than 10 hours
+# for each of four books under models/y86/
+# (y86-basic/common/x86-state, y86-two-level/common/x86-state,
+# y86-two-level-abs/common/x86-state-concrete, and
+# y86-basic/py86/popcount), probably because of the demands of
+# def-gl-thm.  Moreover, LispWorks has too small a value for
+# array-dimension-limit to support these certifications.
+
+  BROKEN_BOOKS += $(filter models/y86/%, $(OK_CERTS))
+endif # ifneq ($(filter CCL ALLEGRO SBCL, $(ACL2_HOST_LISP)), )
+endif # ifneq ($(ACL2_HAS_HONS), )
+
+
+OK_CERTS := $(filter-out $(BROKEN_BOOKS), $(OK_CERTS))
+
+
 # SLOW_BOOKS is a list of books that are too slow (or in any way
 # undesirable) to include as part of an ordinary regression.  There
 # are currently comments in some of the corresponding Makefiles that
@@ -536,11 +574,7 @@ endif
 # SLOW_BOOKS is removed from OK_CERTS just below, but later,
 # ACL2_CUSTOM_TARGETS adds its targets to OK_CERTS.
 
-# Before defining SLOW_BOOKS, we define ADDED_BOOKS to be the books
-# that we want to add back in when using target "everything" instead
-# of the default target, "all".
-
-ADDED_BOOKS := \
+SLOW_BOOKS := \
   books/misc/check-acl2-exports.cert \
   coi/defung/defung-stress-long.cert \
   models/jvm/m5/apprentice.cert \
@@ -561,63 +595,22 @@ ADDED_BOOKS := \
 # AND   directory projects/arm/
 # could be added as x86isa is below.
 
-ADDED_BOOKS += $(filter projects/x86isa/%, $(OK_CERTS))
-ADDED_BOOKS += $(filter projects/filesystems/%, $(OK_CERTS))
+SLOW_BOOKS += $(filter projects/x86isa/%, $(OK_CERTS))
+SLOW_BOOKS += $(filter projects/filesystems/%, $(OK_CERTS))
 
-ADDED_BOOK_TARGETS :=
+SLOW_BOOK_TARGETS :=
 
 ifneq ($(ACL2_HAS_HONS), )
-ADDED_BOOK_TARGETS += milawa-test-basic
+SLOW_BOOK_TARGETS += milawa-test-basic
 endif
 
-# Now SLOW_BOOKS is defined as the list above, except that below, we
-# also include in SLOW_BOOKS some books that are too slow for both an
-# ordinary regression (target "all") and an "everything" regression.
-# Then we remove SLOW_BOOKS from regressions, restoring its subset,
-# ADDED_BOOKS, for the "everything" target.
+# Now SLOW_BOOKS is defined as the list above.
+SLOW_BOOKS += $(SLOW_BOOK_TARGETS)
 
-SLOW_BOOKS := $(ADDED_BOOKS) $(ADDED_BOOK_TARGETS)
+# We used to filter out the slow books here. As of mid-2020, we do it later, as
+# part of the `regression` target
+# OK_CERTS := $(filter-out $(SLOW_BOOKS), $(OK_CERTS))
 
-# The models/y86 books are a special case.  We prefer to include them
-# only with the "everything" target, not the "all" target, since they
-# have large memory requirements -- and then, only for certain host
-# Lisps.  Originally we handled them in a custom way, using old-style
-# Makefiles based on Makefile-generic rather than cert.pl, but then we
-# did not get the benefit of the cert.pl dependency analysis; for
-# example, if arithmetic-5/top.cert was out of date then "make" would
-# not rebuild the models/y86/ books as it should.  So we no longer
-# exclude them in the "egrep -v" command above, instead allowing
-# cert.pl to do its thing.
-
-ifneq ($(ACL2_HAS_HONS), )
-ifneq ($(filter CCL ALLEGRO SBCL, $(ACL2_HOST_LISP)), )
-
-# When the Lisp is not one of those mentioned on the line above, we
-# skip the models/y86/ books, even for the "everything" target.  In
-# particular, we exclude GCL: in one ANSI GCL ACL2(h) regression,
-# certification runs were still proceeding after more than 10 hours
-# for each of four books under models/y86/
-# (y86-basic/common/x86-state, y86-two-level/common/x86-state,
-# y86-two-level-abs/common/x86-state-concrete, and
-# y86-basic/py86/popcount), probably because of the demands of
-# def-gl-thm.  Moreover, LispWorks has too small a value for
-# array-dimension-limit to support these certifications.
-
-  ADDED_BOOKS += $(filter models/y86/%, $(OK_CERTS))
-endif # ifneq ($(filter CCL ALLEGRO SBCL, $(ACL2_HOST_LISP)), )
-endif # ifneq ($(ACL2_HAS_HONS), )
-
-# Remove ADDED_BOOKS as necessary because of dependence on Quicklisp,
-# HONS, CCL, etc.:
-ADDED_BOOKS := $(filter $(ADDED_BOOKS), $(OK_CERTS))
-
-OK_CERTS := $(filter-out $(SLOW_BOOKS) models/y86/%, $(OK_CERTS))
-
-
-# Books that currently don't certify (or don't certify on some
-# systems), and that we want to work around for the moment:
-BROKEN_BOOKS :=
-OK_CERTS := $(filter-out $(BROKEN_BOOKS), $(OK_CERTS))
 
 ##############################
 ### Section: Cleaning
@@ -759,7 +752,7 @@ ifeq ($(ACL2_HAS_REALS), )
 # command that is used to define REBUILD_MAKEFILE_BOOKS, above.
 # Otherwise we might make the same file twice, would could cause
 # conflicts if -j is other than 1.  Also: Do not include any targets
-# that we don't always want built with "all".
+# that we don't always want built with "regression".
 
 ACL2_CUSTOM_TARGETS := \
   system/toothbrush/success.txt \
@@ -1139,9 +1132,9 @@ OK_CERTS := $(filter-out $(addsuffix %, $(EXCLUDED_PREFIXES)), $(OK_CERTS))
 # Keep this section at the end, so that all variable definitions have
 # been completed (in particular, for OK_CERTS).
 
-# Warning: ACL2's GNUmakefile uses the "all" target of this Makefile
-# to implement its target, "regression".  So please be careful about
-# making major changes to "all" in this Makefile.
+# Warning: ACL2's GNUmakefile uses the "regression" target of this
+# Makefile to implement its target, "regression".  So please be
+# careful about making major changes to "regression" in this Makefile.
 
 # First, we let the user filter the books by specifying the roots of
 # the forest of books to be certified.  Our implementation reduces
@@ -1181,23 +1174,21 @@ ifeq ($(shell ls workshops 2> /dev/null), )
 OK_CERTS := $(filter-out workshops/%, $(OK_CERTS))
 endif # ifeq ($(realpath workshops), )
 
-all: $(OK_CERTS)
+regression: $(filter-out $(SLOW_BOOKS), $(OK_CERTS))
 
-.PHONY: almost-everything
-almost-everything: all
+# Starting 8/15/2014, regression-everything does not automatically set
+# USE_QUICKLISP=1, even in the HONS case.  In particular, "make
+# regression-everything" no longer makes doc/manual/; for that, specify
+# USE_QUICKLISP=1.  Update as of 7/30/2020: I think USE_QUICKLISP=1 is now the
+# default, so we should probably remove this comment and the couple sentences
+# before it.
+.PHONY: regression-everything
 
-# Starting 8/15/2014, everything does not automatically set USE_QUICKLISP=1,
-# even in the HONS case.  In particular, "make everything" no longer makes
-# doc/manual/; for that, specify USE_QUICKLISP=1.
-.PHONY: everything
+regression-everything: $(OK_CERTS)
 
-#everything:
-#	$(MAKE) all $(ADDED_BOOKS) $(ADDED_BOOK_TARGETS)
+.PHONY: all
 
-# [Jared] I think this is how everything should work.  All of this
-# ADDED_BOOKS stuff seems really complicated. :(
-
-everything: all $(ADDED_BOOKS) $(ADDED_BOOK_TARGETS)
+all: regression-everything
 
 # The critical path report will work only if you have set up certificate timing
 # BEFORE you build the books.  See ./critpath.pl --help for details.
@@ -1440,13 +1431,6 @@ clean: milawa-clean
 dummy:
 	@echo "Making dummy -- nothing to do."
 
-### TEMPORARY code added 7/30/2020 to support changes to ../GNUmakefile;
-### these lines will not be included in the revised version of ./GNUmakefile
-### that should be coming soon from David Rager....
-.PHONY: regression regression-everything
-regression: all
-regression-everything: everything
-
 # We now provide a way (adapted from the old Makefile-generic) for
 # developers to be able to check well-formedness of the ACL2 world
 # after including each book.  Note that we skip two problematic
@@ -1640,7 +1624,7 @@ centaur/getopt/demo2-test.ok: centaur/getopt/demo2 \
 	@cd centaur/getopt; cp demo2-test.out demo2-test.ok
 	@ls -l centaur/getopt/demo2-test.ok
 
-all: centaur/getopt/demo2-test.ok
+regression: centaur/getopt/demo2-test.ok
 
 
 
@@ -1744,7 +1728,12 @@ git_status:
 #    find Lisp files instead of maintaining (by hand) lists of directories.  We
 #    also do not need to manually keep track of dependencies between
 #    directories, etc.
-
+#
+# In 2019/2020, David Rager <ragerdl@defthm.com>, with support from the
+# community, changed the "all" target so that it really builds all of the
+# (non-broken) books.  He also reworked the logic for the "slow book" mechanism,
+# and created a target for contibutors to use when making pull requests/pushes
+# to the ACL2 community github.
 
 
 

--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -57,8 +57,8 @@
 ; Book release notes are sometimes disorganized.
 ; They are often cleaned up before a release.
 
-; Starting with Version 7.3, we no longer maintain release notes
-; note-x-x-books.  Instead, we hope that the ACL2 Community will track
+; Starting with Version 7.3, Matt and J no longer maintain release notes
+; note-x-x-books.  Instead, they hope that the ACL2 Community will track
 ; changes to the books by maintaining note-x-x-books as they go.
 
 (defxdoc release-notes-books
@@ -725,6 +725,12 @@
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
    (xdoc::h3 "Build System Updates")
+
+   (xdoc::p
+    "The books makefile has updated targets.  The new target @('regression')
+    builds what was formerly known as @('all').  The new target
+    @('regression-everything') builds all of the books, and the target @('all')
+    is now an alias for @('regression-everything').")
 
    (xdoc::p
     "By default, @('make') commands for certifying ACL2 books take advantage of


### PR DESCRIPTION
I started down the route of changing GNUmakefile but stopped, because I wasn't sure how to go about testing all of the changes in a reasonable amount of time.  Do I need to test it on every Lisp?  Do I need to test it with every version of ACL2?  Do I need to test all of the different targets?  I did test it on CCL with the default (hons) version of ACL2.

Also, I'd feel more comfortable if someone were to check the logic changes for removing the slow books.  I know it is a change, but is it a reasonable one, and did I implement it correctly?  Please keep in mind that the primary goal is to make the build more maintainable, and having all sorts of random functionality isn't all that important relative to that first goal, imho.

Please don't merge this directly.  I've used "WIP:" as a prefix, which arguably prevents a merge from occurring on gitlab (but this is github).  There's a handful of commits to cherry-pick.

I renamed the regression/pull-request target to "pull-request".  I just figured we should call a smurf a smurf (and only once), but if the community wants to call it "regression" instead, that's quite fine by me.

Thus, I submit this to the community, as a draft, and hope that someone else will pick it up.  There are some obvious changes that still need to occur, like change the documentation to accommodate the new targets (both the documentation in GNUmakefile and the contribution xdoc).  And, I think the community can decide how much testing they think is needed.

Maybe after some feedback I'll be convinced that it's not too much work to just finish it myself.  But, I'm also happy to have someone else finish it :).