### PR TITLE
Make include-book local; change a few references

### DIFF
--- a/books/nonstd/nsa/sqrt-iter.lisp
+++ b/books/nonstd/nsa/sqrt-iter.lisp
@@ -48,7 +48,7 @@ To load this book, it is sufficient to do something like this:
 
 (in-package "ACL2")
 
-(include-book "arithmetic/top" :dir :system)
+(local (include-book "arithmetic/top" :dir :system))
 
 ;;
 ;; We start out by defining the bisection approximation to square root.  At one

--- a/books/workshops/2018/gamboa-cowles/complex-continuity.lisp
+++ b/books/workshops/2018/gamboa-cowles/complex-continuity.lisp
@@ -10,7 +10,6 @@
 (include-book "complex-lemmas")
 (include-book "norm2")
 
-
 (defun region-p (region)
   (and (consp region)
        (interval-p (car region))


### PR DESCRIPTION
This is at least a partial fixing of the ACL2(r) build.

The key was to make the inclusion of arithmetic/top local.  I think it's unreasonable to roast @kini for this oversight, because he had clearly asked for a review.  It was interesting to me how many books broke as a result.

I'm currently running both a vanilla and acl2(r) build overnight on leeroy2 (see http://leeroy2.defthm.com/job/fixing-acl2r/) and will merge accordingly tomorrow.  I'll need to merge in the latest from the testing branch before doing that, but I don't plan to worry about it too much.

Please nobody "undo" Keshav's PR #1135.  At this point, let's just push through with it.  Hopefully Keshav can address whatever feedback Ruben has in a follow-up commit.