### PR TITLE
[centaur] Reduce dependencies of tshell.

### DIFF
--- a/books/centaur/aignet/abc.lisp
+++ b/books/centaur/aignet/abc.lisp
@@ -32,6 +32,7 @@
 
 (include-book "aiger")
 (include-book "centaur/misc/tshell" :dir :system)
+(include-book "std/strings/defs" :dir :system) ; previously came in via tshell
 (local (include-book "std/strings/decimal" :dir :system))
 (defttag aignet-abc)
 

--- a/books/centaur/misc/tshell-tests.lisp
+++ b/books/centaur/misc/tshell-tests.lisp
@@ -30,6 +30,7 @@
 
 (in-package "ACL2")
 (include-book "tshell")
+(include-book "std/strings/defs" :dir :system) ; for str::strprefixp
 
 ; Well, this is pretty pathetic.  But it's hard to test much here, e.g., how
 ; can we emulate interrupts, etc.?

--- a/books/centaur/misc/tshell.lisp
+++ b/books/centaur/misc/tshell.lisp
@@ -32,7 +32,7 @@
 (in-package "ACL2")
 (include-book "tools/include-raw" :dir :system)
 (include-book "std/util/define" :dir :system)
-(include-book "std/strings/defs" :dir :system) ;; used in the raw code
+;; (include-book "std/strings/defs" :dir :system) ;; used in the raw code
 (include-book "quicklisp/shellpool" :dir :system)
 ;; (depends-on "tshell-raw.lsp")
 

--- a/books/centaur/satlink/top.lisp
+++ b/books/centaur/satlink/top.lisp
@@ -38,6 +38,7 @@
 (include-book "projects/sat/lrat/sorted/lrat-parser" :dir :system)
 (include-book "std/strings/decimal" :dir :system)
 (include-book "std/strings/strnatless" :dir :system)
+(include-book "std/strings/defs" :dir :system) ; previously came in via tshell
 (include-book "oslib/tempfile" :dir :system)
 (include-book "centaur/misc/tshell" :dir :system)
 (include-book "config")


### PR DESCRIPTION
Tshell currently depends (transitively, including via local includes) on 200 books.  Many of these seem unnecessary, such as IHS and osets and much more.  This change cuts the dependencies down to 24 books.

The comment "used in the raw code" on an include-book that I commented out gave me pause, but it doesn't seem to be true.  Everything still seems to build (after I added a few include-books in other places).

We have a use case where it would be very nice to have tshell depend on less stuff, because it supports an application we want to package up with Docker, and we want to certify and ship less stuff.

