### PR TITLE
Make cert.pl use the useless runes files the same way as 'make' does.

### DIFF
--- a/books/build/cert.pl
+++ b/books/build/cert.pl
@@ -123,6 +123,10 @@ my $make = $ENV{"MAKE"} || "make";
 my @make_args = ();
 my $acl2 = $ENV{"ACL2"};
 my $acl2_books = $ENV{"ACL2_SYSTEM_BOOKS"};
+# add default useless runes setting if undefined
+if (! defined($ENV{"ACL2_USELESS_RUNES"}) ) {
+    $ENV{"ACL2_USELESS_RUNES"} = "-25";
+}
 my $startjob = $ENV{"STARTJOB"};
 if (! $startjob ) { $startjob = "bash"; }
 my $keep_going = 0;


### PR DESCRIPTION
Prior to this if you use `cert.pl` to certify a book,
and if the environment variable `ACL2_USELESS_RUNES`
is not defined and exported, then `cert.pl` ignores
the useless runes files.

After this PR, `cert.pl` looks at `ACL2_USELESS_RUNES`
and if it is not defined, it sets it to -25, which is the default
for `make` in the community books directory.

One common use case that this speeds up a lot is when
you want to work on a particular book (whether that is in
the community books or not), and you want to certify all
of its dependencies without doing a full regression.
It is convenient to just do `cert.pl oracle` or some such command, 
but if there are any slow community books that need to be certified,
this could take longer than doing the full regression due to
`cert.pl` ignoring the useless runes files.