### PR TITLE
[Seq] Improve `:s=` and `:w=`.

### DIFF
--- a/books/misc/seq.lisp
+++ b/books/misc/seq.lisp
@@ -427,7 +427,7 @@ creation of warnings while processing the stream.</p>")
                                         (len !!!stream))))
                              (prog2$ (er hard? "SEQ count failed for (~x0 ~x1.)~%"
                                          ',(car x) ',action)
-                                     (mv "SEQ count failure." nil !!!stream)))
+                                     (mv "SEQ count failure." nil ,stream)))
                             (t
                              (check-vars-not-free (!!!error !!!val !!!stream)
                                                   ,rest)))))))
@@ -459,7 +459,7 @@ creation of warnings while processing the stream.</p>")
                                                (len !!!stream))))
                                     (prog2$ (er hard? "SEQ count failed for (~x0 ~x1 ~x2.)~%"
                                                 ',nametree ',type ',action)
-                                            (mv "SEQ count failure." nil !!!stream)))
+                                            (mv "SEQ count failure." nil ,stream)))
                                    (t
                                     (check-vars-not-free (!!!error !!!val !!!stream) ,rest)))))))
 
@@ -485,7 +485,7 @@ creation of warnings while processing the stream.</p>")
                                              (len !!!stream))))
                                   (prog2$ (er hard?  "SEQ count failed for (~x0 ~x1 ~x2.)~%"
                                               ',nametree ',type ',action)
-                                          (mv "SEQ count failure." nil !!!stream)))
+                                          (mv "SEQ count failure." nil ,stream)))
                                  (t
                                   (let ,(seq-nametree-to-let-bindings nametree '!!!val)
                                     (check-vars-not-free (!!!error !!!val !!!stream) ,rest)))))))))))))


### PR DESCRIPTION
Instead of returning the original stream if the `mbt` check fails, return the remaining stream from the call that fails the `mbt` check. The advantage is that often the stream processing functions fix the stream to its type, and therefore unconditionally return a remaining stream of the right type. However, if `:s=` and `:w=` return the initial stream, which is not fixed to the right type, then functions using these operators need conditional return theorems. Note that the exact stream returned if the `mbt` check fails does not matter in guard-verified code, because it is provably never returned. But I'm not sure if there are good use cases for returning the original stream instead, when the code is not guard-verified (e.g. in program mode).