### PR TITLE
[jenkins] list osicat cache dir and quicklisp/base.* files before and…

### DIFF
--- a/books/build/jenkins/build-single.sh
+++ b/books/build/jenkins/build-single.sh
@@ -57,6 +57,32 @@ $STARTJOB -c "nice make acl2 -f books/build/jenkins/Makefile LISP=$LISP"
 echo "Building the books."
 cd books
 
+
+### TEMPORARY SECTION 1 of 2
+# Take a look at the osicat cache both before and after a build.
+# I suspect something is deleting it in a previous build or somehow in the setup.
+# Also look at quicklisp/base.*, since whether that is certified should track
+# the binary files in the asdf-home/cache.
+#
+OSICAT_CACHE_DIR="quicklisp/asdf-home/cache/common-lisp/ccl-1.12-f98-linux-x64/var/lib/jenkins/workspace/acl2-testing/books/quicklisp/bundle/software/osicat-20220220-git/src"
+
+if [ -d "$OSICAT_CACHE_DIR" ]; then
+    echo
+    echo 'Listing osicat cache dir:'
+    echo "ls -la $OSICAT_CACHE_DIR"
+    ls -la "$OSICAT_CACHE_DIR"
+    echo
+else
+    echo
+    echo '!! OSICAT_CACHE_DIR does not exist !!'
+    echo
+fi
+echo 'Also listing quicklisp/base.*':
+ls -la quicklisp/base.*
+#
+### END OF TEMPORARY SECTION
+
+
 # See https://serverfault.com/questions/786981/adjust-oom-score-at-process-launch
 # for OOM Killer discussion, which includes:
 # Because it's in parentheses, it launches a subshell, sets the OOM score for
@@ -71,6 +97,26 @@ OOM_KILLER_ADJUSTMENT=500 # medium value for the build-single case
 CMD="nice -n $NICENESS make $TARGET ACL2=$WORKSPACE/saved_acl2 -j $BOOK_PARALLELISM_LEVEL -l $BOOK_PARALLELISM_LEVEL $MAKEOPTS USE_QUICKLISP=1"
 CMD_WITH_OOM_KILLER_ADJUSTMENT="(echo ${OOM_KILLER_ADJUSTMENT} > /proc/self/oom_score_adj && exec ${CMD})"
 $STARTJOB -c "${CMD_WITH_OOM_KILLER_ADJUSTMENT}"
+
+
+### TEMPORARY SECTION 2 of 2
+# For a successful build, list the osicat cache and quicklisp/base.*
+if [ -d "$OSICAT_CACHE_DIR" ]; then
+    echo
+    echo 'Listing osicat cache dir:'
+    echo "ls -la $OSICAT_CACHE_DIR"
+    ls -la "$OSICAT_CACHE_DIR"
+    echo
+else
+    echo
+    echo '!! OSICAT_CACHE_DIR does not exist !!'
+    echo
+fi
+echo 'Also listing quicklisp/base.*':
+ls -la quicklisp/base.*
+#
+### END OF TEMPORARY SECTION
+
 
 echo "Build was successful."
 


### PR DESCRIPTION
… after every books build, to get more information about where the osicat bundle cache binaries might be going missing