### PR TITLE
Rename package of Schröder-Bernstein project

### DIFF
--- a/books/projects/schroder-bernstein/acl2-customization.lsp
+++ b/books/projects/schroder-bernstein/acl2-customization.lsp
@@ -6,4 +6,4 @@
 
 (ld "~/acl2-customization.lsp" :ld-missing-input-ok t)
 (ld "package.lsp")
-(in-package "SB")
+(in-package "SBT")

--- a/books/projects/schroder-bernstein/chains.lisp
+++ b/books/projects/schroder-bernstein/chains.lisp
@@ -4,7 +4,7 @@
 ;
 ; Author: Grant Jurgensen (grant@kestrel.edu)
 
-(in-package "SB")
+(in-package "SBT")
 
 (include-book "std/util/define" :dir :system)
 (include-book "std/util/define-sk" :dir :system)

--- a/books/projects/schroder-bernstein/package.lsp
+++ b/books/projects/schroder-bernstein/package.lsp
@@ -11,7 +11,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; "SB" = "Schroder-Bernstein"
-(defpkg "SB"
+;; "SBT" = "Schroder-Bernstein Theorem"
+(defpkg "SBT"
   (append *std-pkg-symbols*
           '(define-sk)))

--- a/books/projects/schroder-bernstein/portcullis.lisp
+++ b/books/projects/schroder-bernstein/portcullis.lisp
@@ -4,4 +4,4 @@
 ;
 ; Author: Grant Jurgensen (grant@kestrel.edu)
 
-(in-package "SB")
+(in-package "SBT")

--- a/books/projects/schroder-bernstein/schroder-bernstein.lisp
+++ b/books/projects/schroder-bernstein/schroder-bernstein.lisp
@@ -4,7 +4,7 @@
 ;
 ; Author: Grant Jurgensen (grant@kestrel.edu)
 
-(in-package "SB")
+(in-package "SBT")
 
 (include-book "std/util/define" :dir :system)
 (include-book "std/util/define-sk" :dir :system)

--- a/books/projects/schroder-bernstein/setup.lisp
+++ b/books/projects/schroder-bernstein/setup.lisp
@@ -4,7 +4,7 @@
 ;
 ; Author: Grant Jurgensen (grant@kestrel.edu)
 
-(in-package "SB")
+(in-package "SBT")
 
 (include-book "std/util/define" :dir :system)
 (include-book "std/util/defrule" :dir :system)

--- a/books/projects/schroder-bernstein/witness.lisp
+++ b/books/projects/schroder-bernstein/witness.lisp
@@ -4,7 +4,7 @@
 ;
 ; Author: Grant Jurgensen (grant@kestrel.edu)
 
-(in-package "SB")
+(in-package "SBT")
 
 (include-book "std/util/define" :dir :system)
 (include-book "std/util/define-sk" :dir :system)


### PR DESCRIPTION
This renames the package from `SB` to `SBT` to avoid overlap with the other `SB` package (in `books/projects/sb-machine`).