### PR TITLE
[cert.pl] Attempt to fix cert.pl.

### DIFF
--- a/books/build/lib/Certlib.pm
+++ b/books/build/lib/Certlib.pm
@@ -234,11 +234,13 @@ sub determine_acl2_dirs {
 	# Check whether the SYSTEM dir was set when reading the acl2_projects file and set it if so.
 	$acl2_books = lookup_colon_dir("SYSTEM", {});
 
-	# In this case we skip the rest because the path should be
-	# canonicalized already and is already added to the $dirs.
-	my $acl2_books_env = path_export($acl2_books);
-	$ENV{"ACL2_SYSTEM_BOOKS"} = $acl2_books_env;
-	return $acl2_books;
+        if ($acl2_books) {
+            # In this case we skip the rest because the path should be
+            # canonicalized already and is already added to the $dirs.
+            my $acl2_books_env = path_export($acl2_books);
+            $ENV{"ACL2_SYSTEM_BOOKS"} = $acl2_books_env;
+            return $acl2_books;
+        }
     }
     
     # Fourth way: directory named books under the directory containing acl2

--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -758,7 +758,13 @@ chmod(0750,$shtmp);
 
 my $START_TIME = mytime();
 
-    system("$STARTJOB", "./$shtmp");
+    my $firstchar = substr $shtmp, 0, 1;
+    if ($firstchar eq "/") {
+        system("$STARTJOB", "$shtmp");
+    }
+    else {
+        system("$STARTJOB", "./$shtmp");
+    }
     $status = $? >> 8;
 
 my $END_TIME = mytime();

--- a/books/build/make_cert_help.pl
+++ b/books/build/make_cert_help.pl
@@ -758,14 +758,9 @@ chmod(0750,$shtmp);
 
 my $START_TIME = mytime();
 
-    my $firstchar = substr $shtmp, 0, 1;
-    if ($firstchar eq "/") {
-        system("$STARTJOB", "$shtmp");
-    }
-    else {
-        system("$STARTJOB", "./$shtmp");
-    }
-    $status = $? >> 8;
+$shtmp = File::Spec->file_name_is_absolute($shtmp) ? $shtmp : "./$shtmp";
+system("$STARTJOB", "$shtmp");
+$status = $? >> 8;
 
 my $END_TIME = mytime();
 


### PR DESCRIPTION
Recent changes broke cert.pl for many of us.  The issue seems to be that it isn't finding the system books dir using the ACL2 environment variable, due to the function determine_acl2_dirs returning before it can reach the fourth way of setting acl2_books.  So I just conditionalized that return (in the code for the third way).

Big disclaimer: I don't know perl, or anything about cert.pl, so somebody should review this.