### PR TITLE
[FTY] Enable `alistp` in fixtype macros.

### DIFF
--- a/books/centaur/fty/deftypes.lisp
+++ b/books/centaur/fty/deftypes.lisp
@@ -119,6 +119,7 @@
     hons
     open-member-equal-on-list-of-tags
     alistp-compound-recognizer
+    alistp
     ;;  len
     ;; equal-of-plus-one fix
     prod-car
@@ -851,7 +852,6 @@
              (local (in-theory (acl2::enable* deftypes-theory
                                               ,@(flextypes-collect-enable-rules x)
                                               . ,enable-rules)))
-             (local (in-theory (enable alistp)))
              (local (set-default-hints
                      '((and stable-under-simplificationp
                             '(:in-theory (enable deftypes-orig-theory))))))

--- a/books/centaur/fty/deftypes.lisp
+++ b/books/centaur/fty/deftypes.lisp
@@ -812,7 +812,7 @@
 
 (defun deftypes-events (x state)
   (b* (((flextypes x) x)
-       (- (flextypelist-check-bad-name x.types)) 
+       (- (flextypelist-check-bad-name x.types))
        (fix/pred-pairs (flextypes-collect-fix/pred-pairs x.types))
        ((mv enable-rules temp-thms) (collect-fix/pred-enable-rules fix/pred-pairs (w state)))
        (verbosep (getarg :verbosep nil x.kwd-alist)))
@@ -851,6 +851,7 @@
              (local (in-theory (acl2::enable* deftypes-theory
                                               ,@(flextypes-collect-enable-rules x)
                                               . ,enable-rules)))
+             (local (in-theory (enable alistp)))
              (local (set-default-hints
                      '((and stable-under-simplificationp
                             '(:in-theory (enable deftypes-orig-theory))))))
@@ -1116,4 +1117,3 @@
 (defmacro defomap (&whole form &rest args)
   (declare (ignore args))
   `(make-event (defomap-fn ',form state)))
-


### PR DESCRIPTION
Disabling built-in functions, including `alistp`, reveals that `fty::defprod` relies on `alistp` to be enabled in order for the proofs generated by `fty::defprod` to work. This commit enables `alistp` locally inside the events generated by `fty::defprod`. Enabling this locally to the events makes `fty::defprod` more robust.