### PR TITLE
[quicklisp osicat] do not define %open-temporary-file/fd-streams in ccl

### DIFF
--- a/books/quicklisp/bundle/software/osicat-20220220-git/src/osicat.lisp
+++ b/books/quicklisp/bundle/software/osicat-20220220-git/src/osicat.lisp
@@ -318,7 +318,11 @@ PATHSPEC exists and is a symlink pointing to an existent file."
         (pathname (concatenate 'string system-tmpdir "/")))))
 
 ;; Windows has no MKSTEMP.
-#-windows
+;; 2023-07-14 ccl added here for now to prevent a compilcation error on ccl,
+;; which caused (asdf:load-system "osicat") to always recompile.
+;; To remove this condition on :ccl, hyou may be able to add (to fd-streams.lisp)
+;; a wrapper for osicat::make-fd-stream to call ccl::make-fd-stream.
+#-(or windows ccl)
 (defun %open-temporary-file/fd-streams (filename element-type external-format)
   (handler-case
       (multiple-value-bind (fd path)

--- a/books/quicklisp/bundle/software/osicat-20220220-git/src/osicat.lisp
+++ b/books/quicklisp/bundle/software/osicat-20220220-git/src/osicat.lisp
@@ -320,8 +320,9 @@ PATHSPEC exists and is a symlink pointing to an existent file."
 ;; Windows has no MKSTEMP.
 ;; 2023-07-14 ccl added here for now to prevent a compilcation error on ccl,
 ;; which caused (asdf:load-system "osicat") to always recompile.
-;; To remove this condition on :ccl, hyou may be able to add (to fd-streams.lisp)
+;; To remove this condition on :ccl, you may be able to add (to fd-streams.lisp)
 ;; a wrapper for osicat::make-fd-stream to call ccl::make-fd-stream.
+;; For more background See https://github.com/osicat/osicat/issues/37
 #-(or windows ccl)
 (defun %open-temporary-file/fd-streams (filename element-type external-format)
   (handler-case


### PR DESCRIPTION
This PR works around the problem that, on CCL, every time you do
(asdf:load-system "osicat"), it needs to recompile and put a new `.lx64fsl`
file in the bundle cache.
This has caused occasional failures with regressions, especially on leeroy.
(I do not see an issue for it here, though.)
There was already an issue for the underlying problem in osicat:
https://github.com/osicat/osicat/issues/37
I added a comment on that issue.
