### PR TITLE
Add base case option to `isodata` `:undefined` parameter

### DIFF
--- a/books/kestrel/apt/isodata-doc.lisp
+++ b/books/kestrel/apt/isodata-doc.lisp
@@ -398,6 +398,15 @@
        "@(':auto'), to use @('nil') or @('(mv nil ... nil)') for single-value
         and multi-value functions respectively.")
       (xdoc::li
+       "@(':base-case'), to search for a base-case within the domain of the new
+        function. A base-case of a term may be be the whole term when the term
+        does not include any recursive calls, or it may be a base-case of the
+        `then' or `else' branch when the translated term is an `if'. This
+        search for a base-case is biased toward `else' branches.")
+      (xdoc::li
+       "@(':base-case-then'), to search for a base-case with a bias toward
+        `then' branches.")
+      (xdoc::li
        "Any other term. It must be a term that only references logic-mode
         functions and that includes no free variables other than
         @('x1'), ..., @('xn'). This term must have no output
@@ -405,7 +414,8 @@
         as @('old'). This term must not reference @('old')."))
      (xdoc::p
       "If one wishes to use the term @(':auto') as the undefined result, this
-       may be accomplished by providing the quoted constant @('\':auto').")
+       may be accomplished by providing the quoted constant @('\':auto'). The
+       same applies for @(':base-case') and @(':base-case-then').")
      (xdoc::p
       "Even if the generated function is guard-verified
        (which is determined by the @(':verify-guards') input; see below),

--- a/books/kestrel/apt/isodata-doc.lisp
+++ b/books/kestrel/apt/isodata-doc.lisp
@@ -398,14 +398,14 @@
        "@(':auto'), to use @('nil') or @('(mv nil ... nil)') for single-value
         and multi-value functions respectively.")
       (xdoc::li
-       "@(':base-case'), to search for a base-case within the domain of the new
+       "@(':base-case-then'), to search for a base-case within the domain of the new
         function. A base-case of a term may be be the whole term when the term
         does not include any recursive calls, or it may be a base-case of the
         `then' or `else' branch when the translated term is an `if'. This
-        search for a base-case is biased toward `else' branches.")
+        search for a base-case is biased toward `then' branches.")
       (xdoc::li
-       "@(':base-case-then'), to search for a base-case with a bias toward
-        `then' branches.")
+       "@(':base-case-else'), to search for a base-case with a bias toward
+        `else' branches.")
       (xdoc::li
        "Any other term. It must be a term that only references logic-mode
         functions and that includes no free variables other than
@@ -415,7 +415,7 @@
      (xdoc::p
       "If one wishes to use the term @(':auto') as the undefined result, this
        may be accomplished by providing the quoted constant @('\':auto'). The
-       same applies for @(':base-case') and @(':base-case-then').")
+       same applies for @(':base-case-then') and @(':base-case-else').")
      (xdoc::p
       "Even if the generated function is guard-verified
        (which is determined by the @(':verify-guards') input; see below),

--- a/books/kestrel/apt/isodata-tests.lisp
+++ b/books/kestrel/apt/isodata-tests.lisp
@@ -846,7 +846,7 @@
 
 (must-succeed*
 
- (test-title "Check UNDEFINED :base-case.")
+ (test-title "Check UNDEFINED :base-case-then and :base-case-else.")
 
  (defun f (x)
    (declare (xargs :guard (natp x)))
@@ -857,25 +857,6 @@
      (if (< 1 x)
          (1+ (f (- x 1)))
        0)))
-
- (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined :base-case)
-  (must-be-redundant
-   (DEFUN F{1} (X)
-     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
-                     :MEASURE (ACL2-COUNT (IDENTITY X))
-                     :RULER-EXTENDERS :ALL
-                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
-                     :VERIFY-GUARDS T))
-     (IF (MBT$ (NATP X))
-         (IF (ZP (IDENTITY X))
-             (IF NIL
-                 (F{1} (IDENTITY (+ -1 (IDENTITY X))))
-                 (+ 1 (IDENTITY X)))
-             (IF (< 1 (IDENTITY X))
-                 (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
-                 0))
-         0))))
 
  (must-succeed*
   (isodata f ((x (natp natp identity identity))) :undefined :base-case-then)
@@ -897,7 +878,7 @@
          (+ 1 (identity x))))))
 
  (must-succeed*
-  (isodata f ((x (natp natp identity identity))) :undefined ':base-case)
+  (isodata f ((x (natp natp identity identity))) :undefined :base-case-else)
   (must-be-redundant
    (DEFUN F{1} (X)
      (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
@@ -913,7 +894,7 @@
              (IF (< 1 (IDENTITY X))
                  (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
                  0))
-         :base-case))))
+         0))))
 
  (must-succeed*
   (isodata f ((x (natp natp identity identity))) :undefined ':base-case-then)
@@ -934,6 +915,25 @@
                  0))
          :base-case-then))))
 
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined ':base-case-else)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (IF (ZP (IDENTITY X))
+             (IF NIL
+                 (F{1} (IDENTITY (+ -1 (IDENTITY X))))
+                 (+ 1 (IDENTITY X)))
+             (IF (< 1 (IDENTITY X))
+                 (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
+                 0))
+         :base-case-else))))
+
  (defun g (x)
    (declare (xargs :guard (natp x)))
    (cond ((zp x)
@@ -944,7 +944,7 @@
                 (t 0)))))
 
  (must-succeed*
-  (isodata g ((x (natp natp identity identity))) :undefined :base-case)
+  (isodata g ((x (natp natp identity identity))) :undefined :base-case-else)
   (must-be-redundant
    (DEFUN G{1} (X)
      (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
@@ -1018,7 +1018,7 @@
      (g (- x 1))))
 
  (must-succeed*
-  (isodata g ((x (natp natp identity identity))) :undefined :base-case)
+  (isodata g ((x (natp natp identity identity))) :undefined :base-case-else)
   (must-be-redundant
    (DEFUN G{1} (X)
      (DECLARE (XARGS :WELL-FOUNDED-RELATION O<

--- a/books/kestrel/apt/isodata-tests.lisp
+++ b/books/kestrel/apt/isodata-tests.lisp
@@ -846,6 +846,126 @@
 
 (must-succeed*
 
+ (test-title "Check UNDEFINED :base-case.")
+
+ (defun f (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (if nil
+           (f (- x 1))
+         (1+ x))
+     (if (< 1 x)
+         (1+ (f (- x 1)))
+       0)))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined :base-case)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (IF (ZP (IDENTITY X))
+             (IF NIL
+                 (F{1} (IDENTITY (+ -1 (IDENTITY X))))
+                 (+ 1 (IDENTITY X)))
+             (IF (< 1 (IDENTITY X))
+                 (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
+                 0))
+         0))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined :base-case-then)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (IF (ZP (IDENTITY X))
+             (IF NIL
+                 (F{1} (IDENTITY (+ -1 (IDENTITY X))))
+                 (+ 1 (IDENTITY X)))
+             (IF (< 1 (IDENTITY X))
+                 (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
+                 0))
+         (+ 1 (identity x))))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined ':base-case)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (IF (ZP (IDENTITY X))
+             (IF NIL
+                 (F{1} (IDENTITY (+ -1 (IDENTITY X))))
+                 (+ 1 (IDENTITY X)))
+             (IF (< 1 (IDENTITY X))
+                 (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
+                 0))
+         :base-case))))
+
+ (must-succeed*
+  (isodata f ((x (natp natp identity identity))) :undefined ':base-case-then)
+  (must-be-redundant
+   (DEFUN F{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (IF (ZP (IDENTITY X))
+             (IF NIL
+                 (F{1} (IDENTITY (+ -1 (IDENTITY X))))
+                 (+ 1 (IDENTITY X)))
+             (IF (< 1 (IDENTITY X))
+                 (+ 1 (F{1} (IDENTITY (+ -1 (IDENTITY X)))))
+                 0))
+         :base-case-then))))
+
+ (defun g (x)
+   (declare (xargs :guard (natp x)))
+   (cond ((zp x)
+          (cond (nil (g (- x 1)))
+                (t (1+ x))))
+         (t
+          (cond ((< 1 x) (1+ (g (- x 1))))
+                (t 0)))))
+
+ (must-succeed*
+  (isodata g ((x (natp natp identity identity))) :undefined :base-case)
+  (must-be-redundant
+   (DEFUN G{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (COND ((MBT$ (NATP X))
+            (COND ((ZP (IDENTITY X))
+                   (IF NIL
+                       (G{1} (IDENTITY (+ -1 (IDENTITY X))))
+                       (+ 1 (IDENTITY X))))
+                  (T (IF (< 1 (IDENTITY X))
+                         (+ 1 (G{1} (IDENTITY (+ -1 (IDENTITY X)))))
+                         0))))
+           (T 0)))))
+
+ :with-output-off nil)
+
+(must-succeed*
+
  (test-title "Check UNDEFINED input on multi-valued function.")
 
  (defun f (x) ; OLD with just a top-level MV
@@ -890,6 +1010,29 @@
   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv 0 0 0)))
   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv y 0)))
   (must-fail (isodata f ((x (natp natp identity identity))) :undefined (mv (f (+ x 1)) 0))))
+
+ (defun g (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (mv (+ x x) (* x x))
+     (g (- x 1))))
+
+ (must-succeed*
+  (isodata g ((x (natp natp identity identity))) :undefined :base-case)
+  (must-be-redundant
+   (DEFUN G{1} (X)
+     (DECLARE (XARGS :WELL-FOUNDED-RELATION O<
+                     :MEASURE (ACL2-COUNT (IDENTITY X))
+                     :RULER-EXTENDERS :ALL
+                     :GUARD (AND (NATP X) (NATP (IDENTITY X)))
+                     :VERIFY-GUARDS T))
+     (IF (MBT$ (NATP X))
+         (IF (ZP (IDENTITY X))
+             (MV (+ (IDENTITY X) (IDENTITY X))
+                 (* (IDENTITY X) (IDENTITY X)))
+             (G{1} (IDENTITY (+ -1 (IDENTITY X)))))
+         (MV (+ (IDENTITY X) (IDENTITY X))
+             (* (IDENTITY X) (IDENTITY X)))))))
 
  :with-output-off nil)
 

--- a/books/kestrel/apt/isodata.lisp
+++ b/books/kestrel/apt/isodata.lisp
@@ -1123,8 +1123,7 @@
         (value (if (< 1 m)
                    (fcons-term 'mv (repeat m nil))
                  nil)))
-       ((when (or (eq :base-case-then undefined)
-                  (eq :base-case-else undefined)))
+       ((when (member-eq undefined '(:base-case-then :base-case-else)))
         (value undefined))
        ((er (list term stobjs-out))
         (ensure-value-is-untranslated-term$ undefined

--- a/books/kestrel/apt/isodata.lisp
+++ b/books/kestrel/apt/isodata.lisp
@@ -1112,7 +1112,7 @@
                                    ctx
                                    state)
   :returns (mv erp
-               (undefined$ "Either @(':base-case'), @(':base-case-then'), or
+               (undefined$ "Either @(':base-case-then'), @(':base-case-else'), or
                             a @(tsee pseudo-termp).")
                state)
   :mode :program
@@ -1123,8 +1123,8 @@
         (value (if (< 1 m)
                    (fcons-term 'mv (repeat m nil))
                  nil)))
-       ((when (or (eq :base-case undefined)
-                  (eq :base-case-then undefined)))
+       ((when (or (eq :base-case-then undefined)
+                  (eq :base-case-else undefined)))
         (value undefined))
        ((er (list term stobjs-out))
         (ensure-value-is-untranslated-term$ undefined
@@ -2362,7 +2362,7 @@
   ((old$ symbolp)
    (arg-isomaps isodata-symbol-isomap-alistp)
    (res-isomaps isodata-pos-isomap-alistp)
-   (undefined$ "Either @(':base-case'), @(':base-case-then'), or a
+   (undefined$ "Either @(':base-case-then'), @(':base-case-else'), or a
                 @(tsee pseudo-termp).")
    (new$ symbolp)
    compatibility
@@ -2385,9 +2385,9 @@
      the resulting term is the code of the new function's body (see below).
      Then we construct an @(tsee if) as follows.
      The test is the conjunction of @('(newp1 x1)'), ..., @('(newpn xn)').
-     If @('undefined$') is @(':base-case'), then the `else' branch is the
-     `else'-biased base-case search result of the `then' branch. If
-     @('undefined$') is @(':base-case-then'), then it is the `then'-biased
+     If @('undefined$') is @(':base-case-then'), then the `else' branch is the
+     `then'-biased base-case search result of the `then' branch. If
+     @('undefined$') is @(':base-case-else'), then it is the `else'-biased
      result. Otherwise, it is @('undefined$').
      For the `then' branch, there are three cases:
      (i) if no results are transformed, we use the core term above;
@@ -2430,10 +2430,10 @@
                                      old-body-with-back-of-x1...xn
                                      (fcons-term 'mv forth-of-y1...ym))))))
        (else-branch
-        (cond ((eq :base-case undefined$)
-               (acl2::find-a-base-case-translated then-branch (list new$) nil))
-              ((eq :base-case-then undefined$)
+        (cond ((eq :base-case-then undefined$)
                (acl2::find-a-base-case-translated then-branch (list new$) t))
+              ((eq :base-case-else undefined$)
+               (acl2::find-a-base-case-translated then-branch (list new$) nil))
               (t undefined$))))
     (cond ((and compatibility
                 (not (recursivep old$ nil wrld)) then-branch))
@@ -2448,8 +2448,8 @@
                                  (arg-isomaps isodata-symbol-isomap-alistp)
                                  (res-isomaps isodata-pos-isomap-alistp)
                                  (predicate$ booleanp)
-                                 (undefined$ "Either @(':base-case'),
-                                              @(':base-case-then'), or a
+                                 (undefined$ "Either @(':base-case-then'),
+                                              @(':base-case-else'), or a
                                               @(tsee pseudo-termp).")
                                  (new$ symbolp)
                                  compatibility
@@ -2516,8 +2516,8 @@
                             (arg-isomaps isodata-symbol-isomap-alistp)
                             (res-isomaps isodata-pos-isomap-alistp)
                             (predicate$ booleanp)
-                            (undefined$ "Either @(':base-case'),
-                                              @(':base-case-then'), or a
+                            (undefined$ "Either @(':base-case-then'),
+                                              @(':base-case-else'), or a
                                               @(tsee pseudo-termp).")
                             (new$ symbolp)
                             (new-enable$ booleanp)
@@ -4075,7 +4075,7 @@
    (arg-isomaps isodata-symbol-isomap-alistp)
    (res-isomaps isodata-pos-isomap-alistp)
    (predicate$ booleanp)
-   (undefined$ "Either @(':base-case'), @(':base-case-then'), or a
+   (undefined$ "Either @(':base-case-then'), @(':base-case-else'), or a
                 @(tsee pseudo-termp).")
    (new$ symbolp)
    (new-enable$ booleanp)

--- a/books/kestrel/apt/utilities/find-a-base-case-tests.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case-tests.lisp
@@ -1,0 +1,298 @@
+;; Author: Grant Jurgensen (grant@kestrel.edu)
+
+(in-package "ACL2")
+
+(include-book "find-a-base-case")
+
+(include-book "std/testing/must-succeed-star" :dir :system)
+(include-book "std/testing/assert-equal" :dir :system)
+(include-book "std/testing/must-fail-with-hard-error" :dir :system)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case-translated
+
+(must-succeed*
+ (defun f (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (1+ x)
+     (1+ (f (- x 1)))))
+
+ (assert-equal
+  '(binary-+ '1 x)
+  (find-a-base-case-translated
+   '(IF (ZP X)
+        (BINARY-+ '1 X)
+        (BINARY-+ '1 (F (BINARY-+ '-1 X))))
+   '(f)
+   t))
+
+ (assert-equal
+  '(binary-+ '1 x)
+  (find-a-base-case-translated
+   '(IF (ZP X)
+        (BINARY-+ '1 X)
+        (BINARY-+ '1 (F (BINARY-+ '-1 X))))
+   '(f)
+   nil))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case-translated on multiple-base-cases term
+
+(must-succeed*
+ (defun f (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (if nil
+           (f (- x 1))
+         (1+ x))
+     (if (< 1 x)
+         (1+ (f (- x 1)))
+       0)))
+
+ (assert-equal
+  '(binary-+ '1 x)
+  (find-a-base-case-translated
+   '(IF (ZP X)
+        (IF 'NIL
+            (F (BINARY-+ '-1 X))
+            (BINARY-+ '1 X))
+        (IF (< '1 X)
+            (BINARY-+ '1 (F (BINARY-+ '-1 X)))
+            '0))
+   '(f)
+   t))
+
+ (assert-equal
+  ''0
+  (find-a-base-case-translated
+   '(IF (ZP X)
+        (IF 'NIL
+            (F (BINARY-+ '-1 X))
+            (BINARY-+ '1 X))
+        (IF (< '1 X)
+            (BINARY-+ '1 (F (BINARY-+ '-1 X)))
+            '0))
+   '(f)
+   nil))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case
+
+(must-succeed*
+ (defun f (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (if nil
+           (f (- x 1))
+         (1+ x))
+     (if (< 1 x)
+         (1+ (f (- x 1)))
+       0)))
+
+ (assert-equal
+  '(1+ x)
+  (find-a-base-case
+   '(if (zp x)
+        (if nil
+            (f (- x 1))
+          (1+ x))
+      (if (< 1 x)
+          (1+ (f (- x 1)))
+        0))
+   '(f)
+   nil
+   t
+   state))
+
+ (assert-equal
+  '0
+  (find-a-base-case
+   '(if (zp x)
+        (if nil
+            (f (- x 1))
+          (1+ x))
+      (if (< 1 x)
+          (1+ (f (- x 1)))
+        0))
+   '(f)
+   nil
+   nil
+   state))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case with fake-fns
+
+(must-succeed*
+ (assert-equal
+  '(1+ x)
+  (find-a-base-case
+   '(if (zp x)
+        (if nil
+            (f (- x 1))
+          (1+ x))
+      (if (< 1 x)
+          (1+ (f (- x 1)))
+        0))
+   nil
+   '((f . 1))
+   t
+   state))
+
+ (assert-equal
+  '0
+  (find-a-base-case
+   '(if (zp x)
+        (if nil
+            (f (- x 1))
+          (1+ x))
+      (if (< 1 x)
+          (1+ (f (- x 1)))
+        0))
+   nil
+   '((f . 1))
+   nil
+   state))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case with flet
+
+(must-succeed*
+ (defun f (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (flet ((f (x) x))
+         (f (1+ x)))
+     (1+ (f (- x 1)))))
+
+ (assert-equal
+  '(flet ((f (x) x)) (f (1+ x)))
+  (find-a-base-case
+   '(if (zp x)
+        (flet ((f (x) x))
+          (f (1+ x)))
+      (1+ (f (- x 1))))
+   '(f)
+   nil
+   t
+   state))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case on macro forms
+
+(must-succeed*
+ (defun f (x)
+   (declare (xargs :guard (natp x)))
+   (cond ((zp x)
+          (cond (nil (f (- x 1)))
+                (t (1+ x))))
+         (t
+          (cond ((< 1 x) (1+ (f (- x 1))))
+                (t 0)))))
+
+ (assert-equal
+  '(1+ x)
+  (find-a-base-case
+   '(cond ((zp x)
+           (cond (nil (f (- x 1)))
+                 (t (1+ x))))
+          (t
+           (cond ((< 1 x) (1+ (f (- x 1))))
+                 (t 0))))
+   '(f)
+   nil
+   t
+   state))
+
+ (assert-equal
+  '0
+  (find-a-base-case
+   '(cond ((zp x)
+           (cond (nil (f (- x 1)))
+                 (t (1+ x))))
+          (t
+           (cond ((< 1 x) (1+ (f (- x 1))))
+                 (t 0))))
+   '(f)
+   nil
+   nil
+   state))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case with multiple fns
+
+(must-succeed*
+ (defun f (x)
+   (declare (xargs :guard t))
+   x)
+
+ (defun g (x)
+   (declare (xargs :guard (natp x)))
+   (if (zp x)
+       (if (equal 1 x)
+           (f 1)
+         (1+ x))
+     (1+ (g (- x 1)))))
+
+ (assert-equal
+  '(if (equal 1 x) (f 1) (1+ x))
+  (find-a-base-case
+   '(if (zp x)
+        (if (equal 1 x)
+            (f 1)
+          (1+ x))
+      (1+ (g (- x 1))))
+   '(g)
+   nil
+   t
+   state))
+
+ (assert-equal
+  '(1+ x)
+  (find-a-base-case
+   '(if (zp x)
+        (if (equal 1 x)
+            (f 1)
+          (1+ x))
+      (1+ (g (- x 1))))
+   '(f g)
+   nil
+   t
+   state))
+
+ :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test find-a-base-case failure when no base-case
+
+(must-fail-with-hard-error
+ (find-a-base-case
+  '(if (zp x)
+       (f (1+ x))
+     (if (< 1 x)
+         (1+ (f (- x 1)))
+       (f 0)))
+  nil
+  '((f . 1))
+  t
+  state))

--- a/books/kestrel/apt/utilities/find-a-base-case.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case.lisp
@@ -10,20 +10,23 @@
 (local (include-book "kestrel/typed-lists-light/pseudo-term-listp" :dir :system))
 (local (include-book "kestrel/typed-lists-light/symbol-listp" :dir :system))
 
-(defthm pseudo-termp-of-if-condition
-  (implies (and (pseudo-termp term)
-                (eq 'if (ffn-symb term)))
-           (pseudo-termp (farg1 term))))
+(local
+ (defthm pseudo-termp-of-if-condition
+   (implies (and (pseudo-termp term)
+                 (eq 'if (ffn-symb term)))
+            (pseudo-termp (farg1 term)))))
 
-(defthm pseudo-termp-of-if-then-branch
-  (implies (and (pseudo-termp term)
-                (eq 'if (ffn-symb term)))
-           (pseudo-termp (farg2 term))))
+(local
+ (defthm pseudo-termp-of-if-then-branch
+   (implies (and (pseudo-termp term)
+                 (eq 'if (ffn-symb term)))
+            (pseudo-termp (farg2 term)))))
 
-(defthm pseudo-termp-of-if-else-branch
-  (implies (and (pseudo-termp term)
-                (eq 'if (ffn-symb term)))
-           (pseudo-termp (farg3 term))))
+(local
+ (defthm pseudo-termp-of-if-else-branch
+   (implies (and (pseudo-termp term)
+                 (eq 'if (ffn-symb term)))
+            (pseudo-termp (farg3 term)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/apt/utilities/find-a-base-case.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case.lisp
@@ -1,0 +1,154 @@
+;; Author: Grant Jurgensen (grant@kestrel.edu)
+
+(in-package "ACL2")
+
+(include-book "std/util/bstar" :dir :system)
+(include-book "kestrel/utilities/forms" :dir :system)
+(include-book "kestrel/terms-light/expr-calls-fn" :dir :system)
+(include-book "kestrel/utilities/translate" :dir :system)
+(include-book "kestrel/utilities/magic-macroexpand" :dir :system)
+(local (include-book "kestrel/typed-lists-light/pseudo-term-listp" :dir :system))
+(local (include-book "kestrel/typed-lists-light/symbol-listp" :dir :system))
+
+(defthm pseudo-termp-of-if-condition
+  (implies (and (pseudo-termp term)
+                (eq 'if (ffn-symb term)))
+           (pseudo-termp (farg1 term))))
+
+(defthm pseudo-termp-of-if-then-branch
+  (implies (and (pseudo-termp term)
+                (eq 'if (ffn-symb term)))
+           (pseudo-termp (farg2 term))))
+
+(defthm pseudo-termp-of-if-else-branch
+  (implies (and (pseudo-termp term)
+                (eq 'if (ffn-symb term)))
+           (pseudo-termp (farg3 term))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Variant on translated terms
+
+;; `term` is the term to find a base-case within.
+;; `fns` is a list of functions to avoid. A base-case must not include these functions.
+;; If `prefer-then` is `t`, we search with a bias toward "then" branches. If it
+;; is `nil`, we are biased toward "else" branches.
+
+;; Returns `(mv erp all-base largest)`, where `erp` is `nil` when a base-case
+;; is found, `all-base` is `t` when the entire term is a base-case, and
+;; if `erp` and `all-base` are both `nil`, then `largest` is the largest base-case.
+(defun find-a-base-case-translated-aux (term fns prefer-then)
+  (declare (xargs :guard (and (pseudo-termp term)
+                              (symbol-listp fns)
+                              (booleanp prefer-then))))
+  (b* (((unless (consp term)) (mv nil t nil))
+       ((unless (eq 'if (ffn-symb term)))
+        (if (expr-calls-some-fn fns term)
+            (mv t nil nil)
+          (mv nil t nil)))
+       ((mv erp-then all-base-then largest-then)
+        (find-a-base-case-translated-aux (farg2 term) fns prefer-then))
+       ((mv erp-else all-base-else largest-else)
+        (find-a-base-case-translated-aux (farg3 term) fns prefer-then)))
+    (cond (erp-then
+           (if erp-else
+               (mv erp-else nil nil)
+             (mv nil nil (if all-base-else
+                             (farg3 term)
+                           largest-else))))
+          (erp-else
+           (mv nil nil (if all-base-then
+                           (farg2 term)
+                         largest-then)))
+          (all-base-then
+           (if all-base-else
+               (if (not (expr-calls-some-fn fns (farg1 term)))
+                   (mv nil t nil)
+                 (mv nil nil (if prefer-then
+                                 (farg2 term)
+                               (farg3 term))))
+             (mv nil nil (farg2 term))))
+          (all-base-else
+           (mv nil nil (farg3 term)))
+          (prefer-then (mv nil nil largest-then))
+          (t (mv nil nil largest-else)))))
+
+(defun find-a-base-case-translated (term fns prefer-then)
+  (declare (xargs :guard (and (pseudo-termp term)
+                              (symbol-listp fns)
+                              (booleanp prefer-then))))
+  (mv-let (erp all-base largest)
+          (find-a-base-case-translated-aux term fns prefer-then)
+          (cond (erp (hard-error 'find-a-base-case "Cannot find a base case!" nil))
+                (all-base term)
+                (t largest))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Variant on untranslated terms
+
+(include-book "kestrel/utilities/fake-worlds" :dir :system)
+
+(defun untranslated-expr-calls-some-fn (fns term wrld)
+  (declare (xargs :guard (and (symbol-listp fns)
+                              (plist-worldp wrld))
+                  :mode :program))
+  (expr-calls-some-fn fns (translate-term term 'top wrld)))
+
+(defun find-a-base-case-aux (term fns prefer-then wrld state)
+  (declare (xargs :guard (and (symbol-listp fns)
+                              (booleanp prefer-then)
+                              (plist-worldp wrld))
+                  :mode :program
+                  :stobjs state))
+  (b* (((unless (consp term)) (mv nil t nil))
+       ((mv erp term) (magic-macroexpand term 'magic wrld state))
+       ((when erp) (mv erp nil nil))
+       ((unless (consp term)) (mv nil t nil))
+       ((unless (eq 'if (ffn-symb term)))
+        (if (untranslated-expr-calls-some-fn fns term wrld)
+            (mv t nil nil)
+          (mv nil t nil)))
+       ((mv erp-then all-base-then largest-then)
+        (find-a-base-case-aux (farg2 term) fns prefer-then wrld state))
+       ((mv erp-else all-base-else largest-else)
+        (find-a-base-case-aux (farg3 term) fns prefer-then wrld state)))
+    (cond (erp-then
+           (if erp-else
+               (mv erp-else nil nil)
+             (mv nil nil (if all-base-else
+                             (farg3 term)
+                           largest-else))))
+          (erp-else
+           (mv nil nil (if all-base-then
+                           (farg2 term)
+                         largest-then)))
+          (all-base-then
+           (if all-base-else
+               (if (not (untranslated-expr-calls-some-fn fns (farg1 term) wrld))
+                   (mv nil t nil)
+                 (mv nil nil (if prefer-then
+                                 (farg2 term)
+                               (farg3 term))))
+             (mv nil nil (farg2 term))))
+          (all-base-else
+           (mv nil nil (farg3 term)))
+          (prefer-then (mv nil nil largest-then))
+          (t (mv nil nil largest-else)))))
+
+(defun find-a-base-case (term fns fake-fns prefer-then state)
+  (declare (xargs :guard (and (symbol-listp fns)
+                              (symbol-alistp fake-fns)
+                              (nat-listp (strip-cdrs fake-fns))
+                              (booleanp prefer-then))
+                  :mode :program
+                  :stobjs state))
+  (mv-let (erp all-base largest)
+          (find-a-base-case-aux term
+                                (append fns (strip-cars fake-fns))
+                                prefer-then
+                                (add-fake-fns-to-world fake-fns (w state))
+                                state)
+          (cond (erp (hard-error 'find-a-base-case "Cannot find a base case!" nil))
+                (all-base term)
+                (t largest))))

--- a/books/kestrel/apt/utilities/find-a-base-case.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case.lisp
@@ -7,6 +7,7 @@
 (include-book "kestrel/terms-light/expr-calls-fn" :dir :system)
 (include-book "kestrel/utilities/translate" :dir :system)
 (include-book "kestrel/utilities/magic-macroexpand" :dir :system)
+(include-book "kestrel/utilities/fake-worlds" :dir :system)
 (local (include-book "kestrel/typed-lists-light/pseudo-term-listp" :dir :system))
 (local (include-book "kestrel/typed-lists-light/symbol-listp" :dir :system))
 
@@ -82,15 +83,13 @@
                               (booleanp prefer-then))))
   (mv-let (erp all-base largest)
           (find-a-base-case-translated-aux term fns prefer-then)
-          (cond (erp (hard-error 'find-a-base-case "Cannot find a base case!" nil))
+          (cond (erp (hard-error 'find-a-base-case-translated "Cannot find a base case!" nil))
                 (all-base term)
                 (t largest))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Variant on untranslated terms
-
-(include-book "kestrel/utilities/fake-worlds" :dir :system)
 
 (defun untranslated-expr-calls-some-fn (fns term wrld)
   (declare (xargs :guard (and (symbol-listp fns)
@@ -105,7 +104,7 @@
                   :mode :program
                   :stobjs state))
   (b* (((unless (consp term)) (mv nil t nil))
-       ((mv erp term) (magic-macroexpand term 'magic wrld state))
+       ((mv erp term) (magic-macroexpand term 'find-a-base-case wrld state))
        ((when erp) (mv erp nil nil))
        ((unless (consp term)) (mv nil t nil))
        ((unless (eq 'if (ffn-symb term)))

--- a/books/kestrel/apt/utilities/find-a-base-case.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case.lisp
@@ -64,7 +64,7 @@
      base-cases, we return one of those, with the aforementioned biases.
      Otherwise, we pick the largest base-case in the biased branch."))
   (b* (((unless (consp term)) (mv nil t nil))
-       ((unless (eq 'if (ffn-symb term)))
+       ((unless (eq 'if (car term)))
         (if (expr-calls-some-fn fns term)
             (mv t nil nil)
           (mv nil t nil)))


### PR DESCRIPTION
This adds `:base-case` and `:base-case-then` as options to `isodata`'s `:undefined` parameter. When either of these options are provided, `isodata` will choose the undefined value by looking for a base case within the newly generated function. A base case of a term may either be the whole term when the term does not include a recursive call, or if the term is an `if`, then it may be a base case of the `then` or `else` branch. A term may have several base cases; the `:base-case` option is biased toward selecting base cases in `else` branches, while `:base-case-then` is biased toward `then` branches.

The motivation for this feature is that a base-case will likely have a desirable type, and the result may be amenable to combining nested `if`s.