### PR TITLE
[xdoc] Fix guards on XDOC `extend-links-fal`

### DIFF
--- a/books/xdoc/importance.lisp
+++ b/books/xdoc/importance.lisp
@@ -185,8 +185,8 @@
    targets   ; string list, keys of the pages linked to from source
    links-fal ; the fal being constructed
    )
-  (declare (xargs :guard (and (stringp source)
-                              (symbol-listp targets))))
+  (declare (xargs :guard (and (symbolp source)
+                              (string-listp targets))))
   (b* (((when (atom targets))
         links-fal)
        (target1      (car targets))


### PR DESCRIPTION
The guards on the `extend-links-fal` function in `books/xdoc/importance.lisp` were inconsistent with comments in that file, and the actual types of arguments that were being passed in. This caused `xdoc::save` to fail for me. I updated the guards so that they are consistent with comments and the actual types of arguments being passed in.

I'm not 100% sure why this wasn't caught by anyone else previously - maybe something about the environment in which I call `xdoc::save`?