### PR TITLE
books/sorting/merge-sort-term-order.lisp has a new lemma that help certify that book faster

### DIFF
--- a/books/sorting/merge-sort-term-order.lisp
+++ b/books/sorting/merge-sort-term-order.lisp
@@ -6,8 +6,15 @@
 (include-book "term-ordered-perms")
 (include-book "convert-perm-to-how-many")
 
+(local
+ (defthm term-order-total
+   (implies (not (term-order x y))
+            (term-order y x))))
+
 (defthm term-orderedp-merge-sort-term-order
-  (term-orderedp (merge-sort-term-order x)))
+  (term-orderedp (merge-sort-term-order x))
+  :hints (("Goal"
+           :in-theory (e/d () (term-order)))))
 
 (defthm true-listp-merge-sort-term-order
   (implies (true-listp x)


### PR DESCRIPTION
_books/sorting/merge-sort-term-order.lisp_ is updated with a new _term-order-total lemma_ that helps the existing _term-orderedp-merge-sort-term-order_ event to run much faster.

Before, _cert.pl_ took 15 minutes and "_make regression_" (probably with the help of useless-runes file) took around 4 minutes to certify that book. Now, it takes less than a second for both.