### PR TITLE
Remove TABs from XDOC strings.

### DIFF
--- a/books/centaur/fty/bitstruct.lisp
+++ b/books/centaur/fty/bitstruct.lisp
@@ -1294,8 +1294,8 @@ correspond to sub-subfields of the subfield type.  For example:</p>
  (defbitstruct toplevel
    ((ss innermost :subfields (saa sbb))
     (tt midlevel  :subfields ((tii (tiaa tibb))
-			      tqq
-			      tjj))))
+                              tqq
+                              tjj))))
  })
 
 <p>For the @('toplevel') bitstruct, this generates the following subfield

--- a/books/centaur/gl/def-gl-rewrite.lisp
+++ b/books/centaur/gl/def-gl-rewrite.lisp
@@ -260,7 +260,7 @@ symbol:</p>
 
 @({
 (cdr (assoc-eq 'gl::run-gified
-	       (table-alist 'gl::latest-greatest-gl-clause-proc (w state))))
+               (table-alist 'gl::latest-greatest-gl-clause-proc (w state))))
 })
 
 <p>For example, this function symbol is 'gl::glcp-run-gified immediately after

--- a/books/centaur/ipasir/ipasir-logic.lisp
+++ b/books/centaur/ipasir/ipasir-logic.lisp
@@ -853,9 +853,9 @@ flags apply to the recursive make of the core solver library.</li>
 > CXXFLAGS= -g -std=c++11 -Wall -DNDEBUG -O3 -fPIC
 > export CXXFLAGS
 70c70
-<       $(CXX) -g  -std=c++11 $(CXXLAGS) \
+< 	$(CXX) -g  -std=c++11 $(CXXLAGS) \
 ---
->       $(CXX) -g  -std=c++11 $(CXXFLAGS) \
+> 	$(CXX) -g  -std=c++11 $(CXXFLAGS) \
  })
 
 <p>After fixing the makefile, run "make".  This should produce

--- a/books/centaur/ipasir/ipasir-logic.lisp
+++ b/books/centaur/ipasir/ipasir-logic.lisp
@@ -853,9 +853,9 @@ flags apply to the recursive make of the core solver library.</li>
 > CXXFLAGS= -g -std=c++11 -Wall -DNDEBUG -O3 -fPIC
 > export CXXFLAGS
 70c70
-< 	$(CXX) -g  -std=c++11 $(CXXLAGS) \
+<       $(CXX) -g  -std=c++11 $(CXXLAGS) \
 ---
-> 	$(CXX) -g  -std=c++11 $(CXXFLAGS) \
+>       $(CXX) -g  -std=c++11 $(CXXFLAGS) \
  })
 
 <p>After fixing the makefile, run "make".  This should produce

--- a/books/ihs/logops-definitions.lisp
+++ b/books/ihs/logops-definitions.lisp
@@ -246,8 +246,8 @@
    (defthm lousy-unsigned-byte-p-of-*-mixed
      ;; Probably won't ever unify with anything.
      (implies (and (unsigned-byte-p n1 a)
-		   (unsigned-byte-p n2 b))
-	      (unsigned-byte-p (+ n1 n2) (* a b)))
+                   (unsigned-byte-p n2 b))
+              (unsigned-byte-p (+ n1 n2) (* a b)))
      :hints((\"Goal\" :use ((:instance upper-bound)))))
   })
 
@@ -1531,4 +1531,3 @@ building the word.</p>"
     (cond
      ((endp bits) 0)
      (t `(LOGAPP 1 ,(car bits) (MAKE-WORD-FROM-BITS ,@(cdr bits)))))))
-

--- a/books/kestrel/crypto/ecdsa/deterministic-ecdsa-secp256k1.lisp
+++ b/books/kestrel/crypto/ecdsa/deterministic-ecdsa-secp256k1.lisp
@@ -1647,9 +1647,9 @@
    (xdoc::p "The call")
    (xdoc::blockquote (xdoc::@call "ecdsa-sign-deterministic-sha-256"))
    (xdoc::p "signs the message @('m')
-	     using <see topic=\"SHA2____SHA-2\">SHA-256</see> both for hashing
-	     the input message and when
-	     applying <see topic=\"HMAC____HMAC\">HMAC</see>.")
+             using <see topic=\"SHA2____SHA-2\">SHA-256</see> both for hashing
+             the input message and when
+             applying <see topic=\"HMAC____HMAC\">HMAC</see>.")
    (xdoc::p "Arguments:")
    (xdoc::ol
     (xdoc::li
@@ -1766,9 +1766,9 @@
    (xdoc::p "The call")
    (xdoc::blockquote (xdoc::@call "ecdsa-sign-deterministic-keccak-256"))
    (xdoc::p "signs the message @('m')
-	     using <see topic=\"KECCAK____KECCAK\">KECCAK-256</see> for hashing the input message,
-	     but using <see topic=\"SHA2____SHA-2\">SHA-256</see> when
-	     applying <see topic=\"HMAC____HMAC\">HMAC</see>.")
+             using <see topic=\"KECCAK____KECCAK\">KECCAK-256</see> for hashing the input message,
+             but using <see topic=\"SHA2____SHA-2\">SHA-256</see> when
+             applying <see topic=\"HMAC____HMAC\">HMAC</see>.")
    (xdoc::p "Arguments:")
    (xdoc::ol
     (xdoc::li

--- a/books/projects/x86isa/machine/decoding-and-spec-utils.lisp
+++ b/books/projects/x86isa/machine/decoding-and-spec-utils.lisp
@@ -855,23 +855,23 @@ the @('fault') field instead.</li>
 
     :short "Calculates effective address when SIB is present."
     :long "<p>Source: Intel Vol. 2A, Table 2-3.</p>
-	   <p>Also see Intel Vol. 2A, Table 2-2 and Figure 2-6.</p>
-	   <p>In 64-bit mode,
-	   we use @('rgfi') to read bases as signed linear addresses,
-	   which encode canonical linear addresses,
-	   which are also effective addresses in 64-bit mode.
-	   In 32-bit mode,
-	   we use @('rr32') to read bases as unsigned effective addresses.</p>
-	   <p>In 64-bit mode,
-	   we use @('rgfi') to read indices as signed 64-bit values.
-	   In 32-bit mode,
-	   we limit them to signed 32-bit values.</p>
-	   <p>Note that, in 32-bit mode,
-	   we call this function only when the address size is 32 bits.
-	   When the address size is 16 bits, there is no SIB byte:
-	   See Intel Vol. 2 Table 2-1.</p>
-	   <p>The displacement is read as a signed values:
-	   see AMD manual, Dec'17, Volume 3, Section 1.5.</p>"
+           <p>Also see Intel Vol. 2A, Table 2-2 and Figure 2-6.</p>
+           <p>In 64-bit mode,
+           we use @('rgfi') to read bases as signed linear addresses,
+           which encode canonical linear addresses,
+           which are also effective addresses in 64-bit mode.
+           In 32-bit mode,
+           we use @('rr32') to read bases as unsigned effective addresses.</p>
+           <p>In 64-bit mode,
+           we use @('rgfi') to read indices as signed 64-bit values.
+           In 32-bit mode,
+           we limit them to signed 32-bit values.</p>
+           <p>Note that, in 32-bit mode,
+           we call this function only when the address size is 32 bits.
+           When the address size is 16 bits, there is no SIB byte:
+           See Intel Vol. 2 Table 2-1.</p>
+           <p>The displacement is read as a signed values:
+           see AMD manual, Dec'17, Volume 3, Section 1.5.</p>"
 
     :returns (mv flg
 		 (non-truncated-memory-address
@@ -991,7 +991,7 @@ the @('fault') field instead.</li>
 		 (increment-rip-by natp)
 		 (x86 x86p :hyp (x86p x86)))
     :short "Calculate the displacement for
-	    16-bit effective address calculation."
+            16-bit effective address calculation."
     :long
     "<p>
      This is according to Intel manual, Mar'17, Vol. 2, Table 2-1.
@@ -1193,17 +1193,17 @@ the @('fault') field instead.</li>
       <p>Quoting Intel Vol. 1 Sec. 3.3.7 (Address Calculations in
       64-Bit Mode):</p>
 
-	<p><em>All 16-bit and 32-bit address calculations are
-	zero-extended in IA-32e mode to form 64-bit addresses. Address
-	calculations are first truncated to the effective address size
-	of the current mode (64-bit mode or compatibility mode), as
-	overridden by any address-size prefix. The result is then
-	zero-extended to the full 64-bit address width. Because of
-	this, 16-bit and 32-bit applications running in compatibility
-	mode can access only the low 4 GBytes of the 64-bit mode
-	effective addresses. Likewise, a 32-bit address generated in
-	64-bit mode can access only the low 4 GBytes of the 64-bit
-	mode effective addresses.</em></p>
+        <p><em>All 16-bit and 32-bit address calculations are
+        zero-extended in IA-32e mode to form 64-bit addresses. Address
+        calculations are first truncated to the effective address size
+        of the current mode (64-bit mode or compatibility mode), as
+        overridden by any address-size prefix. The result is then
+        zero-extended to the full 64-bit address width. Because of
+        this, 16-bit and 32-bit applications running in compatibility
+        mode can access only the low 4 GBytes of the 64-bit mode
+        effective addresses. Likewise, a 32-bit address generated in
+        64-bit mode can access only the low 4 GBytes of the 64-bit
+        mode effective addresses.</em></p>
 
     <p>Also: Intel Vol 1, Section 3.3.7 says that we need
     sign-extended displacements in effective address calculations. In
@@ -1368,8 +1368,8 @@ the @('fault') field instead.</li>
      ;; instruction. For details, see *Z-addressing-method-info* in
      ;; x86isa/utils/decoding-utilities.lisp.
      (num-imm-bytes  :type (unsigned-byte 3)
-		     "Number of immediate bytes (0, 1, 2, or 4)
-		      that follow the sib (or displacement bytes, if any).")
+                     "Number of immediate bytes (0, 1, 2, or 4)
+                      that follow the sib (or displacement bytes, if any).")
      x86)
 
 
@@ -1572,17 +1572,17 @@ reference made from privilege level 3.</blockquote>"
     ((proc-mode     :type (integer 0 #.*num-proc-modes-1*))
      (reg-type      :type (unsigned-byte  1)
        "@('reg-type') is @('*gpr-access*') for GPRs, and
-		   @('*xmm-access*') for XMMs.")
+                   @('*xmm-access*') for XMMs.")
      (operand-size  :type (member 1 2 4 6 8 10 16))
      (inst-ac?      booleanp
                     "@('t') if instruction does alignment checking,
-		   @('nil') otherwise.")
+                   @('nil') otherwise.")
      (memory-ptr?   booleanp
                     "@('t') if the operand is a memory operand of the
-		   form m16:16, m16:32, or m16:64")
+                   form m16:16, m16:32, or m16:64")
      (seg-reg       (integer-range-p 0 *segment-register-names-len* seg-reg)
                     "Register of the segment to read the operand from
-		   (when reading the operand from memory).")
+                   (when reading the operand from memory).")
      (p4?           :type (or t nil)
        "Address-Size Override Prefix Present?")
      (temp-rip      :type (signed-byte   #.*max-linear-address-size*))
@@ -1763,11 +1763,11 @@ reference made from privilege level 3.</blockquote>"
                     "@('t') if instruction does alignment checking, @('nil') otherwise")
      (memory-ptr?   booleanp
                     "@('t') if the operand is a memory operand
-		   of the form m16:16, m16:32, or m16:64")
+                   of the form m16:16, m16:32, or m16:64")
      (operand      :type (integer 0 *))
      (seg-reg       (integer-range-p 0 *segment-register-names-len* seg-reg)
                     "Register of the segment to read the operand from
-		   (when reading the operand from memory).")
+                   (when reading the operand from memory).")
      (addr         :type (signed-byte 64))
      (rex-byte     :type (unsigned-byte 8))
      (r/m          :type (unsigned-byte 3))
@@ -1819,11 +1819,11 @@ reference made from privilege level 3.</blockquote>"
      (operand-size  :type (member 4 8 16))
      (inst-ac?      booleanp
                     "@('t') if instruction does alignment checking,
-		   @('nil') otherwise")
+                   @('nil') otherwise")
      (operand       :type (integer 0 *))
      (seg-reg       (integer-range-p 0 *segment-register-names-len* seg-reg)
                     "Register of the segment to read the operand from
-		   (when reading the operand from memory).")
+                   (when reading the operand from memory).")
      (addr          :type (signed-byte 64))
      (rex-byte      :type (unsigned-byte 8))
      (r/m           :type (unsigned-byte 3))

--- a/books/projects/x86isa/machine/linear-memory.lisp
+++ b/books/projects/x86isa/machine/linear-memory.lisp
@@ -4635,9 +4635,9 @@
 	     (byte-listp (take n xs))))
 
   (define combine-n-bytes ((low  natp "Index of the first byte")
-			   (num  natp "Number of bytes to combine,
-				       starting at @('pos')")
-			   (bytes byte-listp))
+                           (num  natp "Number of bytes to combine,
+                                       starting at @('pos')")
+                           (bytes byte-listp))
     :guard (<= (+ low num) (len bytes))
     :enabled t
     (combine-bytes (take num (nthcdr low bytes)))

--- a/books/projects/x86isa/machine/prefix-modrm-sib-decoding.lisp
+++ b/books/projects/x86isa/machine/prefix-modrm-sib-decoding.lisp
@@ -857,10 +857,10 @@
   (define compute-mandatory-prefix-for-three-byte-opcode
     ((proc-mode          :type (integer 0 #.*num-proc-modes-1*))
      (second-escape-byte :type (unsigned-byte 8)
-			 "Second byte of the three-byte opcode; either
-			 @('0x38') or @('0x3A')")
+                         "Second byte of the three-byte opcode; either
+                         @('0x38') or @('0x3A')")
      (opcode             :type (unsigned-byte 8)
-			 "Third byte of the three-byte opcode")
+                         "Third byte of the three-byte opcode")
      (prefixes           :type (unsigned-byte #.*prefixes-width*)))
 
     :inline t

--- a/books/projects/x86isa/machine/segmentation.lisp
+++ b/books/projects/x86isa/machine/segmentation.lisp
@@ -464,7 +464,7 @@
 	       (lin-addrs "A @('nil')-terminated list of @(tsee i64p)s."))
   :parents (segmentation)
   :short "Translate a sequence of contiguous effective addresses
-	  to linear addresses."
+          to linear addresses."
   :long
   "<p>
    The contiguous effective addresses are

--- a/books/projects/x86isa/tools/execution/init-state.lisp
+++ b/books/projects/x86isa/tools/execution/init-state.lisp
@@ -249,7 +249,7 @@
 (define seg-visiblei-alistp (alst)
   :parents (initialize-x86-state)
   :short "Recognizer for pairs of segment register indices and
-	  values for the visible portions of the registers"
+          values for the visible portions of the registers"
   :long "<p>Note that the register values are required to be @('n16p') </p>"
   :enabled t
 
@@ -289,7 +289,7 @@
 (define seg-hidden-basei-alistp (alst)
   :parents (initialize-x86-state)
   :short "Recognizer for pairs of segment register indices and values for the
-	  hidden portions containing the base addresses of the registers"
+          hidden portions containing the base addresses of the registers"
   :long "<p>Note that the register values are required to be @('n64p') </p>"
   :enabled t
 
@@ -308,7 +308,7 @@
 (define seg-hidden-limiti-alistp (alst)
   :parents (initialize-x86-state)
   :short "Recognizer for pairs of segment register indices and values for the
-	  hidden portions containing the limit value of the registers"
+          hidden portions containing the limit value of the registers"
   :long "<p>Note that the register values are required to be @('n32p') </p>"
   :enabled t
 
@@ -327,7 +327,7 @@
 (define seg-hidden-attri-alistp (alst)
   :parents (initialize-x86-state)
   :short "Recognizer for pairs of segment register indices and values for the
-	  hidden portions containing the attr value of the registers"
+          hidden portions containing the attr value of the registers"
   :long "<p>Note that the register values are required to be @('n16p') </p>"
   :enabled t
 

--- a/books/projects/x86isa/tools/execution/top.lisp
+++ b/books/projects/x86isa/tools/execution/top.lisp
@@ -280,9 +280,9 @@ routine, where we might see an instruction moving the value in
 <code>
 ...
 0000000100000e60 @('<_popcount_32>'):
-   100000e60:	55                     push   %rbp
-   100000e61:	48 89 e5               mov    %rsp,%rbp
-   100000e64:	89 7d fc               mov    %edi,-0x4(%rbp)
+   100000e60:   55                     push   %rbp
+   100000e61:   48 89 e5               mov    %rsp,%rbp
+   100000e64:   89 7d fc               mov    %edi,-0x4(%rbp)
 ...
 </code>
 


### PR DESCRIPTION
I'm making a PR, instead of pushing directly, because this affects books written by others, in particular @MattKaufmann, @jaredcdavis, @solswords, @shigoel, and @bendyarm. If nobody objects, I'll merge this in a few days.

This is a follow-up  to an email sent by @MattKaufmann on the acl2-books mailing list.
