### PR TITLE
Make file locations shown at top of xdoc topic pages be links

### DIFF
--- a/books/xdoc/fancy/xdoc.js
+++ b/books/xdoc/fancy/xdoc.js
@@ -781,9 +781,23 @@ function datLongTopic(key)
     }
 
     var from = xdata[key][XD_FROM];
-    var fromp = (from == "Unknown")
-                   ? "<p class='from'>Unknown Origin</p>"
-                   : "<p class='from'>" + from + "</p>";
+    var fromp;
+    if (from == "Unknown") {
+        fromp = "<p class='from'>Unknown Origin</p>";
+    }
+    else if (from == "ACL2 Sources") {
+        // link to main ACL2 sources dir:
+        fromp = "<p class='from'><a href=\"https://github.com/acl2/acl2\">ACL2 Sources</a></p>";
+    }
+    else if (from.startsWith("[books]")) {
+        // link to the specific file on GitHub:
+        fromp = "<p class='from'><a href=\"https://github.com/acl2/acl2/tree/master/books"
+            + from.substring(7) // strip "[books]" from front
+            + "\">" + from + "</a></p>";
+    }
+    else {
+        fromp = "<p class='from'>" + from + "</p>";
+    }
 
     var basepkg = htmlEncode(xdata[key][XD_BASEPKG]);
     var basediv = (basepkg == "ACL2")


### PR DESCRIPTION
This patch improves the ACL2 manual by making the file paths shown at the top of each topic be clickable links to GitHub.

When the path is something like "[books]/path/to/file.lisp" the link goes to that particular file on GitHub.

When the path is just "ACL2 sources", the link goes to the GitHub page that lists the files in the main ACL2 directory (since we can't tell from the text "ACL2 Sources" which source file should be shown).

Warning: This required editing Javascript, but I don't know Javascript!