### PR TITLE
Irrelevant formals fix

### DIFF
--- a/books/std/system/irrelevant-formals-input.lsp
+++ b/books/std/system/irrelevant-formals-input.lsp
@@ -144,8 +144,8 @@
    (defun even-natp (x irrelevant1 irrelevant2)
      (if (zp x)
          t
-       (not (odd-natp (+ -1 x) irrelevant irrelevant2))))
-   (defun odd-natp (x irrelevant irrelevant2)
+       (not (odd-natp (+ -1 x) irrelevant1 irrelevant2))))
+   (defun odd-natp (x irrelevant3 irrelevant4)
      (if (zp x)
          nil
-       (not (even-natp (+ -1 x) irrelevant irrelevant2))))))
+       (not (even-natp (+ -1 x) irrelevant3 irrelevant4))))))

--- a/books/std/system/irrelevant-formals-input.lsp
+++ b/books/std/system/irrelevant-formals-input.lsp
@@ -35,7 +35,7 @@
      (if (consp x0) (f (cdr x0) x1 x2 x5 x4 x3) nil)))
  :dcls nil)
 
-; This returns ((F1 . Y) (F2 . Y)) because y is an irrelevant formal
+; This returns ((F1 Y) (F2 Y)) because y is an irrelevant formal
 ; for both f1 and f2.
 (irrelevant-formals-info
  '((defun f1 (x y)
@@ -137,3 +137,15 @@
      (if (consp x) (f2 (cdr x) y) t))
    (defun f2 (x y)
      (if (consp x) (f1 (cdr x) y) nil))))
+
+;; Mutual-recursion example with more than one irrelevant formal
+(irrelevant-formals-info
+ '(mutual-recursion
+   (defun even-natp (x irrelevant1 irrelevant2)
+     (if (zp x)
+         t
+       (not (odd-natp (+ -1 x) irrelevant irrelevant2))))
+   (defun odd-natp (x irrelevant irrelevant2)
+     (if (zp x)
+         nil
+       (not (even-natp (+ -1 x) irrelevant irrelevant2))))))

--- a/books/std/system/irrelevant-formals-log.txt
+++ b/books/std/system/irrelevant-formals-log.txt
@@ -38,13 +38,13 @@ ACL2 !>>(IRRELEVANT-FORMALS-INFO
                       (IF (CONSP X) (F2 (CDR X) Y) T))
                (DEFUN F2 (X Y)
                       (IF (CONSP X) (F1 (CDR X) Y) NIL))))
-((F1 . Y) (F2 . Y))
+((F1 Y) (F2 Y))
 ACL2 !>>(IRRELEVANT-FORMALS-INFO
              '(MUTUAL-RECURSION (DEFUN F1 (X Y)
                                        (IF (CONSP X) (F2 (CDR X) Y) T))
                                 (DEFUN F2 (X Y)
                                        (IF (CONSP X) (F1 (CDR X) Y) NIL))))
-((F1 . Y) (F2 . Y))
+((F1 Y) (F2 Y))
 ACL2 !>>(IRRELEVANT-FORMALS-INFO
              '(MUTUAL-RECURSION (DEFUN F1 (X Y)
                                        (IF (CONSP X) (F2 (CDR X)) T))
@@ -166,4 +166,18 @@ ACL2 Error in CHK-IRRELEVANT-FORMALS-OK:  The second formal of F1,
 Y, and the second formal of F2, Y, are irrelevant but not declared
 to be irrelevant.  See :DOC irrelevant-formals.
 
+ACL2 !>>(IRRELEVANT-FORMALS-INFO
+             '(MUTUAL-RECURSION
+                   (DEFUN EVEN-NATP (X IRRELEVANT1 IRRELEVANT2)
+                          (IF (ZP X)
+                              T
+                              (NOT (ODD-NATP (+ -1 X)
+                                             IRRELEVANT IRRELEVANT2))))
+                   (DEFUN ODD-NATP (X IRRELEVANT IRRELEVANT2)
+                          (IF (ZP X)
+                              NIL
+                              (NOT (EVEN-NATP (+ -1 X)
+                                              IRRELEVANT IRRELEVANT2))))))
+((EVEN-NATP IRRELEVANT1 IRRELEVANT2)
+ (ODD-NATP IRRELEVANT IRRELEVANT2))
 ACL2 !>>Bye.

--- a/books/std/system/irrelevant-formals-log.txt
+++ b/books/std/system/irrelevant-formals-log.txt
@@ -172,12 +172,12 @@ ACL2 !>>(IRRELEVANT-FORMALS-INFO
                           (IF (ZP X)
                               T
                               (NOT (ODD-NATP (+ -1 X)
-                                             IRRELEVANT IRRELEVANT2))))
-                   (DEFUN ODD-NATP (X IRRELEVANT IRRELEVANT2)
+                                             IRRELEVANT1 IRRELEVANT2))))
+                   (DEFUN ODD-NATP (X IRRELEVANT3 IRRELEVANT4)
                           (IF (ZP X)
                               NIL
                               (NOT (EVEN-NATP (+ -1 X)
-                                              IRRELEVANT IRRELEVANT2))))))
+                                              IRRELEVANT3 IRRELEVANT4))))))
 ((EVEN-NATP IRRELEVANT1 IRRELEVANT2)
- (ODD-NATP IRRELEVANT IRRELEVANT2))
+ (ODD-NATP IRRELEVANT3 IRRELEVANT4))
 ACL2 !>>Bye.

--- a/books/std/system/irrelevant-formals.lisp
+++ b/books/std/system/irrelevant-formals.lisp
@@ -59,7 +59,10 @@
         (t (irrelevant-slots-to-alist-1
             (cdr slots)
             (let ((slot (car slots)))
-              (put-assoc-eq (car slot) (cddr slot) alist))))))
+              (put-assoc-eq (car slot)
+                            (append (cdr (assoc-eq (car slot) alist))
+                                    (list (cddr slot)))
+                            alist))))))
 
 (defun irrelevant-slots-to-alist (names slots)
   (irrelevant-slots-to-alist-1 slots (pairlis$ names nil)))
@@ -248,7 +251,7 @@
 (defxdoc irrelevant-formals-info
   :parents (std/system system-utilities-non-built-in irrelevant-formals)
   :short "Determine whether @(see irrelevant-formals) are OK in definitions."
-  :long "<p>This utility returns a Boolean.  For a related utility that can
+  :long "<p>For a related utility that can
  cause an error, see @(see chk-irrelevant-formals-ok).</p>
 
  @({
@@ -353,7 +356,7 @@
       (if (consp x0) (f (cdr x0) x1 x2 x5 x4 x3) nil)))
   :dcls nil)
 
- ; This returns ((F1 . Y) (F2 . Y)) because y is an irrelevant formal
+ ; This returns ((F1 Y) (F2 Y)) because y is an irrelevant formal
  ; for both f1 and f2.
  (irrelevant-formals-info
   '((defun f1 (x y)


### PR DESCRIPTION
Here is an example for which the old version gave what seems to be the wrong answer:

(irrelevant-formals-info
 '(mutual-recursion
   (defun even-natp (x irrelevant1 irrelevant2)
     (if (zp x)
         t
       (not (odd-natp (+ -1 x) irrelevant1 irrelevant2))))
   (defun odd-natp (x irrelevant3 irrelevant4)
     (if (zp x)
         nil
       (not (even-natp (+ -1 x) irrelevant3 irrelevant4))))))

It gave:
((EVEN-NATP . IRRELEVANT2)
 (ODD-NATP . IRRELEVANT4))

which is missing irrelevant1 and irrelevant3.  After this change, it gives:

((EVEN-NATP IRRELEVANT1 IRRELEVANT2)
 (ODD-NATP IRRELEVANT3 IRRELEVANT4))