### PR TITLE
fix links to 2004 workshop paper and slides on std/osets

### DIFF
--- a/books/centaur/vl/doc.lisp
+++ b/books/centaur/vl/doc.lisp
@@ -109,7 +109,7 @@ and transistor-level constructs.</li>
 <li>(unreleased) We have used it to implement <i>VL-Mangle</i>, a web-based
 Verilog refactoring tool.  A paper describing this tool can be found in: Jared
 Davis. <a
-href='http://www.cs.utexas.edu/users/jared/publications/2013-doform-embedding/embedding.pdf'>Embedding
+href='https://www.kookamara.com/jared/2013-doform-embedding.pdf'>Embedding
 ACL Models in End-User Applications</a>.  In <a
 href='http://www.cs.bham.ac.uk/research/projects/formare/events/aisb2013/'>Do-Form
 2013</a>.  April, 2013, Exeter, UK.</li>

--- a/books/centaur/vl2014/doc.lisp
+++ b/books/centaur/vl2014/doc.lisp
@@ -147,7 +147,7 @@ and transistor-level constructs.</li>
 <li>(unreleased) We have used it to implement <i>VL-Mangle</i>, a web-based
 Verilog refactoring tool.  A paper describing this tool can be found in: Jared
 Davis. <a
-href='http://www.cs.utexas.edu/users/jared/publications/2013-doform-embedding/embedding.pdf'>Embedding
+href='https://www.kookamara.com/jared/2013-doform-embedding.pdf'>Embedding
 ACL Models in End-User Applications</a>.  In <a
 href='http://www.cs.bham.ac.uk/research/projects/formare/events/aisb2013/'>Do-Form
 2013</a>.  April, 2013, Exeter, UK.</li>
@@ -432,4 +432,3 @@ subsidiary helpers to carry out its work.  This work transforms various parts
 of the module, and meanwhile the warnings are perhaps extended.  Finally, the
 function returns a new @(see vl-module-p) which is updated with the extended
 list of warnings.</p>")
-

--- a/books/std/osets/top.lisp
+++ b/books/std/osets/top.lisp
@@ -122,9 +122,9 @@ disabled and may be enabled using:</p>
 
 <p>Besides this @(see xdoc::xdoc) documentation, you may be interested in the
 2004 ACL2 workshop paper, <a
-href='http://www.cs.utexas.edu/users/jared/publications/2004-acl2-osets/set-theory.pdf'>Finite
+href='https://www.cs.utexas.edu/users/moore/acl2/workshop-2004/contrib/davis/set-theory.pdf'>Finite
 Set Theory based on Fully Ordered Lists</a>, and see also the <a
-href='http://www.cs.utexas.edu/users/jared/osets/Slides/2004-02-seminar-slides.pdf'>slides</a>
+href='https://www.cs.utexas.edu/users/moore/acl2/workshop-2004/contrib/davis/workshop-osets-slides.pdf'>slides</a>
 from the accompanying talk.</p>")
 
 ; We begin with the definitions of the set theory functions and a few trivial


### PR DESCRIPTION
This changes two links in the xdoc to match the links from the workshop page  
https://www.cs.utexas.edu/users/moore/acl2/workshop-2004/

Not changed, but needs to be changed:  
A grep turns up two more broken links that I did not change
because I did not see an appropriate link target.  Those links are
```
./books/centaur/vl2014/doc.lisp:href='http://www.cs.utexas.edu/users/jared/publications/2013-doform-embedding/embedding.pdf'>Embedding
./books/centaur/vl/doc.lisp:href='http://www.cs.utexas.edu/users/jared/publications/2013-doform-embedding/embedding.pdf'>Embedding
```
Maybe Jared or another knowledgeable reviewer can update these other broken links.