### PR TITLE
[defaggregate] Allow a defaggregte to be local in most cases.

### DIFF
--- a/books/std/util/defaggregate.lisp
+++ b/books/std/util/defaggregate.lisp
@@ -1282,9 +1282,12 @@ would have had to call @('(student->fullname x)').  For instance:</p>
                  doc-events
                '())
 
-           ,(if (eq mode :logic)
-                '(logic)
-              '(program))
+           ,@(if (eq mode current-defun-mode)
+                 nil ; already in the right mode
+               ;; In these cases, the defaggregate can't be local:
+               (if (eq mode :logic)
+                   '((logic))
+                 '((program))))
 
            ,@(if already-definedp
                  nil


### PR DESCRIPTION
This avoids putting in (logic) or (program) when not needed, since those prevent the defaggregate from being local.  Defaggregate uses progn instead of encapsulate (see comment in defaggregate.lisp), and ACL2 doesn't allow things like (local (progn (logic))).