### PR TITLE
For apt::restrict, allow ':guard' to denote the function's guard

### DIFF
--- a/books/kestrel/apt/restrict-doc.lisp
+++ b/books/kestrel/apt/restrict-doc.lisp
@@ -152,6 +152,8 @@
       "Denotes the restricting predicate for the domain of @('old'),
        i.e. the predicate that will be added to the guard
        and as the test that wraps the body.")
+     (xdoc::p
+      "The special value @(':guard') can be used to denote the guard predicate itself.")
      (xdoc::evmac-desc-term
       :free-vars "@('x1'), ..., @('xn')"
       :1res t

--- a/books/kestrel/apt/restrict.lisp
+++ b/books/kestrel/apt/restrict.lisp
@@ -154,6 +154,9 @@
   :mode :program
   :short "Process the @('restriction') input."
   (b* ((wrld (w state))
+       (restriction (if (equal restriction ':guard)
+                        (guard old nil wrld)
+                      restriction))
        ((er (list term stobjs-out))
         (ensure-value-is-untranslated-term$ restriction
                                             "The second input" t nil))
@@ -487,7 +490,9 @@
                                    :in-theory nil
                                    :use (:termination-theorem ,old)))))
        (old-guard (guard old nil wrld))
-       (new-guard (conjoin2 old-guard restriction))
+       (new-guard (if (equal old-guard restriction)
+                      old-guard
+                    (conjoin2 old-guard restriction))) ; Could produce a simpler version
        (new-guard (untranslate new-guard t wrld))
        (local-event
         `(local


### PR DESCRIPTION
Makes it convenient to restrict a function to its guard.