### PR TITLE
Add to the lemmas automatically generated by defsort

### DIFF
--- a/books/centaur/4v-sexpr/sexpr-loop-debug.lisp
+++ b/books/centaur/4v-sexpr/sexpr-loop-debug.lisp
@@ -247,6 +247,18 @@
      (cw "~%")
      (verilog-summarize-translated-loops-aux (+ 1 n) (cdr comma-strs)))))
 
+(defthm
+   vl2014::string-list-listp-of-len-sort
+   (iff (vl2014::string-list-listp (len-sort x))
+        (vl2014::string-list-listp x))
+   :hints
+   (("goal" :in-theory (disable vl2014::string-list-listp-when-subsetp-equal)
+            :use ((:instance vl2014::string-list-listp-when-subsetp-equal
+                             (y (len-sort x)))
+                  (:instance vl2014::string-list-listp-when-subsetp-equal
+                             (x (len-sort x))
+                             (y x))))))
+
 (defund verilog-summarize-translated-loops (x)
   (declare (xargs :guard t))
   (b* ((loops (verilog-loops-from-translated-loops x))
@@ -349,5 +361,3 @@
                  (cons sig-number ndeps)))
 
 (defattach sneaky-loop-say-how-bad jared-sneaky-loop-say-how-bad)
-
-

--- a/books/defsort/defsort.lisp
+++ b/books/defsort/defsort.lisp
@@ -797,9 +797,8 @@ it has a special hack for that particular case.</p>
                        consp-of-comparable-mergesort
                        ,subst1)))
 
-           (defthm ,(mksym prefix "-IS-IDENTITY-UNDER-SET-EQUIV")
-             (equal (consp (,sort x . ,extra-args))
-                    (consp x))
+           (defthm ,(mksym prefix "-SORT-IS-IDENTITY-UNDER-SET-EQUIV")
+             (set-equiv (,sort x . ,extra-args) x)
              :hints ((defsort-functional-inst
                        comparable-mergesort-under-set-equiv
                        ,subst1)))))

--- a/books/defsort/defsort.lisp
+++ b/books/defsort/defsort.lisp
@@ -795,6 +795,13 @@ it has a special hack for that particular case.</p>
                     (consp x))
              :hints ((defsort-functional-inst
                        consp-of-comparable-mergesort
+                       ,subst1)))
+
+           (defthm ,(mksym prefix "-IS-IDENTITY-UNDER-SET-EQUIV")
+             (equal (consp (,sort x . ,extra-args))
+                    (consp x))
+             :hints ((defsort-functional-inst
+                       comparable-mergesort-under-set-equiv
                        ,subst1)))))
 
        ((when weak) (value events1))
@@ -903,5 +910,3 @@ it has a special hack for that particular case.</p>
 (defmacro defsort (&rest args)
   `(make-event
     (defsort-fn ',args state)))
-
-

--- a/books/projects/filesystems/abs-syscalls.lisp
+++ b/books/projects/filesystems/abs-syscalls.lisp
@@ -207,11 +207,6 @@
              abs-place-file-helper-of-fat32-filename-list-fix
              (path path-equiv))))))
 
-(defthm
-  abs-place-file-helper-of-ctx-app-lemma-1
-  (implies (>= (nfix n) (len l))
-           (fat32-filename-equiv (nth n l) nil)))
-
 (defund
   abs-place-file (frame path file)
   (declare
@@ -5447,8 +5442,6 @@
           (:rewrite member-of-abs-addrs-when-natp . 2)
           (:definition hifat-file-alist-fix)
           (:type-prescription assoc-when-zp-len)
-          (:rewrite
-           abs-place-file-helper-of-ctx-app-lemma-1)
           (:rewrite abs-addrs-of-ctx-app-2)
           (:definition put-assoc-equal)
           (:rewrite abs-mkdir-correctness-lemma-42)

--- a/books/projects/filesystems/file-system-lemmas.lisp
+++ b/books/projects/filesystems/file-system-lemmas.lisp
@@ -1179,8 +1179,7 @@
          (no-duplicatesp-equal (strip-cars alist))))
 
 (defthm nth-when->=-n-len-l
-  (implies (and (true-listp l)
-                (>= (nfix n) (len l)))
+  (implies (>= (nfix n) (len l))
            (equal (nth n l) nil)))
 
 (defthm strip-cars-of-remove1-assoc

--- a/books/projects/filesystems/file-system-lemmas.lisp
+++ b/books/projects/filesystems/file-system-lemmas.lisp
@@ -1464,6 +1464,7 @@
                              (acc 0))))
     :rule-classes :linear))
 
+;; Contributed to books/std/lists/nthcdr.lisp
 (defthm
   subsetp-of-nthcdr
   (subsetp-equal (nthcdr n l) l))

--- a/books/std/lists/nthcdr.lisp
+++ b/books/std/lists/nthcdr.lisp
@@ -217,12 +217,6 @@ library."
          :corollary (implies (and (subsetp x y) (not (member a y)))
                              (not (member a x)))))))
 
-    (local
-     (defthm nthcdr-when->=-n-len-l
-       (implies (and (true-listp l)
-                     (>= (nfix n) (len l)))
-                (equal (nthcdr n l) nil))))
-
     (defthm
       subsetp-of-nthcdr
       (subsetp-equal (nthcdr n l) l)

--- a/books/std/lists/nthcdr.lisp
+++ b/books/std/lists/nthcdr.lisp
@@ -191,7 +191,48 @@ library."
 
   (def-projection-rule nthcdr-of-elementlist-projection
     (equal (nthcdr n (elementlist-projection x))
-           (elementlist-projection (nthcdr n x)))))
+           (elementlist-projection (nthcdr n x))))
+
+  (encapsulate
+    ()
+
+    (local
+     (defthm subsetp-trans
+       (implies (and (subsetp x y) (subsetp y z))
+                (subsetp x z))))
+
+    (local
+     (defthm
+       subsetp-member
+       (implies (and (member a x) (subsetp x y))
+                (member a y))
+       :rule-classes
+       ((:rewrite)
+        (:rewrite :corollary (implies (and (subsetp x y) (member a x))
+                                      (member a y)))
+        (:rewrite
+         :corollary (implies (and (not (member a y)) (subsetp x y))
+                             (not (member a x))))
+        (:rewrite
+         :corollary (implies (and (subsetp x y) (not (member a y)))
+                             (not (member a x)))))))
+
+    (local
+     (defthm nthcdr-when->=-n-len-l
+       (implies (and (true-listp l)
+                     (>= (nfix n) (len l)))
+                (equal (nthcdr n l) nil))))
+
+    (defthm
+      subsetp-of-nthcdr
+      (subsetp-equal (nthcdr n l) l)
+      :hints (("Goal" :induct (nthcdr n l)
+               :in-theory
+               (disable
+                (:rewrite nthcdr-of-cons)
+                (:rewrite nthcdr-when-atom)
+                (:rewrite nthcdr-when-zp)
+                (:rewrite open-small-nthcdr)))))))
 
 
 (defsection rest-n


### PR DESCRIPTION
I thought it would be nice to have the obvious set-equiv theorem automatically generated by defsort. I mostly stuck to local events, but I did add an event to the nthcdr book. Additionally, I made local copies of lemmas that appear in other books, such as subsetp-trans, subsetp-member and subsetp-append1. Let me know if you would prefer me to include those books instead.

The filesystem books are also updated as part of this pull request.