### PR TITLE
Hardin 2020 ACL2 Workshop Materials (Try #2)

### DIFF
--- a/books/workshops/2020/hardin/README.md
+++ b/books/workshops/2020/hardin/README.md
@@ -1,0 +1,5 @@
+Simple stack data type implemented using Restricted Algorithmic (RAC), and automatically 
+translated to ACL2, at which point functional correctness proofs can be performed.
+
+Creation of the ACL2 code from the RAC sources requires that RAC tools are built and installed.
+See projects/rac in the ACL2 books directory for more information on RAC.

--- a/books/workshops/2020/hardin/stk-thms.lisp
+++ b/books/workshops/2020/hardin/stk-thms.lisp
@@ -1,0 +1,149 @@
+(in-package "RTL")
+
+(include-book "stk")
+
+(include-book "rtl/rel11/lib/bits" :dir :system)
+
+(include-book "std/lists/update-nth" :dir :system)
+
+(include-book "data-structures/list-defthms" :dir :system)
+
+(include-book "arithmetic-5/top" :dir :system)
+
+(defconst *STK_EXP* 14)
+(defconst *STK_MSB* (1- *STK_EXP*))
+(defconst *STK_VAL_EXP* 63)
+(defconst *STK_MAX_NODE1* (1- (expt 2 *STK_EXP*)))           ;; 16383
+(defconst *STK_MAX_NODE* (1- *STK_MAX_NODE1*))               ;; 16382
+(defconst *STK_MIN_VAL* (- (expt 2 *STK_VAL_EXP*)))          ;; -2**63
+(defconst *STK_MAX_VAL* (1- (expt 2 *STK_VAL_EXP*)))         ;; (2**63 - 1)
+
+(defthmd integerp-forward-to-rationalp--thm
+  (implies (integerp x)
+           (rationalp x))
+  :rule-classes ((:forward-chaining :trigger-terms ((integerp x))) :rewrite))
+
+(defthmd integerp-forward-to-acl2-numberp--thm
+  (implies (integerp x)
+           (acl2-numberp x))
+  :rule-classes ((:forward-chaining :trigger-terms ((integerp x))) :rewrite))
+
+(DEFTHM BITS-UPPER-BOUND
+  (IMPLIES (AND (INTEGERP I) (INTEGERP J))
+           (< (BITS X I J) (EXPT 2 (1+ (- I J)))))
+  :INSTRUCTIONS
+  (:PROMOTE
+   (:CLAIM (AND (NATP (BITS X I J))
+                (< (BITS X I J) (EXPT 2 (1+ (- I J)))))
+           :HINTS (("Goal" :USE (:INSTANCE BITS-BOUNDS))))
+   :BASH)
+  :rule-classes ((:forward-chaining :trigger-terms ((BITS X I J))) :rewrite))
+
+(DEFTHM BITS-UPPER-BOUND-LE
+ (IMPLIES (AND (INTEGERP I) (INTEGERP J) (<= 0 I) (>= i j))
+          (<= (BITS X I j) (1- (EXPT 2 (1+ (- I J))))))
+ :INSTRUCTIONS
+ (:PROMOTE (:CLAIM (INTEGERP (EXPT 2 (1+ (- I J)))))
+           (:CLAIM (< (BITS X I J) (EXPT 2 (1+ (- I J))))
+                   :HINTS (("Goal" :USE (:INSTANCE BITS-UPPER-BOUND))))
+           :BASH)
+  :rule-classes ((:forward-chaining :trigger-terms ((BITS X I J))) :rewrite))
+
+(DEFTHM BITS-ELIM--THM
+  (IMPLIES
+   (AND
+    (INTEGERP X)
+    (INTEGERP I)
+    (<= 0 I)
+    (<= 0 X)
+    (< X (EXPT 2 (1+ I))))
+   (EQUAL (BITS X I 0) X))
+  :hints (("Goal" :in-theory (e/d (bits-mod) ()))))
+
+
+;; STK theorems
+
+(defun stknodeArrp (arr)
+  (or (null arr)
+      (and (integerp (cdr (car arr)))
+           (>= (cdr (car arr)) *STK_MIN_VAL*)
+           (<= (cdr (car arr)) *STK_MAX_VAL*)
+           (stknodeArrp (cdr arr)))))
+
+(defthm stknodeArr-true-listp--thm
+  (implies (stknodeArrp arr)
+           (true-listp arr)))
+
+(defun stkp (Obj)
+  (and (consp Obj)
+       (integerp (ag 'nodeTop Obj))
+       (<= 0 (ag 'nodeTop Obj))
+       (<= (ag 'nodeTop Obj) *STK_MAX_NODE1*)
+       (stknodeArrp (ag 'nodeArr Obj))
+       (<= (len (ag 'nodeArr Obj)) *STK_MAX_NODE1*)))
+
+
+(defun spacep (Obj)
+  (> (ag 'nodeTop Obj) 0))
+
+(defthm bitn-eq-0--thm
+  (implies
+   (AND (INTEGERP R) (integerp N)
+        (>= r 0)
+        (< r (expt 2 n)))
+   (= (bitn r n) 0))
+  :hints (("Goal" :in-theory (e/d (bitn bvecp) ()))))
+
+
+(defthm STK_top-of-STK_push-no-err--thm
+  (implies
+   (and
+    (stkp Obj)
+    (spacep Obj)
+    (acl2::signed-byte-p 64 n))
+   (= (nth 0 (STK_top (STK_push n Obj))) 0)))
+
+(defthm STK_top-of-STK_push-val--thm
+  (implies
+   (and
+    (stkp Obj)
+    (spacep Obj)
+    (acl2::signed-byte-p 64 n))
+   (= (nth 1 (STK_top (STK_push n Obj))) n)))
+
+
+(defthm stk_sz-of-STK_push--thm
+  (implies
+   (and
+    (stkp Obj)
+    (spacep Obj)
+    (acl2::signed-byte-p 64 n))
+   (= (stk_sz (STK_push n Obj))
+      (1+ (stk_sz Obj)))))
+  
+
+(defthm stk_sz-of-STK_pop--thm
+  (implies
+   (and
+    (stkp Obj)
+    (< 0 (stk_sz Obj)))
+   (= (stk_sz (STK_pop Obj)) (1- (stk_sz Obj)))))
+
+;;;
+
+(defthm STK_top-of-STK_pop-of-STK_push-no-err-thm
+  (implies
+   (and
+    (stkp Obj)
+    (spacep Obj)
+    (acl2::signed-byte-p 64 n))
+   (= (nth 0 (STK_top (STK_pop (STK_push n Obj)))) (nth 0 (STK_top Obj)))))
+
+(defthm STK_top-of-STK_pop-of-STK_push-val--thm
+  (implies
+   (and
+    (stkp Obj)
+    (spacep Obj)
+    (acl2::signed-byte-p 64 n))
+   (= (nth 1 (STK_top (STK_pop (STK_push n Obj)))) (nth 1 (STK_top Obj)))))
+

--- a/books/workshops/2020/hardin/stk-thms.lisp
+++ b/books/workshops/2020/hardin/stk-thms.lisp
@@ -1,3 +1,26 @@
+; Copyright (C) 2020 David S. Hardin
+;
+; License: (An MIT/X11-style license)
+;
+;   Permission is hereby granted, free of charge, to any person obtaining a
+;   copy of this software and associated documentation files (the "Software"),
+;   to deal in the Software without restriction, including without limitation
+;   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+;   and/or sell copies of the Software, and to permit persons to whom the
+;   Software is furnished to do so, subject to the following conditions:
+;
+;   The above copyright notice and this permission notice shall be included in
+;   all copies or substantial portions of the Software.
+;
+;   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;   DEALINGS IN THE SOFTWARE.
+
+
 (in-package "RTL")
 
 (include-book "stk")

--- a/books/workshops/2020/hardin/stk.cpp
+++ b/books/workshops/2020/hardin/stk.cpp
@@ -1,0 +1,103 @@
+// RAC example: Simple Array-Based Stack
+
+// Note: Stack grows from high array indices to low array indices for convenience
+
+#define _STK_BODY
+
+#include "stk.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Stack (STK) operators
+// 
+
+// Initialize 'just enough' state
+
+STYP STK_init (STKObj amp(SObj)) {
+  SObj.nodeTop = STK_MAX_NODE1;
+
+  return SVAL;
+}
+
+
+// Restore to factory defaults
+
+STYP STK_initAll (STKObj amp(SObj)) {
+  SObj.nodeTop = STK_MAX_NODE1;
+  for (uint i = 0; i < STK_MAX_NODE1; i++) {
+    SObj.nodeArr[i] = 0;
+  }
+  return SVAL;
+}
+
+
+tuple<ui8, i64> STK_top (STKObj amp(SObj)) {
+  if (SObj.nodeTop == STK_MAX_NODE1) {
+    return tuple<ui8, i64>(STK_OCCUPANCY_ERR, 0);
+  } else {
+    return tuple<ui8, i64>(STK_OK, SObj.nodeArr[SObj.nodeTop]);
+  }
+}
+
+
+tuple<ui8, i64> STK_next (STKObj amp(SObj)) {
+  if ((STK_MAX_NODE1 - SObj.nodeTop) < 2) {
+    return tuple<ui8, i64>(STK_OCCUPANCY_ERR, 0);
+  } else {
+    return tuple<ui8, i64>(STK_OK, SObj.nodeArr[SObj.nodeTop + 1]);
+  }
+}
+
+
+ui14 STK_sz (STKObj amp(SObj)) {
+  return (STK_MAX_NODE1 - SObj.nodeTop);
+}
+
+
+ui14 STK_space (STKObj amp(SObj)) {
+  return SObj.nodeTop;
+}
+
+
+// Remove from head of list
+
+STYP STK_pop (STKObj amp(SObj)) {
+  if (SObj.nodeTop == STK_MAX_NODE1) {
+    return SVAL;
+  } else {
+    SObj.nodeTop++;
+    return SVAL;
+  }
+}
+
+
+STYP STK_popTo (i64 datum, STKObj amp(SObj)) {
+  if ((STK_MAX_NODE1 - SObj.nodeTop) == 0) {
+    return SVAL;
+  } else {
+    ui14 d = 0;
+    uint i;
+    for (i = 0;
+         ((i < (STK_MAX_NODE1 - SObj.nodeTop)) &&
+          SObj.nodeArr[i+ SObj.nodeTop] != datum);
+         i++) {
+      d++;
+    }
+    SObj.nodeTop += d;
+    return SVAL;
+  }
+}
+
+
+// Push to top of stack
+
+STYP STK_push (i64 v, STKObj amp(SObj)) {
+  if (SObj.nodeTop == 0) {
+    return SVAL;
+  } else {
+    SObj.nodeTop--;
+    SObj.nodeArr[SObj.nodeTop] = v;
+    return SVAL;
+  }
+}

--- a/books/workshops/2020/hardin/stk.cpp
+++ b/books/workshops/2020/hardin/stk.cpp
@@ -1,3 +1,26 @@
+// Copyright (C) 2020 David S. Hardin
+//
+// License: (An MIT/X11-style license)
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a
+//   copy of this software and associated documentation files (the "Software"),
+//   to deal in the Software without restriction, including without limitation
+//   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//   and/or sell copies of the Software, and to permit persons to whom the
+//   Software is furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in
+//   all copies or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//   DEALINGS IN THE SOFTWARE.
+
+
 // RAC example: Simple Array-Based Stack
 
 // Note: Stack grows from high array indices to low array indices for convenience

--- a/books/workshops/2020/hardin/stk.h
+++ b/books/workshops/2020/hardin/stk.h
@@ -1,3 +1,26 @@
+// Copyright (C) 2020 David S. Hardin
+//
+// License: (An MIT/X11-style license)
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a
+//   copy of this software and associated documentation files (the "Software"),
+//   to deal in the Software without restriction, including without limitation
+//   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//   and/or sell copies of the Software, and to permit persons to whom the
+//   Software is furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in
+//   all copies or substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//   DEALINGS IN THE SOFTWARE.
+
+
 #ifndef _RAC_SETUP
 
 #include <iostream>

--- a/books/workshops/2020/hardin/stk.h
+++ b/books/workshops/2020/hardin/stk.h
@@ -1,0 +1,99 @@
+#ifndef _RAC_SETUP
+
+#include <iostream>
+#include <ac_int.h>
+#include <rac.h>
+
+using namespace std;
+
+typedef unsigned long uint64; // Just used to facilitate printing
+
+// RAC begin
+
+typedef ac_int<1,false> ui1;
+typedef ac_int<2,false> ui2;
+typedef ac_int<3,false> ui3;
+typedef ac_int<4,false> ui4;
+typedef ac_int<5,false> ui5;
+typedef ac_int<6,false> ui6;
+typedef ac_int<7,false> ui7;
+typedef ac_int<8,false> ui8;
+typedef ac_int<9,false> ui9;
+typedef ac_int<11,false> ui11;
+typedef ac_int<12,false> ui12;
+typedef ac_int<13,false> ui13;
+typedef ac_int<14,false> ui14;
+typedef ac_int<15,false> ui15;
+typedef ac_int<16,false> ui16;
+typedef ac_int<17,false> ui17;
+typedef ac_int<18,false> ui18;
+typedef ac_int<19,false> ui19;
+typedef ac_int<20,false> ui20;
+typedef ac_int<21,false> ui21;
+typedef ac_int<23,false> ui23;
+typedef ac_int<24,false> ui24;
+typedef ac_int<25,false> ui25;
+typedef ac_int<32,false> ui32;
+typedef ac_int<32,true> i32;
+typedef ac_int<64,false> ui64;
+typedef ac_int<64,true> i64;
+
+#define _RAC_SETUP
+
+#else
+#endif
+
+//#define BIG_STRUCT
+
+#ifdef BIG_STRUCT
+#define STYP void
+#define SVAL 
+#define amp(x) &x
+#define SASN
+#else
+#define STYP STKObj
+#define SVAL SObj
+#define amp(x) x
+#define SASN SObj =
+#endif
+
+#define STK_MAX_NODE 16382
+#define STK_MAX_NODE1 (STK_MAX_NODE + 1)
+
+#define STK_OK 0
+#define STK_OCCUPANCY_ERR 255
+
+
+struct STKObj {
+  ui14 nodeTop;
+  array<i64, STK_MAX_NODE1> nodeArr;
+};
+
+
+#ifdef COMPILE_ME
+
+#ifndef _STK_BODY
+
+STYP STK_init (STKObj amp(SObj));
+
+STYP STK_initAll (STKObj amp(SObj));
+
+tuple<ui8, i64> STK_top (STKObj amp(SObj));
+
+tuple<ui8, i64> STK_next (STKObj amp(SObj));
+
+ui14 STK_sz (STKObj amp(SObj));
+
+ui14 STK_space (STKObj amp(SObj));
+
+STYP STK_pop (STKObj amp(SObj));
+
+STYP STK_popTo (i64 datum, STKObj amp(SObj));
+
+STYP STK_push (i64 n, STKObj amp(SObj));
+
+#else
+#endif
+
+#else
+#endif

--- a/books/workshops/2020/hardin/stk.lisp
+++ b/books/workshops/2020/hardin/stk.lisp
@@ -1,0 +1,95 @@
+(IN-PACKAGE "RTL")
+
+(INCLUDE-BOOK "rtl/rel11/lib/rac" :DIR :SYSTEM)
+
+(SET-IGNORE-OK T)
+
+(SET-IRRELEVANT-FORMALS-OK T)
+
+(DEFUN STK_INIT (SOBJ)
+       (AS 'NODETOP
+           (BITS (+ 16382 1) 13 0)
+           SOBJ))
+
+(DEFUN STK_INITALL-LOOP-0 (I SOBJ)
+       (DECLARE (XARGS :MEASURE (NFIX (- (+ 16382 1) I))))
+       (IF (AND (INTEGERP I)
+                (INTEGERP (+ 16382 1))
+                (< I (+ 16382 1)))
+           (LET ((SOBJ (AS 'NODEARR
+                           (AS I (BITS 0 63 0) (AG 'NODEARR SOBJ))
+                           SOBJ)))
+                (STK_INITALL-LOOP-0 (+ I 1) SOBJ))
+           SOBJ))
+
+(DEFUN STK_INITALL (SOBJ)
+       (LET ((SOBJ (AS 'NODETOP
+                       (BITS (+ 16382 1) 13 0)
+                       SOBJ)))
+            (STK_INITALL-LOOP-0 0 SOBJ)))
+
+(DEFUN STK_TOP (SOBJ)
+       (IF1 (LOG= (AG 'NODETOP SOBJ) (+ 16382 1))
+            (MV (BITS 255 7 0) (BITS 0 63 0))
+            (MV (BITS 0 7 0)
+                (AG (AG 'NODETOP SOBJ)
+                    (AG 'NODEARR SOBJ)))))
+
+(DEFUN STK_NEXT (SOBJ)
+       (IF1 (LOG< (- (+ 16382 1) (AG 'NODETOP SOBJ))
+                  2)
+            (MV (BITS 255 7 0) (BITS 0 63 0))
+            (MV (BITS 0 7 0)
+                (AG (+ (AG 'NODETOP SOBJ) 1)
+                    (AG 'NODEARR SOBJ)))))
+
+(DEFUN STK_SZ (SOBJ)
+       (BITS (- (+ 16382 1) (AG 'NODETOP SOBJ))
+             13 0))
+
+(DEFUN STK_SPACE (SOBJ)
+       (AG 'NODETOP SOBJ))
+
+(DEFUN STK_POP (SOBJ)
+       (IF1 (LOG= (AG 'NODETOP SOBJ) (+ 16382 1))
+            SOBJ
+            (AS 'NODETOP
+                (BITS (+ (AG 'NODETOP SOBJ) 1) 13 0)
+                SOBJ)))
+
+(DEFUN STK_POPTO-LOOP-0 (I SOBJ DATUM D)
+       (DECLARE (XARGS :MEASURE (NFIX (- (- (+ 16382 1) (AG 'NODETOP SOBJ))
+                                         I))))
+       (IF (AND (INTEGERP I)
+                (INTEGERP (- (+ 16382 1) (AG 'NODETOP SOBJ)))
+                (AND (< I (- (+ 16382 1) (AG 'NODETOP SOBJ)))
+                     (NOT (EQL (SI (AG (+ I (AG 'NODETOP SOBJ))
+                                       (AG 'NODEARR SOBJ))
+                                   64)
+                               (SI DATUM 64)))))
+           (LET ((D (BITS (+ D 1) 13 0)))
+                (STK_POPTO-LOOP-0 (+ I 1) SOBJ DATUM D))
+           (MV I D)))
+
+(DEFUN STK_POPTO (DATUM SOBJ)
+       (IF1 (LOG= (- (+ 16382 1) (AG 'NODETOP SOBJ))
+                  0)
+            SOBJ
+            (LET ((D (BITS 0 13 0)) (I 0))
+                 (MV-LET (I D)
+                         (STK_POPTO-LOOP-0 0 SOBJ DATUM D)
+                         (AS 'NODETOP
+                             (BITS (+ (AG 'NODETOP SOBJ) D) 13 0)
+                             SOBJ)))))
+
+(DEFUN STK_PUSH (V SOBJ)
+       (IF1 (LOG= (AG 'NODETOP SOBJ) 0)
+            SOBJ
+            (LET ((SOBJ (AS 'NODETOP
+                            (BITS (- (AG 'NODETOP SOBJ) 1) 13 0)
+                            SOBJ)))
+                 (AS 'NODEARR
+                     (AS (AG 'NODETOP SOBJ)
+                         V (AG 'NODEARR SOBJ))
+                     SOBJ))))
+

--- a/books/workshops/2020/hardin/stk.lisp
+++ b/books/workshops/2020/hardin/stk.lisp
@@ -1,3 +1,26 @@
+; Copyright (C) 2020 David S. Hardin
+;
+; License: (An MIT/X11-style license)
+;
+;   Permission is hereby granted, free of charge, to any person obtaining a
+;   copy of this software and associated documentation files (the "Software"),
+;   to deal in the Software without restriction, including without limitation
+;   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+;   and/or sell copies of the Software, and to permit persons to whom the
+;   Software is furnished to do so, subject to the following conditions:
+;
+;   The above copyright notice and this permission notice shall be included in
+;   all copies or substantial portions of the Software.
+;
+;   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+;   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+;   DEALINGS IN THE SOFTWARE.
+
+
 (IN-PACKAGE "RTL")
 
 (INCLUDE-BOOK "rtl/rel11/lib/rac" :DIR :SYSTEM)


### PR DESCRIPTION
A basic example for my talk at the 2020 ACL2 Workshop.

ACL2 books (stk and stk-thms) should certify with standard cert.pl.

The .c and .h files are only "for show" -- the stk.lisp code is generated from them 
using Russinoff's RAC tools, but those tools aren't normally built, and there's no 
reason for the average user to concern themselves with recapitulating the 
C -> ACL2 translation.

Please let me know if there are any issues with these files.


-- David Hardin
