### PR TITLE
[Std/typed-lists] Add a rule and rename another rule.

### DIFF
--- a/books/std/typed-lists/symbol-listp.lisp
+++ b/books/std/typed-lists/symbol-listp.lisp
@@ -62,8 +62,7 @@ std::deflist).</p>"
     ;; It is disabled by default because true-listp is a common match;
     ;; it can be enabled where needed.
     (implies (symbol-listp x)
-             (true-listp x))
-    :rule-classes ((:rewrite :backchain-limit-lst 1)))
+             (true-listp x)))
 
   (defthm symbol-listp-of-remove-equal
     ;; BOZO probably add to deflist

--- a/books/std/typed-lists/symbol-listp.lisp
+++ b/books/std/typed-lists/symbol-listp.lisp
@@ -49,9 +49,18 @@ std::deflist).</p>"
     ;; Set :parents to nil to avoid overwriting the built-in ACL2 documentation
     :parents nil)
 
-  (defthm true-listp-when-symbol-listp-rewrite
+  (defthm true-listp-when-symbol-listp-rewrite-backchain-1
     ;; The deflist gives us a compound-recognizer, but in this case having a
     ;; rewrite rule seems worth it.
+    ;; We limit backchaining, because true-listp is a common match.
+    (implies (symbol-listp x)
+             (true-listp x))
+    :rule-classes ((:rewrite :backchain-limit-lst 1)))
+
+  (defthmd true-listp-when-symbol-listp-rewrite
+    ;; This is a rewrite rule without backchaining limit, unlike the one above.
+    ;; It is disabled by default because true-listp is a common match;
+    ;; it can be enabled where needed.
     (implies (symbol-listp x)
              (true-listp x))
     :rule-classes ((:rewrite :backchain-limit-lst 1)))


### PR DESCRIPTION
The new rule backchains from `true-listp` to `symbol-listp` without limit; it is disabled by default.

The renamed rule is one that backchains at most once, and is enabled.

It seems that using the unqualified `true-listp-when-symbol-listp-rewrite` for the first rule is more consistent with other libraries. This is the reason for renaming the second rule in a way that describes its specific characteristics.