### PR TITLE
add xdoc links from 8.3 relnotes to ecurve, ecdsa, and keccak

### DIFF
--- a/books/acl2s/mode-acl2s-dependencies.lisp
+++ b/books/acl2s/mode-acl2s-dependencies.lisp
@@ -7,7 +7,9 @@
 (begin-book t :ttags :all);$ACL2s-Preamble$|#
 
 ;; Note: This book just gathers in one place all ACL2 books
-;; that need to be certified for acl2s-mode to be used in emacs.
+;; that should be certified to build ACL2s.
+
+;; Books ACL2s depends on.
 (in-package "ACL2")
 
 (include-book "misc/expander" :dir :system)
@@ -53,3 +55,4 @@
 ;;         (include-book "centaur/gl/bfr-satlink" :dir :system :ttags :all)
 ;;         (include-book "centaur/satlink/check-config" :dir :system))
 ;;    '(value-triple :invisible)))
+

--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -142,6 +142,29 @@
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+   (xdoc::h4 "Arithmetic-light library")
+
+   (xdoc::p "The @('[books]/kestrel/arithmetic-light') directory contains a
+   library about arithmetic that aims to be as lightweight as possible.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   (xdoc::h4 "BV (bit vector) library")
+
+   (xdoc::p "The @('[books]/kestrel/bv') directory contains a formalization of
+   bit vectors as natural numbers that underlies several tools developed by
+   Kestrel researchers.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   (xdoc::h4 "BV-Lists library")
+
+   (xdoc::p "The @('[books]/kestrel/bv-lists') directory contains a library
+   about lists of bit vectors, including packing, unpacking, and conversions
+   between lists of bits and lists of bytes.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
    (xdoc::h4 "Centaur meta-reasoning library")
 
    (xdoc::p "The @('centaur/meta') directory contains various new books focused
@@ -164,6 +187,29 @@
     (xdoc::seeurl "crypto::cryptography" "cryptographic") ", "
     (xdoc::seeurl "bitcoin::bitcoin" "Bitcoin") ", and "
     (xdoc::seeurl "ethereum::ethereum" "Ethereum") " libraries.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   (xdoc::h4 "Library-wrappers library")
+
+   (xdoc::p "The @('[books]/kestrel/library-wrappers') directory contains books
+   that aim to improve other libraries by including them and then disabling
+   or replacing rules that may be problematic.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   (xdoc::h4 "Lists-light library")
+
+   (xdoc::p "The @('[books]/kestrel/lists-light') directory contains a
+   library about lists that aims to be as lightweight as possible.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   (xdoc::h4 "Prime-fields library")
+
+   (xdoc::p "The @('[books]/kestrel/prime-fields') directory contains a
+   formalization of prime fields and associated operations.  A prime field is a
+   finite field consisting of the integers modulo some prime p.")
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -274,6 +320,11 @@
      has been added.")
    ;; xdoc to be added later
    ;; (xdoc::seeurl "kdf::pbkdf2-hmac-sha-512")
+
+   (xdoc::p
+    "A sub-library has been added that includes formal specifications for
+    several common padding operations used in cryptography.  The new
+    sub-library is in @('[books]/kestrel/crypto/padding/').")
 
    (xdoc::p
     "A macro @(tsee crypto::definterface-hash) has been added
@@ -441,6 +492,19 @@
    (xdoc::p
     "Some of the native Java implementations of the ACL2 primitive functions
      have been optimized.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+   (xdoc::h4 "Kestrel Utilities")
+
+   (xdoc::p
+    "A new book, @('[books]/kestrel/utilities/smaller-termp'), contains
+     a utility to compare the sizes of terms.")
+
+   (xdoc::p
+    "A new book, @('[books]/kestrel/utilities/equal-of-booleans'), contains
+     rules to break an equality of two booleans into the equivalent conjunction
+     of two implications.")
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -280,7 +280,8 @@
    (xdoc::h4 (xdoc::seeurl "crypto::cryptography" "Cryptographic Library"))
 
    (xdoc::p
-    "A sub-library for elliptic curves has been added,
+    "A " (xdoc::seeurl "ecurve::elliptic-curves" "sub-library for elliptic curves")
+    " has been added,
      which currently contains all the secp256k1 domain parameters,
      and fixtypes for secp256k1 field elements, points, and keys.
      The parameters and the fixtypes that were previously part of the "
@@ -291,8 +292,10 @@
      from the new sub-library.")
 
    (xdoc::p
-    "A sub-library for ECDSA (Elliptic Curve Digital Signature Algorithm)
-     has been added, which curently contains the secp256k1 signing interface,
+    "A " (xdoc::seeurl "ecdsa::elliptic-curve-digital-signature-algorithm"
+		       "sub-library for ECDSA")
+    " (Elliptic Curve Digital Signature Algorithm)
+     has been added, which now contains the secp256k1 signing interface,
      which was previously part of the "
     (xdoc::seeurl "ecurve::secp256k1-interface"
                   "elliptic curve secp256k1 interface") ".")
@@ -303,10 +306,8 @@
     sub-library is in @('[books]/kestrel/crypto/sha-2/').")
 
    (xdoc::p
-    "A sub-library for KECCAK / SHA-3 hash functions
-     has been added.")
-   ;; xdoc to be added later
-   ;; (xdoc::seeurl "keccak::keccak")
+    "A " (xdoc::seeurl "keccak::keccak" "sub-library for KECCAK / SHA-3 hash functions")
+     " has been added.")
 
    (xdoc::p
     "A sub-library has been added that includes formal specifications for

--- a/doc/acl2-code-size.txt
+++ b/doc/acl2-code-size.txt
@@ -1,14 +1,14 @@
 Source files (not including doc.lisp):
 ------------------------------------
   CODE LINES:
-  141159 lines,   6280057 characters
+  141159 lines,   6280045 characters
   COMMENT LINES:
    78877 lines,   4739413 characters
   BLANK LINES:
    33076 lines,     33076 characters
   TOTAL:
-  253112 lines,  11052546 characters
+  253112 lines,  11052534 characters
 ------------------------------------
 Documentation (file books/system/doc/acl2-doc.lisp):
-  127770 lines,   5634923 characters
+  127775 lines,   5635164 characters
 ------------------------------------

--- a/doc/home-page.html
+++ b/doc/home-page.html
@@ -152,7 +152,7 @@ Other Releases</a>
 <center>
 <b><a href="mailto:kaufmann@cs.utexas.edu">Matt Kaufmann</a> and <a href="mailto:moore@cs.utexas.edu">J Strother Moore</a></b><br>
 <a href="http://www.utexas.edu">University of Texas at Austin</a><br>
-August 21, 2019
+August 22, 2019
 </center>
 
 <p>

--- a/other-events.lisp
+++ b/other-events.lisp
@@ -17588,7 +17588,7 @@
                               ((t)
                                `((verify-guards ,name
                                    ,@(and guard-hints
-                                          (list :guard-hints guard-hints)))))
+                                          (list :hints guard-hints)))))
                               ((nil)
                                nil)
                               (otherwise ; '?
@@ -17596,7 +17596,7 @@
                                   ,guard-p
                                   ,name
                                   ,@(and guard-hints
-                                         (list :guard-hints
+                                         (list :hints
                                                guard-hints))))))))))))))))))
 
 (defmacro defun-sk (&whole form name args &rest rest)


### PR DESCRIPTION
add xdoc links from 8.3 relnotes to ecurve, ecdsa, and keccak