### PR TITLE
small doc changes to run-script and xdoc

### DIFF
--- a/books/tools/run-script.lisp
+++ b/books/tools/run-script.lisp
@@ -8,7 +8,7 @@
 
 (defxdoc run-script
   :parents (testing-utilities)
-  :short "Run a script"
+  :short "Run a script."
   :long "<p>@('Run-script') is a utility for testing evaluation of the forms in
  a given file, to check that the output is as expected.  The forms need not be
  embedded event forms (see @(see events)), and they need not all evaluate
@@ -25,7 +25,9 @@
              )
  })
 
- <p>where the keyword arguments are evaluated.</p>
+ <p>where the keyword arguments are evaluated.
+ For information on the keyword arguments, see @(tsee set-inhibited-summary-types),
+ @(tsee set-inhibit-output-lst), and @(tsee ld-error-action).</p>
 
  <p>Example form:</p>
 
@@ -33,9 +35,13 @@
  (run-script \"mini-proveall\")
  })
 
- <p>In order to call @('(run-script NAME)') (with or without keyword
- arguments), you will need four files corresponding to @('NAME'), as described
- below.  For an example, see the files @('books/demos/mini-proveall-*.*') in
+ <p>When you call @('(run-script NAME)'), the forms in @('NAME-input.lsp')
+ are evaluated and a transcript is written to @('NAME-log.out').
+ Forms that are @(see command)s change the logical world.</p>
+
+ <p>To use @('run-script') for regression testing, you will need
+ to create three files in addition to the input file, as described below.
+ For an example, see the files @('books/demos/mini-proveall-*.*') in
  the @(see community-books); there, @('NAME') is @('mini-proveall').</p>
 
  <ul>

--- a/books/xdoc/constructors.lisp
+++ b/books/xdoc/constructors.lisp
@@ -934,7 +934,7 @@
 
 (generate-primitive-constructor-for-dir/&& :@tsee
   "Construct an XDOC tree
-   for a typewriter topic link directive <tt>@</tt><tt>(csee ...)</tt>.")
+   for a typewriter topic link directive <tt>@</tt><tt>(tsee ...)</tt>.")
 
 (generate-primitive-constructor-for-dir/&& :@see?
   "Construct an XDOC tree


### PR DESCRIPTION
I changed the wording a little in run-script that cleared up a misunderstanding I had when I first read it, and added some links that explain the keyword arguments.
The only change in xdoc was a cut-and-paste error where it referred to csee when it should have referred to tsee.