### PR TITLE
[Seq] Fix user documentation.

### DIFF
--- a/books/misc/seq.lisp
+++ b/books/misc/seq.lisp
@@ -118,13 +118,13 @@ inaccessible.</p>
 write:</p>
 
 <ul>
-<li>@(':w=') &mdash; weak count decrease</li>
-<li>@(':s=') &mdash; strong count decrease</li>
+<li>@(':w=') &mdash; weak length decrease</li>
+<li>@(':s=') &mdash; strong length decrease</li>
 </ul>
 
 <p>These act the same as @(':='), except that they add some @('(mbe :logic
 ...)')-only checks that ensure that the returned stream has a weakly lower or
-strongly lower @(see acl2-count) than the stream going into the action.  This
+strongly lower @(tsee len) than the stream going into the action.  This
 is sometimes needed when using Seq in mutually-recursive functions.</p>
 
 
@@ -684,4 +684,3 @@ creation of warnings while processing the stream.</p>")
 
 (defmacro seq-backtrack (stream &rest blocks)
   (seq-backtrack-fn stream blocks))
-


### PR DESCRIPTION
The `:w=` and `:s=` operators enforce inequalities on the lengths, not the counts, as is evident by looking at the code that implements them.