### PR TITLE
[quicklisp] make the asdf bundle info remember it was loaded and do nothing if reloaded

### DIFF
--- a/books/quicklisp/bundle/bundle.lisp
+++ b/books/quicklisp/bundle/bundle.lisp
@@ -5,6 +5,15 @@
   (unless (find-package '#:asdf)
     (error "ASDF could not be required")))
 
+; Prevent the bundle form from reloading.
+; See acl2/acl2 issue 1508 for details.
+(defvar *already-loaded-bundle?* nil)
+
+(if *already-loaded-bundle?*
+    t
+  (prog1
+
+;; The original form, before the once-only wrapper.
 (let ((indicator '#:ql-bundle-v1)
       (searcher-name '#:ql-bundle-searcher)
       (base (make-pathname :name nil :type nil
@@ -159,3 +168,5 @@
         (setf (symbol-function searcher-name) #'search-function)
         (push searcher-name asdf:*system-definition-search-functions*)))
     t))
+
+    (setq *already-loaded-bundle?* t)))


### PR DESCRIPTION
Fixes issue #1508 .

After this PR, redoing (include-raw "bundle/bundle.lisp" ..)
(which is called from "quicklisp/base")
does not reset the asdf info since it recognizes it has already been done
in the current environment.
So the second part of the instructions in the comment on issue #1508  becomes:

; 2. Now load the main quicklisp loader book.
ACL2 !>(include-book "quicklisp/base" :dir :system)
ACL2 !>:q
* (asdf:already-loaded-systems)
(... "zippy" ...)
