### PR TITLE
Fixing the soundness bug that unary-/ can be interpreted as integer division in Smtlink

### DIFF
--- a/books/projects/smtlink/examples/examples.lisp
+++ b/books/projects/smtlink/examples/examples.lisp
@@ -751,3 +751,21 @@ Possible counter-example found: ((M2 (SOME 0)) (M1 (SOME 0)))
   :hints(("Goal"
           :smtlink (:abstract (abstract-p))))
   :rule-classes nil)
+
+;; Thanks to Andrew Walter and Pete Manolios for providing this bug example.
+;; In this example, it used to be that unary-/ is translated to be integer
+;; division in Z3. Since unary-/ is interpreted as integer division and x >=
+;; 10, 1/x is 0, which makes y 0. We fixed this problem by casting the input of
+;; unary-/ to be real. Check the reciprocal function in ACL2_to_Z3.py for
+;; detail.
+(acl2::must-fail
+ (defthm smt-not-integer-division
+   (implies (and (integerp x)
+                 (integerp y)
+                 (integerp z)
+                 (>= x 10)
+                 (= y (* (unary-/ x) z)))
+            (= y 0))
+   :hints (("goal" :smtlink nil))
+   :rule-classes nil)
+ )

--- a/books/projects/smtlink/z3_interface/ACL2_to_Z3.py
+++ b/books/projects/smtlink/z3_interface/ACL2_to_Z3.py
@@ -81,17 +81,25 @@ class ACL22SMT(object):
     def rationalp(self, x): return sort(x) == RealSort()
     def booleanp(self, x): return sort(x) == BoolSort()
 
+    # manually casting integer sort to real sort
+    def to_real(self, x):
+        if(hasattr(x, 'sort') and x.sort() == IntSort()):
+            return(ToReal(x))
+        else:
+            return(x)
+
     def plus(self, *args): return reduce(lambda x, y: x+y, args)
     def times(self, *args): return reduce(lambda x, y: x*y, args)
 
     def reciprocal(self, x):
         if(type(x) is int): return(Q(1,x))
         elif(type(x) is float): return 1.0/x
-        else: return 1.0/x
+        # Casting variable of IntSort to real
+        else: return 1.0/self.to_real(x)
 
     def negate(self, x): return -x
-    def lt(self, x,y): return x<y
-    def equal(self, x,y): return x==y
+    def lt(self, x,y): return self.to_real(x) < self.to_real(y)
+    def equal(self, x,y): return self.to_real(x) == self.to_real(y)
     def notx(self, x): return Not(x)
     def implies(self, x, y): return Implies(x,y)
     def Qx(self, x, y): return Q(x,y)


### PR DESCRIPTION
Andrew Walter and Pete Manolios have brought to our attention of a soundness bug in Smtlink. It is recommended that theorems depending on Smtlink (especially ones using the macro /)should be recertified using this new version of Smtlink. Sorry for the trouble.

The bug is from how I handled the translation of unary-/. For example, when encountering (unary-/ x) where x is of integerp, Smtlink will translate it into 1.0/x. Z3 does not follow the Python convention but uses integer division in this expression.

In file examples.lisp, the diff is an example showing the soundness problem of this translation. Below theorem gets proved because of this bug.
```
(defthm smt-not-integer-division
   (implies (and (integerp x)
                 (integerp y)
                 (integerp z)
                 (>= x 10)
                 (= y (* (unary-/ x) z)))
            (= y 0))
   :hints (("goal" :smtlink nil))
   :rule-classes nil)
```

In this example, unary-/ is treated as integer division, and because x >= 10, Z3 concludes (unary-/ x) is 0, which makes y 0. Thanks to Andrew and Pete for providing this example.

The fix is to cast the variable x to a real in the expression 1.0/x. The fix can be found in the diff in file ACL2_to_Z3.py.