### PR TITLE
[walter-acl2-workshop-2023] Remove extended package prefix syntax from acl2s-setup.lisp

### DIFF
--- a/books/workshops/2023/walter-etal/README.md
+++ b/books/workshops/2023/walter-etal/README.md
@@ -49,11 +49,17 @@ example as noted previously in this README.
 ## Running the CLI locally
 
 ### Prerequisites
+- ACL2 built using SBCL (NOT CCL)
 - Java 17
 - An ACL2s image (see [the scripts](https://gitlab.com/acl2s/external-tool-support/scripts) repo)
 - Quicklisp
 
 ### Instructions
+Note that we use [extended package prefix
+syntax](https://www.sbcl.org/manual/#Extended-Package-Prefix-Syntax)
+in many places in our code. This is not supported by CCL, so you
+cannot build this system using CCL. We use SBCL.
+
 If the ACL2s image is not on your `PATH`, you must set the `ACL2S_EXE`
 environment variable to the absolute path to the image.
 

--- a/books/workshops/2023/walter-etal/acl2s-setup.lisp
+++ b/books/workshops/2023/walter-etal/acl2s-setup.lisp
@@ -60,16 +60,16 @@
   '(min-theory executable-theory))
 
 (deftheory arith-theory
-  'acl2::(Associativity-of-+
-          Commutativity-of-+
-          Unicity-of-0
-          Inverse-of-+
-          Associativity-of-*
-          Commutativity-of-*
-          Unicity-of-1
-          Inverse-of-*
-          Distributivity
-          Rational-implies2))
+  '(acl2::Associativity-of-+
+    acl2::Commutativity-of-+
+    acl2::Unicity-of-0
+    acl2::Inverse-of-+
+    acl2::Associativity-of-*
+    acl2::Commutativity-of-*
+    acl2::Unicity-of-1
+    acl2::Inverse-of-*
+    acl2::Distributivity
+    acl2::Rational-implies2))
 
 (defun valid-acl2s-termp (term state)
   (declare (xargs :mode :program :stobjs state))


### PR DESCRIPTION
I removed [extended package prefix syntax](https://www.sbcl.org/manual/#Extended-Package-Prefix-Syntax) from acl2s-setup.lisp, as it picked up in the regression-everything build that Leeroy performs with CCL. CCL does not support extended package prefix syntax, which is why this caused a failure on Leeroy.

I also added a comment in the README that SBCL is required for building this system locally, as the non-ACL2-book parts of the system use this syntax extensively.