### PR TITLE
[acl2s] Minor improvements to ACL2s installation instructions and tutorial

### DIFF
--- a/books/acl2s/extra-doc.lisp
+++ b/books/acl2s/extra-doc.lisp
@@ -48,7 +48,7 @@ group <b>General</b>.  Give a name to the project that will contain
 your ACL2 developments and click <b>Finish</b>.
 </p><p>
 <b>Open the \"ACL2 Development\" perspective</b>:  Select
-<b>Window</b> | <b>Open Perspective</b> | <b>ACL2 Development</b>.
+<b>Window</b> | <b>Perspective</b> | <b>Open Perspective</b> | <b>Other...</b> and then select <b>ACL2 Development</b> and then <b>Open</b> in the window that appears.
 You could have instead clicked on the
 <icon src=\"res/acl2s/new_persp.gif\" width=\"16\" height=\"16\"/> icon in the top-right corner.
 The new perspective will change the layout of your workbench.
@@ -132,36 +132,9 @@ clicking the
 icon in the toolbar.
 </p>
 
-<box>
-<h4>Note: First-time ACL2s initialization...</h4>
-
 <p>
-<em>The first time you start a session,</em> there is some
-bookkeeping that ACL2s must take care of.  This will happen
-automatically (except for a couple confirmation dialogs), but the
-process could take several minutes (5-10).
-</p>
-
-<p>
-First, the ACL2 Image for Eclipse will need to fix .cert files for the
-absolute path of Eclipse on your computer.  If you move Eclipse, this
-step will automatically be repeated. Be patient and let it finish this
-one-time bookkeeping task, it might take around 5 minutes.
-</p>
-      
-<p>
-Second, the ACL2s <em>system books</em>, our visible and invisible
-extensions to ACL2, need to be certified and compiled by ACL2.  This
-step could be required again if you change your ACL2 version or when
-you update ACL2s to a new version.
-</p>
-
-</box>
-
-<p>
-After this bookkeeping, you should be able to click the \"restart
-session\" icon on the toolbar and have ACL2 start up, resulting in the
-\"<tt>ACL2 &gt;</tt>\" prompt.
+ACL2 should start up, resulting in a .a2s file opening up and the \"<tt>ACL2S &gt;</tt>\" prompt
+appearing after a few seconds.
 </p>
 
 

--- a/books/acl2s/installation.lisp
+++ b/books/acl2s/installation.lisp
@@ -77,7 +77,7 @@ occurring.
   </li>
   <li>Run @('mkdir C:\\wslDistroStorage')</li>
   <li>Run @('wsl --import acl2s C:\\wslDistroStorage\\acl2s Downloads\\distro.tar.gz')</li>
-  <li>Run @('wsl -d acl2s') and confirm that the output is something like @({cs2800@YOURCOMPUTER:/mnt/c/Users/yourusername}). If so, you can close the terminal.</li>
+  <li>Run @('wsl -d acl2s') and confirm that the output is something like @({cs2800@YOURCOMPUTER:/mnt/c/Users/yourusername}). If so, you can close the terminal. Note that this may take some time and you may see some errors about @('DISPLAY') first.</li>
   </ol>
 </li>
 <li>Install Xming and launch it
@@ -109,8 +109,8 @@ occurring.
 </li>
 <li>Run Eclipse
 <ol>
-  <li>Download <a href=\"https://github.com/mister-walter/homebrew-acl2s/releases/download/acl2s-0.1.6/run-acl2s.bat\">run-acl2s.bat</a> and save it somewhere memorable.</li>
-  <li>Double click on @('run-acl2s.bat') to launch a WSL terminal and Eclipse.</li>
+  <li>Download <a href=\"https://github.com/mister-walter/homebrew-acl2s/releases/download/acl2s-0.1.6/run-acl2s.bat\">run-acl2s.bat</a> and save it somewhere memorable. Note that depending on your browser, you might get a warning when you download this file, but you should click \"Keep\" or \"Download Anyways\".</li>
+  <li>Double click on @('run-acl2s.bat') to launch a WSL terminal and Eclipse. A window titled \"Windows protected your PC\" may appear. If so, click on \"More info\" and then \"Run anyways\" at the bottom of the window.</li>
   <li>When Eclipse asks for a workspace, enter @('/mnt/c/<FOLDER>'),
   where @('<FOLDER>') should be replaced with the name of the folder
   that you just created.</li>

--- a/books/acl2s/installation.lisp
+++ b/books/acl2s/installation.lisp
@@ -62,7 +62,7 @@ occurring.
   side of the screen and searching for @('cmd'). Then, right click
   on the \"Command Prompt\" item and select \"Run as administrator\".</li>
   <li>Run @('dism.exe /online /enable-feature /featurename:Microsoft-Windows-Subsystem-Linux /all /norestart')</li>
-  <li>Run @('dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart)</li>
+  <li>Run @('dism.exe /online /enable-feature /featurename:VirtualMachinePlatform /all /norestart')</li>
   <li>Restart your computer and reopen an administrator terminal as
       you did previously.</li>
   <li>Run @('wsl --update')</li>


### PR DESCRIPTION
Fix a markup issue in the ACL2s Windows installation instructions
Add comments about Smartscreen and BAT file downloading in the ACL2s Windows installation instructions
Update the ACL2s tutorial so that it is consistent with our updated ACL2s plugin and Eclipse 2022-09