### PR TITLE
[async] Reduce dependencies of ASYNC package.

### DIFF
--- a/books/projects/async/macros.lisp
+++ b/books/projects/async/macros.lisp
@@ -13,6 +13,7 @@
 
 (include-book "misc/defopener" :dir :system)
 (include-book "std/util/bstar" :dir :system)
+(include-book "std/util/define" :dir :system)
 
 ;; ======================================================================
 

--- a/books/projects/async/package.lsp
+++ b/books/projects/async/package.lsp
@@ -3,7 +3,8 @@
 ;; License: A 3-clause BSD license.  See the LICENSE file distributed with
 ;; ACL2.
 
-(include-book "std/strings/istrprefixp" :dir :system)
+;; (include-book "std/strings/istrprefixp" :dir :system)
+(include-book "std/portcullis" :dir :system)
 
 ;; ======================================================================
 


### PR DESCRIPTION
This allows me to get the ADE package (in the async books) without having to also take std/strings/istrprefixp, which can cause name clashes.

I had to include define in one book, to compensate for this change.