### PR TITLE
[X86ISA] Add support for some MOVD/MOVQ variants.

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -386,6 +386,10 @@
      Now the CPUID features are arbitrary but fixed in the model.
      See the documentation in the @(tsee x86isa::cpuid) topic for details.")
 
+   (xdoc::p
+    "Support has been added for the MOVD and MOVQ instruction variants
+     that move data from/to the XMM registers.")
+
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
    (xdoc::h4 (xdoc::seetopic "yul::yul" "Yul Library"))

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -6820,7 +6820,7 @@
     (INST "MOVD/Q"
           (OP :OP #xF6E :PFX :66 :FEAT '(:SSE2))
           (ARG :OP1 '(V Y) :OP2 '(E Y))
-          'NIL
+          '(X86-MOVD/MOVQ-TO-XMM)
           '((:EX (CHK-EXC :TYPE-5 (:SSE2)))))
     (INST "VMOVQ"
           (OP :OP #xF6E
@@ -8452,7 +8452,7 @@
     (INST "MOVD/Q"
           (OP :OP #xF7E :PFX :66 :FEAT '(:SSE2))
           (ARG :OP1 '(E Y) :OP2 '(V Y))
-          'NIL
+          '(X86-MOVD/MOVQ-FROM-XMM)
           '((:EX (CHK-EXC :TYPE-5 (:SSE2)))))
     (INST "MOVQ"
           (OP :OP #xF7E :PFX :F3 :FEAT '(:SSE2))


### PR DESCRIPTION
These are the variants of those instructions that move data between (i)
general-purpose registers or memory and (ii) XMM registers.