### PR TITLE
Removes hard-coded python name from expt example config

### DIFF
--- a/books/projects/smtlink/examples/examples.lisp
+++ b/books/projects/smtlink/examples/examples.lisp
@@ -162,9 +162,7 @@ clause-processors. They help ensure the soundness of Smtlink.</p>
     (declare (xargs :guard t))
     (change-smtlink-config (default-smt-cnf)
                            :smt-module    "RewriteExpt"
-                           :smt-class     "to_smt_w_expt"
-                           :smt-cmd       "python"
-                           :pythonpath    "")))
+                           :smt-class     "to_smt_w_expt")))
 
 (def-saved-event smtconf-expt-defattach-tutorial
   (defattach custom-smt-cnf my-smtlink-expt-config))


### PR DESCRIPTION
Smtlink example 2 shows how to extend smtlink's functionality with a custom python module. Unfortunately, the example also hardcodes the user-configurable python program name, smt-cmd. This change restores the expected behaviour, which pairs the custom module with the user-configured python executable.