### PR TITLE
[xdoc] Fix defpointer to tolerate symbols with unusual names.

### DIFF
--- a/books/xdoc/top.lisp
+++ b/books/xdoc/top.lisp
@@ -504,17 +504,38 @@
       (concatenate-symbol-names (list ,@args))
       mksym-package-symbol)))
 
+
+;; Converts SYM to a string in such a way that it can be read back in as SYM.
+;; Always includes the package prefix and always puts vertical bars around the
+;; symbol (in case it has mixed case, or contains a space, or is something like
+;; the symbol '...).
+;; TODO: Avoid the vertical bars in common cases when appropriate (perhaps call
+;; needs-slashes, but consider that that function gives nil on "...").
+;; TODO: Add a package argument and avoid the package prefix for symbols in
+;; that package (will only be useful *if* we know what the package will be when
+;; the symbol is later read / parsed).
+(defund symbol-as-readable-string (sym)
+  (declare (xargs :guard (symbolp sym)))
+  (concatenate 'string
+               (symbol-package-name sym)
+               "::|"
+               (symbol-name sym)
+               "|"))
+;; Examples:
+;;(SYMBOL-AS-READABLE-STRING 'natp) gives "ACL2::|NATP|"
+;;(SYMBOL-AS-READABLE-STRING '|NAtp|) gives "ACL2::|NAtp|"
+;;(SYMBOL-AS-READABLE-STRING '|foo bar|) gives "ACL2::|foo bar|"
+;;(defpkg "FOO" nil) (SYMBOL-AS-READABLE-STRING 'foo::bar) gives "FOO::|BAR|"
+
 (defmacro defpointer (from to &optional keyword-p)
   (declare (xargs :guard (and (symbolp from) (symbolp to))))
-  (let ((from-name (acl2::string-downcase (symbol-name         from)))
-        (to-pkg    (acl2::string-downcase (symbol-package-name to)))
-        (to-name   (acl2::string-downcase (symbol-name         to))))
+  (let ((from-name (acl2::string-downcase (symbol-name         from))))
     `(defxdoc ,from
        :parents (pointers)
        :short ,(concatenate
                 'string
                 "See @(see "
-                to-pkg "::" to-name
+                (symbol-as-readable-string to)
                 ")"
                 (if keyword-p
                     (concatenate


### PR DESCRIPTION
This pull request fixes a problem that occurs when defpointer is used to point to an xdoc topic whose name is an unusual symbol, such as a symbol that includes spaces. Without this patch, the following gives an error:

(include-book "xdoc/topics" :dir :system)
(defxdoc |foo bar| :short "example")
(defpointer my-pointer |foo bar|)
:doc my-pointer

The error message is:
; xdoc error in MY-POINTER:
"In SEE directive, expected ) after FOO. Near See @(see acl2::foo bar)..".
ACL2::MY-POINTER -- Current Interactive Session

Note the space between foo and bar in the generated @(see ...) form; this is not suitable for reading back in the symbol |foo bar|.

This fix is more conservative than one I proposed a long time ago in that it always includes the package of the symbol.
