### PR TITLE
Fix ACL2(p) bug in SBCL

### DIFF
--- a/prove.lisp
+++ b/prove.lisp
@@ -6891,14 +6891,18 @@
            (let ((new-ht (make-hash-table :test 'equal :size (expt 2 13)
 
 ; Parallelism blemish: CCL locks these hashtable operations automatically
-; because of the argument :shared t below.  However in SBCL and LispWorks, we
-; should really lock these hashtable operations ourselves.  Note that the SBCL
-; documentation at http://www.sbcl.org/manual/Hash-Table-Extensions.html
-; describes a keyword, :synchronized, that is like CCL's :shared but is labeled
-; as "experimental".  At any rate, we are willing to take our chances for now
-; with SBCL and Lispworks.
+; because of the argument :shared t below.  SBCL documentation at
+; http://www.sbcl.org/manual/#Hash-Table-Extensions introduces the keyword,
+; :synchronized, that provides such a locking mechanism.  SBCL's :synchronized
+; is claimed to be experimental but has been around since at least 2011.  Using
+; this experimental feature is easier (and probably more performant) than
+; implenting the locking ourselves.  In LispWorks, we should probably lock
+; these hashtable oprations ourselves.  Seeing, however, as it's difficult to
+; obtain Lispworks and develop with it, we are willing to take our chances for
+; now with Lispworks.
 
-                                          #+ccl :shared #+ccl t)))
+                                          #+ccl :shared #+ccl t
+                                          #+sbcl :synchronized #+sbcl t)))
              (setf *waterfall-parallelism-timings-ht-alist*
                    (acons name
                           new-ht


### PR DESCRIPTION
In SBCL, change the way we create the
*waterfall-parallelism-timings-ht* by including an argument intended
to make read/writes threadsafe.

Without this change, we encounter errors like:

***********************************************
************ ABORTING from raw Lisp ***********
********** (see :DOC raw-lisp-error) **********
Error:  Unsafe concurrent operations on #<HASH-TABLE :TEST EQUAL :COUNT 8191 {1011E10023}> detected.
***********************************************

My hope is that this is easy for the acl2 maintainers to review and incorporate.  Please let me know if you have any questions -- perhaps with a phone call to minimize the back and forth.  Also, if you want to just copy+paste this into your own copy of `master` and push it yourself, that's okay with me.  I've made this request against `master`, as it's my guess that the maintainers would prefer to merge this change directly into `master` and then run the purity script, rather than wait for it to percolate through `testing`.  I'm also happy to create it against `testing`, as desired.