### PR TITLE
Factor two functions out of pseudo-good-worldp.lisp.

### DIFF
--- a/books/system/pseudo-event-form-listp.lisp
+++ b/books/system/pseudo-event-form-listp.lisp
@@ -1,0 +1,17 @@
+; Copyright (C) 2013, Regents of the University of Texas
+; Written by Matt Kaufmann and J Strother Moore
+; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
+; Contributions by Alessandro Coglio
+
+(in-package "ACL2")
+
+(include-book "pseudo-event-formp")
+
+; Here we recognize true lists of event forms.  See pseudo-event-form.lisp.
+
+(defun pseudo-event-form-listp (x)
+  (declare (xargs :guard t))
+  (if (atom x)
+      (equal x nil)
+    (and (pseudo-event-formp (car x))
+         (pseudo-event-form-listp (cdr x)))))

--- a/books/system/pseudo-event-formp.lisp
+++ b/books/system/pseudo-event-formp.lisp
@@ -1,0 +1,22 @@
+; Copyright (C) 2013, Regents of the University of Texas
+; Written by Matt Kaufmann and J Strother Moore
+; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
+; Contributions by Alessandro Coglio
+
+(in-package "ACL2")
+
+; Here we formalize some constraints on untranslated event forms.  Because of
+; macros it is almost impossible to put constraints on event forms.  For example,
+; with an appropriate defmacro of barf, this could be a form (barf (1 . 2)).
+; But even macros have to be symbols and take a true list of args.  So we know
+; that much at the top but all bets are off after that.  The most rigorous test
+; would translate the alleged form, but that would require state and the
+; specification of translate's many options like whether stobjs are treated
+; specially.  Until we need it, we're not going to try to formalize the
+; stronger test.
+
+(defun pseudo-event-formp (x)
+  (declare (xargs :guard t))
+  (and (consp x)
+       (true-listp x)
+       (symbolp (car x)))) ; This symbolp could be a macro or a function.

--- a/books/system/pseudo-good-worldp.lisp
+++ b/books/system/pseudo-good-worldp.lisp
@@ -244,16 +244,6 @@
 
 ; EVENT-LANDMARK [GLOBAL-VALUE]
 
-; A ``form'' in the sense used here is an untranslated event or command form or
-; even a raw List form.  Because of macros it is almost impossible to put
-; constraints on forms.  For example, with an appropriate defmacro of barf,
-; this could be a form (barf (1 . 2)).  But even macros have to be symbols and
-; take a true-list of args.  So we know that much at the top but all bets are
-; off after that.  The most rigorous test would translate the alleged form, but
-; that would require state and the specification of translate's many options
-; like whether stobjs are treated specially.  Until we need it, we're not going
-; to try to implement the stronger test.
-
 (defun pseudo-function-symbolp (fn n)
 
 ; The n above is just a placeholder to allow me to record the requirements on

--- a/books/system/pseudo-good-worldp.lisp
+++ b/books/system/pseudo-good-worldp.lisp
@@ -4,6 +4,16 @@
 
 (in-package "ACL2")
 
+; -----------------------------------------------------------------
+
+; The files included here were originally part of this file, but they have been
+; factored out so that they can be used by other files in the community books
+; in a more modular way.
+
+(include-book "pseudo-event-form-listp")
+
+; -----------------------------------------------------------------
+
 ; This book is used by the book worldp-check.lisp to check the concept of a
 ; ``good world'', as discussed below.  If that check fails, proceed as follows.
 
@@ -259,17 +269,6 @@
       (null lst)
       (and (pseudo-function-symbolp (car lst) n)
            (pseudo-function-symbol-listp (cdr lst) n))))
-
-(defun pseudo-event-formp (x)
-  (and (consp x)
-       (true-listp x)
-       (symbolp (car x)))) ; This symbolp could be a macro or a function.
-
-(defun pseudo-event-form-listp (x)
-  (if (atom x)
-      (equal x nil)
-      (and (pseudo-event-formp (car x))
-           (pseudo-event-form-listp (cdr x)))))
 
 (defun string-or-symbol-listp (x)
   (if (atom x)


### PR DESCRIPTION
@MattKaufmann Can you please quickly review and either merge or ask me to make changes?

This was discussed with Matt and J.

The functions PSEUDO-EVENT-FORMP and PSEUDO-EVENT-FORM-LISTP in
[books]/system/pseudo-good-worldp.lisp have been moved to two separate
files. The comment block just after 'EVENT-LANDMARK [GLOBAL-VALUE]' has been
moved to the new file pseudo-event-formp.lisp, and slightly tweaked, since it
essentially referred to event forms.

A :GUARD T declaration has been added to both functions, since they are no
longer under the VERIFY-GUARDS-EAGERNESS 2 setting of pseudo-good-worldp.lisp.
This way, they are still guard-verified.

Now pseudo-good-worldp.lisp includes pseudo-event-form-listp.lisp (which
obviously includes pseudo-event-formp.lisp). A comment has been added just
before this book inclusion in pseudo-good-worldp.lisp.