### PR TITLE
Remove unneeded acl2-mv-as-values from misc/profiling raw code

### DIFF
--- a/books/misc/profiling-raw.lsp
+++ b/books/misc/profiling-raw.lsp
@@ -126,9 +126,7 @@
 #+sbcl
 (require :sb-sprof)
 
-#+(and sbcl acl2-mv-as-values)
-; We expect acl2-mv-as-values to be set for every sbcl installation these days
-; (June 2011).  If not, someone can complain and we can fix this.
+#+sbcl
 (defmacro with-sprofiling-internal-raw (&whole whole options form)
 
 ; A good value for options is (:report :graph :loop nil).  See
@@ -146,7 +144,7 @@
        (format t "~%")
        (values-list ,result-var))))
 
-#-(and sbcl acl2-mv-as-values)
+#-sbcl
 (defmacro with-sprofiling-internal-raw (options form)
   (declare (ignore options))
   `(with-profiling-no-op-warning with-sprofiling (:sbcl) ,form))


### PR DESCRIPTION
Some of the raw Lisp code for `misc/profiling` was gated on the `acl2-mv-as-values feature`, which was removed from ACL2 in August 2021 as it is true on all of the Lisps that ACL2 supports at this time. This meant that the raw Lisp code would never evaluate, preventing `misc/profiling` from working. This PR modifies the code to stop gating the relevant code on the `acl2-mv-as-values` feature.