### PR TITLE
[acl2s] Fix incorrect type specifier in acl2s-interface-utils

### DIFF
--- a/books/acl2s/interface/acl2s-interface-utils.lsp
+++ b/books/acl2s/interface/acl2s-interface-utils.lsp
@@ -212,7 +212,7 @@ can't be a macro."
 ;;(assert (equal (acl2s-arity 'append) nil)) ;; is nil since append is a macro
 ;;(assert (equal (acl2s-arity 'binary-append) 2))
 
-(declaim (ftype (function (symbol) bool) is-theorem?))
+(declaim (ftype (function (symbol) boolean) is-theorem?))
 (defun is-theorem? (sym)
   "Determine if the given symbol symbol names a theorem."
   (let* ((query `(acl2::theorem-namep ',sym (w state)))


### PR DESCRIPTION
An incorrect type specifier in the raw Lisp acl2s-interface-utils file was causing issues on SBCL with safety settings turned up.