### PR TITLE
[Std & FTY] Factor out POS-FIX.

### DIFF
--- a/books/centaur/fty/basetypes.lisp
+++ b/books/centaur/fty/basetypes.lisp
@@ -30,6 +30,7 @@
 
 (in-package "ACL2")
 (include-book "std/basic/defs" :dir :system)
+(include-book "std/basic/pos-fix" :dir :system)
 (include-book "std/lists/list-defuns" :dir :system)
 (include-book "fixtype")
 (local (include-book "std/lists/equiv" :dir :system))
@@ -167,28 +168,6 @@ identity function for execution.</p>"
   (fty::defbasetype symbol-equiv symbolp :topic symbolp)
 
   (defcong symbol-equiv equal (symbol-name x) 1))
-
-
-(defsection pos-fix
-  :parents (fty::basetypes posp)
-  :short "@(call pos-fix) is a fixing function for @(see posp): it is the
-identity for positive integers, or returns 1 for any other object."
-
-  :long "<p>This has no guard.  For better efficiency, see @(see lposfix).</p>"
-
-  (defund pos-fix (x)
-    (declare (xargs :guard t))
-    (if (posp x) x 1))
-
-  (local (in-theory (enable pos-fix)))
-
-  (defthm posp-of-pos-fix
-    (posp (pos-fix x))
-    :rule-classes :type-prescription)
-
-  (defthm pos-fix-when-posp
-    (implies (posp x)
-             (equal (pos-fix x) x))))
 
 
 (defsection pos-equiv

--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -285,6 +285,16 @@
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+   (xdoc::h4 (xdoc::seeurl "std/basic" "Standard Basic Definitions"))
+
+   (xdoc::p
+    "The function @(tsee pos-fix),
+     along with its accompanying theorems and XDOC topic,
+     has been moved from @('[books]/centaur/fty/basetypes.lisp')
+     to a new file @('[books]/std/basic/pos-fix.lisp').")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
    (xdoc::h4 (xdoc::seeurl "stobjs::std/stobjs" "Standard STOBJs Library"))
 
    (xdoc::p

--- a/books/std/basic/pos-fix.lisp
+++ b/books/std/basic/pos-fix.lisp
@@ -1,5 +1,6 @@
 ; Std/basic - Basic definitions
-; Copyright (C) 2008-2013 Centaur Technology
+;
+; Copyright (C) 2014 Centaur Technology
 ;
 ; Contact:
 ;   Centaur Technology Formal Verification Group
@@ -26,23 +27,34 @@
 ;   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 ;   DEALINGS IN THE SOFTWARE.
 ;
-; Original author: Jared Davis <jared@centtech.com>
+; Original author: Sol Swords <sswords@centtech.com>
+; Contributing author: Alessandro Coglio <coglio@kestrel.edu>
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (in-package "ACL2")
-(include-book "bytep")
-(include-book "nibblep")
-(include-book "pos-fix")
-(include-book "defs")
-(include-book "arith-equivs")
-(include-book "two-nats-measure")
-(include-book "intern-in-package-of-symbol")
 
-(defxdoc std/basic
-  :parents (std)
-  :short "A collection of very basic functions that are occasionally
-convenient."
+(include-book "xdoc/top" :dir :system)
 
-  :long "<p>The @('std/basic') library adds a number of very basic definitions
-that are not built into ACL2.  There's very little to this, it's generally just
-a meant to be a home for very simple definitions that don't fit into bigger
-libraries.</p>")
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defsection pos-fix
+  :parents (posp)
+  :short "@(call pos-fix) is a fixing function for @(see posp): it is the
+identity for positive integers, or returns 1 for any other object."
+
+  :long "<p>This has guard @('t').  For better efficiency, see @(see lposfix).</p>"
+
+  (defund pos-fix (x)
+    (declare (xargs :guard t))
+    (if (posp x) x 1))
+
+  (local (in-theory (enable pos-fix)))
+
+  (defthm posp-of-pos-fix
+    (posp (pos-fix x))
+    :rule-classes :type-prescription)
+
+  (defthm pos-fix-when-posp
+    (implies (posp x)
+             (equal (pos-fix x) x))))


### PR DESCRIPTION
The function POS-FIX, along with its accompanying theorems and XDOC topic, has
been moved from [books]/centaur/fty/basetypes.lisp to a new file
[books]/std/basic/pos-fix.lisp, for improved modularity.

:DOC POS-FIX has been slightly modified: (1) the FTY::BASETYPES parent has been
removed because it is now a more general independent topic compared to its role
in FTY, and (2) the wording has been tweaked.