### PR TITLE
Move a lemma to community books

### DIFF
--- a/books/projects/filesystems/hifat.lisp
+++ b/books/projects/filesystems/hifat.lisp
@@ -466,12 +466,6 @@
                                             (set-equiv (intersection-equal y x)
                                                        x))))))
 
-;; Move to community books later.
-(defthm prefixp-when-prefixp
-  (implies (prefixp y x)
-           (equal (prefixp x y) (list-equiv x y)))
-  :hints (("goal" :in-theory (enable prefixp))))
-
 (defthmd
   painful-debugging-lemma-14
   (implies (not (zp cluster-size))

--- a/books/std/lists/prefixp.lisp
+++ b/books/std/lists/prefixp.lisp
@@ -148,7 +148,7 @@ the list @('y')."
                     (list-equiv x y)))
     :hints(("Goal" :in-theory (enable prefixp list-equiv))))
 
-  ;; Mihir M. mod: Eight lemmas are added below. prefixp-transitive generates
+  ;; Mihir M. mod: Nine lemmas are added below. prefixp-transitive generates
   ;; two rewrite rules which are identical except in how they bind the free
   ;; variable y; it is similar with prefixp-one-way-or-another and the free
   ;; variable z. In nth-when-prefixp, the rewrite rule is a little less general
@@ -216,4 +216,9 @@ the list @('y')."
                        (take (len x) z))
                 (prefixp y (nthcdr (len x) z))))
     :hints (("goal" :in-theory (enable prefixp)
-             :induct (prefixp x z)))))
+             :induct (prefixp x z))))
+
+  (defthm prefixp-when-prefixp
+    (implies (prefixp y x)
+             (equal (prefixp x y) (list-equiv x y)))
+    :hints (("goal" :in-theory (enable prefixp)))))


### PR DESCRIPTION
This lemma probably shouldn't cause excessive backchaining, because it only gets tried when prefixp is already being reasoned about.