### PR TITLE
Reduce deps of leftist trees

### DIFF
--- a/books/projects/leftist-trees/leftist-tree-sort.lisp
+++ b/books/projects/leftist-trees/leftist-tree-sort.lisp
@@ -25,9 +25,11 @@
 
 (in-package "ACL2")
 
-(include-book "sorting/perm" :dir :system)
-(include-book "sorting/ordered-perms" :dir :system)
-(include-book "sorting/convert-perm-to-how-many" :dir :system)
+;;(include-book "sorting/perm" :dir :system)
+;;(include-book "sorting/ordered-perms" :dir :system)
+(include-book "sorting/orderedp" :dir :system)
+(include-book "sorting/how-many" :dir :system)
+(local (include-book "sorting/convert-perm-to-how-many" :dir :system))
 
 (include-book "leftist-tree-defuns")
 (include-book "leftist-tree-defthms")

--- a/books/sorting/convert-perm-to-how-many.lisp
+++ b/books/sorting/convert-perm-to-how-many.lisp
@@ -7,14 +7,7 @@
 
 (include-book "perm")
 
-(defun how-many (e x)
-  (cond
-   ((endp x)
-    0)
-   ((equal e (car x))
-    (1+ (how-many e (cdr x))))
-   (t
-    (how-many e (cdr x)))))
+(include-book "how-many")
 
 ; We aim to prove that (perm x y) is the same as checking that for all e,
 ; (how-many e x) is (how-many e y).  We can do that by defining the function
@@ -104,7 +97,3 @@
            ((:instance perm-counter-example-is-counterexample-for-true-lists
                        (x (tlfix x))
                        (y (tlfix y)))))))
-
-
-
-

--- a/books/sorting/how-many.lisp
+++ b/books/sorting/how-many.lisp
@@ -1,0 +1,10 @@
+(in-package "ACL2")
+
+(defun how-many (e x)
+  (cond
+   ((endp x)
+    0)
+   ((equal e (car x))
+    (1+ (how-many e (cdr x))))
+   (t
+    (how-many e (cdr x)))))

--- a/books/sorting/ordered-perms.lisp
+++ b/books/sorting/ordered-perms.lisp
@@ -4,13 +4,7 @@
 
 (include-book "perm")
 
-(defun orderedp (x)
-       (if (endp x)
-           t
-         (if (endp (cdr x))
-             t
-           (and (lexorder (car x) (car (cdr x)))
-                (orderedp (cdr x))))))
+(include-book "orderedp")
 
 (encapsulate nil
              (local (defthm orderedp-rm
@@ -49,4 +43,3 @@
                         (equal (equal a b)
                                (perm a b)))
                :rule-classes nil))
-

--- a/books/sorting/orderedp.lisp
+++ b/books/sorting/orderedp.lisp
@@ -1,0 +1,9 @@
+(in-package "ACL2")
+
+(defun orderedp (x)
+  (if (endp x)
+      t
+    (if (endp (cdr x))
+        t
+      (and (lexorder (car x) (car (cdr x)))
+           (orderedp (cdr x))))))


### PR DESCRIPTION
This pull request deals with an upcoming name conflict on 'perm'.  The
leftist-trees project brings in a definition of perm from books/sorting/.
However, leftist-trees doesn't need to export anything involving perm.
Furthermore, this version of perm comes into the manual only via leftist-trees.

The changes are in two parts:

1. In books/sorting/, split two functions, how-many and orderedp, into separate
small books containing only these definitions.

2. Change leftist-trees to include these new, smaller books (non-locally) and
to include a book about perm only locally.

The result is that the version of perm from books/sorting/ is not in the manual
and so doesn't conflict with the one in books/kestrel/lists-light/perm (which
we use fairly extensively, including in material we hope to add to the manual
soon).

These changes could be considered beneficial in their own right, since they
make leftist-trees more usable (less likely to conflict with a user's books).
