### PR TITLE
Remove "/usr/bin/env" in smtlink config

### DIFF
--- a/books/projects/smtlink/config.lisp
+++ b/books/projects/smtlink/config.lisp
@@ -51,7 +51,7 @@ where the system books are."))
     (make-smtlink-config :interface-dir interface-dir
                          :smt-module "ACL2_to_Z3"
                          :smt-class "ACL22SMT"
-                         :smt-cmd "/usr/bin/env python"
+                         :smt-cmd "python"
                          :pythonpath "")))
 
 ;; -----------------------------------------------------------------

--- a/books/projects/smtlink/examples/examples.lisp
+++ b/books/projects/smtlink/examples/examples.lisp
@@ -75,7 +75,7 @@ Subgoal 2
 Subgoal 2.2
 Subgoal 2.2'
 Using default SMT-trusted-cp...
-; SMT solver: `/usr/bin/env python /tmp/py_file/smtlink.w59zR`: 0.52 sec, 7,904 bytes
+; SMT solver: `python /tmp/py_file/smtlink.w59zR`: 0.52 sec, 7,904 bytes
 Proved!
 Subgoal 2.2''
 Subgoal 2.1
@@ -139,7 +139,7 @@ read back into ACL2.  Below are the outputs from this clause processor called
 
 @({
 Using default SMT-trusted-cp...
-; SMT solver: `/usr/bin/env python /tmp/py_file/smtlink.w59zR`: 0.52 sec, 7,904 bytes
+; SMT solver: `python /tmp/py_file/smtlink.w59zR`: 0.52 sec, 7,904 bytes
 Proved!
 })
 

--- a/books/projects/smtlink/smtlink-config
+++ b/books/projects/smtlink/smtlink-config
@@ -1,1 +1,1 @@
-smt-cmd=/usr/bin/env python
+smt-cmd=python


### PR DESCRIPTION
/usr/bin/env is not available in Nix build environments, and its use
in the smtlink default configs seems to be redundant.