### PR TITLE
Small xdoc changes

### DIFF
--- a/books/kestrel/java/atj/code-generation.lisp
+++ b/books/kestrel/java/atj/code-generation.lisp
@@ -953,18 +953,24 @@
    (xdoc::p
     "In the shallow embedding approach,
      ACL2 lambda expressions (i.e. @(tsee let)s)
-     are handled by introducing Java local variables
-     for the formal parameters of the lambda expression
-     and assigning to them the Java expressions
-     generated from the actual parameters of the lambda expression.
+     are handled by assigning the Java expressions
+     generated from the actual parameters of the lambda expression
+     to Java local variables corresponding to the formal parameters.
      This function generates these bindings,
      given the ACL2 variables that are the formal arguments
      and the Java expressions to assign to them.")
    (xdoc::p
     "Prior to calling this function,
+     the variables of all the lambda expressiona have been marked
+     as `new' or `old' via @(tsee atj-mark-term).
+     We extract this mark and use it to generate
+     either a variable declaration with initializer (for `new')
+     or an assignment to an existing variable (for `old').")
+   (xdoc::p
+    "Prior to calling this function,
      the variables of all the lambda expressions have been annotated
      via @(tsee atj-type-annotate-term).
-     Thus, each ACL2 variable name carried its own type,
+     Thus, each ACL2 variable name carries its own type,
      which we use to determine the Java type of the Java variable.")
    (xdoc::p
     "Prior to calling this function,
@@ -975,9 +981,12 @@
   (b* (((when (endp vars)) nil)
        (var (car vars))
        (jexpr (car jexprs))
+       ((mv var new?) (atj-unmark-var var))
        ((mv var type) (atj-type-unannotate-var var))
        (jvar (symbol-name var))
-       (first-jblock (jblock-locvar (atj-type-to-jtype type) jvar jexpr))
+       (first-jblock (if new?
+                         (jblock-locvar (atj-type-to-jtype type) jvar jexpr)
+                       (jblock-asg (jexpr-name jvar) jexpr)))
        (rest-jblock (atj-gen-shallow-let-bindings (cdr vars)
                                                   (cdr jexprs))))
     (append first-jblock rest-jblock)))
@@ -1160,7 +1169,8 @@
     "These code generation functions assume that the ACL2 terms
      have been type-annotated via @(tsee atj-type-annotate-term).
      They also assume that all the variables of the ACL2 terms
-     have been renamed via @(tsee atj-rename-term).
+     have been maked via @(tsee atj-mark-var)
+     and renamed via @(tsee atj-rename-term).
      If the @(':guards') input is @('nil'),
      then all the type annotations consist of
      the type @(':value') of all ACL2 values,
@@ -1769,7 +1779,8 @@
          ((unless term) ; for termination proof
           (mv nil (jexpr-name "dummy") jvar-value-index jvar-result-index))
          ((when (variablep term))
-          (b* (((mv var &) (atj-type-unannotate-var term))
+          (b* (((mv var &) (atj-unmark-var term))
+               ((mv var &) (atj-type-unannotate-var var))
                (jexpr (jexpr-name (symbol-name var)))
                (jexpr (atj-adapt-jexpr-to-type jexpr src-type dst-type)))
             (mv nil jexpr jvar-value-index jvar-result-index)))
@@ -2370,6 +2381,7 @@
        ((mv formals body)
         (atj-pre-translate fn formals body in-types out-type nil guards$ wrld))
        (jmethod-name (atj-gen-shallow-fnname fn curr-pkg))
+       ((mv formals &) (atj-unmark-vars formals))
        ((mv formals &) (atj-type-unannotate-vars formals))
        (jmethod-params (atj-gen-jparamlist (symbol-name-lst formals)
                                            (atj-types-to-jtypes in-types)))

--- a/books/kestrel/java/atj/code-generation.lisp
+++ b/books/kestrel/java/atj/code-generation.lisp
@@ -1168,8 +1168,8 @@
    (xdoc::p
     "These code generation functions assume that the ACL2 terms
      have been type-annotated via @(tsee atj-type-annotate-term).
-     They also assume that all the variables of the ACL2 terms
-     have been maked via @(tsee atj-mark-var)
+     They also assume that all the variables of the ACL2 terms have been marked
+     via @(tsee atj-mark-var-new) and @(tsee atj-mark-var-old),
      and renamed via @(tsee atj-rename-term).
      If the @(':guards') input is @('nil'),
      then all the type annotations consist of

--- a/books/kestrel/java/package.lsp
+++ b/books/kestrel/java/package.lsp
@@ -81,6 +81,7 @@
                          pure-raw-p
                          quote-listp
                          rawp
+                         remove-assocs-eq
                          remove-mbe-exec
                          remove-mbe-logic
                          remove-progn

--- a/books/kestrel/std/system/remove-trivial-vars.lisp
+++ b/books/kestrel/std/system/remove-trivial-vars.lisp
@@ -44,6 +44,12 @@
      Applying this function to the example above yields
      @('((lambda (x) (binary-+ x y)) '3)').")
    (xdoc::p
+    "If all the formal parameters are trivial,
+     we replace the lambda expression with its body.
+     A lambda expression with all trivial formal parameters
+     may not result from hand-written code,
+     but could result from generated code.")
+   (xdoc::p
     "We obtain terms whose lambda expressions may not be closed.
      These do not satisfy @(tsee termp),
      but they still satisfy @(tsee pseudo-termp).
@@ -75,7 +81,8 @@
          ((unless (mbt (equal (len formals)
                               (len actuals)))) nil) ; for termination
          ((mv nontrivial-formals nontrivial-actuals)
-          (remove-trivial-vars-aux formals actuals)))
+          (remove-trivial-vars-aux formals actuals))
+         ((when (eq nontrivial-formals nil)) (remove-trivial-vars body)))
       (fcons-term (make-lambda nontrivial-formals
                                (remove-trivial-vars body))
                   (remove-trivial-vars-lst nontrivial-actuals))))

--- a/books/kestrel/std/system/remove-unused-vars.lisp
+++ b/books/kestrel/std/system/remove-unused-vars.lisp
@@ -52,10 +52,10 @@
          (body (lambda-body fn))
          (actuals (fargs term))
          (body-vars (all-vars body))
-         ((unless (mbt (equal (len formals) (len actuals)))) nil)
-         ((mv formals actuals) (remove-unused-vars-aux formals
-                                                       actuals
-                                                       body-vars))
+         ((unless (mbt (equal (len formals)
+                              (len actuals)))) nil) ; for termination
+         ((mv formals actuals)
+          (remove-unused-vars-aux formals actuals body-vars))
          ((when (eq formals nil)) (remove-unused-vars body))
          (actuals (remove-unused-vars-lst actuals))
          (body (remove-unused-vars body)))

--- a/books/kestrel/std/typed-alists/symbol-symbol-alistp-tests.lisp
+++ b/books/kestrel/std/typed-alists/symbol-symbol-alistp-tests.lisp
@@ -1,0 +1,31 @@
+; Standard Typed Alists Library
+;
+; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Alessandro Coglio (coglio@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "ACL2")
+
+(include-book "symbol-symbol-alistp")
+
+(include-book "misc/assert" :dir :system)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(assert! (symbol-symbol-alistp nil))
+
+(assert! (symbol-symbol-alistp '((a . b))))
+
+(assert! (symbol-symbol-alistp '((t . nil) (:logic . :program))))
+
+(assert! (not (symbol-symbol-alistp 3)))
+
+(assert! (not (symbol-symbol-alistp '(3))))
+
+(assert! (not (symbol-symbol-alistp '((x . y) (2/3 . nil)))))
+
+(assert! (not (symbol-symbol-alistp '((xx . yy) (t . "nil")))))

--- a/books/std/alists/remove-assocs.lisp
+++ b/books/std/alists/remove-assocs.lisp
@@ -123,7 +123,11 @@
 
   (defthm alistp-of-remove-assocs-equal
     (implies (alistp alist)
-             (alistp (remove-assocs-equal keys alist)))))
+             (alistp (remove-assocs-equal keys alist))))
+
+  (defthm symbol-alistp-of-remove-assocs-equal
+    (implies (symbol-alistp alist)
+             (symbol-alistp (remove-assocs-equal keys alist)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
I saw a couple of built-in functions, first-n-ac and make-list-ac, which seemed like they should have documentation topics even if only one line long.