### PR TITLE
[rtl] Put macros like local-defun in ACL2 package (but import into RT…

### DIFF
--- a/books/rtl/rel11/lib/util.lisp
+++ b/books/rtl/rel11/lib/util.lisp
@@ -16,24 +16,7 @@
 
 (local (include-book "../support/top"))
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/localize-macros.lisp
+++ b/books/rtl/rel11/localize-macros.lisp
@@ -1,0 +1,32 @@
+; RTL - A Formal Theory of Register-Transfer Logic and Computer Arithmetic
+; Copyright (C) 1995-2013 Advanced Mirco Devices, Inc.
+;
+; Contact:
+;   David Russinoff
+;   1106 W 9th St., Austin, TX 78703
+;   http://www.russsinoff.com/
+;
+; See license file books/rtl/rel11/license.txt.
+;
+; Author: David M. Russinoff (david@russinoff.com)
+
+(in-package "ACL2")
+
+;;These macros facilitate localization of events:
+
+(defmacro local-defun (&rest body)
+  (list 'local (cons 'defun body)))
+
+(defmacro local-defund (&rest body)
+  (list 'local (cons 'defund body)))
+
+(defmacro local-defthm (&rest body)
+  (list 'local (cons 'defthm body)))
+
+(defmacro local-defthmd (&rest body)
+  (list 'local (cons 'defthmd body)))
+
+(defmacro local-in-theory (&rest body)
+  (cons 'local
+	(cons (cons 'in-theory (append body 'nil))
+	      'nil)))

--- a/books/rtl/rel11/package.lsp
+++ b/books/rtl/rel11/package.lsp
@@ -13,7 +13,8 @@
                       '(sum$))
    *common-lisp-symbols-from-main-lisp-package*
    STD::*std-exports*
-   '(defxdoc defsection
+   '(local-defun local-defund local-defthm local-defthmd local-in-theory
+      defxdoc defsection
       rtl ; simplifies dealing with this xdoc topic name
       *default-step-limit* ; should perhaps be in *acl2-exports*
       binary-logand binary-logior binary-logxor binary-logeqv ; used in lib/log.lisp

--- a/books/rtl/rel11/rel9-rtl-pkg/lib/util.lisp
+++ b/books/rtl/rel11/rel9-rtl-pkg/lib/util.lisp
@@ -16,24 +16,7 @@
 
 (local (include-book "../support/top/top"))
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/rel9-rtl-pkg/support/lib1/util.lisp
+++ b/books/rtl/rel11/rel9-rtl-pkg/support/lib1/util.lisp
@@ -15,25 +15,7 @@
 (set-enforce-redundancy t)
 
 (local (include-book "../support/util"))
-
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(local (include-book "../../../localize-macros"))
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/rel9-rtl-pkg/support/lib2.delta1/util.lisp
+++ b/books/rtl/rel11/rel9-rtl-pkg/support/lib2.delta1/util.lisp
@@ -15,24 +15,7 @@
 
 (local (include-book "../lib2/top"))
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../../../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/rel9-rtl-pkg/support/lib2/util.lisp
+++ b/books/rtl/rel11/rel9-rtl-pkg/support/lib2/util.lisp
@@ -16,24 +16,7 @@
 
 (local (include-book "base"))
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../../../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/rel9-rtl-pkg/support/lib3/util.lisp
+++ b/books/rtl/rel11/rel9-rtl-pkg/support/lib3/util.lisp
@@ -16,24 +16,7 @@
 
 (local (include-book "base"))
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../../../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/rel9-rtl-pkg/support/support/util.lisp
+++ b/books/rtl/rel11/rel9-rtl-pkg/support/support/util.lisp
@@ -12,24 +12,7 @@
 
 (in-package "RTL")
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../../../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name

--- a/books/rtl/rel11/support/util.lisp
+++ b/books/rtl/rel11/support/util.lisp
@@ -12,24 +12,7 @@
 
 (in-package "RTL")
 
-;;These macros facilitate localization of events:
-
-(defmacro local-defun (&rest body)
-  (list 'local (cons 'defun body)))
-
-(defmacro local-defund (&rest body)
-  (list 'local (cons 'defund body)))
-
-(defmacro local-defthm (&rest body)
-  (list 'local (cons 'defthm body)))
-
-(defmacro local-defthmd (&rest body)
-  (list 'local (cons 'defthmd body)))
-
-(defmacro local-in-theory (&rest body)
-  (cons 'local
-	(cons (cons 'in-theory (append body 'nil))
-	      'nil)))
+(include-book "../localize-macros")
 
 (defmacro defbvecp (name formals width &key thm-name hyp hints)
   (let* ((thm-name


### PR DESCRIPTION
…L package).

This will allow references to remain working as books are moved to the ACL2 package.

Also, avoid having 8 copies of these macros by centralizing them to a new book.