### PR TITLE
Xdoc include book form

### DIFF
--- a/books/xdoc/display.lisp
+++ b/books/xdoc/display.lisp
@@ -693,6 +693,21 @@
                                             state)))
                         (value fal))))))))
 
+;; Corresponds to includeBookFormForFrom in fancy/xdoc.js
+(defun include-book-form-for-from (from)
+  ;; Check the exact pattern expected for `from`, so that the worst that could
+  ;; happen if the pattern changes is to revert to the previous behavior.
+  (if (or (not (stringp from))
+          (let ((from-len (length from)))
+            (or (not (> (length from) 18))
+                (not (equal (subseq from (- from-len 18) from-len)
+                            ".lisp :DIR :SYSTEM")))))
+      from
+    (concatenate 'string
+                 "(include-book \""
+                 (subseq from 0 (- (length from) 18))
+                 "\" :dir :system)")))
+
 (defun topic-to-text (x all-topics state)
   "Returns (MV TEXT STATE)"
   (b* ((name (cdr (assoc :name x)))
@@ -738,7 +753,7 @@
        (from  (cdr (assoc :from x)))
        (ans (if from
                 (b* ((ans (str::revappend-chars " -- " ans))
-                     (ans (str::revappend-chars from ans))
+                     (ans (str::revappend-chars (include-book-form-for-from from) ans))
                      (ans (cons #\Newline ans)))
                   ans)
               ans))

--- a/books/xdoc/fancy/xdoc.js
+++ b/books/xdoc/fancy/xdoc.js
@@ -745,6 +745,21 @@ function datCollapse(dat_id)
 
 var warned_about_history_state = false;
 
+function includeBookFormForFrom(from)
+{
+    // Currently the "from" string is something like
+    //   kestrel/c/atc/table.lisp :DIR :SYSTEM
+    // If it ends in ".lisp :DIR :SYSTEM" we strip that and
+    // turn it into a usable include-book form like
+    //   (include-book "kestrel/c/atc/table" :dir :system)
+    var tailPart = ".lisp :DIR :SYSTEM";
+    if ( from.endsWith(tailPart) ) {
+	return "(include-book \"" + from.slice(0,-(tailPart.length)) + "\" :dir :system)";
+    } else {
+	return from;
+    }
+}
+
 function datLongTopic(key)
 {
     // Assumes xdata[key] is ready
@@ -793,7 +808,7 @@ function datLongTopic(key)
         // link to the specific file on GitHub:
         fromp = "<p class='from'><a href=\"https://github.com/acl2/acl2/tree/master/books/"
             + from.slice(0,-13) // strip " :DIR :SYSTEM" from end
-            + "\">" + from + "</a></p>";
+            + "\">" + includeBookFormForFrom(from) + "</a></p>";
     }
     else {
         fromp = "<p class='from'>" + from + "</p>";


### PR DESCRIPTION
There are two commits here that do the same thing for two ways of rendering xdoc.   The file name at the top changes so that it is a copyable, executable include-book form.  For example, for the topic `crypto-hdwallet`, this text:
```
kestrel/hdwallet/wallet.lisp :DIR :SYSTEM
```
changes to
```
(include-book "kestrel/hdwallet/wallet" :dir :system)
```

The first commit handles the html rendering.  For example, what you would see at 
https://www.cs.utexas.edu/users/moore/acl2/manuals/latest/index.html?topic=HDWALLET____CRYPTO-HDWALLET

The second commit handles the rendering used by the `:doc` command.

It is possible we will want another commit to handle the rendering used by the `m-x acl2-doc` Emacs command; that is TBD.