### PR TITLE
[X86ISA] Avoid `subset-equal`.

### DIFF
--- a/books/projects/x86isa/machine/cpuid.lisp
+++ b/books/projects/x86isa/machine/cpuid.lisp
@@ -50,12 +50,6 @@
 
 ;; CPUID-related definitions:
 
-(define subset-equal (x y)
-  :guard (true-listp y)
-  (or (atom x)
-      (and (member-equal (first x) y)
-           (subset-equal (rest x) y))))
-
 (defsection cpuid
   :parents (machine opcode-maps)
   :short "Determining which CPUID features are supported in @('x86isa')"
@@ -412,9 +406,9 @@
    (and (equal (feature-flag :maxphyaddr) 52)
         (equal (feature-flag :linearaddr) 48)))
 
-  (define feature-flags (features)
-    :guard (subset-equal features *supported-feature-flags*)
-    :guard-hints (("Goal" :in-theory (enable subset-equal)))
+  (define feature-flags ((features true-listp))
+    :guard (subsetp-equal features *supported-feature-flags*)
+    :guard-hints (("Goal" :in-theory (enable subsetp-equal)))
     (cond ((atom features) 1)
           ((eql (feature-flag (first features)) 0) 0)
           (t (feature-flags (rest features))))))

--- a/books/projects/x86isa/machine/dispatch-macros.lisp
+++ b/books/projects/x86isa/machine/dispatch-macros.lisp
@@ -243,7 +243,7 @@
 		    x86)
 
   :guard (and (member-eq decode-context '(:legacy :vex :evex))
-	      (subset-equal feature-flags *supported-feature-flags*))
+	      (subsetp-equal feature-flags *supported-feature-flags*))
   :guard-hints (("Goal" :in-theory (e/d () (x86$ap xr ifix))))
   (declare (ignore opcode modr/m sib)) ;; don't use these yet, but include them anyways..
 


### PR DESCRIPTION
Before this commit, a file in the X86ISA project defined a `subset-equal` function that is similar to the built-in `subsetp-equal` except for a slightly weaker guard. This commit removes that function, using the built-in `subsetp-equal` instead. A guard of another function had to be slightly strengthened so that its call of `subsetp-equal` can be guard-verified.