### PR TITLE
[Std/util] Add an :IFERR option to the ER binder.

### DIFF
--- a/books/std/util/bstar.lisp
+++ b/books/std/util/bstar.lisp
@@ -27,6 +27,7 @@
 ;   DEALINGS IN THE SOFTWARE.
 ;
 ; Original author: Sol Swords <sswords@centtech.com>
+; Contributing author: Alessandro Coglio <coglio@kestrel.edu>
 
 (in-package "ACL2")
 (include-book "xdoc/base" :dir :system)
@@ -1113,8 +1114,46 @@ recursive binder, and @('assocs') may be nested inside other bindings.</p>"
 })
 
 <p>The @('er') binder only makes sense as a top-level binding, but its argument
-may be a recursive binding.</p>"
-  :decls ((declare (xargs :guard (destructure-guard er args forms 1))))
+may be a recursive binding.</p>
+
+<p>To return a different value in case of error,
+the different value can be specified via @(':iferr'):</p>
+
+@({
+    (b* (((er x :iferr eval) (error-triple-form)))
+      (result-form))
+})
+
+<p>which is approximately equivalent to</p>
+
+@({
+    (mv-let (erp val state)
+            (error-triple-form)
+       (if erp
+           (mv erp eval state) ; note eval instead of val
+         (result-form)))
+})"
+
+  :decls ((declare
+           (xargs :guard (and (or (and (true-listp args)
+                                       (or (eql (len args) 1)
+                                           (and (eql (len args) 3)
+                                                (eq (cadr args) :iferr))))
+                                  (cw "~%~%**** ERROR ****~%~
+                                       Pattern constructor ER needs ~
+                                       either a true list of 1 argument ~
+                                       or a true list of 3 arguments ~
+                                       whose second argument is :IFERR,
+                                       but was given ~x0~%~%"
+                                      args))
+                              (or (and (consp forms)
+                                       (eq (cdr forms) nil))
+                                  (cw "~%~%**** ERROR ****~%~
+                                       Pattern constructor ER needs ~
+                                       exactly one binding expression, ~
+                                       but was given ~x0~%~%"
+                                      forms))))))
+
   :body
   `(mv-let (patbind-er-fresh-variable-for-erp
             patbind-er-fresh-variable-for-val
@@ -1122,7 +1161,9 @@ may be a recursive binding.</p>"
      ,(car forms)
      (if patbind-er-fresh-variable-for-erp
          (mv patbind-er-fresh-variable-for-erp
-             patbind-er-fresh-variable-for-val
+             ,(if (eql (len args) 1)
+                  'patbind-er-fresh-variable-for-val
+                (caddr args))
              state)
        (patbind ,(car args)
                 (patbind-er-fresh-variable-for-val)


### PR DESCRIPTION
In
```
 (b* (...
      ((er x) <something>)
      ...)
   ...)
```
if `<something>` returns `(mv erp val state)` with non-`nil` `erp`, the `b*` also returns
`(mv erp val state)`.

Instead, in
```
 (b* (...
      ((er x :iferr eval) <something>)
      ...)
   ...)
```
if `<something>` returns `(mv erp val state)` with non-`nil` `erp`, the `b*` returns `(mv
erp eval state)`, i.e. the chosen `eval` instead of `val`.

This is useful, for example, when writing code that traffics in error triples
whose value components must have different types, when we want those types to be
unconditional. For instance, the `b*` could be in a function `g` whose returned `val`
is unconditionally a string, while `<something>` is a call of a function `f` whose
returned `val` is unconditionally an integer: using just `(er x)` would lead to a
type violation (manifesting as a return theorem not being proved), while using
`(er x :iferr "")` would let `g` unconditionally return a string.

This is more compact then binding the whole triple and checking `erp`, i.e.
```
 (b* (...
      ((mv erp val state) <something>)
      ((when erp) (mv erp eval state))
      ...)
   ...)
```
The guard of `patbind-er`, which was previously just `destructure-guard`, has been
relaxed to allow the option, while inlining the relevant parts of
`destructure-guard`.