### PR TITLE
[X86ISA] Tweak models of `div` and `idiv`.

### DIFF
--- a/books/projects/x86isa/machine/instructions/divide.lisp
+++ b/books/projects/x86isa/machine/instructions/divide.lisp
@@ -57,7 +57,7 @@
 (local
  (defthm x86-div-guard-proof-helper-1
    (implies (n16p rr16-a)
-	    (equal (logand 18446462598732906495 rr16-a)
+	    (equal (logand 18446744069414649855 rr16-a)
 		   rr16-a))
    :hints (("Goal" :in-theory (e/d () (unsigned-byte-p))))))
 
@@ -145,7 +145,7 @@
 		     rAX
 		   (mbe :logic (part-install rDX rAX
 					     :low   (ash reg/mem-size 3)
-					     :width (ash reg/mem-size 4))
+					     :width (ash reg/mem-size 3))
 			:exec (logior (ash rDX (ash reg/mem-size 3)) rAX))))
        ((mv overflow? quotient remainder)
 	(div-spec reg/mem-size dividend reg/mem))
@@ -266,7 +266,7 @@
 		     rAX
 		   (mbe :logic (part-install rDX rAX
 					     :low   (ash reg/mem-size 3)
-					     :width (ash reg/mem-size 4))
+					     :width (ash reg/mem-size 3))
 			:exec (logior (ash rDX (ash reg/mem-size 3)) rAX))))
 
        ;; Compute the result


### PR DESCRIPTION
The width should be the same as the low bit index, i.e. 8 times the operand size in bytes (i.e. the operand size in bits). It is actually equivalent, because the extra bits are 0, but it seems cleaner to do it this way.

This issue was brought up by Eric Smith.

A guard verification lemma had to be tweaked in order for the guard proofs to go through.