### PR TITLE
Connect syntheto and wrap-output documentation fixing xdoc generation…

### DIFF
--- a/books/kestrel/apt/doc.lisp
+++ b/books/kestrel/apt/doc.lisp
@@ -52,6 +52,8 @@
 (include-book "tailrec")
 (include-book "tailrec-doc")
 
+(include-book "wrap-output")
+
 ; (depends-on "images/apt-logo.png")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/apt/top.lisp
+++ b/books/kestrel/apt/top.lisp
@@ -38,3 +38,5 @@
 (include-book "solve-method-acl2-rewriter")
 
 (include-book "tailrec")
+
+(include-book "wrap-output")

--- a/books/kestrel/apt/wrap-output.lisp
+++ b/books/kestrel/apt/wrap-output.lisp
@@ -83,8 +83,6 @@ mutually recursive.</p>
 
 <p>where @('free-1'), ..., @('free-k') are free variables possibly introduced in @('wrapper') if it is a lambda term.</p>
 
-<p>This transformation is in some sense the dual of @(see wrap-input).</p>
-
 <h3>Example Scenarios</h3>
 
 <ul>
@@ -138,7 +136,11 @@ functions that axe has lifted).</li>
 })
 
 
-<p>TODO: Add check: For now, the wrapper should only be over one variable.</p>")
+<p>TODO: Add check: For now, the wrapper should only be over one variable.</p>"
+
+  ;; TODO: When wrap-input is added to community books, restore the following:
+  ;; <p>This transformation is in some sense the dual of @(see wrap-input).</p>
+  )
 
 (defun untranslated-lambdap (x)
   (declare (xargs :guard t))

--- a/books/kestrel/doc.lisp
+++ b/books/kestrel/doc.lisp
@@ -45,7 +45,7 @@
 (include-book "solidity/top")
 (include-book "std/top")
 (include-book "strings-light/doc")
-;; (include-book "syntheto/top")
+(include-book "syntheto/top")
 (include-book "typed-lists-light/doc")
 (include-book "utilities/top")
 (include-book "utilities/ubi-doc")

--- a/books/kestrel/syntheto/language/static-semantics.lisp
+++ b/books/kestrel/syntheto/language/static-semantics.lisp
@@ -3242,7 +3242,7 @@
   (xdoc::topstring
    (xdoc::p
     "This is used both by @(tsee check-function-definition)
-     and by @(tsee check-function-definition-in-recursion).")
+     and by @(tsee check-function-definition-list).")
    (xdoc::p
     "At the top level, the context has no
      types being defined,
@@ -3252,7 +3252,7 @@
      obligation hypotheses.
      But the caller of this function,
      either  @(tsee check-function-definition)
-     or @(tsee check-function-definition-in-recursion),
+     or @(tsee check-function-definition-list),
      extends the context component for the functions being defined;
      thus, this function definition's header is always in the context.
      This motivates the extra guard condition of this ACL2 function.")

--- a/books/std/util/bstar.lisp
+++ b/books/std/util/bstar.lisp
@@ -29,7 +29,7 @@
 ; Original author: Sol Swords <sswords@centtech.com>
 
 (in-package "ACL2")
-(include-book "xdoc/base" :dir :system)
+(include-book "xdoc/top" :dir :system)
 
 (defxdoc b*
   :parents (macro-libraries)
@@ -693,18 +693,22 @@ for more details.</p>")
                               decls
                               body)
   (let* ((macro-name (macro-name-for-patbind name))
-         (short      (if short-p
-                         short
+         (doc-p (or parents  ; Todo: Don't create doc if there is no short or long provided?
+                 short-p long-p))
+         (short (if short-p
+                    short
+                  (and doc-p
                        (concatenate 'string
-                                    "@(see acl2::b*) binder form @('" (symbol-name name)
-                                    "') (placeholder).")))
-         (long       (if long-p
-                         long
-                       (concatenate 'string
-                                    "<p>This is a b* binder introduced with @(see acl2::def-b*-binder).</p>
-                                     @(def " (symbol-name macro-name) ")"))))
+                                    "@(see acl2::b*) binder form @('" (xdoc::symbol-as-readable-string name)
+                                         "') (placeholder)."))))
+         (long (if long-p
+                   long
+                 (and doc-p
+                      (concatenate 'string
+                                   "<p>This is a b* binder introduced with @(see acl2::def-b*-binder).</p>
+                                     @(def " (xdoc::symbol-as-readable-string macro-name) ")")))))
     `(progn
-       ,@(if (or parents short long)
+       ,@(if doc-p
              ;; Want to be able to turn off documentation, e.g., for ret binders
              `((defxdoc ,macro-name :parents ,parents :short ,short :long ,long))
            nil)


### PR DESCRIPTION
… for some b* binders.

Was causing xdoc errors for binders in different packages or with lower case characters.