### PR TITLE
Use `current-theory` in Paco's `transfer-nume-to-rune-map` function instead of `universal-theory`

### DIFF
--- a/books/projects/paco/database.lisp
+++ b/books/projects/paco/database.lisp
@@ -558,8 +558,7 @@
 
 ; This function makes the value of (@ nume-to-rune-map) be a structure
 ; that maps all numes to their runes.  Actually, the structure is an
-; enabled structure and we just use the universal-theory to compute
-; it.
+; enabled structure and we just use the current-theory to compute it.
 
   (let ((d (car
             (cadr
@@ -605,8 +604,8 @@
        (t
         (er-let*
           ((map (load-theory-into-enabled-structure
-                 '(universal-theory-fn :here (w state)) ;;; theory-expr
-                 (universal-theory-fn :here (w state))  ;;; theory
+                 '(current-theory-fn :here (w state))   ;;; theory-expr
+                 (current-theory-fn :here (w state))    ;;; theory
                  nil                                    ;;; augmented-p
                  map                                    ;;; ens
                  nil                                    ;;; incrmt-array-name-flg


### PR DESCRIPTION
With ACL2 8.4 on Linux, proving a (trivial) theorem using Paco results in the following error:

```
ACL2 !>(include-book "projects/paco/paco" :dir :system)

Summary
Form:  ( INCLUDE-BOOK "projects/paco/paco" ...)
Rules: NIL
Time:  5.53 seconds (prove: 0.00, print: 0.02, other: 5.52)
 "/home/kazarmy/tar/acl2-8.4/books/projects/paco/paco.lisp"
ACL2 !>:paco
 "PACO"
PACO !>(dthm true t)

Computing and transferring the ACL2 environment to Paco...

ACL2 Error in ACL2::TRANSFER-NUME-TO-RUNE-MAP:  Theory invariant 1,
defined in book
"/home/kazarmy/tar/acl2-8.4/books/arithmetic/equalities.lisp", failed
on the theory produced by
(ACL2::UNIVERSAL-THEORY-FN :HERE (ACL2::W ACL2::STATE)).  Theory invariant
1 is
(NOT (AND (ACL2::ACTIVE-RUNEP '(:REWRITE ACL2::UNIQUENESS-OF-*-INVERSES))
          (ACL2::ACTIVE-RUNEP '(:REWRITE ACL2::EQUAL-/))))
which asserts that the runes (:REWRITE ACL2::UNIQUENESS-OF-*-INVERSES)
and (:REWRITE ACL2::EQUAL-/) are not both enabled at the same time.
This theory invariant violation causes an error.  See :DOC theory-
invariant.
```

But one of the runes is indeed disabled:

```
PACO !>:pr ACL2::UNIQUENESS-OF-*-INVERSES

Rune:         (:REWRITE ACL2::UNIQUENESS-OF-*-INVERSES)
Enabled:      NIL
Hyps:         T
Equiv:        EQUAL
Lhs:          (EQUAL (* ACL2::X ACL2::Y) 1)
Rhs:          (AND (NOT (EQUAL (ACL2::FIX ACL2::X) 0))
                   (EQUAL ACL2::Y (/ ACL2::X)))
Backchain-limit-lst: NIL
Subclass:     ACL2::BACKCHAIN
Loop-stopper: NIL
```

Redefining the `ACL2::TRANSFER-NUME-TO-RUNE-MAP` function according to this PR allows the environment transfer to proceed, and it does seem to make sense to use `current-theory` instead of `universal-theory` since disabled runes should stay disabled, and so this pr proposes such a change to Paco.