### PR TITLE
[Std/alists] Add theorem.

### DIFF
--- a/books/std/alists/alistp.lisp
+++ b/books/std/alists/alistp.lisp
@@ -59,6 +59,10 @@ Accordingly, you may not really need to reason about @('alistp') at all.</p>"
              (true-listp x))
     :rule-classes :compound-recognizer)
 
+  (defthmd true-listp-when-alistp-rewrite
+    (implies (alistp x)
+             (true-listp x)))
+
   (defthm alistp-of-append
     (equal (alistp (append x y))
            (and (alistp (list-fix x))


### PR DESCRIPTION
[Making a PR since it affects Std. I'll merge in a few days if there are no objections.]

This is disabled by default, because the hypothesis is about alists while the
conclusion is about lists and involves a common predicate.

There is already a compound recognizer version of this rule, but in some cases
the rewrite rule seems needed. This new theorem can be enabled in those cases.

Another option could be to just add :rewrite to the rule classes of the existing
compound recognizer rule. Maybe there should be a more unified policy about
this, at least in the Std library, ideally as a more general ACL2 style guide.