### PR TITLE
Automatically generate some rules

### DIFF
--- a/books/projects/filesystems/abstract-separate.lisp
+++ b/books/projects/filesystems/abstract-separate.lisp
@@ -3037,12 +3037,6 @@
                     (frame-val-p nil))))
   :hints (("goal" :in-theory (enable frame-p))))
 
-(defthm frame-p-of-put-assoc-equal
-  (implies (frame-p alist)
-           (equal (frame-p (put-assoc-equal name val alist))
-                  (and (natp name) (frame-val-p val))))
-  :hints (("goal" :in-theory (enable frame-p))))
-
 (defthm frame-p-of-remove-assoc
   (implies (frame-p alist)
            (frame-p (remove-assoc-equal x alist)))

--- a/books/projects/filesystems/hifat-syscalls.lisp
+++ b/books/projects/filesystems/hifat-syscalls.lisp
@@ -1023,19 +1023,6 @@
       (m1-file-alist2
        (hifat-file-alist-fix m1-file-alist1)))))))
 
-(def-alistp-rule alistp-of-put-assoc-equal
-  (implies (and (keyval-alist-p x)
-                (not (keyval-alist-final-cdr-p t)))
-           (iff (keyval-alist-p (put-assoc-equal name val x))
-                (and (keytype-p name) (valtype-p val))))
-  :name keyval-alist-p-of-put-assoc-equal
-  :requirement (and true-listp single-var)
-  :body
-  (implies (and (keyval-alist-p x))
-           (iff (keyval-alist-p (put-assoc-equal name val x))
-                (and (keytype-p name) (valtype-p val))))
-  :tags (:alistp))
-
 (fty::defprod
  dir-stream
  ((file-list fat32-filename-list-p)))

--- a/books/projects/filesystems/hifat.lisp
+++ b/books/projects/filesystems/hifat.lisp
@@ -1272,10 +1272,35 @@
      (dir-ent-directory-p dir-ent-set-first-cluster-file-size)
      (logbitp)))))
 
+(def-listfix-rule nth-of-element-list-fix
+  (equal (nth n (element-list-fix x))
+         (if (< (nfix n) (len x))
+             (element-fix (nth n x))
+           nil)))
+
+(def-listp-rule list-equiv-refines-element-list-equiv
+  (implies (and (list-equiv x y)
+                (not (element-list-final-cdr-p t)))
+           (element-list-equiv x y))
+  :hints (("Goal" :induct (fast-list-equiv x y)
+           :in-theory (enable fast-list-equiv)))
+  :name list-equiv-refines-element-list-equiv
+  :requirement (not true-listp)
+  :body
+  (implies (list-equiv x y)
+           (element-list-equiv x y))
+  :inst-rule-classes :refinement)
+
+(def-listfix-rule
+  prefixp-of-element-list-fix
+  (implies (prefixp x y)
+           (prefixp (element-list-fix x)
+                    (element-list-fix y)))
+  :hints (("goal" :in-theory (enable prefixp))))
+
 (fty::deflist fat32-filename-list
               :elt-type fat32-filename      ;; required, must have a known fixing function
-              :true-listp t
-              )
+              :true-listp t)
 
 ;; The fact that we're having to insert this indicates that deflist should have
 ;; an option to make it come up disabled.

--- a/books/projects/filesystems/hifat.lisp
+++ b/books/projects/filesystems/hifat.lisp
@@ -1959,13 +1959,6 @@
     (t (hifat-find-file fs x))))
   :hints (("goal" :in-theory (enable hifat-find-file))))
 
-(defthm
-  m1-file-alist-p-of-put-assoc-equal
-  (implies
-   (m1-file-alist-p alist)
-   (equal (m1-file-alist-p (put-assoc-equal name val alist))
-          (and (fat32-filename-p name) (m1-file-p val)))))
-
 (defund
   hifat-place-file
   (fs path file)

--- a/books/std/alists/abstract.lisp
+++ b/books/std/alists/abstract.lisp
@@ -391,7 +391,20 @@ about keyval-alistp."
     (implies (and (keyval-alist-p x)
                   (keyval-alist-p y))
              (keyval-alist-p (hons-shrink-alist x y)))
-    :name keyval-alist-p-of-hons-shrink-alist))
+    :name keyval-alist-p-of-hons-shrink-alist)
+
+  (def-alistp-rule alistp-of-put-assoc
+    (implies (and (keyval-alist-p x)
+                  (not (keyval-alist-final-cdr-p t)))
+             (iff (keyval-alist-p (put-assoc-equal name val x))
+                  (and (keytype-p name) (valtype-p val))))
+    :name keyval-alist-p-of-put-assoc
+    :requirement true-listp
+    :body
+    (implies (and (keyval-alist-p x))
+             (iff (keyval-alist-p (put-assoc-equal name val x))
+                  (and (keytype-p name) (valtype-p val))))
+    :tags (:alistp)))
 
 
 ;; expensive...

--- a/books/std/typed-alists/string-string-alistp.lisp
+++ b/books/std/typed-alists/string-string-alistp.lisp
@@ -27,10 +27,4 @@
   (defthm stringp-of-cdr-of-assoc-equal-when-string-string-alistp
     (implies (string-string-alistp alist)
              (iff (stringp (cdr (assoc-equal key alist)))
-                  (assoc-equal key alist))))
-
-  (defthm string-string-alistp-of-put-assoc-equal
-    (implies (string-string-alistp alist)
-             (equal (string-string-alistp (put-assoc-equal key val alist))
-                    (and (stringp key)
-                         (stringp val))))))
+                  (assoc-equal key alist)))))

--- a/books/std/typed-alists/string-symbollist-alistp.lisp
+++ b/books/std/typed-alists/string-symbollist-alistp.lisp
@@ -26,10 +26,4 @@
 
   (defthm symbol-listp-of-cdr-of-assoc-equal-when-string-symbollist-alistp
     (implies (string-symbollist-alistp alist)
-             (symbol-listp (cdr (assoc-equal key alist)))))
-
-  (defthm string-symbollist-alistp-of-put-assoc-equal
-    (implies (string-symbollist-alistp alist)
-             (equal (string-symbollist-alistp (put-assoc-equal key val alist))
-                    (and (stringp key)
-                         (symbol-listp val))))))
+             (symbol-listp (cdr (assoc-equal key alist))))))

--- a/books/std/typed-alists/symbol-pseudoterm-alistp.lisp
+++ b/books/std/typed-alists/symbol-pseudoterm-alistp.lisp
@@ -26,10 +26,4 @@
 
   (defthm pseudo-termp-of-cdr-of-assoc-equal-when-symbol-pseudoterm-alistp
     (implies (symbol-pseudoterm-alistp alist)
-             (pseudo-termp (cdr (assoc-equal key alist)))))
-
-  (defthm symbol-pseudoterm-alistp-of-put-assoc-equal
-    (implies (symbol-pseudoterm-alistp alist)
-             (equal (symbol-pseudoterm-alistp (put-assoc-equal key val alist))
-                    (and (symbolp key)
-                         (pseudo-termp val))))))
+             (pseudo-termp (cdr (assoc-equal key alist))))))

--- a/books/std/typed-alists/symbol-symbollist-alistp.lisp
+++ b/books/std/typed-alists/symbol-symbollist-alistp.lisp
@@ -26,10 +26,4 @@
 
   (defthm symbol-listp-of-cdr-of-assoc-equal-when-symbol-symbollist-alistp
     (implies (symbol-symbollist-alistp alist)
-             (symbol-listp (cdr (assoc-equal key alist)))))
-
-  (defthm symbol-symbollist-alistp-of-put-assoc-equal
-    (implies (symbol-symbollist-alistp alist)
-             (equal (symbol-symbollist-alistp (put-assoc-equal key val alist))
-                    (and (symbolp key)
-                         (symbol-listp val))))))
+             (symbol-listp (cdr (assoc-equal key alist))))))


### PR DESCRIPTION
There's a fairly common kind of rule which can be automatically generated by `fty::defalist`. I removed some existing rules which either had a name conflict with the newly generated rules, or else did the same thing under a different name.

The filesystem books are also updated as part of this pull request.