### PR TITLE
[Std/osets] Minor improvements

### DIFF
--- a/books/coi/osets/set-order.lisp
+++ b/books/coi/osets/set-order.lisp
@@ -124,8 +124,8 @@
 
 (defthmd tail-insert
   (equal (tail (insert a X))
-         (cond ((empty X) (sfix X))
-               ((<< a (head X)) (sfix X))
+         (cond ((empty X) nil)
+               ((<< a (head X)) X)
                ((equal a (head X)) (tail X))
                (t (insert a (tail X))))))
 
@@ -185,4 +185,3 @@
     cons-to-insert-empty
     cons-to-insert-nonempty
     cons-in))
-

--- a/books/std/osets/primitives.lisp
+++ b/books/std/osets/primitives.lisp
@@ -437,8 +437,8 @@ following loop:</p>
 
   (defthm tail-insert
     (equal (tail (insert a X))
-           (cond ((empty X) (sfix X))
-                 ((<< a (head X)) (sfix X))
+           (cond ((empty X) nil)
+                 ((<< a (head X)) X)
                  ((equal a (head X)) (tail X))
                  (t (insert a (tail X))))))
 

--- a/books/std/osets/primitives.lisp
+++ b/books/std/osets/primitives.lisp
@@ -550,11 +550,11 @@ following loop:</p>
 ; Now we are interested in setting up theories and in disabling most of the
 ; potentially bad issues that might arise.
 ;
-; You should never need to use primitive-theory unless you are using non-set
+; You should never need to use primitive-rules unless you are using non-set
 ; functions, e.g. cons, to build sets.
 ;
-; The primitive order theory is intended to be disabled for typical reasoning,
-; but is needed for some theorems in the membership level.
+; The order-rules are intended to be disabled for typical reasoning,
+; but are needed for some theorems in the membership level.
 
 (def-ruleset primitive-rules
   '(setp empty head tail sfix insert))

--- a/books/std/osets/primitives.lisp
+++ b/books/std/osets/primitives.lisp
@@ -159,7 +159,7 @@ non-set convention and always returns true for ill-formed sets.</p>"
              (setp X))))
 
 (defthm empty-set-unique
-  ;; BOZO probably expensive.  We don't export this from sets.lisp, and we keep
+  ;; BOZO probably expensive.  We don't export this from top.lisp, and we keep
   ;; it out of the docs above.
   (implies (and (setp X)
                 (setp Y)

--- a/books/std/osets/top.lisp
+++ b/books/std/osets/top.lisp
@@ -1131,8 +1131,8 @@ from the accompanying talk.</p>")
 
 (defthmd tail-insert
   (equal (tail (insert a X))
-	 (cond ((empty X) (sfix X))
-	       ((<< a (head X)) (sfix X))
+	 (cond ((empty X) nil)
+	       ((<< a (head X)) X)
                ((equal a (head X)) (tail X))
                (t (insert a (tail X))))))
 


### PR DESCRIPTION
- Slightly simplified a theorem (along with two redundant instances of it):
  - In the first case, if `X` satisfies `empty`, its `sfix` is always `nil`.
  - In the second case, we know that `X` does not satisfy `empty`, and thus it always satisfies `setp`, and there's no need to fix it with `sfix`.
- Fixed and updated some documentation.
