### PR TITLE
[Std/lists] Swap two theorems in a file.

### DIFF
--- a/books/std/lists/rev.lisp
+++ b/books/std/lists/rev.lisp
@@ -88,6 +88,10 @@ perform quite well thanks to @(see mbe).</p>"
                    (list a)))
     :hints(("Goal" :in-theory (enable rev))))
 
+  (defthm rev-of-append
+    (equal (rev (append x y))
+           (append (rev y) (rev x))))
+
 ; Commented out by Matt K., since deduced type-prescription rule for rev at
 ; definition time already provides this.
 ; (defthm true-listp-of-rev
@@ -126,10 +130,6 @@ perform quite well thanks to @(see mbe).</p>"
     (implies (true-listp x)
              (equal (reverse x)
                     (rev x))))
-
-  (defthm rev-of-append
-    (equal (rev (append x y))
-           (append (rev y) (rev x))))
 
   (encapsulate
     ()


### PR DESCRIPTION
This avoids a double (nested) induction in the proof of `rev-of-rev`. It also seems more natural for `rev-of-append` to immediately follow `rev-of-cons`. Now that `rev-of-append` precedes `rev-of-rev`, the latter is proved with a single induction.