### PR TITLE
Remove :execp from fty::deffixtype

### DIFF
--- a/books/centaur/fty/fixtype.lisp
+++ b/books/centaur/fty/fixtype.lisp
@@ -163,8 +163,11 @@
                              (get-fixtypes-alist world))))))))
 
 
-(defmacro deffixtype (name &key pred fix equiv (executablep 't)
-                           ;; optional
+(defmacro deffixtype (name &key
+                           pred
+                           fix
+                           equiv
+                           (executablep 't)
                            define
                            verbosep
                            hints

--- a/books/centaur/fty/fixtype.lisp
+++ b/books/centaur/fty/fixtype.lisp
@@ -55,7 +55,7 @@
 (defun get-fixtypes-alist (world)
   (cdr (assoc 'fixtype-alist (table-alist 'fixtypes world))))
 
-(defun deffixtype-fn (name predicate fix equiv executablep execp definep inline equal topic verbosep hints forward)
+(defun deffixtype-fn (name predicate fix equiv executablep definep inline equal topic verbosep hints forward)
   (if definep
       `(with-output ,@(and (not verbosep) '(:off :all :on acl2::error)) :stack :push
          (encapsulate nil
@@ -67,13 +67,13 @@
                      (value-triple
                       (er hard? 'deffixtype
                           "Failed to prove that ~x0 is idempotent.~%" ',fix)))))
-           (,(cond ((or (not executablep) (not execp)) 'defun-nx)
+           (,(cond ((not executablep) 'defun-nx)
                    ((not inline) 'defun)
                    (t            'defun-inline))
             ,equiv (x y)
              (declare (xargs :normalize nil
-                             ,@(and executablep execp `(:guard (and (,predicate x) (,predicate y))))
-                             :verify-guards ,(and executablep execp)))
+                             ,@(and executablep `(:guard (and (,predicate x) (,predicate y))))
+                             :verify-guards ,executablep))
              (,equal (,fix x) (,fix y)))
            (local (in-theory '(,equiv tmp-deffixtype-idempotent
                                       booleanp-compound-recognizer)))
@@ -114,10 +114,10 @@
                                                      :pred predicate
                                                      :fix fix
                                                      :equiv equiv
-                                                     :executablep (and executablep execp)
+                                                     :executablep executablep
                                                      :equiv-means-fixes-equal
                                                      ;; BOZO stupid ACL2 is so awful...
-                                                     (if (and executablep execp inline)
+                                                     (if (and executablep inline)
                                                          (intern-in-package-of-symbol
                                                           (concatenate 'string (symbol-name equiv) "$INLINE")
                                                           equiv)
@@ -154,7 +154,7 @@
                                                    :pred predicate
                                                    :fix fix
                                                    :equiv equiv
-                                                   :executablep (and executablep execp)
+                                                   :executablep executablep
                                                    :equiv-means-fixes-equal thmname
                                                    :inline inline
                                                    :equal equal
@@ -163,7 +163,7 @@
                              (get-fixtypes-alist world))))))))
 
 
-(defmacro deffixtype (name &key pred fix equiv (executablep 't) (execp 't)
+(defmacro deffixtype (name &key pred fix equiv (executablep 't)
                            ;; optional
                            define
                            verbosep
@@ -175,7 +175,7 @@
 ; We contemplated making "equal" the default equivalence relation but decided
 ; against it.  See Github Issue 240 for relevant discussion.
   (declare (xargs :guard (and pred fix equiv)))
-  (deffixtype-fn name pred fix equiv executablep execp define inline equal
+  (deffixtype-fn name pred fix equiv executablep define inline equal
     (if topic-p topic name)
     verbosep hints forward))
 


### PR DESCRIPTION
Before merging this PR, users of `fty::deffixtype` who use `:execp` in non-community-book files should update those files to use `:executablep` instead, which is the option described in the user documentation. (All the community books that used `:execp` have already been updated to use `:executablep` in a previous commit.)

The second commit is purely aesthetic.
