### PR TITLE
[xdoc] Fix defpointer to allow pointing to topics with unusual names.

### DIFF
--- a/books/xdoc/top.lisp
+++ b/books/xdoc/top.lisp
@@ -504,17 +504,30 @@
       (concatenate-symbol-names (list ,@args))
       mksym-package-symbol)))
 
+;; Convert SYM to a string in such a way that it could be read
+;; back in as SYM.
+(defund symbol-as-readable-string (sym)
+  (declare (xargs :guard (symbolp sym)
+                  :mode :program))
+  (mv-let (col str)
+    (fmt1-to-string "~x0"
+                    (acons #\0 sym nil)
+                    0
+                    :fmt-control-alist '((print-case . :downcase)
+                                         (fmt-soft-right-margin . 1000000)
+                                         (fmt-hard-right-margin . 1000000)))
+    (declare (ignore col))
+    str))
+
 (defmacro defpointer (from to &optional keyword-p)
   (declare (xargs :guard (and (symbolp from) (symbolp to))))
-  (let ((from-name (acl2::string-downcase (symbol-name         from)))
-        (to-pkg    (acl2::string-downcase (symbol-package-name to)))
-        (to-name   (acl2::string-downcase (symbol-name         to))))
+  (let ((from-name (acl2::string-downcase (symbol-name         from))))
     `(defxdoc ,from
        :parents (pointers)
        :short ,(concatenate
                 'string
                 "See @(see "
-                to-pkg "::" to-name
+                (symbol-as-readable-string to)
                 ")"
                 (if keyword-p
                     (concatenate


### PR DESCRIPTION
This pull request fixes a problem that occurs when defpointer is used to point to an xdoc topic whose name is an unusual symbol, such as a symbol that includes spaces.  Without this patch, the following gives an error:

(include-book "xdoc/topics" :dir :system)
(defxdoc |foo bar| :short "example")
(defpointer my-pointer |foo bar|)
:doc my-pointer

The error message is:
; xdoc error in MY-POINTER: 
"In SEE directive, expected ) after FOO. Near See @(see acl2::foo bar)..".
ACL2::MY-POINTER -- Current Interactive Session

Note the space between foo and bar in the generated @(see ...) form; this is not suitable for reading back in the symbol |foo bar|.
