### PR TITLE
Minor xdoc fix for defflexsum

### DIFF
--- a/books/centaur/fty/docgen.lisp
+++ b/books/centaur/fty/docgen.lisp
@@ -542,8 +542,10 @@ binder.</p>")
     (mv (append (and (not sum-name-shared-with-prod-name) main-doc)
                 prods-doc
                 `((xdoc::order-subtopics ,x.name
-                                         ,(remove nil (list* x.pred x.fix x.kind x.equiv x.count
-                                                             (remove x.name type-names))))))
+                                         ,(remove nil
+                                                  (remove x.name
+                                                          (list* x.pred x.fix x.kind x.equiv x.count
+                                                                 type-names))))))
         state)))
 
 (defun defoption->defxdoc (x parents kwd-alist base-pkg state)

--- a/books/centaur/fty/docgen.lisp
+++ b/books/centaur/fty/docgen.lisp
@@ -543,7 +543,7 @@ binder.</p>")
                 prods-doc
                 `((xdoc::order-subtopics ,x.name
                                          ,(remove nil (list* x.pred x.fix x.kind x.equiv x.count
-                                                             type-names)))))
+                                                             (remove x.name type-names))))))
         state)))
 
 (defun defoption->defxdoc (x parents kwd-alist base-pkg state)


### PR DESCRIPTION
This pull request addresses a minor xdoc issue that produces warnings like this:

WARNING: in topic AIGNET::AXI-LIT, subtopic order mentions topics that
are not children: AIGNET::AXI-LIT.

Note that the topic is being listed among its own children, which I think never makes sense.  Disclaimer: I don't know much about defflexsum, but the call (member x.name type-names) a few lines above my change indicates that this situation can happen.

With this change, the related warnings go away.