### PR TITLE
[FTY] Tweak a call of translate-cmp.

### DIFF
--- a/books/centaur/fty/fixtype.lisp
+++ b/books/centaur/fty/fixtype.lisp
@@ -293,7 +293,7 @@
                       (concatenate
                        'string (symbol-name arg) "-EQUIV")
                       pkg)))
-       ((mv err tr-form) (acl2::translate-cmp form t t nil 'deffixequiv-basic-parse
+       ((mv err tr-form) (acl2::translate-cmp form t nil nil 'deffixequiv-basic-parse
                                               world (acl2::default-state-vars t)))
        ((when err)
         (raise "Error translating form: ~@0" tr-form))


### PR DESCRIPTION
This calls translate-cmp with logic-modep=nil, to prevent an error when the form involved contains :program mode functions.

This is related to deffixequiv and seems needed to allow a define with :hooks (:fix) to work when submitted in :program mode.  My head's not in this machinery, and perhaps there is a legitimate reason to ban this.  But I suspect this use case was simply not considered.  Ideally, tools like define would still work even in :program mode (but proofs would be skipped, of course).
