### PR TITLE
[X86ISA] Fix two typos in code.

### DIFF
--- a/books/projects/x86isa/machine/instructions/fp/arith-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/arith-spec.lisp
@@ -250,7 +250,7 @@
   (b* (((mv flg result mxcsr)
 	(sse-max/min operation op1 op2 mxcsr
 		     #.*IEEE-DP-EXP-WIDTH* #.*IEEE-DP-FRAC-WIDTH*))
-       (result (n32 result))
+       (result (n64 result))
        (mxcsr (mbe :logic (n32 mxcsr)
 		   :exec  mxcsr)))
     (mv flg result mxcsr))

--- a/books/projects/x86isa/machine/instructions/fp/cvt-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/cvt-spec.lisp
@@ -530,7 +530,7 @@
         (sse-cvt-int-to-fp op mxcsr
                            #.*IEEE-DP-EXP-WIDTH* #.*IEEE-DP-FRAC-WIDTH*))
 
-       (result (n32 result)))
+       (result (n64 result)))
     (mv flg result mxcsr))
   ///
 


### PR DESCRIPTION
These are similar to the one in a previous commit.

Eric Smith first noticed these.

I checked these against the Intel manual.