### PR TITLE
Be more flexible in loading libipasirglucose4.so

### DIFF
--- a/books/build/features.sh
+++ b/books/build/features.sh
@@ -73,6 +73,45 @@ rm -f Makefile-features;
 ACL2_CUSTOMIZATION=NONE $STARTJOB -c "$ACL2 < cert_features.lsp &> Makefile-features.out" || echo "*** Failed to run ACL2! ***" 1>&2
 
 
+search_ld_library_path () {
+    local target=$1
+    local dirs=(); IFS=:; for x in $LD_LIBRARY_PATH; do dirs+=("$x"); done; unset IFS
+    for x in "${dirs[@]}"; do
+        [[ -e $x/$target ]] && return 0
+    done
+    return 1
+}
+
+check_ipasir () {
+    if [[ $IPASIR_SHARED_LIBRARY == */* && -e $IPASIR_SHARED_LIBRARY ]]; then
+        # found at user-supplied absolute or relative path (ld.so
+        # treats it as such if it contains a slash)
+        return 0
+    else
+        # look in $LD_LIBRARY_PATH for either the user-supplied library name or
+        # libipasirglucose4.so if the user didn't supply a library name
+        if search_ld_library_path ${IPASIR_SHARED_LIBRARY:-libipasirglucose4.so}; then
+            return 0
+        fi
+    fi
+    # Ideally there should be another if-branch here checking the actual
+    # dynamic load path using `ldconfig -p` or `ld.so` or something but there
+    # doesn't seem to be an easy portable way to do that, so I'm skipping it.
+    if [[ -n $IPASIR_SHARED_LIBRARY ]]; then
+        # user supplied path but this simple script couldn't find it;
+        # maybe ld.so still can, so we press on
+        cat <<EOF 1>&2
+!!! WARNING: \$IPASIR_SHARED_LIBRARY was set to "$IPASIR_SHARED_LIBRARY", which
+             could be found neither as an absolute or relative path, nor in
+             \$LD_LIBRARY_PATH.  Books requiring an ipasir shared library will
+             be tried anyway, but may fail.  If you want to skip them, unset
+             \$IPASIR_SHARED_LIBRARY.
+EOF
+        return 0
+    fi
+    return 1
+}
+
 echo "Determining whether Glucose is installed" 1>&2
 if glucose --help 2> /dev/null;
 then
@@ -82,20 +121,12 @@ EXPORTED_VARS += OS_HAS_GLUCOSE
 EOF
 fi
 
-
 echo "Determining whether an ipasir shared library is installed" 1>&2
-if [[ $IPASIR_SHARED_LIBRARY != '' ]];
-then
-    if [[ -e $IPASIR_SHARED_LIBRARY ]];
-    then
-	cat >> Makefile-features <<EOF
+if check_ipasir; then
+    cat >> Makefile-features <<EOF
 export OS_HAS_IPASIR ?= 1
 EXPORTED_VARS += OS_HAS_IPASIR
 EOF
-    else
-	echo "!!!WARNING: IPASIR_SHARED_LIBRARY was set to \"${IPASIR_SHARED_LIBRARY}\"," 1>&2
-	echo "but this file doees not exist." 1>&2
-    fi
 fi
 
 echo "Determining whether ABC is installed" 1>&2

--- a/books/build/shell.nix
+++ b/books/build/shell.nix
@@ -63,6 +63,5 @@ in mkShell rec {
   ];
   shellHook = ''
     export LD_LIBRARY_PATH=${stdenv.lib.makeLibraryPath [ openssl.out libipasirglucose4 ]}
-    export IPASIR_SHARED_LIBRARY=${libipasirglucose4}/lib/libipasirglucose4.so
   '';
 }

--- a/books/centaur/ipasir/ipasir-logic.lisp
+++ b/books/centaur/ipasir/ipasir-logic.lisp
@@ -868,11 +868,26 @@ files "ipasirglucoseglue.o" and "libipasirglucose4.a".</p>
 <p>(Note: Counterintuitively, it is important that the .o file is listed before the .a file.)</p>
 
 <p>Finally, move the resulting shared library "libipasirglucose4.so" to a
-permanent location and set the IPASIR_SHARED_LIBRARY environment variable to
-its absolute path.  Or, ensure that its destination directory is listed in
-your LD_LIBRARY_PATH environment variable and set IPASIR_SHARED_LIBRARY
-to "libipasirglucose4.so".</p>
+permanent location and either:</p>
 
+<ul>
+
+<li>Ensure that the directory containing the shared library is listed in your
+$LD_LIBRARY_PATH environment variable. (Note: this assumes the library is named
+"libipasirglucose4.so"; if you name it something else, then also set
+$IPASIR_SHARED_LIBRARY to its filename, e.g. "foobar.so".)</li>
+
+<li>Or, just set the $IPASIR_SHARED_LIBRARY environment variable to the full
+absolute path of the shared library.</li>
+
+<li>If you want to be really fancy, install the shared library into your system
+libraries using @('ldconfig') or similar.  However, our build system isn't
+smart enough to tell that you have done this, so you should also set
+$IPASIR_SHARED_LIBRARY to the name of the installed library,
+e.g. "libipasirglucose4.so", otherwise these IPASIR-related books will be
+skipped when building the community books.</li>
+
+</ul>
 """})
 
 (defxdoc ipasir

--- a/books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp
+++ b/books/centaur/ipasir/load-ipasir-sharedlib-raw.lsp
@@ -29,12 +29,12 @@
 ; Original authors: Sol Swords <sswords@centtech.com>
 
 (er-let* ((libname (acl2::getenv$ "IPASIR_SHARED_LIBRARY" acl2::*the-live-state*)))
-         (if libname
-             (handler-case 
-               (cffi::load-foreign-library libname)
-               (error () (er hard? 'load-ipasir-shardlib-raw
-                             "Couldn't load the specified ipasir shared library, ~s0."
-                             libname)))
-           (er hard? 'load-ipasir-shardlib-raw
-               "Couldn't load an ipasir library because the ~
-                IPASIR_SHARED_LIBRARY environment variable was unset.")))
+  (handler-case
+      (cffi::load-foreign-library
+       (or libname
+           (cw "WARNING: $IPASIR_SHARED_LIBRARY not specified, ~
+                defaulting to \"libipasirglucose4.so\"")
+           "libipasirglucose4.so"))
+    (error () (er hard? 'load-ipasir-shardlib-raw
+                  "Couldn't load ipasir shared library from ~s0."
+                  libname))))


### PR DESCRIPTION
The doc topic IPASIR::BUILDING-AN-IPASIR-SOLVER-LIBRARY claims that to
get the ipasir shared library working, it is sufficient to set
$IPASIR_SHARED_LIBRARY to the library's filename alone, and put its
directory in the $LD_LIBRARY_PATH list.

Unfortunately, while the loading code in load-ipasir-sharedlib-raw.lsp
itself is able to handle this, features.sh is stricter and requires
$IPASIR_SHARED_LIBRARY to contain a full path to the shared library,
so running `make regression` will skip the ipasir books if the library
is pointed to by a directory path in $LD_LIBRARY_PATH and a filename
in $IPASIR_SHARED_LIBRARY.

This commit generally expands the different ways in which the user is
able to provide an ipasir shared library for the ipasir-related books
to build from.  See the changes made to the aforementioned doc topic
for more details.