### PR TITLE
[FTY] Locally enable `identity`.

### DIFF
--- a/books/centaur/fty/deftypes.lisp
+++ b/books/centaur/fty/deftypes.lisp
@@ -120,6 +120,7 @@
     open-member-equal-on-list-of-tags
     alistp-compound-recognizer
     alistp
+    identity
     ;;  len
     ;; equal-of-plus-one fix
     prod-car


### PR DESCRIPTION
Disabling the built-in functions reveals that some FTY macros expect `identity` to be enabled. This commit adds this definition to the theory used in the FTY macros.