### PR TITLE
Just include arithmetic-5/top, not arithmetic/top

### DIFF
--- a/books/workshops/2017/coglio-kaufmann-smith/support/example-integers.lisp
+++ b/books/workshops/2017/coglio-kaufmann-smith/support/example-integers.lisp
@@ -19,7 +19,7 @@
 
 (include-book "simplify-defun")
 
-(local (include-book "arithmetic/top" :dir :system))
+(local (include-book "arithmetic-5/top" :dir :system))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -38,8 +38,6 @@
    ((gte32 * *) => * :formals (u v) :guard (and (int32p u) (int32p v))))
 
   (local (include-book "ihs/basic-definitions" :dir :system))
-
-  (local (include-book "arithmetic-5/top" :dir :system))
 
   ;; For witnessing the constrained functions,
   ;; we represent two's complement 32-bit integers
@@ -234,8 +232,8 @@
                          (IF (< (INT D) 0)
                              (INT32 (+ (INT D) (* 2 (INT B))))
                              (INT32 (+ (INT D)
-                                       (- (* 2 (INT A)))
-                                       (* 2 (INT B)))))
+                                       (* 2 (INT B))
+                                       (* -2 (INT A)))))
                          (DRAWPOINT X Y SCREEN)))
    :UNDEFINED))
 

--- a/books/workshops/2020/coglio-westfold/integer-example.lisp
+++ b/books/workshops/2020/coglio-westfold/integer-example.lisp
@@ -14,7 +14,7 @@
 (include-book "std/testing/must-be-redundant" :dir :system)
 (include-book "workshops/2017/coglio-kaufmann-smith/support/simplify-defun" :dir :system)
 
-(local (include-book "arithmetic/top" :dir :system))
+(local (include-book "arithmetic-5/top" :dir :system))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -43,8 +43,6 @@
    ((gte32 * *) => * :formals (u v) :guard (and (int32p u) (int32p v))))
 
   (local (include-book "ihs/basic-definitions" :dir :system))
-
-  (local (include-book "arithmetic-5/top" :dir :system))
 
   ;; For witnessing the constrained functions,
   ;; we represent two's complement 32-bit integers
@@ -378,7 +376,7 @@
                                  (IF (< D 0) Y (+ 1 Y))
                                  (IF (< D 0)
                                      (+ D (* 2 B))
-                                     (+ D (- (* 2 A)) (* 2 B)))
+                                     (+ D (* 2 B) (* -2 A)))
                                  (DRAWPOINT (INT32 X) (INT32 Y) SCREEN)))
            :UNDEFINED)
        NIL)))


### PR DESCRIPTION
Avoids incompatible rule application that can easily lead to stack overflow
and did so with Matt's dependency scanner loaded.
Fix expected result because simplification produces slightly different result