### PR TITLE
[join-thms] Fix two error messages.

### DIFF
--- a/books/clause-processors/join-thms.lisp
+++ b/books/clause-processors/join-thms.lisp
@@ -194,11 +194,10 @@
                            ',alist)))
         (cond ((not if-rule)
                (er soft 'def-join-thms
-                   (msg "Unable to find a rewrite rule for (~x0 X A) when ~
-                         (CAR X) is IF~%" ',ev)))
+                   "Unable to find a rewrite rule for (~x0 X A) when ~
+                         (CAR X) is IF~%" ',ev))
               ((not quote-rule)
                (er soft 'def-join-thms
-                   (msg "Unable to find a rewrite rule for (~x0 X A) when ~
-                         (CAR X) is QUOTE~%" ',ev)))
+                   "Unable to find a rewrite rule for (~x0 X A) when ~
+                         (CAR X) is QUOTE~%" ',ev))
               (t (value (sublis alist *def-join-thms-body*))))))))
-


### PR DESCRIPTION
This fixes two calls of (er soft ...) which previously led to bad calls of FMT1.

To reproduce the problem fixed by this commit, do:

(include-book "clause-processors/join-thms" :dir :system)
(defevaluator evl evl-list nil)
(def-join-thms ev)