### PR TITLE
[RAC] Small parser improvements

### DIFF
--- a/books/projects/rac/src/Makefile
+++ b/books/projects/rac/src/Makefile
@@ -1,20 +1,39 @@
+CXX=g++
+CXXFLAGS=-O3 -march=native
+
+# Tricks to force to use a C++ compiler and bison and not a C compiler / Yacc
+# (by default make consider that a *.c file is a C code and *.y is a Yacc
+# # file).
+CC=${CXX}
+CFLAGS=${CXXFLAGS}
+YACC=bison
+
+OBJ=parser.tab.o lex.yy.o output.o main.o
+
 
 all: ../bin/rac ../bin/parse
 
-../bin/parse: parser.l parser.y parser.h output.c main.c
-	bison -d -v parser.y
-	flex parser.l
-	g++ -g -o parse parser.tab.c lex.yy.c output.c main.c
+../bin/parse: ${OBJ}
+	${CXX} ${CXXFLAGS} -o parse ${OBJ}
 	install -m 775 parse ${RAC}/bin
 	/bin/rm parse
+
+parser.tab.c parser.tab.h: parser.y
+	bison -d -v parser.y
+
+lex.yy.c: parser.tab.h parser.l
+	flex parser.l
 
 ../bin/rac: rac-skel
 	printf "#!/bin/bash\n\nRAC=${RAC}\nACL2=${ACL2}" | cat - rac-skel > rac
 	install -m 775 rac ${RAC}/bin
 	/bin/rm rac
 
+.PHONY: clean veryclean
+
 clean:
 	/bin/rm -f rac parser.tab.c parser.tab.h parser.output lex.yy.c parser.c
+	/bin/rm -f ${OBJ}
 	/bin/rm -f -r parse.dSym
 
 veryclean: clean

--- a/books/projects/rac/src/main.c
+++ b/books/projects/rac/src/main.c
@@ -34,10 +34,6 @@ int main(int argc, char **argv) {
       buf.pop_back();
       buf.pop_back();
 
-      if (prog.isEmpty())
-        puts("Warning: no function definitions found,"
-             " maybe you forgot the `RAC begin` guard");
-
       if (argc > 1) {
         if (!strcmp(argv[1], "-acl2")) {
           buf +=  ".ast.lsp";

--- a/books/projects/rac/src/main.c
+++ b/books/projects/rac/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 #include <iostream>
 #include <fstream>
 using namespace std;
@@ -10,31 +11,43 @@ extern FILE *yyout;
 extern int yylineno;
 extern Program prog;
 ofstream fout;
-char buf[80];
 
 int main(int argc, char **argv) {
   ++argv, --argc;  /* skip over program name */
+
+
   if (argc > 0) {
-    strcpy(buf, argv[0]);
-    strcat(buf, ".i");
-    yyin = fopen(buf, "r");
+
+    string buf = argv[0];
+
+    buf += ".i";
+    yyin = fopen(buf.c_str(), "r");
     if (yyin == NULL) {
-      printf("Failed to open file '%s'\n", buf);
+      printf("Failed to open file '%s'\n", buf.c_str());
     }
     else {
       yylineno = 1;
-      yyparse();
+      if (yyparse())
+        return 1;
+
+      // Restore basename.
+      buf.pop_back();
+      buf.pop_back();
+
+      if (prog.isEmpty())
+        puts("Warning: no function definitions found,"
+             " maybe you forgot the `RAC begin` guard");
+
       if (argc > 1) {
-        strcpy(buf, argv[0]);
         if (!strcmp(argv[1], "-acl2")) {
-          strcat(buf, ".ast.lsp");
-          fout.open(buf);
+          buf +=  ".ast.lsp";
+          fout.open(buf.c_str());
           prog.display(fout, acl2);
           fout.close();
         }
         else if (!strcmp(argv[1], "-rac")) {
-          strcat(buf, ".pc");
-          fout.open(buf);
+          buf += ".pc";
+          fout.open(buf.c_str());
           prog.display(fout, rac);
           fout.close();
         }

--- a/books/projects/rac/src/output.c
+++ b/books/projects/rac/src/output.c
@@ -2884,3 +2884,8 @@ void Program::display(ostream& os, DispMode mode) {
   os << "\n";
   displayFunDefs(os, mode);
 }
+
+bool Program::isEmpty() const
+{
+  return !funDefs->length();
+}

--- a/books/projects/rac/src/parser.h
+++ b/books/projects/rac/src/parser.h
@@ -1027,6 +1027,7 @@ public:
   void displayFunDefs(ostream& os, DispMode mode, const char *prefix="");
   void displayFunDecs(ostream& os);
   void display(ostream& os, DispMode mode=rac);
+  bool isEmpty() const;
 };
 
 extern Program prog;

--- a/books/projects/rac/src/parser.l
+++ b/books/projects/rac/src/parser.l
@@ -14,14 +14,16 @@ static void comment();
 char* tokstr();
 static void lineba();
 char yyfilenm[1024];
+bool term = false;
+#define yyterminate() return (term = !term)?END : YY_NULL
 %}
 
 %%
 
 {lineba}                    {lineba();}
 
-[ ]*\/\/\ *{Rac}\:?\ *begin\ *\n  {BEGIN ACTIVE;}
-\/\/\ *{Rac}\:?\ *end\ *\n        {BEGIN INITIAL;}
+[ ]*\/\/\ *{Rac}\:?\ *begin\ *\n  {BEGIN ACTIVE; return RAC_BEGIN;}
+\/\/\ *{Rac}\:?\ *end\ *\n        {BEGIN INITIAL; return RAC_END;}
 
 <INITIAL>.*\n               {}
 

--- a/books/projects/rac/src/parser.y
+++ b/books/projects/rac/src/parser.y
@@ -39,8 +39,9 @@ Stack<SymDec> *symTab = new Stack<SymDec>;
 
 %define parse.error verbose
 
+%token END
 %token TYPEDEF CONST STRUCT ENUM TEMPLATE
-%token RAC
+%token RAC RAC_BEGIN RAC_END
 %token INT UINT INT64 UINT64 BOOL
 %token SLC SET_SLC
 %token FOR IF ELSE WHILE DO SWITCH CASE DEFAULT BREAK RETURN ASSERT
@@ -52,7 +53,7 @@ Stack<SymDec> *symTab = new Stack<SymDec>;
 %token <s> RSHFT_OP LSHFT_OP AND_OP OR_OP LE_OP GE_OP EQ_OP NE_OP
 %token <s> ID NAT TRUE FALSE TYPEID TEMPLATEID
 %token <s> '=' '+' '-' '&' '|' '!' '~' '*' '%' '<' '>' '^' '/'
-%start program
+%start guarded_program
 
 %type <t> type_spec typedef_type
 %type <t> primitive_type array_param_type mv_type register_type struct_type enum_type
@@ -93,6 +94,13 @@ Stack<SymDec> *symTab = new Stack<SymDec>;
 // A program consists of a sequence of type definitions, global constant declarations,
 // and function definitions.  The parser produces four linked lists corresponding to
 // these sequences, stored as the values of the variables typeDefs, constDecs, and funDefs.
+
+guarded_program
+  : RAC_BEGIN program RAC_END END {}
+  | RAC_BEGIN program END {yyerror("Missing RAC guard (`// RAC end`)");}
+  | RAC_BEGIN END {yyerror("Missing RAC guard (`// RAC end`)");}
+  | END {yyerror("Missing RAC guard (`// RAC begin`)");}
+  ;
 
 program
   : program program_element {}


### PR DESCRIPTION
Fix a potential read out of bounds in main when the filename is
larger that 80 characters.

Now, when the parsing fails, we abort without trying to generate
code. This was leading to some segfault and strange behavior (like
empty files generated).

Remove debugs flags and enable all optimizations. Also refactor
Makefile for faster build.