### PR TITLE
Add a lemma about str::charlisteqv

### DIFF
--- a/books/projects/filesystems/file-system-lemmas.lisp
+++ b/books/projects/filesystems/file-system-lemmas.lisp
@@ -1091,11 +1091,11 @@
                       (assoc-equal x1 x2)
                       (assoc-equal x1 y)))))
 
-(defthm assoc-equal-of-append-2
+(defthm assoc-of-append-2
   (implies (and (atom (assoc-equal nil x))
                 (atom (assoc-equal nil y)))
-           (atom (assoc-equal nil (append x y))))
-  :rule-classes :type-prescription)
+           (not (consp (assoc-equal nil (append x y)))))
+  :rule-classes (:rewrite :type-prescription))
 
 (encapsulate
   ()
@@ -1717,3 +1717,8 @@
 (defthm subsetp-of-set-difference$
   (subsetp-equal (set-difference-equal x y)
                  x))
+
+(defthm alistp-of-append
+  (equal (alistp (append x y))
+         (and (alistp (true-list-fix x))
+              (alistp y))))

--- a/books/projects/filesystems/hifat-to-lofat-inversion.lisp
+++ b/books/projects/filesystems/hifat-to-lofat-inversion.lisp
@@ -7781,7 +7781,8 @@
       (e/d (lofat-to-hifat-helper
             (:definition hifat-no-dups-p)
             remove1-dir-ent not-intersectp-list
-            (:linear hifat-to-lofat-inversion-lemma-16))
+            (:linear hifat-to-lofat-inversion-lemma-16)
+            hifat-bounded-file-alist-p-of-cdr)
            ((:rewrite nth-of-nats=>chars)
             (:rewrite dir-ent-p-when-member-equal-of-dir-ent-list-p)
             (:rewrite fati-of-hifat-to-lofat-helper-disjoint-lemma-2)

--- a/books/projects/filesystems/hifat.lisp
+++ b/books/projects/filesystems/hifat.lisp
@@ -1680,7 +1680,8 @@
                     (ac1 (- ac 1))
                     (ac2 ac)))))
 
-(defthm hifat-bounded-file-alist-p-of-cdr
+;; Rules like this are just a lot of trouble, actually...
+(defthmd hifat-bounded-file-alist-p-of-cdr
   (implies (hifat-bounded-file-alist-p x)
            (hifat-bounded-file-alist-p (cdr x)))
   :hints (("goal" :in-theory (enable hifat-bounded-file-alist-p))))
@@ -2742,6 +2743,7 @@
    (fat32-name-to-name-helper
     character-list n)))
 
+;; We should consider disabling this...
 (defun fat32-name-to-name (character-list)
   (declare (xargs :guard (and (character-listp character-list)
                               (equal (len character-list) 11))))

--- a/books/projects/filesystems/tar-stuff.lisp
+++ b/books/projects/filesystems/tar-stuff.lisp
@@ -313,7 +313,7 @@
 
 ;; Path is not needed as an argument! This is the recursive part only.
 (defund
-  hifat-get-names-from-dirp
+  get-names-from-dirp
   (dirp dir-stream-table)
   (declare
    (xargs
@@ -326,27 +326,316 @@
     :hints (("goal" :in-theory (enable hifat-readdir)))
     :guard (and (natp dirp) (dir-stream-table-p dir-stream-table))))
   (b*
-      (((mv name errno dir-stream-table)
+      ((dirp (mbe :exec dirp :logic (nfix dirp)))
+       (dir-stream-table
+        (mbe :exec dir-stream-table :logic (dir-stream-table-fix dir-stream-table)))
+       ((mv name errno dir-stream-table)
         (hifat-readdir dirp dir-stream-table))
        ((when (or (equal errno *ebadf*)
                   (equal name *empty-fat32-name*)))
         (mv nil dir-stream-table))
        ((mv tail dir-stream-table)
-        (hifat-get-names-from-dirp dirp dir-stream-table)))
+        (get-names-from-dirp dirp dir-stream-table)))
     (mv (list* name tail) dir-stream-table)))
 
-(defthm fat32-filename-list-p-of-hifat-get-names-from-dirp
+(defthm get-names-from-dirp-alt-lemma-1
+  (implies (and (dir-stream-table-p x)
+                (not (natp n)))
+           (not (consp (assoc-equal n x)))))
+
+(defthm get-names-from-dirp-alt-lemma-2
+  (implies (and (dir-stream-table-p dir-stream-table)
+                (consp (assoc-equal x dir-stream-table)))
+           (dir-stream-p (cdr (assoc-equal x dir-stream-table)))))
+
+(defthm get-names-from-dirp-alt-lemma-3
+  (implies
+   (and
+    (not
+     (consp
+      (dir-stream->file-list (cdr (assoc-equal dirp dir-stream-table)))))
+    (dir-stream-table-p dir-stream-table)
+    (consp (assoc-equal dirp dir-stream-table)))
+   (equal (cdr (assoc-equal dirp dir-stream-table))
+          '((file-list))))
+  :hints
+  (("goal" :do-not-induct t
+    :in-theory (e/d (dir-stream-p dir-stream->file-list)
+                    (get-names-from-dirp-alt-lemma-2))
+    :use (:instance get-names-from-dirp-alt-lemma-2
+                    (x dirp))
+    :expand (strip-cars (cdr (assoc-equal dirp dir-stream-table))))))
+
+(defthm
+  get-names-from-dirp-alt-lemma-4
+  (implies
+   (and
+    (member-equal
+     "           "
+     (cdr (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table))))))
+    (equal
+     (get-names-from-dirp
+      dirp
+      (put-assoc-equal
+       dirp
+       (dir-stream
+        (cdr
+         (dir-stream->file-list
+          (cdr (assoc-equal dirp
+                            (dir-stream-table-fix dir-stream-table))))))
+       (dir-stream-table-fix dir-stream-table)))
+     (list
+      (take
+       (position-equal-ac
+        "           "
+        (cdr
+         (dir-stream->file-list
+          (cdr (assoc-equal dirp
+                            (dir-stream-table-fix dir-stream-table)))))
+        0)
+       (cdr
+        (dir-stream->file-list
+         (cdr (assoc-equal dirp
+                           (dir-stream-table-fix dir-stream-table))))))
+      (put-assoc-equal
+       dirp
+       (dir-stream
+        (cddr
+         (nthcdr
+          (position-equal-ac
+           "           "
+           (cdr
+            (dir-stream->file-list
+             (cdr (assoc-equal dirp
+                               (dir-stream-table-fix dir-stream-table)))))
+           0)
+          (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table)))))))
+       (dir-stream-table-fix dir-stream-table)))))
+   (equal
+    (cons
+     (car (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table)))))
+     (mv-nth
+      0
+      (get-names-from-dirp
+       dirp
+       (put-assoc-equal
+        dirp
+        (dir-stream
+         (cdr
+          (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table))))))
+        (dir-stream-table-fix dir-stream-table)))))
+    (take
+     (position-equal-ac
+      "           "
+      (cdr (dir-stream->file-list
+            (cdr (assoc-equal dirp
+                              (dir-stream-table-fix dir-stream-table)))))
+      1)
+     (dir-stream->file-list
+      (cdr (assoc-equal dirp
+                        (dir-stream-table-fix dir-stream-table)))))))
+  :instructions
+  ((:bash
+    ("goal"
+     :do-not-induct t
+     :in-theory (disable (:rewrite position-equal-ac-of-+))
+     :use
+     (:instance
+      (:rewrite position-equal-ac-of-+)
+      (n 1)
+      (acc 0)
+      (lst
+       (cdr
+        (dir-stream->file-list
+         (cdr (assoc-equal dirp
+                           (dir-stream-table-fix dir-stream-table))))))
+      (item "           "))))
+   (:dive 2 1)
+   := :top (:dive 2)
+   :x :top :bash (:dive 2 1 2)
+   := :up
+   (:=
+    (position-equal-ac
+     "           "
+     (cdr (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table)))))
+     0))
+   :top (:dive 1 2)
+   :=
+   :up :s
+   :top :bash))
+
+(defthm
+  get-names-from-dirp-alt-lemma-5
+  (implies
+   (and
+    (member-equal
+     "           "
+     (cdr (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table))))))
+    (equal
+     (get-names-from-dirp
+      dirp
+      (put-assoc-equal
+       dirp
+       (dir-stream
+        (cdr
+         (dir-stream->file-list
+          (cdr (assoc-equal dirp
+                            (dir-stream-table-fix dir-stream-table))))))
+       (dir-stream-table-fix dir-stream-table)))
+     (list
+      (take
+       (position-equal-ac
+        "           "
+        (cdr
+         (dir-stream->file-list
+          (cdr (assoc-equal dirp
+                            (dir-stream-table-fix dir-stream-table)))))
+        0)
+       (cdr
+        (dir-stream->file-list
+         (cdr (assoc-equal dirp
+                           (dir-stream-table-fix dir-stream-table))))))
+      (put-assoc-equal
+       dirp
+       (dir-stream
+        (cddr
+         (nthcdr
+          (position-equal-ac
+           "           "
+           (cdr
+            (dir-stream->file-list
+             (cdr (assoc-equal dirp
+                               (dir-stream-table-fix dir-stream-table)))))
+           0)
+          (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table)))))))
+       (dir-stream-table-fix dir-stream-table)))))
+   (equal
+    (mv-nth
+     1
+     (get-names-from-dirp
+      dirp
+      (put-assoc-equal
+       dirp
+       (dir-stream
+        (cdr
+         (dir-stream->file-list
+          (cdr (assoc-equal dirp
+                            (dir-stream-table-fix dir-stream-table))))))
+       (dir-stream-table-fix dir-stream-table))))
+    (put-assoc-equal
+     dirp
+     (dir-stream
+      (cdr
+       (nthcdr
+        (position-equal-ac
+         "           "
+         (cdr
+          (dir-stream->file-list
+           (cdr (assoc-equal dirp
+                             (dir-stream-table-fix dir-stream-table)))))
+         1)
+        (dir-stream->file-list
+         (cdr (assoc-equal dirp
+                           (dir-stream-table-fix dir-stream-table)))))))
+     (dir-stream-table-fix dir-stream-table))))
+  :instructions
+  ((:bash
+    ("goal"
+     :in-theory (disable)
+     :use
+     (:instance
+      (:rewrite position-equal-ac-of-+)
+      (n 1)
+      (acc 0)
+      (lst
+       (cdr
+        (dir-stream->file-list
+         (cdr (assoc-equal dirp
+                           (dir-stream-table-fix dir-stream-table))))))
+      (item "           "))))
+   (:dive 1 2)
+   := :up :s :top (:dive 2 2 1 1 1)
+   := :up (:drop 1)
+   :x
+   :top :bash))
+
+(defthmd
+  get-names-from-dirp-alt
+  (equal
+   (get-names-from-dirp dirp dir-stream-table)
+   (cond
+    ((member-equal
+      *empty-fat32-name*
+      (dir-stream->file-list
+       (cdr (assoc-equal (nfix dirp)
+                         (dir-stream-table-fix dir-stream-table)))))
+     (mv
+      (take
+       (position-equal
+        *empty-fat32-name*
+        (dir-stream->file-list
+         (cdr (assoc-equal (nfix dirp)
+                           (dir-stream-table-fix dir-stream-table)))))
+       (dir-stream->file-list
+        (cdr (assoc-equal (nfix dirp)
+                          (dir-stream-table-fix dir-stream-table)))))
+      (put-assoc-equal
+       (nfix dirp)
+       (dir-stream
+        (nthcdr
+         (+
+          1
+          (position-equal
+           *empty-fat32-name*
+           (dir-stream->file-list
+            (cdr (assoc-equal (nfix dirp)
+                              (dir-stream-table-fix dir-stream-table))))))
+         (dir-stream->file-list
+          (cdr (assoc-equal (nfix dirp)
+                            (dir-stream-table-fix dir-stream-table))))))
+       (dir-stream-table-fix dir-stream-table))))
+    ((consp (assoc-equal (nfix dirp)
+                         (dir-stream-table-fix dir-stream-table)))
+     (mv (dir-stream->file-list
+          (cdr (assoc-equal (nfix dirp)
+                            (dir-stream-table-fix dir-stream-table))))
+         (put-assoc-equal (nfix dirp)
+                          (dir-stream nil)
+                          (dir-stream-table-fix dir-stream-table))))
+    (t (mv (dir-stream->file-list
+            (cdr (assoc-equal (nfix dirp)
+                              (dir-stream-table-fix dir-stream-table))))
+           (dir-stream-table-fix dir-stream-table)))))
+  :hints (("goal" :in-theory (e/d (get-names-from-dirp hifat-readdir)
+                                  nil)
+           :induct (get-names-from-dirp dirp dir-stream-table))))
+
+(defthm fat32-filename-list-p-of-get-names-from-dirp
   (fat32-filename-list-p
    (mv-nth 0
-           (hifat-get-names-from-dirp dirp dir-stream-table)))
-  :hints (("goal" :in-theory (enable hifat-get-names-from-dirp
+           (get-names-from-dirp dirp dir-stream-table)))
+  :hints (("goal" :in-theory (enable get-names-from-dirp
                                      hifat-readdir))))
 
-(defthm dir-stream-table-p-of-hifat-get-names-from-dirp
+(defthm dir-stream-table-p-of-get-names-from-dirp
   (dir-stream-table-p
    (mv-nth 1
-           (hifat-get-names-from-dirp dirp dir-stream-table)))
-  :hints (("goal" :in-theory (enable hifat-get-names-from-dirp
+           (get-names-from-dirp dirp dir-stream-table)))
+  :hints (("goal" :in-theory (enable get-names-from-dirp
                                      hifat-readdir))))
 
 ;; Making a recursive function to do tar can get really annoying because in
@@ -366,95 +655,77 @@
 ;; function will not work for looking up a root directory!
 ;; Anyway, to return to the induction scheme, it will be needed to make
 ;; something like a max path length and stop when we get there...
-(defund
-  hifat-tar-name-list-string
-  (fs path name-list fd-table
-      file-table dir-stream-table entry-count)
-  (declare
-   (xargs :guard (and (m1-file-alist-p fs)
-                      (hifat-no-dups-p fs)
-                      (fat32-filename-list-p path)
-                      (natp entry-count)
-                      (fat32-filename-list-p name-list)
-                      (file-table-p file-table)
-                      (fd-table-p fd-table)
-                      (dir-stream-table-p dir-stream-table))
-          :guard-hints
-          (("goal" :in-theory (e/d (hifat-tar-name-list-string)
-                                   (append append-of-cons))
-            :do-not-induct t))
-          :measure (nfix entry-count)
-          :verify-guards nil))
-  (b*
-      ((fd-table (mbe :exec fd-table
-                      :logic (fd-table-fix fd-table)))
-       (file-table (mbe :exec file-table
-                        :logic (file-table-fix file-table)))
-       (dir-stream-table
-        (mbe :exec dir-stream-table
-             :logic (dir-stream-table-fix dir-stream-table)))
-       ((unless (and (consp name-list)
-                     (not (zp entry-count))))
-        (mv "" fd-table file-table))
+(defund hifat-tar-name-list-string
+  (fs path name-list fd-table file-table dir-stream-table entry-count)
+  (declare (xargs :guard (and (m1-file-alist-p fs)
+                              (hifat-no-dups-p fs)
+                              (fat32-filename-list-p path)
+                              (natp entry-count)
+                              (fat32-filename-list-p name-list)
+                              (file-table-p file-table)
+                              (fd-table-p fd-table)
+                              (dir-stream-table-p dir-stream-table))
+                  :guard-hints (("goal" :in-theory (e/d (hifat-tar-name-list-string)
+                                                        (append append-of-cons))
+                                 :do-not-induct t))
+                  :measure (nfix entry-count) :verify-guards nil))
+  (b* ((fd-table (mbe :exec fd-table :logic (fd-table-fix fd-table)))
+       (file-table (mbe :exec file-table :logic (file-table-fix file-table)))
+       (dir-stream-table (mbe :exec dir-stream-table
+                              :logic (dir-stream-table-fix dir-stream-table)))
+       ((unless (and (consp name-list) (not (zp entry-count)))) (mv "" fd-table file-table))
        (head (car name-list))
        (head-path (append path (list head)))
-       ((mv st & &) (hifat-lstat fs head-path))
-       (len (struct-stat->st_size st))
-       ((mv fd-table file-table fd &)
-        (hifat-open head-path fd-table file-table))
-       ((unless (>= fd 0))
-        (mv "" fd-table file-table))
-       ((mv & & pread-error-code)
-        (hifat-pread fd len 0 fs fd-table file-table))
-       ((mv fd-table file-table &)
-        (hifat-close fd fd-table file-table))
-       ((unless (and (<= (len (fat32-path-to-path head-path))
-                         100)))
-        (mv "" fd-table file-table))
-       (head-string (hifat-tar-reg-file-string
-                     fs
-                     (implode (fat32-path-to-path head-path))))
-       ((when (zp pread-error-code))
-        (b* (((mv tail-string fd-table file-table)
-              (hifat-tar-name-list-string
-               fs head-path (cdr name-list)
-               fd-table file-table
-               dir-stream-table (- entry-count 1))))
-          (mv (concatenate 'string
-                           head-string tail-string)
-              fd-table file-table)))
-       ((mv dirp dir-stream-table &)
-        (hifat-opendir fs head-path dir-stream-table))
-       ((mv names dir-stream-table)
-        (hifat-get-names-from-dirp dirp dir-stream-table))
-       ((mv & dir-stream-table)
-        (hifat-closedir dirp dir-stream-table))
-       ((mv head-string fd-table file-table)
-        (hifat-tar-name-list-string
-         fs (append path (list))
-         names fd-table file-table
-         dir-stream-table (- entry-count 1)))
+       ((mv st retval &) (hifat-lstat fs head-path))
        ((mv tail-string fd-table file-table)
-        (hifat-tar-name-list-string
-         fs path (cdr name-list)
-         fd-table file-table
-         dir-stream-table (- entry-count 1))))
-    (mv
-     (concatenate
-      'string
-      (tar-header-block (implode (fat32-path-to-path head-path))
-                        0 *tar-dirtype*)
-      head-string tail-string)
-     fd-table file-table)))
+        (hifat-tar-name-list-string fs path (cdr name-list) fd-table file-table
+                                    dir-stream-table (- entry-count 1)))
+       ((unless (>= retval 0)) (mv tail-string fd-table file-table))
+       (len (struct-stat->st_size st))
+       ((mv fd-table file-table fd &) (hifat-open head-path fd-table file-table))
+       ((mv & & pread-error-code) (hifat-pread fd len 0 fs fd-table file-table))
+       ((mv fd-table file-table &) (hifat-close fd fd-table file-table))
+       ((unless (and (<= (len (fat32-path-to-path head-path)) 100))) (mv "" fd-table file-table)))
+    (if (zp pread-error-code)
+        ;; regular file.
+        (b* ((head-string (hifat-tar-reg-file-string fs
+                                                     (implode (fat32-path-to-path head-path)))))
+          (mv (concatenate 'string head-string tail-string) fd-table file-table))
+      ;; directory file.
+      (b*
+          (((mv dirp dir-stream-table &) (hifat-opendir fs head-path dir-stream-table))
+           ((mv names dir-stream-table) (get-names-from-dirp dirp dir-stream-table))
+           ((mv & dir-stream-table) (hifat-closedir dirp dir-stream-table))
+           ((mv head-string fd-table file-table) (hifat-tar-name-list-string
+                                                  fs head-path
+                                                  names fd-table file-table
+                                                  dir-stream-table (- entry-count 1))))
+        (mv (concatenate 'string
+                         (tar-header-block (implode (fat32-path-to-path head-path))
+                                           0 *tar-dirtype*)
+                         head-string tail-string)
+            fd-table file-table)))))
+
+(defthm
+  fd-table-p-of-hifat-tar-name-list-string-lemma-1
+  (not
+   (consp
+    (assoc-equal (find-new-index (strip-cars alist))
+                 alist)))
+  :hints
+  (("goal" :in-theory (disable (:rewrite find-new-index-correctness-1))
+    :use (:instance (:rewrite find-new-index-correctness-1)
+                    (fd-list (strip-cars alist))))))
 
 (defthm
   fd-table-p-of-hifat-tar-name-list-string
-  (fd-table-p
+  (equal
    (mv-nth 1
            (hifat-tar-name-list-string fs path name-list fd-table file-table
-                                       dir-stream-table entry-count)))
+                                       dir-stream-table entry-count))
+   (fd-table-fix fd-table))
   :hints
-  (("goal" :in-theory (e/d (hifat-tar-name-list-string)
+  (("goal" :in-theory (e/d (hifat-tar-name-list-string hifat-close hifat-open)
                            (append append-of-cons)))))
 
 (defthm
@@ -470,10 +741,592 @@
 
 (defthm
   file-table-p-of-hifat-tar-name-list-string
-  (file-table-p
+  (equal
    (mv-nth 2
            (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count))
+   (file-table-fix file-table))
+  :hints
+  (("goal" :in-theory (e/d (hifat-tar-name-list-string hifat-close hifat-open)
+                           (append append-of-cons)))))
+
+(defthmd
+  hifat-tar-name-list-string-reduction-correctness-lemma-1
+  (equal
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count))
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list nil file-table
                                        dir-stream-table entry-count)))
   :hints
-  (("goal" :in-theory (e/d (hifat-tar-name-list-string)
-                           (append append-of-cons)))))
+  (("goal"
+    :in-theory
+    (e/d (hifat-tar-name-list-string hifat-open hifat-close hifat-pread)
+         (append-of-cons binary-append (:rewrite nth-of-take)
+                         (:rewrite nth-when->=-n-len-l)
+                         (:rewrite prefixp-when-equal-lengths)
+                         (:rewrite fat32-filename-p-correctness-1)
+                         (:rewrite stringp-when-nonempty-stringp)
+                         (:definition len)
+                         (:rewrite prefixp-of-cons-left)
+                         (:rewrite take-of-too-many)
+                         (:rewrite take-of-take-same)
+                         (:linear getopt::defoptions-lemma-8)))
+    :induct
+    (hifat-tar-name-list-string fs path name-list fd-table
+                                file-table dir-stream-table entry-count)
+    :expand
+    (:free (fs path name-list
+               fd-table file-table dir-stream-table)
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count)))))
+
+(defthmd
+  hifat-tar-name-list-string-reduction-correctness-lemma-2
+  (equal
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count))
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list fd-table nil
+                                       dir-stream-table entry-count)))
+  :hints
+  (("goal"
+    :in-theory
+    (e/d (hifat-tar-name-list-string hifat-open hifat-close hifat-pread)
+         (append-of-cons binary-append (:rewrite nth-of-take)
+                         (:rewrite nth-when->=-n-len-l)
+                         (:rewrite prefixp-when-equal-lengths)
+                         (:rewrite fat32-filename-p-correctness-1)
+                         (:rewrite stringp-when-nonempty-stringp)
+                         (:definition len)
+                         (:rewrite prefixp-of-cons-left)
+                         (:rewrite take-of-too-many)
+                         (:rewrite take-of-take-same)
+                         (:linear getopt::defoptions-lemma-8)))
+    :induct
+    (hifat-tar-name-list-string fs path name-list fd-table
+                                file-table dir-stream-table entry-count)
+    :expand
+    (:free (fs path name-list
+               fd-table file-table dir-stream-table)
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count)))))
+
+(defthm
+  hifat-tar-name-list-string-reduction-correctness-lemma-4
+  (implies
+   (not (m1-directory-file-p (mv-nth 0 (hifat-find-file fs path))))
+   (equal
+    (mv-nth 0
+            (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                        dir-stream-table entry-count))
+    ""))
+  :hints
+  (("goal"
+    :in-theory (e/d (hifat-tar-name-list-string hifat-lstat hifat-find-file)
+                    (append append-of-cons)))))
+
+(defthmd
+  hifat-tar-name-list-string-reduction-correctness-lemma-3
+  (equal
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count))
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       nil entry-count)))
+  :hints
+  (("goal"
+    :in-theory
+    (e/d (hifat-tar-name-list-string hifat-open hifat-close
+                                     hifat-pread hifat-opendir hifat-closedir
+                                     hifat-lstat get-names-from-dirp-alt)
+         (append-of-cons binary-append (:rewrite nth-of-take)
+                         (:rewrite nth-when->=-n-len-l)
+                         (:rewrite prefixp-when-equal-lengths)
+                         (:rewrite fat32-filename-p-correctness-1)
+                         (:rewrite stringp-when-nonempty-stringp)
+                         (:definition len)
+                         (:rewrite prefixp-of-cons-left)
+                         (:rewrite take-of-too-many)
+                         (:rewrite take-of-take-same)
+                         (:linear getopt::defoptions-lemma-8)
+                         (:definition strip-cars)
+                         (:linear position-equal-ac-when-member)
+                         (:rewrite nthcdr-when->=-n-len-l)
+                         (:rewrite m1-directory-file-p-when-m1-file-p)
+                         (:definition position-equal-ac)
+                         (:rewrite consp-of-nthcdr)
+                         (:rewrite hifat-find-file-correctness-3)
+                         (:rewrite get-names-from-dirp-alt-lemma-3)
+                         (:rewrite get-names-from-dirp-alt-lemma-1)
+                         (:rewrite
+                          dir-stream-table-p-of-cdr-when-dir-stream-table-p)
+                         (:rewrite
+                          dir-stream-table-p-when-subsetp-equal)
+                         (:rewrite consp-car-of-dir-stream-table-fix)
+                         (:type-prescription
+                          true-listp-nthcdr-type-prescription)
+                         (:rewrite take-fewer-of-take-more)
+                         (:rewrite dir-stream-table-p-when-not-consp)
+                         (:rewrite take-when-atom)
+                         (:linear
+                          len-of-explode-when-m1-file-contents-p-1)
+                         (:rewrite
+                          hifat-find-file-correctness-3-lemma-2)
+                         (:REWRITE DEFAULT-CAR)
+                         (:REWRITE
+                          M1-FILE->CONTENTS$INLINE-OF-M1-FILE-FIX-X-NORMALIZE-CONST)
+                         (:REWRITE
+                          CDR-OF-FAT32-FILENAME-LIST-FIX-X-NORMALIZE-CONST-UNDER-FAT32-FILENAME-LIST-EQUIV)
+                         (:REWRITE
+                          CONS-OF-FAT32-FILENAME-FIX-X-NORMALIZE-CONST-UNDER-FAT32-FILENAME-LIST-EQUIV)
+                         (:REWRITE
+                          CONS-OF-FAT32-FILENAME-LIST-FIX-Y-NORMALIZE-CONST-UNDER-FAT32-FILENAME-LIST-EQUIV)
+                         (:REWRITE
+                          CAR-OF-FAT32-FILENAME-LIST-FIX-X-NORMALIZE-CONST-UNDER-FAT32-FILENAME-EQUIV)
+                         (:REWRITE PUT-ASSOC-EQUAL-WITHOUT-CHANGE . 2)
+                         (:REWRITE
+                          DIR-STREAM-OF-FAT32-FILENAME-LIST-FIX-FILE-LIST-NORMALIZE-CONST)
+                         (:REWRITE
+                          CAR-OF-TRUE-LIST-LIST-FIX-X-NORMALIZE-CONST-UNDER-LIST-EQUIV)
+                         (:TYPE-PRESCRIPTION NATP-POSITION-AC)))
+    :induct
+    (hifat-tar-name-list-string fs path name-list fd-table
+                                file-table dir-stream-table entry-count)
+    :expand
+    (:free (fs path name-list
+               fd-table file-table dir-stream-table)
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count)))))
+
+(defund hifat-tar-name-list-string-reduction
+  (fs path name-list entry-count)
+  (b*
+      (((mv string & &)
+        (hifat-tar-name-list-string fs path name-list nil nil nil entry-count)))
+    string))
+
+(defthmd
+  hifat-tar-name-list-string-reduction-correctness-1
+  (equal
+   (mv-nth 0
+           (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                       dir-stream-table entry-count))
+   (hifat-tar-name-list-string-reduction fs path name-list entry-count))
+  :instructions
+  ((:dive 2)
+   :x :top (:dive 1)
+   (:rewrite hifat-tar-name-list-string-reduction-correctness-lemma-1)
+   (:rewrite hifat-tar-name-list-string-reduction-correctness-lemma-2)
+   (:rewrite hifat-tar-name-list-string-reduction-correctness-lemma-3)
+   :top :s))
+
+(defund alist-shift (alist shift)
+  (if (atom alist)
+      nil
+    (cons (cons (caar alist) (+ shift (cdar alist)))
+          (alist-shift (cdr alist) shift))))
+
+(defund
+  hifat-tar-name-list-alist
+  (fs path name-list entry-count)
+  (declare (xargs :measure (nfix entry-count)))
+  (b*
+      (((unless (and (consp name-list)
+                     (not (zp entry-count))))
+        nil)
+       (head (car name-list))
+       (head-path (append path (list head)))
+       ((mv st retval &) (hifat-lstat fs head-path))
+       (tail-alist
+        (hifat-tar-name-list-alist
+         fs head-path (cdr name-list) (- entry-count 1)))
+       ((unless (>= retval 0)) tail-alist)
+       (len (struct-stat->st_size st))
+       ((mv fd-table file-table fd &)
+        (hifat-open head-path nil nil))
+       ((unless (>= fd 0)) nil)
+       ((mv & & pread-error-code)
+        (hifat-pread fd len 0 fs fd-table file-table))
+       ((mv & & &)
+        (hifat-close fd fd-table file-table))
+       ((unless (and (<= (len (fat32-path-to-path head-path)) 100))) nil)
+       (head-string (hifat-tar-reg-file-string
+                     fs
+                     (implode (fat32-path-to-path head-path))))
+       ((when (zp pread-error-code))
+        (cons (cons head-path 0)
+              (alist-shift tail-alist (len head-string))))
+       ((mv dirp dir-stream-table &)
+        (hifat-opendir fs head-path nil))
+       ((mv names dir-stream-table)
+        (get-names-from-dirp dirp dir-stream-table))
+       ((mv & &)
+        (hifat-closedir dirp dir-stream-table))
+       (head-alist
+        (hifat-tar-name-list-alist fs (append path (list head)) names (- entry-count 1)))
+       (tail-alist
+        (hifat-tar-name-list-alist fs path (cdr name-list) (- entry-count 1))))
+    (append
+     (alist-shift
+      head-alist
+      (length
+       (tar-header-block (implode (fat32-path-to-path head-path))
+                         0 *tar-dirtype*)))
+     (alist-shift
+      tail-alist
+      (+
+       (length
+        (tar-header-block (implode (fat32-path-to-path head-path))
+                          0 *tar-dirtype*))
+       (length (hifat-tar-name-list-string-reduction
+             fs (append path (list head))
+             names (- entry-count 1))))))))
+
+(defthm consp-of-assoc-of-alist-shift
+  (implies (alistp alist)
+           (equal (consp (assoc-equal x (alist-shift alist shift)))
+                  (consp (assoc-equal x alist))))
+  :hints (("goal" :in-theory (enable alist-shift))))
+
+(defthm alistp-of-alist-shift
+  (alistp (alist-shift alist shift))
+  :hints (("goal" :in-theory (enable alist-shift))))
+
+(defthm alistp-of-hifat-tar-name-list-alist
+  (alistp (hifat-tar-name-list-alist fs path name-list entry-count))
+  :hints (("goal" :in-theory (enable hifat-tar-name-list-alist))))
+
+(defthm assoc-of-alist-shift
+  (implies (case-split (not (null x)))
+           (equal (assoc-equal x (alist-shift alist shift))
+                  (if (atom (assoc-equal x alist))
+                      nil
+                      (cons (car (assoc-equal x alist))
+                            (+ shift (cdr (assoc-equal x alist)))))))
+  :hints (("goal" :in-theory (enable alist-shift))))
+
+(defthm hifat-tar-name-list-alist-correctness-lemma-1
+  (consp (assoc-equal (mv-nth 2 (hifat-open path fd-table file-table))
+                      (mv-nth 0
+                              (hifat-open path fd-table file-table))))
+  :hints (("goal" :in-theory (enable hifat-open)))
+  :rule-classes :type-prescription)
+
+(defthm
+  hifat-tar-name-list-alist-correctness-lemma-2
+  (consp
+   (assoc-equal
+    (cdr (assoc-equal (mv-nth 2 (hifat-open path fd-table file-table))
+                      (mv-nth 0
+                              (hifat-open path fd-table file-table))))
+    (mv-nth 1
+            (hifat-open path fd-table file-table))))
+  :hints (("goal" :do-not-induct t
+           :in-theory (enable hifat-open)))
+  :rule-classes :type-prescription)
+
+(defthm
+  hifat-tar-name-list-alist-correctness-lemma-3
+  (implies
+   (not (equal (mv-nth 1 (hifat-find-file fs path))
+               0))
+   (>
+    (mv-nth
+     1
+     (hifat-find-file
+      fs
+      (file-table-element->fid
+       (cdr
+        (assoc-equal
+         (cdr (assoc-equal (mv-nth 2 (hifat-open path fd-table file-table))
+                           (mv-nth 0
+                                   (hifat-open path fd-table file-table))))
+         (mv-nth 1
+                 (hifat-open path fd-table file-table)))))))
+    0))
+  :hints (("goal" :in-theory (enable hifat-open)))
+  :rule-classes :linear)
+
+(defthm
+  subseq-of-implode-of-append-lemma-1
+  (implies (and (not (integerp (- start)))
+                (>= start 0))
+           (> (len x) (- start)))
+  :rule-classes :linear)
+
+;; Move later.
+(defthm str::make-character-list-under-charlisteqv
+  (str::charlisteqv (make-character-list x)
+                    x)
+  :hints (("goal" :in-theory (enable str::charlisteqv))))
+
+(defthm
+  subseq-of-implode-of-append
+  (equal (subseq (implode (append x y))
+                 start end)
+         (cond ((and (not (integerp (- (+ (len x) (len y)) start)))
+                     (null end))
+                "")
+               ((and (not (integerp start))
+                     (<= (len x)
+                         (- (+ (len x) (len y)) start))
+                     (integerp (- (+ (len x) (len y)) start))
+                     (null end))
+                (implode (append x (take (- (len y) start) y))))
+               ((and (integerp start)
+                     (< (len x) start)
+                     (null end))
+                (implode (take (- (+ (len x) (len y)) start)
+                               (nthcdr (- start (len x)) y))))
+               ((and (integerp start)
+                     (< start 0)
+                     (null end))
+                (implode (append x (take (- (len y) start) y))))
+               ((and (not (integerp start))
+                     (integerp (- (+ (len x) (len y)) start))
+                     (< (- (+ (len x) (len y)) start)
+                        (len x))
+                     (null end))
+                (implode (take (- (+ (len x) (len y)) start) x)))
+               ((null end)
+                (implode (append (nthcdr start x) y)))
+               ((stringp y)
+                (implode (take (- end start) (nthcdr start x))))
+               ((not (natp (- end start))) "")
+               ((and (< start 0)
+                     (< (- end start) (len x)))
+                (implode (take (- end start) x)))
+               ((and (not (integerp start))
+                     (< (- end start) (len x)))
+                (implode (take (- end start) x)))
+               ((not (integerp start))
+                (implode (append x (take (- end (+ start (len x))) y))))
+               ((and (<= 0 start)
+                     (<= end (len x))
+                     (not (integerp end)))
+                (implode (take (- end start) x)))
+               ((and (< start 0)
+                     (<= (len x) (- end start)))
+                (implode (append x (take (- end (+ start (len x))) y))))
+               ((< start 0)
+                (implode (take (- end start) x)))
+               ((< (len x) start)
+                (implode (take (- end start)
+                               (nthcdr (- start (len x)) y))))
+               ((<= end (len x))
+                (implode (take (- end start) (nthcdr start x))))
+               (t (implode (append (nthcdr start x)
+                                   (take (- end (len x)) y))))))
+  :hints (("goal" :in-theory (e/d (subseq subseq-list take)
+                                  ((:e force)))
+           :do-not-induct t
+           :use ((:theorem (equal (+ start (- start) (- (len x)))
+                                  (- (len x))))
+                 (:theorem (equal (+ (len x) (- (len x)) (len y))
+                                  (len y)))))))
+
+(defthm hifat-tar-name-list-alist-correctness-lemma-4
+  (implies (and (integerp start)
+                (equal start end)
+                (stringp seq))
+           (equal (subseq seq start end) ""))
+  :hints (("goal" :in-theory (enable subseq subseq-list))))
+
+(defthm hifat-tar-name-list-alist-correctness-lemma-7
+  (equal (subseq "" start end)
+         (implode (repeat (+ end (- start)) nil)))
+  :hints (("goal" :in-theory (enable subseq subseq-list repeat))))
+
+(defthm
+  stringp-of-hifat-tar-name-list-string-reduction
+  (stringp
+   (hifat-tar-name-list-string-reduction fs path name-list entry-count))
+  :hints (("goal" :do-not-induct t
+           :use hifat-tar-name-list-string-reduction-correctness-1))
+  :rule-classes :type-prescription)
+
+(defthm
+  hifat-tar-name-list-alist-correctness-lemma-10
+  (implies
+   (and (consp path)
+        (not (zp (mv-nth 1 (hifat-find-file fs path)))))
+   (equal
+    (mv-nth 0
+            (hifat-tar-name-list-string fs path name-list fd-table file-table
+                                        dir-stream-table entry-count))
+    ""))
+  :hints
+  (("goal"
+    :in-theory (e/d (hifat-tar-name-list-string hifat-lstat hifat-find-file)
+                    (append append-of-cons)))))
+
+(defthm
+  hifat-tar-name-list-alist-correctness-lemma-11
+  (and (< 0
+          (len (explode (tar-header-block path len typeflag))))
+       (not (equal (tar-header-block path len typeflag)
+                   "")))
+  :hints (("goal" :in-theory (enable tar-header-block)))
+  :rule-classes
+  ((:linear
+    :corollary (< 0
+                  (len (explode (tar-header-block path len typeflag)))))
+   (:rewrite :corollary (not (equal (tar-header-block path len typeflag)
+                                    "")))))
+
+(defthm
+  hifat-tar-name-list-alist-correctness-lemma-12
+  (implies (fat32-filename-list-p (path-to-fat32-path (explode path)))
+           (and (not (equal (hifat-tar-reg-file-string fs path)
+                            ""))
+                (< 0
+                   (len (explode (hifat-tar-reg-file-string fs path))))))
+  :hints (("goal" :in-theory (enable hifat-tar-reg-file-string hifat-open)))
+  :rule-classes
+  ((:rewrite
+    :corollary
+    (implies (fat32-filename-list-p (path-to-fat32-path (explode path)))
+             (not (equal (hifat-tar-reg-file-string fs path)
+                         ""))))
+   (:linear
+    :corollary
+    (implies (fat32-filename-list-p (path-to-fat32-path (explode path)))
+             (< 0
+                (len (explode (hifat-tar-reg-file-string fs path))))))))
+
+(encapsulate
+  ()
+
+  (local (in-theory
+          (e/d (hifat-tar-name-list-string
+                hifat-tar-name-list-alist)
+               (append-of-cons binary-append))))
+
+  (defthm
+    not-consp-assoc-nil-hifat-tar-name-list-alist
+    (not
+     (consp
+      (assoc-equal nil
+                   (hifat-tar-name-list-alist fs path name-list entry-count))))
+    :rule-classes :type-prescription)
+
+  (defthm
+    acl2-numberp-of-cdr-of-assoc-of-hifat-tar-name-list-alist
+    (implies
+     (consp
+      (assoc-equal path2
+                   (hifat-tar-name-list-alist fs path1 name-list entry-count)))
+     (acl2-numberp
+      (cdr
+       (assoc-equal path2
+                    (hifat-tar-name-list-alist fs path1 name-list entry-count)))))
+    :rule-classes :type-prescription)
+
+  (defthm
+    hifat-tar-name-list-alist-correctness-lemma-5
+    (implies (and (not (zp (mv-nth 1 (hifat-find-file fs path))))
+                  (consp path))
+             (equal (hifat-tar-name-list-alist fs path name-list entry-count)
+                    nil))
+    :hints (("goal" :in-theory (e/d (alist-shift hifat-pread) nil))))
+
+  (defthm
+    hifat-tar-name-list-alist-correctness-lemma-6
+    (implies
+     (consp
+      (assoc-equal path2
+                   (hifat-tar-name-list-alist fs path1 name-list entry-count)))
+     (natp
+      (cdr (assoc-equal
+            path2
+            (hifat-tar-name-list-alist fs path1 name-list entry-count)))))
+    :rule-classes :type-prescription)
+
+  (defthm
+    hifat-tar-name-list-alist-correctness-lemma-8
+    (implies
+     (equal (mv-nth 1 (hifat-find-file fs path))
+            0)
+     (equal
+      (mv-nth
+       1
+       (hifat-find-file
+        fs
+        (file-table-element->fid
+         (cdr
+          (assoc-equal
+           (cdr (assoc-equal (mv-nth 2 (hifat-open path fd-table file-table))
+                             (mv-nth 0
+                                     (hifat-open path fd-table file-table))))
+           (mv-nth 1
+                   (hifat-open path fd-table file-table)))))))
+      0))
+    :hints (("goal" :do-not-induct t
+             :in-theory (enable hifat-open))))
+
+  (defthm
+    hifat-tar-name-list-alist-correctness-lemma-9
+    (implies
+     (and
+      (not (<= (mv-nth 1 (hifat-find-file fs '("           ")))
+               0)))
+     (not
+      (consp
+       (assoc-equal
+        path2
+        (hifat-tar-name-list-alist
+         fs '(".          ")
+         (mv-nth
+          0
+          (get-names-from-dirp (mv-nth 0
+                                       (hifat-opendir fs '(".          ") nil))
+                               (mv-nth 1
+                                       (hifat-opendir fs '(".          ")
+                                                      nil))))
+         (+ -1 entry-count))))))
+    :hints (("goal" :do-not-induct t
+             :in-theory (enable hifat-open hifat-find-file)))
+    :rule-classes :type-prescription)
+
+  ;; (thm
+  ;;  (b*
+  ;;      ((alist
+  ;;        (hifat-tar-name-list-alist
+  ;;         fs path1 name-list entry-count))
+  ;;       (alist-elem (assoc-equal path2 alist)))
+  ;;    (implies
+  ;;     (and (consp alist-elem)
+  ;;          (dir-stream-table-p dir-stream-table)
+  ;;          (fd-table-p fd-table)
+  ;;          (file-table-p file-table)
+  ;;          (fat32-filename-list-p name-list))
+  ;;     (equal
+  ;;      (subseq
+  ;;       (mv-nth 0
+  ;;               (hifat-tar-name-list-string
+  ;;                fs path1 name-list fd-table file-table dir-stream-table entry-count))
+  ;;       (cdr alist-elem)
+  ;;       (+
+  ;;        (cdr alist-elem)
+  ;;        (length (hifat-tar-reg-file-string
+  ;;                    fs
+  ;;                    (implode (fat32-path-to-path path2))))))
+  ;;      (hifat-tar-reg-file-string
+  ;;       fs
+  ;;       (implode (fat32-path-to-path path2))))))
+  ;;  :hints (("Goal"
+  ;;           :in-theory (e/d (hifat-pread hifat-lstat hifat-open)
+  ;;                           (take-when-prefixp prefixp-of-cons-right
+  ;;                                              take-of-cons
+  ;;                                              fat32-name-to-name))
+  ;;           :induct
+  ;;           (hifat-tar-name-list-string
+  ;;            fs path1 name-list fd-table file-table dir-stream-table
+  ;;            entry-count)
+  ;;           :expand
+  ;;           (HIFAT-TAR-NAME-LIST-ALIST FS PATH1 NAME-LIST ENTRY-COUNT))))
+  )

--- a/books/projects/filesystems/tar-stuff.lisp
+++ b/books/projects/filesystems/tar-stuff.lisp
@@ -1058,12 +1058,6 @@
            (> (len x) (- start)))
   :rule-classes :linear)
 
-;; Move later.
-(defthm str::make-character-list-under-charlisteqv
-  (str::charlisteqv (make-character-list x)
-                    x)
-  :hints (("goal" :in-theory (enable str::charlisteqv))))
-
 (defthm
   subseq-of-implode-of-append
   (equal (subseq (implode (append x y))

--- a/books/std/strings/eqv.lisp
+++ b/books/std/strings/eqv.lisp
@@ -166,6 +166,10 @@ same length and their elements must be @(see chareqv) to one another.</p>
              (not (charlisteqv x y)))
     :hints(("Goal" :induct (ind x y))))
 
+  (defthm make-character-list-is-identity-under-charlisteqv
+    (str::charlisteqv (make-character-list x)
+                      x))
+
   (defthmd charlisteqv*
     ;; For compatibility with the old definition
     (equal (charlisteqv x y)
@@ -230,4 +234,3 @@ same length and their elements must be @(see chareqv) to one another.</p>
   (fty::deffixcong string-list-equiv string-list-equiv (cdr x) x)
   (fty::deffixcong streqv string-list-equiv (cons x y) x)
   (fty::deffixcong string-list-equiv string-list-equiv (cons x y) y))
-


### PR DESCRIPTION
This lemma follows from the definition of charlisteqv, but doesn't seem to exist although I grepped for similar lemmas.

The filesystem books are also updated as part of this pull request.