### PR TITLE
Update satlink_lib.pl to use drat-trim

### DIFF
--- a/books/centaur/satlink/solvers/satlink_lib.pl
+++ b/books/centaur/satlink/solvers/satlink_lib.pl
@@ -187,7 +187,7 @@ sub run_sat_and_check
 
     my ($solver, $args, $infile, $proof_file, $checker, $checkerargs) = @_;
 
-    $checker = defined($checker) ? $checker : "drup-trim";
+    $checker = defined($checker) ? $checker : "drat-trim";
     $checkerargs = defined($checkerargs) ? $checkerargs : [];
     
     my $solution = run_sat_solver($solver, $args);


### PR DESCRIPTION
The `centaur/satlink/solvers/test-glucose-cert.lisp` books builds with this change.

It seems like the `drup-trim` reference is no longer best practices.  My guess is
that this change is already intended, but just hasn't been done yet.