### PR TITLE
Make a minor addition to :doc apt::simplify-defun-examples

### DIFF
--- a/books/kestrel/apt/simplify-defun-doc.lisp
+++ b/books/kestrel/apt/simplify-defun-doc.lisp
@@ -704,6 +704,7 @@
  (defun bar (x)
    (declare (xargs :measure (nfix x)))
    (if (zp x) 0 (+ 1 1 (bar (+ -1 x)))))
+ (include-book \"kestrel/apt/simplify-defun-tests\" :dir :system)
  (simplify-defun bar
                  :new-name bar-simp
                  :thm-name bar-simplified

--- a/books/kestrel/apt/simplify-defun-doc.lisp
+++ b/books/kestrel/apt/simplify-defun-doc.lisp
@@ -704,7 +704,7 @@
  (defun bar (x)
    (declare (xargs :measure (nfix x)))
    (if (zp x) 0 (+ 1 1 (bar (+ -1 x)))))
- (include-book \"kestrel/apt/simplify-defun-tests\" :dir :system)
+ (include-book \"kestrel/apt/simplify\" :dir :system)
  (simplify-defun bar
                  :new-name bar-simp
                  :thm-name bar-simplified


### PR DESCRIPTION
I was trying out simplify-defun earlier, and I had to spend a while figuring out the correct book to include. Perhaps adding this line will help the next reader.