### PR TITLE
Update use of keyword in DEFFIXTYPE.

### DIFF
--- a/books/centaur/sv/mods/alias-norm.lisp
+++ b/books/centaur/sv/mods/alias-norm.lisp
@@ -284,7 +284,7 @@ question -- so then concatenate on that bit's path to w.  Got that?</p>")
            (len aliases)))
 
   (fty::deffixtype aliases-normorderedp :pred aliases-normorderedp :fix aliases-bound-fix
-    :equiv aliases-equiv :define t :forward t :execp nil)
+    :equiv aliases-equiv :define t :forward t :executablep nil)
 
   (local (in-theory (disable aliases-bound-fix)))
 

--- a/books/centaur/sv/mods/lhs.lisp
+++ b/books/centaur/sv/mods/lhs.lisp
@@ -650,7 +650,7 @@ the order given (LSBs-first).</p>")
     (equal x (lhs-norm x))
     ///
     (deffixtype lhs-norm :fix lhs-norm :pred lhs-normp
-      :equiv lhs-norm-equiv :define t :forward t :execp nil)
+      :equiv lhs-norm-equiv :define t :forward t :executablep nil)
 
     (defrefinement lhs-equiv lhs-norm-equiv)
 
@@ -1739,10 +1739,10 @@ the order given (LSBs-first).</p>")
   (defthm svex-lhsrewrite-vars
     (implies (not (member v (svex-vars x)))
              (not (member v (svex-vars (svex-lhsrewrite x w)))))))
-  
-    
-      
-  
+
+
+
+
 
 ;; { a[3:0], b[2:1] } = foo
 
@@ -2369,7 +2369,7 @@ bits of @('foo'):</p>
   (if (atom x)
       (svex-quote (4vec-z))
     (b* (((lhrange xf) (car x)))
-      (svex-concat xf.w 
+      (svex-concat xf.w
                    (lhatom->svex xf.atom)
                    (lhs->svex (cdr x)))))
   ///
@@ -3156,7 +3156,3 @@ bits of @('foo'):</p>
 ;; book that both include...
 (defconst *svex-longest-static-prefix-var*
   :svex-longest-static-prefix)
-
-
-
-

--- a/books/centaur/sv/mods/moddb.lisp
+++ b/books/centaur/sv/mods/moddb.lisp
@@ -2318,7 +2318,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
       (equal (elab-modlist-norm x) x)
       ///
       (deffixtype elab-modlist-norm :fix elab-modlist-norm :pred elab-modlist-normp
-        :equiv elab-modlist-norm-equiv :define t :forward t :execp nil))
+        :equiv elab-modlist-norm-equiv :define t :forward t :executablep nil))
 
     (defthm elab-modlist-fix-of-elab-modlist-norm
       (equal (elab-modlist-fix (elab-modlist-norm x))
@@ -2401,7 +2401,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
       (implies (moddbp moddb)
                (equal (moddb-fix moddb) moddb)))
 
-    (deffixtype moddb :pred moddbp :fix moddb-fix :equiv moddb-equiv :define t :execp nil)
+    (deffixtype moddb :pred moddbp :fix moddb-fix :equiv moddb-equiv :define t :executablep nil)
 
     (defthm nth-of-moddb-fix
       (and (equal (nth 0 (moddb-fix moddb))
@@ -2502,7 +2502,7 @@ to clear out the wires or instances; just start over with a new elab-mod.</p>")
     ///
     (deffixtype moddb-norm :pred moddb-norm-p
       :fix moddb-norm :equiv moddb-norm-equiv
-      :define t :forward t :execp nil)
+      :define t :forward t :executablep nil)
 
     (fty::deffixcong moddb-norm-equiv nat-equiv (nth *moddb->nmods* moddb) moddb)
 


### PR DESCRIPTION
[This is the next step, after adding `:executablep` to `deffixtype`.]

Replace uses of :EXECP with the new :EXECUTABLEP.