### PR TITLE
Slightly generalise two lemmas

### DIFF
--- a/books/std/lists/prefixp.lisp
+++ b/books/std/lists/prefixp.lisp
@@ -135,7 +135,7 @@ the list @('y')."
                   (atom x))))
 
   (defthm prefixp-of-append-when-same-length
-    (implies (equal (len x) (len y))
+    (implies (<= (len x) (len y))
              (equal (prefixp x (append y z))
                     (prefixp x y)))
     :hints(("Goal"
@@ -143,7 +143,7 @@ the list @('y')."
             :in-theory (enable prefixp list-equiv))))
 
   (defthm prefixp-when-equal-lengths
-    (implies (equal (len x) (len y))
+    (implies (>= (len x) (len y))
              (equal (prefixp x y)
                     (list-equiv x y)))
     :hints(("Goal" :in-theory (enable prefixp list-equiv))))


### PR DESCRIPTION
This generalisation, applied to both these lemmas, is somewhat limited
because ACL2 is often able to draw the obvious conclusion when two
number-valued terms satisfy <= and >= at the same time. Sometimes ACL2
isn't, though, and that makes this generalisation worthwhile. It
brings in a case-split arising from the definitions of <= and >=
respectively, but that has not proven to be a problem anywhere in the
regression suite.