### PR TITLE
Modify aarch64 specs to handle AHP mode

### DIFF
--- a/books/projects/rac/lisp/alt-const-fns-gen.lisp
+++ b/books/projects/rac/lisp/alt-const-fns-gen.lisp
@@ -619,5 +619,6 @@
                   ;; :expand :lambdas
                   ;; :in-theory '(,theory-name ,fn-name)
                   :in-theory nil
+                  :do-not '(preprocess)
                   :clause-processor
                   (expand-reduce-cp clause '(mv-list ,@theory-list ,fn-name) state)))))))

--- a/books/rtl/rel11/lib/defs.lisp
+++ b/books/rtl/rel11/lib/defs.lisp
@@ -266,7 +266,9 @@
        (exactp x (prec f))))
 
 (defund nencode (x f)
-  (declare (xargs :guard (nrepp x f)))
+  (declare (xargs :guard (and (rationalp x)
+                              (formatp f)
+                              (exactp x (prec f)))))
   (cat (if (= (sgn x) 1) 0 1)
        1
        (+ (expo x) (bias f))

--- a/books/rtl/rel11/lib/reps.lisp
+++ b/books/rtl/rel11/lib/reps.lisp
@@ -157,7 +157,9 @@
 ;;Encoding function:
 
 (defund nencode (x f)
-  (declare (xargs :guard (nrepp x f)))
+  (declare (xargs :guard (and (rationalp x)
+                              (formatp f)
+                              (exactp x (prec f)))))
   (cat (if (= (sgn x) 1) 0 1)
        1
        (+ (expo x) (bias f))

--- a/books/rtl/rel11/support/definitions.lisp
+++ b/books/rtl/rel11/support/definitions.lisp
@@ -934,7 +934,9 @@
        (exactp x (prec f))))
 
 (defund nencode (x f)
-  (declare (xargs :guard (nrepp x f)
+  (declare (xargs :guard (and (rationalp x)
+                              (formatp f)
+                              (exactp x (prec f)))
                   :verify-guards nil))
   (cat (if (= (sgn x) 1) 0 1)
        1

--- a/books/rtl/rel11/support/excps.lisp
+++ b/books/rtl/rel11/support/excps.lisp
@@ -284,12 +284,31 @@
   :enable (nrepp sgn)
   :use nrepp-lpn))
 
+(local (defrule exactp-lpn-sgn
+  (implies
+    (and
+      (rationalp r)
+      (< (lpn F) (abs r))
+      (formatp f))
+    (exactp (* (lpn f) (sgn r)) (prec f)))
+  :enable (nrepp sgn)
+  :use nrepp-lpn))
+
 (local (defrule nrepp-spn-sgn
   (implies
     (and
       (equal (abs (drnd u mode f)) (spn f))
       (formatp f))
   (nrepp (drnd u mode f) f))
+  :enable nrepp
+  :use nrepp-spn))
+
+(local (defrule exactp-spn-sgn
+  (implies
+    (and
+      (equal (abs (drnd u mode f)) (spn f))
+      (formatp f))
+  (exactp (drnd u mode f) (prec f)))
   :enable nrepp
   :use nrepp-spn))
 

--- a/books/rtl/rel11/support/verify-guards.lisp
+++ b/books/rtl/rel11/support/verify-guards.lisp
@@ -474,7 +474,9 @@
   :hints (("goal" :in-theory (enable nrepp exactp))))
 
 (defund nencode (x f)
-  (declare (xargs :guard (nrepp x f)))
+  (declare (xargs :guard (and (rationalp x)
+                              (formatp f)
+                              (exactp x (prec f)))))
   (cat (if (= (sgn x) 1) 0 1)
        1
        (+ (expo x) (bias f))


### PR DESCRIPTION
Needed to weaken guards for nencode function.

Also made a minor unrelated change in alt-const-fns-gen.