### PR TITLE
 Automatically generate some rules

### DIFF
--- a/books/std/alists/abstract.lisp
+++ b/books/std/alists/abstract.lisp
@@ -404,7 +404,16 @@ about keyval-alistp."
     (implies (and (keyval-alist-p x))
              (iff (keyval-alist-p (put-assoc-equal name val x))
                   (and (keytype-p name) (valtype-p val))))
-    :tags (:alistp)))
+    :tags (:alistp))
+
+  (def-alistp-rule valtype-p-of-cdr-of-assoc-when-keyval-alist-p-valtype-p-nil
+    (implies (and (keyval-alist-p x)
+                  (valtype-p nil))
+             (valtype-p (cdr (assoc-equal k x))))
+    :name valtype-p-of-cdr-of-assoc-when-keyval-alist-p
+    :requirement valtype-p-of-nil
+    :body (implies (keyval-alist-p x)
+                   (valtype-p (cdr (assoc-equal k x))))))
 
 
 ;; expensive...

--- a/books/std/typed-alists/keyword-symbol-alistp.lisp
+++ b/books/std/typed-alists/keyword-symbol-alistp.lisp
@@ -21,9 +21,4 @@
   :val (symbolp x)
   :true-listp t
   :keyp-of-nil nil
-  :valp-of-nil t
-  ///
-
-  (defthm symbolp-of-cdr-of-assoc-equal-when-keyword-symbol-alistp
-    (implies (keyword-symbol-alistp alist)
-             (symbolp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)

--- a/books/std/typed-alists/keyword-truelist-alistp.lisp
+++ b/books/std/typed-alists/keyword-truelist-alistp.lisp
@@ -21,9 +21,4 @@
   :val (true-listp x)
   :true-listp t
   :keyp-of-nil nil
-  :valp-of-nil t
-  ///
-
-  (defthm true-listp-of-cdr-of-assoc-equal-when-keyword-truelist-alistp
-    (implies (keyword-truelist-alistp alist)
-             (true-listp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)

--- a/books/std/typed-alists/string-symbollist-alistp.lisp
+++ b/books/std/typed-alists/string-symbollist-alistp.lisp
@@ -21,9 +21,4 @@
   :val (symbol-listp x)
   :true-listp t
   :keyp-of-nil nil
-  :valp-of-nil t
-  ///
-
-  (defthm symbol-listp-of-cdr-of-assoc-equal-when-string-symbollist-alistp
-    (implies (string-symbollist-alistp alist)
-             (symbol-listp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)

--- a/books/std/typed-alists/symbol-pseudoterm-alistp.lisp
+++ b/books/std/typed-alists/symbol-pseudoterm-alistp.lisp
@@ -21,9 +21,4 @@
   :val (pseudo-termp x)
   :true-listp t
   :keyp-of-nil t
-  :valp-of-nil t
-  ///
-
-  (defthm pseudo-termp-of-cdr-of-assoc-equal-when-symbol-pseudoterm-alistp
-    (implies (symbol-pseudoterm-alistp alist)
-             (pseudo-termp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)

--- a/books/std/typed-alists/symbol-symbol-alistp.lisp
+++ b/books/std/typed-alists/symbol-symbol-alistp.lisp
@@ -21,9 +21,4 @@
   :val (symbolp x)
   :true-listp t
   :keyp-of-nil t
-  :valp-of-nil t
-  ///
-
-  (defthm symbolp-of-cdr-of-assoc-equal-when-symbol-symbol-alistp
-    (implies (symbol-symbol-alistp alist)
-             (symbolp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)

--- a/books/std/typed-alists/symbol-symbollist-alistp.lisp
+++ b/books/std/typed-alists/symbol-symbollist-alistp.lisp
@@ -21,9 +21,4 @@
   :val (symbol-listp x)
   :true-listp t
   :keyp-of-nil t
-  :valp-of-nil t
-  ///
-
-  (defthm symbol-listp-of-cdr-of-assoc-equal-when-symbol-symbollist-alistp
-    (implies (symbol-symbollist-alistp alist)
-             (symbol-listp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)

--- a/books/std/typed-alists/symbol-truelist-alistp.lisp
+++ b/books/std/typed-alists/symbol-truelist-alistp.lisp
@@ -21,9 +21,4 @@
   :val (true-listp x)
   :true-listp t
   :keyp-of-nil t
-  :valp-of-nil t
-  ///
-
-  (defthm true-listp-of-cdr-of-assoc-equal-when-symbol-truelist-alistp
-    (implies (symbol-truelist-alistp alist)
-             (true-listp (cdr (assoc-equal key alist))))))
+  :valp-of-nil t)


### PR DESCRIPTION
There's another fairly common kind of rule which can be automatically generated by fty::defalist. I removed some existing rules which either had a name conflict with the newly generated rules, or else did the same thing under a different name.