### PR TITLE
Remove a redundant lemma

### DIFF
--- a/books/std/lists/list-defuns.lisp
+++ b/books/std/lists/list-defuns.lisp
@@ -309,38 +309,16 @@
 
 (encapsulate
   ()
-  (local (defun simpler-take-induction (n xs)
-           (if (zp n)
-               nil
-             (cons (car xs)
-                   (simpler-take-induction (1- n) (cdr xs))))))
-
-  (local (defthm equivalence-lemma
-           (implies (true-listp acc)
-                    (equal (first-n-ac n xs acc)
-                           (revappend acc (simpler-take-induction n xs))))))
-
-  (local (defthm take-redefinition
-           (equal (take n x)
-                  (if (zp n)
-                      nil
-                    (cons (car x)
-                          (take (1- n) (cdr x)))))
-           :rule-classes ((:definition :controller-alist ((TAKE T NIL))))))
-
-  (local (in-theory (disable take)))
 
   (local (defthm take-when-atom
            (implies (atom x)
                     (equal (take n x)
                            (replicate n nil)))
            :hints(("Goal"
-                   :induct (simpler-take-induction n x)
                    :in-theory (enable replicate)))))
 
   (verify-guards first-n
     :hints(("Goal" :in-theory (enable replicate)))))
-
 
 (defun same-lengthp (x y)
   (declare (xargs :guard t))

--- a/books/std/lists/sets.lisp
+++ b/books/std/lists/sets.lisp
@@ -352,12 +352,6 @@ heavier-weight (but not necessarily recommended) alternative is to use the
     (and (subsetp-equal x y)
          (subsetp-equal y x)))
 
-  (defthm set-equiv-implies-iff
-    (implies (set-equiv x y)
-             (equal (iff (member a x)
-                         (member a y))
-                    t)))
-
   (encapsulate
     ()
     (local (defthm set-equiv-refl


### PR DESCRIPTION
The removed lemma, set-equiv-implies-iff, is completely subsumed by set-equiv-implies-iff-member-2 from the same file, as demonstrated here:
```
(make-event `(thm ,(formula 'set-equiv-implies-iff t (w state)) :hints
                   (("goal" :in-theory (union-theories '(set-equiv-implies-iff-member-2)
                                                        (theory 'minimal-theory))))))
```