### PR TITLE
[rp-rewriter] Remove include-books from portcullis book.

### DIFF
--- a/books/projects/rp-rewriter/meta/cons-to-list-meta.lisp
+++ b/books/projects/rp-rewriter/meta/cons-to-list-meta.lisp
@@ -50,6 +50,8 @@
 
 (include-book "../meta-rule-macros")
 
+(include-book "centaur/meta/def-formula-checks" :dir :system)
+
 (local
  (include-book "../proofs/measure-lemmas"))
 

--- a/books/projects/rp-rewriter/meta/equal-meta.lisp
+++ b/books/projects/rp-rewriter/meta/equal-meta.lisp
@@ -50,6 +50,8 @@
 
 (include-book "../meta-rule-macros")
 
+(include-book "centaur/meta/def-formula-checks" :dir :system)
+
 (local
  (include-book "../proofs/measure-lemmas"))
 

--- a/books/projects/rp-rewriter/meta/fast-alist-free-meta.lisp
+++ b/books/projects/rp-rewriter/meta/fast-alist-free-meta.lisp
@@ -50,6 +50,8 @@
 
 (include-book "../meta-rule-macros")
 
+(include-book "centaur/meta/def-formula-checks" :dir :system)
+
 (defund fast-alist-free-meta (term)
   (declare (xargs :guard t))
   (case-match term

--- a/books/projects/rp-rewriter/meta/hons-acons-meta.lisp
+++ b/books/projects/rp-rewriter/meta/hons-acons-meta.lisp
@@ -50,6 +50,8 @@
 
 (include-book "../meta-rule-macros")
 
+(include-book "centaur/meta/def-formula-checks" :dir :system)
+
 (local
  (in-theory (enable falist-consistent)))
 

--- a/books/projects/rp-rewriter/meta/hons-get-meta.lisp
+++ b/books/projects/rp-rewriter/meta/hons-get-meta.lisp
@@ -50,6 +50,8 @@
 
 (include-book "../meta-rule-macros")
 
+(include-book "centaur/meta/def-formula-checks" :dir :system)
+
 (local
  (include-book "../proofs/measure-lemmas"))
 

--- a/books/projects/rp-rewriter/meta/mv-nth-meta.lisp
+++ b/books/projects/rp-rewriter/meta/mv-nth-meta.lisp
@@ -38,6 +38,8 @@
 
 (include-book "../meta-rule-macros")
 
+(include-book "centaur/meta/def-formula-checks" :dir :system)
+
 (defun mv-nth-meta-aux (index term)
   (declare (xargs :guard (natp index)))
   (case-match term

--- a/books/projects/rp-rewriter/portcullis.acl2
+++ b/books/projects/rp-rewriter/portcullis.acl2
@@ -1,6 +1,7 @@
 ;; (include-book "std/strings/istrprefixp" :dir :system)
 
-(include-book "centaur/meta/def-formula-checks" :dir :system)
+;; (include-book "centaur/meta/def-formula-checks" :dir :system)
+(include-book "centaur/meta/portcullis" :dir :system)
 
 
 (defpkg "RP"

--- a/books/projects/rp-rewriter/portcullis.lisp
+++ b/books/projects/rp-rewriter/portcullis.lisp
@@ -42,4 +42,4 @@
 
 
 
-(include-book "std/strings/istrprefixp" :dir :system)
+;; (include-book "std/strings/istrprefixp" :dir :system)

--- a/books/projects/rp-rewriter/proofs/local-lemmas.lisp
+++ b/books/projects/rp-rewriter/proofs/local-lemmas.lisp
@@ -40,6 +40,8 @@
 (include-book "tools/flag" :dir :system)
 ;(include-book "proof-functions")
 
+(local (include-book "centaur/meta/def-formula-checks" :dir :system)) ; this could perhaps be reduced
+
 ;; lemmas that are to be used locally
 
 ;(make-flag pseudo-termp :defthm-macro-name defthm-pseudo-termp)


### PR DESCRIPTION
Similar to a recent change.  The goal is to let me get the package from the portcullis without getting any books not necessary for that.