### PR TITLE
defrule: suppress nil keyword arguments to defthm

### DIFF
--- a/books/build/features.sh
+++ b/books/build/features.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ACL2 Community Books build system
 # Copyright (C) 2019 Centaur Technology


### PR DESCRIPTION
I found this commit lying around on an old branch and figured I'd submit a PR. I ran a regression successfully except that I ran out of "immobile space" in SBCL when building the manual (I'm pretty sure that's unrelated to this change, though).

----

Before this commit, `defrule` would always add keyword arguments `:hints`, `:otf-flg`, and `:instructions` to the generated `defthm` form, even when their values were `nil` (i.e. equal to their default values).  Now it doesn't add those arguments unless they're necessary, which makes `:pe` output a little less verbose.

Before:

```
ACL2 !>:trans1 (defrule foo bar)
 (DEFTHM FOO BAR
         :HINTS NIL
         :OTF-FLG NIL
         :INSTRUCTIONS NIL)
```

After:

```
ACL2 !>:trans1 (defrule foo bar)
 (DEFTHM FOO BAR)
```