### PR TITLE
[DEFINES] Suppress return-value theorems in :program mode.

### DIFF
--- a/books/std/util/defines.lisp
+++ b/books/std/util/defines.lisp
@@ -862,13 +862,13 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
 
        (defsection rest-events-1
          ,@(and want-xdoc-p `(:extension ,name))
-         ;; It seems OK to do this even if we're in program mode, because in that
-         ;; case you shouldn't be trying to provide return-value theorems, right?
          ,@(and returns-induct
                 `((make-event
-                   (let ((event (returnspec-flag-thm
-                                 ',thm-macro ',gutslist ',returns-hints (w state))))
-                     `(with-output :stack :pop ,event)))))
+                   (if (logic-mode-p ',(defguts->name-fn (car gutslist)) (w state))
+                       (let ((event (returnspec-flag-thm
+                                     ',thm-macro ',gutslist ',returns-hints (w state))))
+                         `(with-output :stack :pop ,event))
+                     (value '(value-triple :invisible))))))
          (with-output :stack :pop (progn . ,rest-events1))
          ,@fn-sections
          (with-output :stack :pop (progn . ,rest-events2)))


### PR DESCRIPTION
Fixes issue #1309.  An existing code comment mentioned this issue but seems wrongheaded, as exemplified by the issue filed by Eric McCarthy.  It seems perfectly reasonable to supply return value types in :program mode, either simply as documentation or because some code is in :program mode only temporarily.  In that case, this commit ensures that defines will not fail.

Normally, generated theorems would be simply skipped in :program mode.  The failure here is caused by the use of defthm-flag to prove them, since the corresponding make-flag is skipped in :program mode.

Standard disclaimers apply: My head is not really in this code.