### PR TITLE
[sb-machine] Reduce dependencies of package.lsp.

### DIFF
--- a/books/projects/sb-machine/package.lsp
+++ b/books/projects/sb-machine/package.lsp
@@ -3,11 +3,12 @@
 ; License: A 3-clause BSD license.  See the LICENSE file distributed with ACL2.
 
 (include-book "std/portcullis" :dir :system)
-(include-book "std/util/define" :dir :system)
-(include-book "std/util/defrule" :dir :system)
+;; (include-book "std/util/define" :dir :system)
+;; (include-book "std/util/defrule" :dir :system)
 
-(include-book "centaur/fty/deftypes" :dir :system)
-(include-book "centaur/fty/basetypes" :dir :system)
+(include-book "centaur/fty/portcullis" :dir :system)
+;; (include-book "centaur/fty/deftypes" :dir :system)
+;; (include-book "centaur/fty/basetypes" :dir :system)
 
 (defconst *fty-imports*
   '(fty::deflist

--- a/books/projects/sb-machine/sb.lisp
+++ b/books/projects/sb-machine/sb.lisp
@@ -44,6 +44,9 @@
 ;; The shared memory is an alist mapping symbols to values (integers).
 
 (in-package "SB")
+(include-book "std/util/defrule" :dir :system)
+(include-book "centaur/fty/basetypes" :dir :system)
+(include-book "centaur/fty/deftypes" :dir :system)
 (set-ignore-ok t)
 
 (in-theory (disable assoc put-assoc nth update-nth))


### PR DESCRIPTION
This allows the package to be obtained without also getting those books.  Add some includes to another book to compensate.