### PR TITLE
[X86ISA] Improve modeling of CPUID features.

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -366,6 +366,15 @@
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+   (xdoc::h4 (xdoc::seetopic "x86isa::x86isa" "X86ISA"))
+
+   (xdoc::p
+    "The dependency of CPUID features on the x86 state has been removed.
+     Now the CPUID features are arbitrary but fixed in the model.
+     See the documentation in the @(tsee x86isa::cpuid) topic for details.")
+
+   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
    (xdoc::h4 (xdoc::seetopic "yul::yul" "Yul Library"))
 
    (xdoc::p

--- a/books/projects/x86isa/machine/cpuid.lisp
+++ b/books/projects/x86isa/machine/cpuid.lisp
@@ -39,8 +39,9 @@
 ; Alessandro Coglio   <coglio@kestrel.edu>
 
 (in-package "X86ISA")
-(include-book "state")
 (include-book "cpuid-constants")
+(include-book "std/util/define" :dir :system)
+(include-book "centaur/bitops/ihsext-basics" :dir :system)
 
 ;; Macros and functions used by utilities in dispatch.lisp to create opcode
 ;; dispatch functions

--- a/books/projects/x86isa/machine/dispatch-macros.lisp
+++ b/books/projects/x86isa/machine/dispatch-macros.lisp
@@ -40,6 +40,7 @@
 (include-book "../utils/structures")
 (include-book "cpuid-constants")
 (include-book "cpuid")
+(include-book "state")
 
 (local (xdoc::set-default-parents 'opcode-maps))
 

--- a/books/projects/x86isa/machine/dispatch-macros.lisp
+++ b/books/projects/x86isa/machine/dispatch-macros.lisp
@@ -202,10 +202,10 @@
   `(msri #.*ia32_efer-idx* x86))
 
 (defmacro feature-flag-macro (x)
-  `(feature-flag ,x x86))
+  `(feature-flag ,x))
 
 (defmacro feature-flags-macro (x)
-  `(feature-flags ,x x86))
+  `(feature-flags ,x))
 
 ;; ----------------------------------------------------------------------
 
@@ -320,7 +320,7 @@
    ((eq type-id :type-vex-gpr)
     ;; from table 2.5.1 from volume 2.. we only need to additionally check
     ;; the cpuid requirements:
-    (cond ((equal (feature-flags feature-flags x86) 0) :ud)))
+    (cond ((equal (feature-flags feature-flags) 0) :ud)))
    ((equal (cr0Bits->ts (cr0)) 1)
     :nm)
    ((and (not (member-eq type-id '(:type-22-7 :type-22-8 :type-22-9)))
@@ -335,7 +335,7 @@
 	;; Table 3-10 (Feature Information Returned in the ECX register)
 	;; Figure 3-8 (Feature Information Returned in the EDX register)
 	;; Table 3-11 (More on Feature Information Returned in the EDX register)
-	(equal (feature-flags feature-flags x86) 0))
+	(equal (feature-flags feature-flags) 0))
     :ud)))
 
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
This is as discussed with Shilpi.

The added documentation (easily in the diff) explains this change.