### PR TITLE
[X86ISA] Fix bounds in IDIV specification.

### DIFF
--- a/books/projects/x86isa/machine/instructions/divide-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/divide-spec.lisp
@@ -251,8 +251,8 @@
 
   (b* ((size*2                 (* 2 size))
        (size*2+1               (1+ size*2))
-       (?smallest-neg-quotient (- (1- (expt 2 (1- size)))))
-       (?largest-pos-quotient  (expt 2 (1- size)))
+       (smallest-neg-quotient (- (expt 2 (1- size))))
+       (largest-pos-quotient (1- (expt 2 (1- size))))
        (fn-name                (mk-name "IDIV-SPEC-" size))
        (str-nbits              (if (eql size 8) "08" size)))
 


### PR DESCRIPTION
It appears that the lower and upper bounds of the signed quotient were slightly
off, as they should be the normal two's complement limits. This commit fixes
them.

This issue was first noticed by Eric Smith.