### PR TITLE
Change regexes for ETAGS invocation so that it gets a few kinds of de…

### DIFF
--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -1623,10 +1623,11 @@ all: centaur/getopt/demo2-test.ok
 # These regular expressions may include things more appropriate for
 # raw Lisp.  May want to remove some of these or extend them to
 # support new types of definitions.
-ETAGS = etags --language=none \
- --ignore-case-regex='/ *set[ \t]?\([^ =]*\)[ \n]*=/\1/' \
- --ignore-case-regex='/(set[^ \t]*[ \t]?\([^ ]*\)[ \t]*/\2/' \
- --ignore-case-regex='/ *(\(memoize\|def[^tc]\|defttag\|deftheory\)[^ \t]*[ \t]?\([^ ]*\)[ \t]*/\2/'
+ETAGS=etags --language=none \
+  --regex='/ *set[ \t]?\([^ =]*\)[ \n]*=/\1/i' \
+  --regex='/(set[^ \t]*[ \t]?\([^ ]*\)[ \t]*/\2/i' \
+  --regex='/ *(memoize[ \t]+\([^ \t\)]*\)[ \t\)]/\1/i' \
+  --regex='/ *(\(def[^t]\|deft[^h]\|defth[^m]\)[^ \t]*[ \t]?\([^ ]*\)[ \t]*/\2/i'
 
 TAGS : $(CERT_PL_SOURCES)
 	@echo "Making TAGS"


### PR DESCRIPTION
…finitions it was previously missing.

The previous regular expressions used for the etags invocation included:
```
def[^tc]\|defttag\|deftheory
```
which seemed like it was intended to omit defthm and defconst events from producing tags, but also had the side effect of omitting several other things that start with "defc" or "deft", such as deftypes, deftagsum, etc.  I have changed this so that it gets everything beginning with "def" except if it begins with "defthm".  Unless I'm missing something it seems harmless to include defconsts.

I also changed from `--ignore-case-regex=//` to `--regex=//i` since the former doesn't seem to be documented whereas the latter is.  Additionally, I split out the regex for `memoize` invocations since they're a bit different than definitions.  I'm not sure if we should really want memoize to generate tags, though.

If this doesn't bother anybody I'll merge it in a day or four.
