### PR TITLE
[make-flag] Improve defthm-flag.

### DIFF
--- a/books/tools/flag.lisp
+++ b/books/tools/flag.lisp
@@ -895,12 +895,18 @@ one such form may affect what you might think of as the proof of another.</p>
        (thmname (intern-in-package-of-symbol
                  (concatenate 'string "THEOREM-FOR-" (symbol-name fnname))
                  fnname))
-       (hyp1 (intern-in-package-of-symbol "HYP1" fnname))
-       (hyp2 (intern-in-package-of-symbol "HYP2" fnname))
+       (fnguard (getprop fnname 'guard acl2::*t* 'current-acl2-world world))
+       (hyp (if (not (equal fnguard acl2::*t*))
+                ;; use the function's guard, since it's non-trivial:
+                (untranslate fnguard t world)
+              ;; use a placeholder hyp:
+              (let ((hyp1 (intern-in-package-of-symbol "HYP1" fnname))
+                    (hyp2 (intern-in-package-of-symbol "HYP2" fnname)))
+                `(and ,hyp1 ,hyp2))))
        (prop (intern-in-package-of-symbol "PROP" fnname))
        (fnargs  (get-formals fnname world))
        (mock-thm `(defthm ,thmname
-                    (implies (and ,hyp1 ,hyp2)
+                    (implies ,hyp
                              (,prop (,fnname . ,fnargs)))
                     :flag ,flag-symbol)))
     (cons mock-thm


### PR DESCRIPTION
When defthm-flag-xxx is called with no arguments, it creates a template form for the user to fill out.  That form includes placeholder hyps for each template theorem.  Previously these were always literally (AND HYP1 HYP2), with the user expected to replace the meaningless HYP1 and HYP2 with meaningful hyps (or delete them).  Now, for a function with a non-trivial guard, that guard is used for the hyp instead, since it is fairly likely to be needed in theorems about the function.  The user is still welcome to edit the hyps, of course.

Here is an example for all-vars1 (note the hyps):

Old behavior:
```
(DEFTHM-FLAG-ALL-VARS1 (DEFTHM THEOREM-FOR-ALL-VARS1
                               (IMPLIES (AND HYP1 HYP2)
                                        (PROP (ALL-VARS1 TERM ANS)))
                               :FLAG ALL-VARS1)
                       (DEFTHM THEOREM-FOR-ALL-VARS1-LST
                               (IMPLIES (AND HYP1 HYP2)
                                        (PROP (ALL-VARS1-LST LST ANS)))
                               :FLAG ALL-VARS1-LST))
```

New behavior:
```
(DEFTHM-FLAG-ALL-VARS1 (DEFTHM THEOREM-FOR-ALL-VARS1
                               (IMPLIES (AND (PSEUDO-TERMP TERM)
                                             (SYMBOL-LISTP ANS))
                                        (PROP (ALL-VARS1 TERM ANS)))
                               :FLAG ALL-VARS1)
                       (DEFTHM THEOREM-FOR-ALL-VARS1-LST
                               (IMPLIES (AND (PSEUDO-TERM-LISTP LST)
                                             (SYMBOL-LISTP ANS))
                                        (PROP (ALL-VARS1-LST LST ANS)))
                               :FLAG ALL-VARS1-LST))
```