### PR TITLE
[DEFINE] Tweak printing.

### DIFF
--- a/books/std/util/define.lisp
+++ b/books/std/util/define.lisp
@@ -1549,7 +1549,7 @@ examples.</p>")
     `(with-output
        :stack :push
        ,@(and (not verbosep)
-              '(:on (acl2::error) :off :all))
+              '(:off (:other-than acl2::error)))
        (make-event
         (define-fn ',name ',args (w state))))))
 


### PR DESCRIPTION
Avoid turning error output back on if it is already inhibited when define is called.

This allows, for example, building tools such as improve-book that submit events that are expected to sometimes fail where we want the failures to be silent.