### PR TITLE
[directed-untranslate] Fix crash in handling of mv-let.

### DIFF
--- a/books/kestrel/utilities/directed-untranslate.lisp
+++ b/books/kestrel/utilities/directed-untranslate.lisp
@@ -1578,7 +1578,7 @@
                                               wrld
                                               state-vars)
                                (and (null erp)
-                                    (not (intersectp-eq ignore-vars tbody)))))
+                                    (not (intersectp-eq ignore-vars (all-vars tbody))))))
                             `(mv-let ,vars
                                ,mv-let-body
                                ,@(and ignore-vars


### PR DESCRIPTION
This fixes a crash in directed-untranslate.  To see the crash, do this:

(include-book "kestrel/utilities/directed-untranslate" :dir :system)

(defun foo (a b) (mv a b))

(directed-untranslate
 ;; uterm:                                                                                                                                                    
 '(mv-let (a b) (foo 1 0) (declare (ignore b)) a)
 ;; translated form of uterm:                                                                                                                                 
 '((lambda (mv)
           ((lambda (a b) a)
            (mv-nth '0 mv)
            (hide (mv-nth '1 mv))))
   (foo '1 '0))
 ;; term to untranslate (same as previous argument):                                                                                                          
 '((lambda (mv)
           ((lambda (a b) a)
            (mv-nth '0 mv)
            (hide (mv-nth '1 mv))))
   (foo '1 '0))
 nil nil (w state))

My head's not really in this code, but the fix seems like an improvement, avoids this crash, and doesn't seem to cause other problems (though some tests are still in progress).