### PR TITLE
[Std/alists] Add a file with theorems about ASSOC-EQUAL.

### DIFF
--- a/books/std/alists/assoc.lisp
+++ b/books/std/alists/assoc.lisp
@@ -1,0 +1,25 @@
+; Standard Association Lists Library
+;
+; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Alessandro Coglio (coglio@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "ACL2")
+
+(include-book "xdoc/top" :dir :system)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defsection std/alists/assoc-equal
+  :parents (std/alists assoc)
+  :short "Theorems about @(tsee assoc-equal)
+          in the @(see std/alists) library."
+
+  (defthm consp-of-assoc-equal
+    (implies (alistp alist)
+             (iff (consp (assoc-equal key alist))
+                  (assoc-equal key alist)))))

--- a/books/std/alists/top.lisp
+++ b/books/std/alists/top.lisp
@@ -59,6 +59,7 @@
 (include-book "remove-assoc-equal")
 (include-book "alist-map-keys")
 (include-book "alist-map-vals")
+(include-book "assoc")
 
 (include-book "alist-defuns")
 


### PR DESCRIPTION
Currently this only contains one theorem. More can be added as needed. The file
includes an XDOC topic that shows the theorem(s).

NOTE: I'm making a PR, instead of pushing directly, because this affects Std. The addition of this theorem was discussed on Slack, and there was no objection, and some conditional support where the condition was that it didn't break many existing books. In fact, `make everything` passes without the need to change any book. I'll merge this in a few days, unless I hear objections.