### PR TITLE
Fix fastnumio on sbcl

### DIFF
--- a/books/quicklisp/base-raw.lsp
+++ b/books/quicklisp/base-raw.lsp
@@ -41,38 +41,39 @@
 ; packages that are both being built at separate times in separate threads,
 ; crashing into each other's working space.
 
-#-sbcl
+;; #-sbcl
 (defmacro load-system-from-acl2-quicklisp-bundle (name)
   `(asdf:load-system ,name))
 
-#+sbcl
-(defmacro load-system-from-acl2-quicklisp-bundle (name)
-  ;; [Jared] Gross hack.
-  ;;
-  ;; Development versions of SBCL from 1.3.1.108-e9046da through at least SBCL
-  ;; 1.3.1.185-bb7a213 seem to have a bug that is provoked by loading CL+SSL
-  ;; (included via hunchentoot) when the optimize settings are set to a high
-  ;; level, as they are in ACL2.  For details and status on this bug see
-  ;; #1530390:
-  ;;
-  ;;    https://bugs.launchpad.net/sbcl/+bug/1530390
-  ;;
-  ;; As a workaround, if we are using SBCL, then explicitly set the compiler
-  ;; policy to something less aggressive, which seems to avoid the problem.
-  ;; When the SBCL bug is fixed, I think we should feel free to get rid of this
-  ;; hack.
-  `(cl:with-compilation-unit
-     (:policy '(optimize (speed 1)
-                         (space 1)
-                         (safety 1)
-                         (debug 1)
-                         (compilation-speed 1)))
-     (sb-ext:restrict-compiler-policy 'safety 1)
-     (sb-ext:restrict-compiler-policy 'space 1)
-     (sb-ext:restrict-compiler-policy 'speed 1)
-     (sb-ext:restrict-compiler-policy 'debug 1)
-     (sb-ext:restrict-compiler-policy 'compilation-speed 1)
-     (asdf:load-system ,name)))
+;; [westfold] This was fixed in 2016
+;; #+sbcl
+;; (defmacro load-system-from-acl2-quicklisp-bundle (name)
+;;   ;; [Jared] Gross hack.
+;;   ;;
+;;   ;; Development versions of SBCL from 1.3.1.108-e9046da through at least SBCL
+;;   ;; 1.3.1.185-bb7a213 seem to have a bug that is provoked by loading CL+SSL
+;;   ;; (included via hunchentoot) when the optimize settings are set to a high
+;;   ;; level, as they are in ACL2.  For details and status on this bug see
+;;   ;; #1530390:
+;;   ;;
+;;   ;;    https://bugs.launchpad.net/sbcl/+bug/1530390
+;;   ;;
+;;   ;; As a workaround, if we are using SBCL, then explicitly set the compiler
+;;   ;; policy to something less aggressive, which seems to avoid the problem.
+;;   ;; When the SBCL bug is fixed, I think we should feel free to get rid of this
+;;   ;; hack.
+;;   `(cl:with-compilation-unit
+;;      (:policy '(optimize (speed 1)
+;;                          (space 1)
+;;                          (safety 1)
+;;                          (debug 1)
+;;                          (compilation-speed 1)))
+;;      (sb-ext:restrict-compiler-policy 'safety 1)
+;;      (sb-ext:restrict-compiler-policy 'space 1)
+;;      (sb-ext:restrict-compiler-policy 'speed 1)
+;;      (sb-ext:restrict-compiler-policy 'debug 1)
+;;      (sb-ext:restrict-compiler-policy 'compilation-speed 1)
+;;      (asdf:load-system ,name)))
 
 (load-system-from-acl2-quicklisp-bundle "bordeaux-threads")
 (load-system-from-acl2-quicklisp-bundle "bt-semaphore")
@@ -84,10 +85,7 @@
 ; to fix that.  For now just don't include it on Allegro.  Actually it looks
 ; like there may be bugs on CMUCL also.
 #+(and (not cmucl)
-       (not allegro)
-; Matt K: SBCL 1.4.7 has problems too.  See the comment in fastnumio-raw.lsp.
-; For now I'll take the easy way out and avoid SBCL here too.
-       (not sbcl))
+       (not allegro))
 (load-system-from-acl2-quicklisp-bundle "fastnumio")
 
 (load-system-from-acl2-quicklisp-bundle "html-template")
@@ -107,4 +105,3 @@
 (load-system-from-acl2-quicklisp-bundle "osicat")
 (load-system-from-acl2-quicklisp-bundle "shellpool")
 (load-system-from-acl2-quicklisp-bundle "uiop")
-

--- a/books/quicklisp/bundle/local-projects/fastnumio/write-hex.lisp
+++ b/books/quicklisp/bundle/local-projects/fastnumio/write-hex.lisp
@@ -432,7 +432,7 @@
 ; Note: SBCL on Linux X86-64 represents bignums as vectors of 64-bit 'digits',
 ; with the least significant digit in place 0.
 
-#+(and sbcl x86-64)
+#+(and sbcl 64-bit)
 (progn
 
   ;; Basic sanity checking to see if we still understand the internal API.
@@ -446,7 +446,7 @@
   (let* ((x      #xfeedf00ddeadd00ddeadbeef99998888)
          (digit  (sb-bignum::%bignum-ref x 0))
          (high32 (sb-bignum::%digit-logical-shift-right digit 32))
-         (low32  (sb-bignum::%logand digit #xFFFFFFFF)))
+         (low32  (logand digit #xFFFFFFFF)))
     (assert (typep high32 'fixnum))
     (assert (typep low32 'fixnum))
     (assert (typep high32 '(unsigned-byte 32)))
@@ -544,7 +544,7 @@
   (declaim (inline write-nth-hex-bignum-digit-with-leading-zeroes))
   (defun write-nth-hex-bignum-digit-with-leading-zeroes (n val stream)
     (let ((high32 (sb-bignum::%digit-logical-shift-right (sb-bignum::%bignum-ref val n) 32))
-          (low32  (sb-bignum::%logand (sb-bignum::%bignum-ref val n) #xFFFFFFFF)))
+          (low32  (logand (sb-bignum::%bignum-ref val n) #xFFFFFFFF)))
       (declare (type (unsigned-byte 32) high32 low32))
       (write-hex-u32-with-leading-zeroes high32 stream)
       (write-hex-u32-with-leading-zeroes low32 stream)))
@@ -554,7 +554,7 @@
     ;; If digit is nonzero, we print it and return T.
     ;; If digit is zero,    we do not print anything and return NIL.
     (let* ((high32 (sb-bignum::%digit-logical-shift-right (sb-bignum::%bignum-ref val n) 32))
-           (low32  (sb-bignum::%logand (sb-bignum::%bignum-ref val n) #xFFFFFFFF)))
+           (low32  (logand (sb-bignum::%bignum-ref val n) #xFFFFFFFF)))
       (declare (type (unsigned-byte 32) high32 low32))
       (if (eql high32 0)
           (if (eql low32 0)
@@ -603,7 +603,7 @@
   (declare (type unsigned-byte val))
 
   #+(and (not (and Clozure x86-64))
-         (not (and sbcl x86-64)))
+         (not (and sbcl 64-bit)))
   (write-hex val stream)
 
   #+(and Clozure x86-64)
@@ -614,7 +614,7 @@
     ;; fixnums are still 60 bits.
     (scary-unsafe-write-hex-bignum-ccl val stream))
 
-  #+(and sbcl x86-64)
+  #+(and sbcl 64-bit)
   (if (typep val 'fixnum)
       (write-hex-fixnum-without-leading-zeroes val stream)
     (scary-unsafe-write-hex-bignum-sbcl val stream))

--- a/books/quicklisp/fastnumio-raw.lsp
+++ b/books/quicklisp/fastnumio-raw.lsp
@@ -30,13 +30,4 @@
 
 (in-package "ACL2")
 
-; Matt K.: There are package-lock problems with SBCL 1.4.7 that I have been
-; able to overcome here.  I tried each of the following in raw Lisp.
-; (without-package-locks (load "fastnumio-raw.lsp"))
-; (without-package-lock "SB-BIGNUM" (load "fastnumio-raw.lsp"))
-; (with-unlocked-packages '("SB-BIGNUM") (load "fastnumio-raw.lsp"))
-; (without-package-locks (asdf:load-system "fastnumio"))
-; (without-package-lock "SB-BIGNUM" (asdf:load-system "fastnumio"))
-; (with-unlocked-packages '("SB-BIGNUM") (asdf:load-system "fastnumio"))
-#-sbcl
 (asdf:load-system "fastnumio")


### PR DESCRIPTION
Also allows it to work on M1 Macs
Also removes bug workaround that was fixed long ago