### PR TITLE
Move books/doc/top-slow.lisp to books/top.lisp.

### DIFF
--- a/books/kestrel/auto-termination/README
+++ b/books/kestrel/auto-termination/README
@@ -29,7 +29,7 @@ community books, and then for a call of defunt to peruse that database
 in order to prove termination automatically.
 
 As of this writing, the database is initialized by including system
-book "doc/top-slow" and then writing a termination database to file
+book "top" and then writing a termination database to file
 td-cands.lisp.  That database is what's perused by a call of defunt.
 
 There are heuristics for keeping the database from being too large.
@@ -80,7 +80,7 @@ ACL2 3 >
 
 II.  Infrastructure/flow
 
-PREREQUISITE.  Certify doc/top-slow.lisp and all books in the current
+PREREQUISITE.  Certify books/top.lisp and all books in the current
 directory (possibly excepting td-cands.lisp and the two books that
 depend on it, defunt-top.lisp and defunt-tests.lisp).
 
@@ -105,7 +105,7 @@ by the call of LD in write-td-cands.lsp that is made by the script
 write-td-cands.sh, starting with the following:
 
 (1) Include many of the community books together, as follows (this can
-take quite a few minutes): (include-book "doc/top-slow" :dir :system).
+take quite a few minutes): (include-book "top" :dir :system).
 
 (2) Create a "termination database" stobj, td, from all
 singly-recursive logic-mode functions in the resulting world.

--- a/books/kestrel/auto-termination/termination-database.lisp
+++ b/books/kestrel/auto-termination/termination-database.lisp
@@ -5,7 +5,7 @@
 ; See README for an overview of the algorithm implemented by this file, and see
 ; write-td-cands.lsp for how it is invoked.  The fundamental idea is to include
 ; this book after including a book with many termination theorems underneath it
-; -- normally, community book doc/top-slow.lisp -- and then invoke td-init and
+; -- normally, community book books/top.lisp -- and then invoke td-init and
 ; write-td to build the termination-database and write it out, respectively.
 
 (in-package "ACL2")
@@ -655,15 +655,15 @@
 
 (defun write-td-fn-include-books-extra (chan state)
 
-; After (include-book "doc/top-slow" :dir :system), in raw Lisp, we find the
-; packages that are present but whose book is "doc/top-slow" (here, <ACL2>
+; After (include-book "top" :dir :system), in raw Lisp, we find the
+; packages that are present but whose book is "top" (here, <ACL2>
 ; denotes the path to the top-level ACL2 directory):
 
 ;   (value :q)
 ;   (let ((doc-top-book
 ;          (concatenate 'string
 ;                       (f-get-global 'system-books-dir *the-live-state*)
-;                       "doc/top-slow.lisp")))
+;                       "top.lisp")))
 ;     (loop for x in (known-package-alist *the-live-state*)
 ;           when (equal (car (package-entry-book-path x))
 ;                       doc-top-book)
@@ -699,7 +699,7 @@
            (cond ((and sysfile
                        (if (sysfile-p sysfile)
                            (not (equal (sysfile-filename sysfile)
-                                       "doc/top-slow"))
+                                       "top"))
                          t))
                   (cons sysfile
                         (pkg-books-1 (cdr pkg-entries) system-books-dir)))
@@ -763,12 +763,12 @@
         (pprogn (princ$ *td-fn-header* chan state)
                 (princ$ "
 ; The following books are included to provide the packages that are
-; defined after including system book \"doc/top-slow\".
+; defined after including system book \"top\".
 "
                         chan state)
                 (fms!-lst (pkg-include-books state) chan state)
                 (fms "~%; Next we deal with packages whose associated book ~
-                      in~%;~ ~ ~ ~x0~%; is community book \"doc/top-slow\", ~
+                      in~%;~ ~ ~ ~x0~%; is community book \"top\", ~
                       which is too large to include efficiently.~%"
                      (list (cons #\0 '(known-package-alist state)))
                      chan state nil)

--- a/books/kestrel/auto-termination/write-td-cands.lsp
+++ b/books/kestrel/auto-termination/write-td-cands.lsp
@@ -11,7 +11,7 @@
 (ld '(
 
 ; Include a lot of books.
-(include-book "doc/top-slow" :dir :system) ; probably takes several minutes
+(include-book "top" :dir :system) ; probably takes several minutes
 
 ; The following three forms probably speed things up.
 (set-gc-strategy :egc)

--- a/books/top.acl2
+++ b/books/top.acl2
@@ -1,0 +1,11 @@
+; Cert flags for top.lisp
+;
+; Copyright (C) 2021 Kestrel Institute
+;
+; License: A 3-clause BSD license. See the file books/3BSD-mod.txt.
+;
+; Author: Eric Smith (eric.smith@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; cert-flags: ? T :TTAGS :ALL

--- a/books/top.lisp
+++ b/books/top.lisp
@@ -27,12 +27,17 @@
 ;   DEALINGS IN THE SOFTWARE.
 ;
 ; Original author: Jared Davis <jared@centtech.com>
+; Supporting Author: Eric Smith <eric.smith@kestrel.edu>
 
 (in-package "ACL2")
 
 ;; Previously, this book generated a manual, but books/doc/top now does that
 ;; better.  So the sole purpose of this book now is to check for name conflicts
 ;; after including as many community books as possible.
+
+;; NOTE: We do not recommend including this book for normal proof work, due to
+;; the likelihood of conflicts (e.g., rewrite loops) between different
+;; libraries that it brings in (and due to its sheer size).
 
 ;; Note about the following commented-out form.  This allows a significant
 ;; reduction of memory usage by this book: of ~130 million conses in the ACL2
@@ -86,8 +91,8 @@
 ;; when building the final documentation.
 (include-book "std/strings/fast-cat" :dir :system)
 
-(include-book "relnotes")
-(include-book "practices")
+(include-book "doc/relnotes" :dir :system)
+(include-book "doc/practices" :dir :system)
 
 (include-book "xdoc/save" :dir :system)
 (include-book "xdoc/archive" :dir :system)


### PR DESCRIPTION
This was discussed on the acl2-books mailing list.  See also the comments at the top of books/top.lisp.

I believe, but am not positive, that I've updated the auto-termination stuff appropriately after this change.