### PR TITLE
Use $(MAKE) variable, not the explicit command name ‘make’

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -606,7 +606,7 @@ doc/home-page.html: doc/home-page.lisp
 # xdoc::save that populates doc/manual/ (not under books/).
 acl2-manual: check-books
 	rm -rf doc/manual books/system/doc/acl2-manual.cert
-	cd books ; make USE_QUICKLISP=1 system/doc/acl2-manual.cert
+	cd books ; $(MAKE) USE_QUICKLISP=1 system/doc/acl2-manual.cert
 	rm -rf doc/manual/download/*
 
 # WARNING: The dependency list just below isn't complete, since it
@@ -636,7 +636,7 @@ update-doc.lisp: books/system/doc/acl2-doc.lisp books/system/doc/rendered-doc.ls
 # been super carefully thought out, so could change.
 books/system/doc/rendered-doc.lsp: check-books
 	rm -f books/system/doc/rendered-doc.lsp
-	cd books ; make USE_QUICKLISP=1 system/doc/render-doc.cert ACL2=$(ACL2)
+	cd books ; $(MAKE) USE_QUICKLISP=1 system/doc/render-doc.cert ACL2=$(ACL2)
 
 .PHONY: STATS
 


### PR DESCRIPTION
Currently, when creating the target `doc` the dependency acl2-manual
is invoked. acl2-manual does not use the MAKE variable but instead
uses the make command directly. The target
books/system/doc/rendered-doc.lsp does the same. According to the
make manual, "recursive make commands should always use the variable
MAKE, not the explicit command name ‘make’" [1]. Since both of these
are recursive calls, the variable should be used instead.
This has already been patched and tested within the Gentoo science
repository [2]. Gentoo's package manager portage will throw a Q/A issue:
"make[1]: warning: jobserver unavailable: using -j1. Add '+' to parent
make rule" when compiling from source code if the patch is not applied.
This further suggests that this change is necessary.

[1] https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html
[2]
https://github.com/gentoo/sci/blob/master/sci-mathematics/acl2/files/acl2-use_make_variable.patch