### PR TITLE
Replace PSEUDO-FORMP, used in PSEUDO-GOOD-WORLDP.

### DIFF
--- a/books/kestrel/utilities/system/event-form-lists.lisp
+++ b/books/kestrel/utilities/system/event-form-lists.lisp
@@ -1,6 +1,6 @@
 ; System Utilities -- Event Form Lists
 ;
-; Copyright (C) 2018 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
@@ -15,11 +15,20 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; for compatibility with [books]/system/pseudo-good-worldp.lisp:
+(defun pseudo-event-form-listp (x)
+  (declare (xargs :guard t))
+  (if (atom x)
+      (equal x nil)
+    (and (pseudo-event-formp (car x))
+         (pseudo-event-form-listp (cdr x)))))
+
 (std::deflist pseudo-event-form-listp (x)
   (pseudo-event-formp x)
   :parents (event-forms)
   :short "Recognize true lists whose elements all have the
           <see topic='@(url pseudo-event-formp)'>basic structure
           of an event form</see>."
+  :long (xdoc::topstring-@def "pseudo-event-form-listp")
   :true-listp t
   :elementp-of-nil nil)

--- a/books/kestrel/utilities/system/event-forms.lisp
+++ b/books/kestrel/utilities/system/event-forms.lisp
@@ -34,9 +34,10 @@
    (xdoc::p
     "This is a shallow check.
      Its satisfaction does not guarantee that @('x') is a valid event form."))
-  (and x
+  (and (consp x)
        (true-listp x)
        (symbolp (car x)))
+  :no-function t
   ///
   (defrule pseudo-event-formp-of-cons
     (equal (pseudo-event-formp (cons a b))

--- a/books/system/pseudo-good-worldp.lisp
+++ b/books/system/pseudo-good-worldp.lisp
@@ -4,6 +4,24 @@
 
 (in-package "ACL2")
 
+; This book is used by the book worldp-check.lisp to check the concept of a
+; ``good world'', as discussed below.  If that check fails, proceed as follows.
+
+;   (include-book "pseudo-good-worldp")
+;   (chk-pseudo-good-worldp "pseudo-good-worldp")
+
+; You will typically see an error message of the following form, for some value
+; of N:
+
+;   Bad World detected by PSEUDO-GOOD-WORLDP2:  (nth N ...) is an illegal
+;   triple.
+
+; In the loop, execute (nth N (w state)), which should evaluate to the
+; offending form.  Then you need to figure out why that form causes a failure.
+; (There are other error messages, probably much less common.  The context, in
+; this case PSEUDO-GOOD-WORLDP2, gives you a function to look at as a starting
+; point.)
+
 ; -----------------------------------------------------------------
 
 ; This file defines the concept of a ``good world''.  But we wrestled with the
@@ -242,17 +260,16 @@
       (and (pseudo-function-symbolp (car lst) n)
            (pseudo-function-symbol-listp (cdr lst) n))))
 
-(defun pseudo-formp (x)
-  (or (atom x)
-      (and (consp x)
-           (true-listp x)
-           (symbolp (car x)))))   ; This symbolp could be a macro or a function.
+(defun pseudo-event-formp (x)
+  (and (consp x)
+       (true-listp x)
+       (symbolp (car x)))) ; This symbolp could be a macro or a function.
 
-(defun pseudo-form-listp (x)
+(defun pseudo-event-form-listp (x)
   (if (atom x)
       (equal x nil)
-      (and (pseudo-formp (car x))
-           (pseudo-form-listp (cdr x)))))
+      (and (pseudo-event-formp (car x))
+           (pseudo-event-form-listp (cdr x)))))
 
 (defun string-or-symbol-listp (x)
   (if (atom x)
@@ -294,7 +311,7 @@
                     (natp (cdr (car val))))) ; = d
            (consp (cdr val))
            (if (symbolp (cadr val))    ; ev-type is recoverable from form
-               (pseudo-formp (cdr val))  ; (cdr val) here is the event form
+               (pseudo-event-formp (cdr val))  ; (cdr val) here is the event form
                (and (consp (cadr val))
                     (consp (car (cadr val))) ; (ev-type . skipped-proofs-p)
                     (symbolp (car (car (cadr val)))) ; ev-type
@@ -306,11 +323,18 @@
                         (string-or-symbol-listp (cadr (cadr val)))) ; list of names introduced
                     (member-eq (cddr (cadr val)) ; symbol-class
                                '(nil :program :ideal :common-lisp-compliant))
-                    (pseudo-formp (cddr val))))))) ; (cddr val) here is the event form
+                    (pseudo-event-formp (cddr val))))))) ; (cddr val) here is the event form
 
 ; -----------------------------------------------------------------
 
 ; COMMAND-LANDMARK [GLOBAL-VALUE]
+
+(defun pseudo-command-formp (x)
+
+; We see no reasonable way to restrict the form of a command, other than to
+; insist that it is a true list.
+
+  (true-listp x))
 
 (defun pseudo-command-landmarkp (val)
 
@@ -323,13 +347,13 @@
        (consp (cadr val))
        (if (keywordp (car (cadr val)))
            (and (eq (car (cadr val)) :logic)
-                (pseudo-formp (cdr (cadr val))))
-           (pseudo-formp (cadr val)))
+                (pseudo-command-formp (cdr (cadr val))))
+           (pseudo-command-formp (cadr val)))
        (consp (cddr val))
        (or (null (caddr val))
            (stringp (caddr val)))
        (or (null (cdddr val))
-           (pseudo-formp (cdddr val)))))
+           (pseudo-command-formp (cdddr val)))))
 
 ; -----------------------------------------------------------------
 ; KNOWN-PACKAGE-ALIST [GLOBAL-VALUE]
@@ -645,8 +669,20 @@
                    (eq (car ignorep) 'defstobj)
                    (pseudo-function-symbolp (cdr ignorep) nil)) ; really must be stobj-name
               (null ignorep))
-          (pseudo-form-listp defs)))
-    (& (pseudo-formp val))))
+
+; We could do better than (true-listp defs) below.  For example
+; (pseudo-event-form-listp defs) should be true, as it is defined in late
+; December 2019 (but perhaps it won't be true in the future -- after all, defs
+; is a list of CDRs of events).  Much more should also be true, but in the
+; "pseudo" spirit we keep this simple.
+
+          (true-listp defs)))
+    (&
+
+; We could probably insist that val be a true-listp in this case, but that is
+; such a weak check that given our lack of certainty, we don't bother.
+
+     t)))
 
 ; The value of TOP-LEVEL-CLTL-COMMAND-STACK is a list of CLTL-COMMAND objects.
 
@@ -934,30 +970,28 @@
 
 (defun skip-proofs-seenp (val)
 
-; Legal values are nil, (:include-book full-book-name), or any translatable form which might be
-; found in a skip-proofs.
+; Legal values are nil, (:include-book full-book-name), or any event form.
 
   (or (null val)
       (and (true-listp val)
            (equal (len val) 2)
            (eq (car val) :include-book)
            (stringp (cadr val)))
-      (pseudo-formp val)))
+      (pseudo-event-formp val)))
 
 ; -----------------------------------------------------------------
 ; REDEF-SEEN [GLOBAL-VALUE]
 
 (defun redef-seenp (val)
 
-; Legal values are nil, (:include-book full-book-name), or any translatable form which might be
-; found in a skip-proofs.
+; Legal values are nil, (:include-book full-book-name), or any event form.
 
   (or (null val)
       (and (true-listp val)
            (equal (len val) 2)
            (eq (car val) :include-book)
            (stringp (cadr val)))
-      (pseudo-formp val)))
+      (pseudo-event-formp val)))
 
 ; -----------------------------------------------------------------
 ; CERT-REPLAY [GLOBAL-VALUE]
@@ -2683,8 +2717,11 @@
 ; UNTRANSLATED-THEOREM
 
 (defun untranslated-theoremp (sym val)
+
+; The form of an untranslated theorem is quite arbitrary, because of macros.
+
   (declare (ignore sym))
-  (pseudo-formp val))
+  (true-listp val))
 
 ; -----------------------------------------------------------------
 


### PR DESCRIPTION
This is for @MattKaufmann to merge.

This is in file [books]/system/pseudo-good-worldp.lisp. The changes to this file
have been written by Matt Kaufmann, but I'm the one creating this commit because
of necessary changes in some Kestrel files noted below. The update consists in
replacing PSEUDO-FORMP, which was used for both event and command forms, and
also allowed atoms, with two new functions PSEUDO-EVENT-FORMP and
PSEUDO-COMMAND-FORMP with more specific checks for events and commands; there
are also the -LISTP versions of both predicates, replacing PSEUDO-FORM-LISTP.

The new functions PSEUDO-EVENT-FORMP and PSEUDO-EVENT-FORM-LISTP are equivalent
to the ones in [books]/kestrel/utilities/system/event-forms.lisp and
[books]/kestrel/utilities/event-form-lists.lisp, which have been tweaked in this
commit to be compatible (i.e. redundant) with the ones in
pseudo-good-worldp.lisp.

This is the 1st step of a 3-step plan in which the new functions will be
factored out of pseudo-good-worldp.lisp, and used instead of the ones in the
Kestrel files, which will be removed/deprecated.

This change was prompted by some discussion with Matt and J about
pseudo-good-worldp.listp, and in particular the PSEUDO-FORMP predicate.