### PR TITLE
[X86ISA] Fix typo in code.

### DIFF
--- a/books/projects/x86isa/machine/instructions/fp/cmp-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/cmp-spec.lisp
@@ -276,7 +276,7 @@
                     (mxcsr     :type (unsigned-byte 32)))
   (b* (((mv flg result mxcsr)
         (sse-cmp operation op1 op2 mxcsr #.*IEEE-DP-EXP-WIDTH* #.*IEEE-DP-FRAC-WIDTH*))
-       (result (n32 result)))
+       (result (n64 result)))
     (mv flg result mxcsr))
   ///
   (defthm-unsigned-byte-p n64p-result-dp-sse-cmp


### PR DESCRIPTION
For the double-precision case, the result must be turned into a 64-bit quantity.

This issue was noticed by Eric Smith.

I checked that against the Intel instruction manual.