### PR TITLE
[xdoc] Avoid including centaur/fty/portcullis in xdoc/cert.acl2.

### DIFF
--- a/books/kestrel/fty/deffixequiv-sk-doc.lisp
+++ b/books/kestrel/fty/deffixequiv-sk-doc.lisp
@@ -10,6 +10,7 @@
 
 (in-package "FTY")
 
+(include-book "centaur/fty/portcullis" :dir :system)
 (include-book "kestrel/event-macros/xdoc-constructors" :dir :system)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/fty/defunit-doc.lisp
+++ b/books/kestrel/fty/defunit-doc.lisp
@@ -10,6 +10,7 @@
 
 (in-package "FTY")
 
+(include-book "centaur/fty/portcullis" :dir :system)
 (include-book "kestrel/event-macros/xdoc-constructors" :dir :system)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/xdoc/cert.acl2
+++ b/books/xdoc/cert.acl2
@@ -29,5 +29,4 @@
 ; Original author: Jared Davis <jared@centtech.com>
 
 (include-book "std/portcullis" :dir :system)
-(include-book "centaur/fty/portcullis" :dir :system)
 ; cert-flags: ? t :ttags :all


### PR DESCRIPTION
Prior to this change, books/xdoc/cert.acl2 contained:
(include-book "centaur/fty/portcullis" :dir :system)
which seemed unnecessary.  I don't see any mentions of fty in xdoc/, and nothing broke when I removed this include-book.

The include-book led to unnecessary dependencies, for example b* depending on books/centaur/bitops/portcullis.lisp (since fty depends on centaur/bitops/portcullis).