### PR TITLE
Move find-a-base-case to APT package

### DIFF
--- a/books/kestrel/apt/isodata.lisp
+++ b/books/kestrel/apt/isodata.lisp
@@ -2430,9 +2430,9 @@
                                      (fcons-term 'mv forth-of-y1...ym))))))
        (else-branch
         (cond ((eq :base-case-then undefined$)
-               (acl2::find-a-base-case-translated then-branch (list new$) t))
+               (find-a-base-case-translated then-branch (list new$) t))
               ((eq :base-case-else undefined$)
-               (acl2::find-a-base-case-translated then-branch (list new$) nil))
+               (find-a-base-case-translated then-branch (list new$) nil))
               (t undefined$))))
     (cond ((and compatibility
                 (not (recursivep old$ nil wrld)) then-branch))

--- a/books/kestrel/apt/utilities/find-a-base-case-tests.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case-tests.lisp
@@ -21,7 +21,7 @@
 
  (assert-equal
   '(binary-+ '1 x)
-  (find-a-base-case-translated
+  (apt::find-a-base-case-translated
    '(IF (ZP X)
         (BINARY-+ '1 X)
         (BINARY-+ '1 (F (BINARY-+ '-1 X))))
@@ -30,7 +30,7 @@
 
  (assert-equal
   '(binary-+ '1 x)
-  (find-a-base-case-translated
+  (apt::find-a-base-case-translated
    '(IF (ZP X)
         (BINARY-+ '1 X)
         (BINARY-+ '1 (F (BINARY-+ '-1 X))))
@@ -56,7 +56,7 @@
 
  (assert-equal
   '(binary-+ '1 x)
-  (find-a-base-case-translated
+  (apt::find-a-base-case-translated
    '(IF (ZP X)
         (IF 'NIL
             (F (BINARY-+ '-1 X))
@@ -69,7 +69,7 @@
 
  (assert-equal
   ''0
-  (find-a-base-case-translated
+  (apt::find-a-base-case-translated
    '(IF (ZP X)
         (IF 'NIL
             (F (BINARY-+ '-1 X))
@@ -99,7 +99,7 @@
 
  (assert-equal
   '(1+ x)
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (if nil
             (f (- x 1))
@@ -114,7 +114,7 @@
 
  (assert-equal
   '0
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (if nil
             (f (- x 1))
@@ -136,7 +136,7 @@
 (must-succeed*
  (assert-equal
   '(1+ x)
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (if nil
             (f (- x 1))
@@ -151,7 +151,7 @@
 
  (assert-equal
   '0
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (if nil
             (f (- x 1))
@@ -180,7 +180,7 @@
 
  (assert-equal
   '(flet ((f (x) x)) (f (1+ x)))
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (flet ((f (x) x))
           (f (1+ x)))
@@ -208,7 +208,7 @@
 
  (assert-equal
   '(1+ x)
-  (find-a-base-case
+  (apt::find-a-base-case
    '(cond ((zp x)
            (cond (nil (f (- x 1)))
                  (t (1+ x))))
@@ -222,7 +222,7 @@
 
  (assert-equal
   '0
-  (find-a-base-case
+  (apt::find-a-base-case
    '(cond ((zp x)
            (cond (nil (f (- x 1)))
                  (t (1+ x))))
@@ -255,7 +255,7 @@
 
  (assert-equal
   '(if (equal 1 x) (f 1) (1+ x))
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (if (equal 1 x)
             (f 1)
@@ -268,7 +268,7 @@
 
  (assert-equal
   '(1+ x)
-  (find-a-base-case
+  (apt::find-a-base-case
    '(if (zp x)
         (if (equal 1 x)
             (f 1)
@@ -286,7 +286,7 @@
 ;; Test find-a-base-case failure when no base-case
 
 (must-fail-with-hard-error
- (find-a-base-case
+ (apt::find-a-base-case
   '(if (zp x)
        (f (1+ x))
      (if (< 1 x)

--- a/books/kestrel/apt/utilities/find-a-base-case.lisp
+++ b/books/kestrel/apt/utilities/find-a-base-case.lisp
@@ -1,6 +1,6 @@
 ;; Author: Grant Jurgensen (grant@kestrel.edu)
 
-(in-package "ACL2")
+(in-package "APT")
 
 (include-book "std/util/bstar" :dir :system)
 (include-book "std/util/define" :dir :system)
@@ -12,6 +12,12 @@
 (include-book "xdoc/constructors" :dir :system)
 (local (include-book "kestrel/typed-lists-light/pseudo-term-listp" :dir :system))
 (local (include-book "kestrel/typed-lists-light/symbol-listp" :dir :system))
+
+
+;; Export fargn macros to APT package
+(defmacro farg1 (x) (list 'acl2::farg1 x))
+(defmacro farg2 (x) (list 'acl2::farg2 x))
+(defmacro farg3 (x) (list 'acl2::farg3 x))
 
 
 (local
@@ -65,7 +71,7 @@
      Otherwise, we pick the largest base-case in the biased branch."))
   (b* (((unless (consp term)) (mv nil t nil))
        ((unless (eq 'if (car term)))
-        (if (expr-calls-some-fn fns term)
+        (if (acl2::expr-calls-some-fn fns term)
             (mv t nil nil)
           (mv nil t nil)))
        ((mv erp-then all-base-then largest-then)
@@ -84,7 +90,7 @@
                          largest-then)))
           (all-base-then
            (if all-base-else
-               (if (not (expr-calls-some-fn fns (farg1 term)))
+               (if (not (acl2::expr-calls-some-fn fns (farg1 term)))
                    (mv nil t nil)
                  (mv nil nil (if prefer-then
                                  (farg2 term)
@@ -123,7 +129,7 @@
    term
    (wrld plist-worldp))
   :mode :program
-  (expr-calls-some-fn fns (translate-term term 'top wrld)))
+  (acl2::expr-calls-some-fn fns (acl2::translate-term term 'top wrld)))
 
 (define find-a-base-case-aux
   (term
@@ -154,7 +160,7 @@
      base-cases, we return one of those, with the aforementioned biases.
      Otherwise, we pick the largest base-case in the biased branch."))
   (b* (((unless (consp term)) (mv nil t nil))
-       ((mv erp term) (magic-macroexpand term 'find-a-base-case wrld state))
+       ((mv erp term) (acl2::magic-macroexpand term 'find-a-base-case wrld state))
        ((when erp) (mv erp nil nil))
        ((unless (consp term)) (mv nil t nil))
        ((unless (eq 'if (ffn-symb term)))
@@ -205,7 +211,7 @@
           (find-a-base-case-aux term
                                 (append fns (strip-cars fake-fns))
                                 prefer-then
-                                (add-fake-fns-to-world fake-fns (w state))
+                                (acl2::add-fake-fns-to-world fake-fns (w state))
                                 state)
           (cond (erp (hard-error 'find-a-base-case "Cannot find a base case!" nil))
                 (all-base term)


### PR DESCRIPTION
This moves `find-a-base-case` functions to the APT package to avoid potential name clashes with functions in the default ACL2 package.