### PR TITLE
Add :undefined option to apt::isodata 

### DIFF
--- a/books/kestrel/apt/isodata-doc.lisp
+++ b/books/kestrel/apt/isodata-doc.lisp
@@ -5,6 +5,7 @@
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
 ; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Contributing Author: Grant Jurgensen (grant@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -398,7 +399,21 @@
        "Any other term. It must be a term that only references logic-mode
         functions and that includes no free variables other than
         @('x1'), ..., @('xn'). This term must have no output
-        @(see acl2::stobj)s. This term must not reference @('old').")))
+        @(see acl2::stobj)s. This term must return the same number of results
+        as @('old'). This term must not reference @('old')."))
+     (xdoc::p
+      "If one wishes to use the term @(':auto') as the undefined result, this
+       may be accomplished by providing the quoted constant @('\':auto').")
+     (xdoc::p
+      "Even if the generated function is guard-verified
+       (which is determined by the @(':verify-guards') input; see below),
+       the undefined term need not be guard-verified.
+       Since the term is governed by the negation of the guard
+       (see the generated new function, below),
+       the verification of its guards always succeeds trivially.")
+     (xdoc::p
+      "In the rest of this documentation page, let @('undefined') be this term
+       specified by @(':undefined')."))
 
     (xdoc::desc-apt-input-new-name)
 
@@ -609,7 +624,7 @@
       "                 ..."
       "                 (newpn xn)))"
       "      old-body<(back1 x1),...,(backn xn)>"
-      "    nil)) ; or (mv nil ... nil)"
+      "    undefined))"
       ""
       ";; when old is not recursive,"
       ";; :predicate is nil,"
@@ -620,7 +635,7 @@
       "                 ..."
       "                 (newpn xn)))"
       "      (forth_r1 old-body<(back1 x1),...,(backn xn)>)"
-      "    nil))"
+      "    undefined))"
       ";; where forth_r1 is actually pushed into"
       ";; the 'if' branches of old-body if it starts with 'if',"
       ";; and recursively into their 'if' branches (if any)"
@@ -636,7 +651,7 @@
       "      (mv-let (y1 ... ym)"
       "        old-body<(back1 x1),...,(backn xn)>"
       "        (mv (forth_r1 y1) ... (forth_rm ym)))"
-      "    (mv nil ... nil)))"
+      "    undefined))"
       ""
       ";; when old is recursive"
       ";; and :predicate is t:"
@@ -684,7 +699,7 @@
       "                    (forthn updater-xn<(back1 x1),"
       "                                       ...,"
       "                                       (backn xn)>))>"
-      "    nil)) ; or (mv nil ... nil)"
+      "    undefined))"
       ""
       ";; when old is recursive,"
       ";; :predicate is nil,"
@@ -712,7 +727,7 @@
       "                               (forthn updater-xn<(back1 x1),"
       "                                                  ...,"
       "                                                  (backn xn)>)))>)"
-      "    nil))"
+      "    undefined))"
       ";; where forth_r1 is actually pushed into"
       ";; the 'if' branches of old-body if it starts with 'if',"
       ";; and recursively into their 'if' branches (if any)"
@@ -747,7 +762,7 @@
       "                                           (backn xn)>))"
       "                   (mv (back_r1 y1) ... (back_rm ym)))>"
       "        (mv (forth_r1 y1) ... (forth_rm ym)))"
-      "    (mv nil ... nil)))")
+      "    undefined))")
      (xdoc::p
       "If @('old') is recursive,
        the measure term of @('new') is

--- a/books/kestrel/apt/isodata-doc.lisp
+++ b/books/kestrel/apt/isodata-doc.lisp
@@ -388,11 +388,17 @@
      (xdoc::p
       "Denotes the value that the generated new function must return
        outside of the new domain.")
-     (xdoc::evmac-desc-term
-      :free-vars "@('x1'), ..., @('xn')"
-      :1res nil
-      :guard nil
-      :dont-call "@('old')"))
+     (xdoc::p
+      "It must be one of the following:")
+     (xdoc::ul
+      (xdoc::li
+       "@(':auto'), to use @('nil') or @('(mv nil ... nil)') for single-value
+        and multi-value functions respectively.")
+      (xdoc::li
+       "Any other term. It must be a term that only references logic-mode
+        functions and that includes no free variables other than
+        @('x1'), ..., @('xn'). This term must have no output
+        @(see acl2::stobj)s. This term must not reference @('old').")))
 
     (xdoc::desc-apt-input-new-name)
 

--- a/books/kestrel/apt/isodata-doc.lisp
+++ b/books/kestrel/apt/isodata-doc.lisp
@@ -116,6 +116,7 @@
      "(isodata old"
      "         isomaps"
      "         :predicate           ; default nil"
+     "         :undefined           ; default :auto"
      "         :new-name            ; default :auto"
      "         :new-enable          ; default :auto"
      "         :old-to-new-name     ; default from table"
@@ -381,6 +382,17 @@
        refer to the case in which @(':predicate') is @('nil'),
        while the sections with `Predicate' in their title
        refer to the case in which @(':predicate') is @('t')."))
+
+    (xdoc::desc
+     "@(':undefined') &mdash; default @(':auto')"
+     (xdoc::p
+      "Denotes the value that the generated new function must return
+       outside of the new domain.")
+     (xdoc::evmac-desc-term
+      :free-vars "@('x1'), ..., @('xn')"
+      :1res nil
+      :guard nil
+      :dont-call "@('old')"))
 
     (xdoc::desc-apt-input-new-name)
 

--- a/books/kestrel/apt/isodata-tests.lisp
+++ b/books/kestrel/apt/isodata-tests.lisp
@@ -493,6 +493,110 @@
 
 (must-succeed*
 
+ (test-title "Check UNDEFINED input on single-valued function.")
+
+ (defun f (x) (declare (xargs :guard (natp x))) (1+ x)) ; OLD
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         NIL))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined :auto)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         NIL))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined ':auto)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         :auto))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined (+ x 1))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         (+ x 1)))))
+
+ (must-succeed*
+   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0)))
+   (must-fail (isodata f ((x (natp natp identity identity))) :undefined y))
+   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (f (+ x 1)))))
+
+ :with-output-off nil)
+
+(must-succeed*
+
+ (test-title "Check UNDEFINED input on multi-valued function.")
+
+ (defun f (x) ; OLD with just a top-level MV
+   (declare (xargs :guard (natp x)))
+   (mv (+ x x) (* x x)))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))
+         (MV NIL NIL)))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined :auto)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))
+         (MV NIL NIL)))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined (mv (+ x 1) (* 42 x)))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))
+         (MV (+ x 1) (* 42 x))))))
+
+ (must-succeed*
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined 0))
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0 0)))
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv y 0)))
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv (f (+ x 1)) 0))))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(must-succeed*
+
  (test-title "Check NEWP input, when ISO is not a name.")
 
  (defun f (x) (declare (xargs :guard (natp x))) (1+ x)) ; OLD

--- a/books/kestrel/apt/isodata-tests.lisp
+++ b/books/kestrel/apt/isodata-tests.lisp
@@ -5,6 +5,7 @@
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
 ; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Contributing Author: Grant Jurgensen (grant@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -493,110 +494,6 @@
 
 (must-succeed*
 
- (test-title "Check UNDEFINED input on single-valued function.")
-
- (defun f (x) (declare (xargs :guard (natp x))) (1+ x)) ; OLD
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))))
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (+ 1 (IDENTITY X))
-         NIL))))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined :auto)
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (+ 1 (IDENTITY X))
-         NIL))))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined ':auto)
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (+ 1 (IDENTITY X))
-         :auto))))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined (+ x 1))
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (+ 1 (IDENTITY X))
-         (+ x 1)))))
-
- (must-succeed*
-   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0)))
-   (must-fail (isodata f ((x (natp natp identity identity))) :undefined y))
-   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (f (+ x 1)))))
-
- :with-output-off nil)
-
-(must-succeed*
-
- (test-title "Check UNDEFINED input on multi-valued function.")
-
- (defun f (x) ; OLD with just a top-level MV
-   (declare (xargs :guard (natp x)))
-   (mv (+ x x) (* x x)))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))))
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (MV (+ (IDENTITY X) (IDENTITY X))
-             (* (IDENTITY X) (IDENTITY X)))
-         (MV NIL NIL)))))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined :auto)
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (MV (+ (IDENTITY X) (IDENTITY X))
-             (* (IDENTITY X) (IDENTITY X)))
-         (MV NIL NIL)))))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined (mv (+ x 1) (* 42 x)))
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (MV (+ (IDENTITY X) (IDENTITY X))
-             (* (IDENTITY X) (IDENTITY X)))
-         (MV (+ x 1) (* 42 x))))))
-
- (must-succeed*
-  (must-fail (isodata f ((x (natp natp identity identity))) :undefined 0))
-  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0 0)))
-  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv y 0)))
-  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv (f (+ x 1)) 0))))
-
- :with-output-off nil)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(must-succeed*
-
  (test-title "Check NEWP input, when ISO is not a name.")
 
  (defun f (x) (declare (xargs :guard (natp x))) (1+ x)) ; OLD
@@ -889,6 +786,110 @@
    (isodata p{*} ((x (natp natp identity identity))) :predicate t))
   (must-succeed (isodata p{*} ((x nat-id)) :predicate t))
   :with-output-off nil)
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(must-succeed*
+
+ (test-title "Check UNDEFINED input on single-valued function.")
+
+ (defun f (x) (declare (xargs :guard (natp x))) (1+ x)) ; OLD
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         NIL))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined :auto)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         NIL))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined ':auto)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         :auto))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined (+ x 1))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (+ 1 (IDENTITY X))
+         (+ x 1)))))
+
+ (must-succeed*
+   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0)))
+   (must-fail (isodata f ((x (natp natp identity identity))) :undefined y))
+   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (f (+ x 1)))))
+
+ :with-output-off nil)
+
+(must-succeed*
+
+ (test-title "Check UNDEFINED input on multi-valued function.")
+
+ (defun f (x) ; OLD with just a top-level MV
+   (declare (xargs :guard (natp x)))
+   (mv (+ x x) (* x x)))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))
+         (MV NIL NIL)))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined :auto)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))
+         (MV NIL NIL)))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined (mv (+ x 1) (* 42 x)))
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))
+         (MV (+ x 1) (* 42 x))))))
+
+ (must-succeed*
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined 0))
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0 0)))
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv y 0)))
+  (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv (f (+ x 1)) 0))))
 
  :with-output-off nil)
 

--- a/books/kestrel/apt/isodata.lisp
+++ b/books/kestrel/apt/isodata.lisp
@@ -2376,8 +2376,7 @@
      the resulting term is the code of the new function's body (see below).
      Then we construct an @(tsee if) as follows.
      The test is the conjunction of @('(newp1 x1)'), ..., @('(newpn xn)').
-     The `else' branch is @('nil') or @('(mv nil ... nil')),
-     depending on whether @('old') returns single or multiple results.
+     The `else' branch is @('undefined').
      For the `then' branch, there are three cases:
      (i) if no results are transformed, we use the core term above;
      (ii) if @('old') is single-valued and its (only) result is transformed,
@@ -2390,13 +2389,7 @@
      in which case we omit test and `else' branch.
      If the compatibility flag is set and @('old') is non-recursive,
      we omit test and `else' branch as well;
-     this is temporary.")
-   (xdoc::p
-    "The `else' branch should use quoted @('nil')s,
-     but we use unquoted ones just so that the untranslation
-     does not turn the @(tsee if) into an @(tsee and).
-     Technically, the unquoted @('nil')s are ``variable'' (symbols),
-     and thus untranslation leaves them alone."))
+     this is temporary."))
   (b* ((x1...xn (formals old$ wrld))
        (m (number-of-results old$ wrld))
        (old-body (if (non-executablep old$ wrld)

--- a/books/kestrel/apt/isodata.lisp
+++ b/books/kestrel/apt/isodata.lisp
@@ -5,6 +5,7 @@
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
 ; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Contributing Author: Grant Jurgensen (grant@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -59,6 +60,7 @@
   "@('old'),
    @('isomaps'),
    @('predicate'),
+   @('undefined'),
    @('new-name'),
    @('new-enable'),
    @('old-to-new-name'),
@@ -78,6 +80,7 @@
 
   "@('old$'),
    @('predicate$'),
+   @('undefined$'),
    @('new-enable$'),
    @('old-to-new-enable$'),
    @('new-to-old-enable$'),
@@ -1107,8 +1110,7 @@
                                    ctx
                                    state)
   :returns (mv erp
-               (undefined "A @(tsee pseudo-termp) that is
-                           the translation of @('undefined').")
+               (undefined$ "A @(tsee pseudo-termp).")
                state)
   :mode :program
   :short "Process the @(':undefined') input."
@@ -2376,7 +2378,7 @@
      the resulting term is the code of the new function's body (see below).
      Then we construct an @(tsee if) as follows.
      The test is the conjunction of @('(newp1 x1)'), ..., @('(newpn xn)').
-     The `else' branch is @('undefined').
+     The `else' branch is @('undefined$').
      For the `then' branch, there are three cases:
      (i) if no results are transformed, we use the core term above;
      (ii) if @('old') is single-valued and its (only) result is transformed,


### PR DESCRIPTION
This option is processed in largely the same way as in `apt::restrict`. It affects what term is placed in the else branch of the top-level `mbt$` conditional of the new function.

The default value of the `:undefined` option is `:auto`, in which case it will default to the current behavior of using `nil` or `(mv nil ... nil)` for single-value and multi-value functions respectively. Note that one can use the quoted value `':auto` if one actually wishes the term `:auto` to be used as the "undefined" value.