### PR TITLE
[VL] Reduce deps of centaur/vl/util/namedb.

### DIFF
--- a/books/centaur/aig/aig2c.lisp
+++ b/books/centaur/aig/aig2c.lisp
@@ -30,6 +30,7 @@
 
 (in-package "ACL2")
 (include-book "std/util/top" :dir :system)
+(include-book "centaur/vl/util/defs" :dir :system)
 (include-book "centaur/vl/util/namedb" :dir :system)
 (include-book "aig-base")
 (include-book "aig-vars-ext")

--- a/books/centaur/bigmem/bigmem.lisp
+++ b/books/centaur/bigmem/bigmem.lisp
@@ -31,6 +31,8 @@
 (in-package "BIGMEM")
 (include-book "concrete")
 (include-book "centaur/defrstobj2/def-multityped-record" :dir :system)
+(include-book "std/lists/repeat" :dir :system)
+(include-book "std/stobjs/absstobjs" :dir :system)
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/centaur/defrstobj/defrstobj.lisp
+++ b/books/centaur/defrstobj/defrstobj.lisp
@@ -43,6 +43,7 @@
 (include-book "std/lists/nth" :dir :system)
 (include-book "std/lists/resize-list" :dir :system)
 (include-book "std/lists/len" :dir :system)
+(include-book "std/lists/repeat" :dir :system)
 
 
 (defsection defrstobj

--- a/books/centaur/defrstobj2/defrstobj.lisp
+++ b/books/centaur/defrstobj2/defrstobj.lisp
@@ -39,6 +39,7 @@
 (include-book "std/lists/nth" :dir :system)
 (include-book "std/lists/resize-list" :dir :system)
 (include-book "std/lists/len" :dir :system)
+(include-book "std/lists/repeat" :dir :system)
 
 
 (defsection defrstobj

--- a/books/centaur/glmc/glmc-generic-proof.lisp
+++ b/books/centaur/glmc/glmc-generic-proof.lisp
@@ -31,6 +31,7 @@
 
 (in-package "GL")
 
+(include-book "centaur/vl/util/defs" :dir :system)
 (include-book "glmc-generic-defs")
 (include-book "centaur/gl/gl-generic-clause-proc" :dir :system)
 (include-book "centaur/gl/gl-generic-interp" :dir :system)

--- a/books/centaur/vl/util/namedb.lisp
+++ b/books/centaur/vl/util/namedb.lisp
@@ -29,7 +29,12 @@
 ; Original author: Jared Davis <jared@centtech.com>
 
 (in-package "VL")
-(include-book "defs")
+(include-book "std/strings/strprefixp" :dir :system)
+(include-book "std/strings/decimal" :dir :system)
+(include-book "std/util/defalist" :dir :system)
+(include-book "defsort/duplicated-members" :dir :system)
+(include-book "fast-memberp")
+(include-book "string-fix")
 (include-book "centaur/fty/deftypes" :dir :system)
 (include-book "centaur/fty/basetypes" :dir :system)
 (local (include-book "arithmetic"))

--- a/books/projects/x86isa/machine/environment.lisp
+++ b/books/projects/x86isa/machine/environment.lisp
@@ -42,6 +42,7 @@
 (in-package "X86ISA")
 
 (include-book "top-level-memory" :ttags (:undef-flg))
+(local (include-book "std/alists/assoc" :dir :system))
 
 ;; ======================================================================
 


### PR DESCRIPTION
This change prevents centaur/vl/util/namedb from including centaur/vl/util/defs.  Various include-books have to be added in namedb.lisp, and other files, to compensate, but the net effect is to greatly reduce what is included by namedb and tools that include it, including defrstobj, the x86 model, and Axe.

This change reduces the number of books included by defrstobj2 from 213 to 127.  Among the things no longer included are utilities for encoding strings in HTML!   The number of books included by kestrel/axe/top decreases from 1238 to 1169.  And projects/x86isa/top goes from 398 books to 329 books.

Further improvements could probably be made in vl by reducing what is included in centaur/vl/util/defs.lisp itself (e.g., not including std/strings/top, which is presumably what brings in the aforementioned HTML utilities).