### PR TITLE
[Std/osets] Rename `empty` to `emptyp`.

### DIFF
--- a/books/acl2s/acl2s-size.lisp
+++ b/books/acl2s/acl2s-size.lisp
@@ -32,7 +32,7 @@ Added these rules as built-in clauses
  Causes rewrite loops. Seems like an ACL2 bug, or at least there is a
  potential for improvement since we should catch such rewrite
  loops. Investigate at some point. (remove similar built-in clauses to
- reproduce) 
+ reproduce)
 
 (defthm acl2s-size-cons
   (implies (consp (double-rewrite x))
@@ -124,19 +124,19 @@ Added these rules as built-in clauses
   :rule-classes :linear)
 
 (defthm tail-acl2s-size
-  (implies (not (set::empty x))
+  (implies (not (set::emptyp x))
            (< (acl2s-size (set::tail x))
               (acl2s-size x)))
-  :hints (("Goal" :in-theory (enable set::empty set::tail)))
-  :rule-classes ((:rewrite :backchain-limit-lst 0) 
+  :hints (("Goal" :in-theory (enable set::emptyp set::tail)))
+  :rule-classes ((:rewrite :backchain-limit-lst 0)
                  (:linear :backchain-limit-lst 0)))
 
 (defthm head-acl2s-size
-  (implies (not (set::empty x))
+  (implies (not (set::emptyp x))
            (< (acl2s-size (set::head x))
               (acl2s-size x)))
-  :hints (("Goal" :in-theory (enable set::empty set::head)))
-  :rule-classes ((:rewrite :backchain-limit-lst 0) 
+  :hints (("Goal" :in-theory (enable set::emptyp set::head)))
+  :rule-classes ((:rewrite :backchain-limit-lst 0)
                  (:linear :backchain-limit-lst 0)))
 
 (defthm split-list-1-acl2s-size
@@ -144,9 +144,9 @@ Added these rules as built-in clauses
            (< (acl2s-size (mv-nth 1 (str::split-list-1 x str::del)))
               (acl2s-size x)))
   :hints (("Goal" :in-theory (enable str::split-list-1)))
-  :rule-classes ((:rewrite :backchain-limit-lst 0) 
+  :rule-classes ((:rewrite :backchain-limit-lst 0)
                  (:linear :backchain-limit-lst 0)))
- 
+
 (defthm records-acl2s-size-linear-arith-<=
   (<= (acl2s-size (mget k r))
       (acl2s-size r))
@@ -528,9 +528,9 @@ Maybe be useful for replacing acl2-count with acl2s-size.
 
 (defthm acl2s-size-built-in-5
   (implies (not (atom x))
-           (and (< (acl2s-size (cdr x)) 
+           (and (< (acl2s-size (cdr x))
                    (acl2s-size x))
-                (o< (acl2s-size (cdr x)) 
+                (o< (acl2s-size (cdr x))
                     (acl2s-size x))))
   :rule-classes :built-in-clause)
 
@@ -716,7 +716,7 @@ Maybe be useful for replacing acl2-count with acl2s-size.
            (equal (acl2s-size x)
                   (integer-abs (numerator x))))
   :rule-classes ((:rewrite :backchain-limit-lst 0)))
-   
+
 (defthm acl2s-size-cons
   (implies (consp x)
            (equal (acl2s-size x)

--- a/books/acl2s/cons-size.lisp
+++ b/books/acl2s/cons-size.lisp
@@ -12,7 +12,7 @@
 
 (defmacro tree-size (x)
   `(cons-size ,x))
-  
+
 (defthm cons-size-type
   (natp (cons-size x))
   :rule-classes
@@ -34,17 +34,17 @@
   :rule-classes :linear)
 
 (defthm head-cons-size
-  (implies (not (set::empty x))
+  (implies (not (set::emptyp x))
            (< (cons-size (set::head x))
               (cons-size x)))
-  :hints (("Goal" :in-theory (enable set::empty set::head)))
+  :hints (("Goal" :in-theory (enable set::emptyp set::head)))
   :rule-classes :linear)
 
 (defthm tail-cons-size
-  (implies (not (set::empty x))
+  (implies (not (set::emptyp x))
            (< (cons-size (set::tail x))
               (cons-size x)))
-  :hints (("Goal" :in-theory (enable set::empty set::tail)))
+  :hints (("Goal" :in-theory (enable set::emptyp set::tail)))
   :rule-classes :linear)
 
 (defthm cons-size-append
@@ -140,7 +140,7 @@
   (implies (mget k r)
            (< (cons-size (mget k r))
               (cons-size r)))
-  :hints (("goal" :in-theory 
+  :hints (("goal" :in-theory
            (enable mget recordp no-nil-val-alistp ordered-unique-key-alistp)))
   :rule-classes :linear)
 

--- a/books/centaur/aignet/internal-observability-super.lisp
+++ b/books/centaur/aignet/internal-observability-super.lisp
@@ -43,7 +43,7 @@
 (include-book "prune") ;; for aignet-copy-dfs-outs, aignet-copy-dfs-nxsts
 
 (local (include-book "std/osets/under-set-equiv" :dir :system))
-  
+
 (local (include-book "arithmetic/top-with-meta" :dir :system))
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 ;; (local (include-book "data-structures/list-defthms" :dir :system))
@@ -165,7 +165,7 @@
   (defthm spath-existsp-of-atom
     (implies (not (consp path))
              (equal (spath-existsp sink path refcounts aignet) t)))
-  
+
   (defthm spath-existsp-of-nil
     (equal (spath-existsp sink nil refcounts aignet) t))
 
@@ -194,7 +194,7 @@
     (implies (not (consp path))
              (equal (spath-endpoint sink path refcounts aignet)
                     (nfix sink))))
-  
+
   (defthm spath-endpoint-of-nil
     (equal (spath-endpoint sink nil refcounts aignet)
            (nfix sink)))
@@ -244,7 +244,7 @@
            (equal (lits-max-id-val (append x y))
                   (max (lits-max-id-val x) (lits-max-id-val y)))
            :hints(("Goal" :in-theory (enable lits-max-id-val)))))
-  
+
   (defthm lits-max-id-val-of-spath-and-literals
     (<= (lits-max-id-val (spath-and-literals sink path refcounts aignet)) (nfix sink))
     :rule-classes :linear)
@@ -392,7 +392,7 @@
              (equal (aignet-eval-parity-toggle res toggles invals regvals aignet)
                     (acl2::b-xor
                      negate
-                     (acl2::b-xor 
+                     (acl2::b-xor
                       (bool->bit (and top
                                       ;; (equal (lit->neg lit) 0)
                                       (posp limit)
@@ -488,12 +488,12 @@
            (equal (b-xor (b-not a) b)
                   (b-not (b-xor a b)))
            :hints(("Goal" :in-theory (enable b-not)))))
-  
+
   (defthm lit-eval-toggle-of-lit-negate
     (equal (lit-eval-toggle (lit-negate x) toggles invals regvals aignet)
            (b-not (lit-eval-toggle x toggles invals regvals aignet)))
     :hints(("Goal" :expand ((:free (x) (lit-eval-toggle x toggles invals regvals aignet))))))
-  
+
   (defthm aignet-eval-conjunction-toggle-when-cube-contradictionp
     (implies (cube-contradictionp x)
              (equal (aignet-eval-conjunction-toggle x toggles invals regvals aignet) 0))
@@ -521,7 +521,7 @@
             :expand ((:free (a b) (ids-multiply-referenced (cons a b) refcounts))
                      (:free (toggles) (aignet-eval-conjunction-toggle nil toggles invals regvals aignet))
                      (:free (var neg toggles) (lit-eval-toggle (make-lit var neg) toggles invals regvals aignet)))))))
-                  
+
 
 (define has-toggling-lit ((x lit-listp) (toggle natp) (toggles nat-listp) invals regvals aignet)
   :guard (and (aignet-lit-listp x aignet)
@@ -535,7 +535,7 @@
 
   ///
   (fty::deffixequiv has-toggling-lit)
-  
+
   (local (Defthm b-xor-of-b-not-1
            (equal (b-xor (b-not a) b)
                   (b-not (b-xor a b)))
@@ -598,7 +598,7 @@
                                        lit-eval-toggle
                                        lit-eval)))))
 
-  
+
   (local (defthmd lit-eval-toggle-when-lit->var-equal-toggle
            (implies (equal (lit->var lit) (nfix toggle))
                     (equal (lit-eval-toggle lit (cons toggle toggles) invals regvals aignet)
@@ -615,7 +615,7 @@
   ;;                 (b-not (lit-eval lit invals regvals aignet)))
   ;;          :hints (("goal" :in-theory (enable lit-eval-toggle-when-lit->var-equal-toggle)))))
 
-  
+
   (local (defthm has-toggling-lit-when-member
            (implies (and (member-equal lit (lit-list-fix supergate))
                          (not (equal (lit-eval-toggle lit (cons toggle toggles) invals regvals aignet)
@@ -648,7 +648,7 @@
   ;;                             (lit-collect-supergate lit top use-muxes limit supergate refcounts aignet))
   ;;                            (lit-eval-toggle 0 toggles invals regvals aignet)
   ;;                            (id-eval-toggle 0 toggles invals regvals aignet))))))
-  
+
   ;; (local (defthm id-eval-toggle-in-terms-of-supergate
   ;;          (implies (and (not (equal (lit-eval lit invals regvals aignet)
   ;;                                    (lit-eval-toggle lit toggles invals regvals aignet)))
@@ -685,7 +685,7 @@
   ;;                             (lit-collect-superxor lit top limit supergate refcounts aignet))
   ;;                            (lit-eval-toggle 0 toggles invals regvals aignet)
   ;;                            (id-eval-toggle 0 toggles invals regvals aignet))))))
-  
+
   ;; (local (defthm id-eval-toggle-in-terms-of-superxor
   ;;          (implies (and (not (equal (lit-eval lit invals regvals aignet)
   ;;                                    (lit-eval-toggle lit toggles invals regvals aignet)))
@@ -708,7 +708,7 @@
   ;;                            (:free (a b) (eval-and-of-lits-toggle a b toggles invals regvals aignet))
   ;;                            (:free (a b) (eval-xor-of-lits-toggle a b toggles invals regvals aignet)))
   ;;                   :do-not-induct t))))
-  
+
   (local (defthm equal-of-b-xors
            (equal (equal (b-xor a b) (b-xor a c))
                   (equal (bfix b) (bfix c)))
@@ -718,7 +718,7 @@
     (implies (and (not (equal (id-eval-toggle sink (cons toggle toggles) invals regvals aignet)
                               (id-eval-toggle sink toggles invals regvals aignet)))
                   (< 1 (nfix (nth toggle refcounts)))
-                  (ids-multiply-referenced toggles refcounts) 
+                  (ids-multiply-referenced toggles refcounts)
                   (not (equal (nfix toggle) (nfix sink)))
                   ;; (not (member (nfix sink) (acl2::nat-list-fix toggles)))
                   )
@@ -800,7 +800,7 @@
                                      (lit-eval-toggle lit toggles invals regvals aignet))))
                     (has-toggling-lit supergate toggle toggles invals regvals aignet))
            :hints(("Goal" :in-theory (enable has-toggling-lit lit-list-fix member-equal)))))
-  
+
   (defret min-toggling-lit-is-minimum
     (implies (and (not (equal (lit-eval-toggle k (cons toggle toggles) invals regvals aignet)
                               (lit-eval-toggle k toggles invals regvals aignet)))
@@ -828,15 +828,15 @@
    ;; variables less than the minimum toggling literal of the supergate, so none
    ;; of them may be contradictory either.  Whew.
 
-   
-   
+
+
    (local (defthm member-equal-when-lits-max-id-val-less
             (implies (< (lits-max-id-val y) (lit->var x))
                      (not (member-equal x (lit-list-fix y))))
             :hints(("Goal" :in-theory (enable lit-list-fix lits-max-id-val member-equal)))))
 
 
-   
+
    (local (defthm not-two-cubes-contradictionp-when-no-toggling-lit
             (implies (and (two-cubes-contradictionp x y)
                           (not (lit-list-has-const0-under-toggle
@@ -848,7 +848,7 @@
                                               has-toggling-lit
                                               two-cubes-contradictionp
                                               lit-list-has-const0-under-toggle-when-member)))))
-   
+
    (defthmd not-two-cubes-contradictionp-lemma
      (implies (and (not (lit-list-has-const0-under-toggle
                          x toggle toggles invals regvals aignet))
@@ -904,7 +904,7 @@
                                         source toggles invals regvals refcounts aignet)))
   ///
   (local (in-theory (disable (:d toggle-witness-spath))))
-  
+
   (defret spath-existsp-of-<fn>
     (implies (and (not (equal (id-eval-toggle sink toggles invals regvals aignet)
                               (id-eval-toggle sink (cons source toggles) invals regvals aignet)))
@@ -934,8 +934,8 @@
                                            (member-equal toggle toggles)))
                            (id-eval-toggle x toggles invals regvals aignet))))
     :hints(("Goal" :in-theory (enable* id-eval-toggle acl2::arith-equiv-forwarding))))
-                        
-  
+
+
   (defret spath-endpoint-of-<fn>
     (implies (and (not (equal (id-eval-toggle sink toggles invals regvals aignet)
                               (id-eval-toggle sink (cons source toggles) invals regvals aignet)))
@@ -977,15 +977,15 @@
   (local (defthm lit->var-of-nth-single-0
            (equal (lit->var (nth n '(0))) 0)
            :hints (("goal" :expand ((nth n '(0)))))))
-  
-  (local (defthm spath-and-literals-of-zero 
+
+  (local (defthm spath-and-literals-of-zero
            (equal (spath-and-literals 0 path refcounts aignet) nil)
            :hints(("Goal" :in-theory (enable spath-and-literals
                                              gate-node-supergate)
                    :expand ((spath-and-literals 0 path refcounts aignet)
                             (LIT-COLLECT-SUPERGATE 0 T NIL 1000 NIL REFCOUNTS AIGNET))
                    :induct (len path)))))
-  
+
   (defret contradictionp-of-<fn>
     (implies (and (not (equal (id-eval-toggle sink toggles invals regvals aignet)
                               (id-eval-toggle sink (cons source toggles) invals regvals aignet)))
@@ -1067,7 +1067,7 @@
   ///
   (defret setp-of-<fn>
     (set::setp doms))
-  
+
   (defthm obs-sdom-info->doms-of-make-obs-sdom-info-reached
     (equal (obs-sdom-info->doms (make-obs-sdom-info-reached doms))
            (set::mergesort (lit-list-fix doms)))
@@ -1181,7 +1181,7 @@
 
 (local
  (defsection set-stuff-in-terms-of-list-stuff
-   
+
    (defthm head-when-setp
      (implies (set::setp x)
               (equal (set::head x) (car x)))
@@ -1192,10 +1192,10 @@
               (equal (set::tail x) (cdr x)))
      :hints(("Goal" :in-theory (enable set::tail))))
 
-   (defthm empty-when-setp
+   (defthm emptyp-when-setp
      (implies (set::setp x)
-              (equal (set::empty x) (atom x)))
-     :hints(("Goal" :in-theory (enable set::empty))))
+              (equal (set::emptyp x) (atom x)))
+     :hints(("Goal" :in-theory (enable set::emptyp))))
 
    (defthm setp-of-cdr
      (implies (set::setp x)
@@ -1252,7 +1252,7 @@
                   (not (cube-contradictionp (obs-sdom-info->doms y)))
                   (not (member-equal lit (obs-sdom-info->doms y))))
              (not (member lit (obs-sdom-info->doms x)))))
-  
+
   (defthmd obs-sdom-info-subsetp-transitive
     (implies (and (obs-sdom-info-subsetp a b)
                   (obs-sdom-info-subsetp b c))
@@ -1321,7 +1321,7 @@
     (implies (equal (stype (car (lookup-id fanout aignet))) :xor)
              (equal child-fanout-info
                     (obs-sdom-info-fix fanout-info))))
-  
+
   (defret <fn>-when-and
     (implies (equal (stype (car (lookup-id fanout aignet))) :and)
              (equal child-fanout-info
@@ -1391,7 +1391,7 @@
                                            cube-contradictionp-sorted)))
   (mbe :logic (cube-contradictionp x)
        :exec
-       (if (set::empty x)
+       (if (set::emptyp x)
            nil
          (or (set::in (lit-negate (set::head x)) (set::tail x))
              (cube-contradictionp-sorted (set::tail x))))))
@@ -1411,7 +1411,7 @@
   ;;                        (lit-listp cube))
   ;;                   (cube-contradictionp cube))
   ;;          :hints(("Goal" :in-theory (enable cube-contradictionp)))))
-  
+
   ;; (local (defthm cube-contradictionp-when-subsetp
   ;;          (implies (and (subsetp x y)
   ;;                        (cube-contradictionp x)
@@ -1419,7 +1419,7 @@
   ;;                   (cube-contradictionp y))
   ;;          :hints(("Goal" :in-theory (enable cube-contradictionp
   ;;                                            subsetp)))))
-  
+
   (defret subsetp-of-<fn>-1
     (iff (obs-sdom-info-subsetp new-x y)
          (obs-sdom-info-subsetp x y))
@@ -1445,7 +1445,7 @@
   ///
   (local (in-theory (enable obs-sdom-info-subsetp
                             obs-sdom-info-normalize)))
-  
+
   (local (defthm subsetp-of-intersect-1
            (subsetp (intersection$ x y) x)))
   (local (defthm subsetp-of-intersect-2
@@ -1472,7 +1472,7 @@
                     (not (cube-contradictionp x)))
            :hints (("goal" :use ((:instance cube-contradiction-by-subsetp))
                     :in-theory (disable cube-contradiction-by-subsetp)))))
-  
+
   (defret obs-sdom-info-subsetp-of-obs-sdom-info-intersect-1
     (obs-sdom-info-subsetp int x))
 
@@ -1482,7 +1482,7 @@
   (defret obs-sdom-info-intersect-preserves-obs-sdom-info-subsetp-1
     (implies (obs-sdom-info-subsetp x z)
              (obs-sdom-info-subsetp int z)))
-  
+
   (defret obs-sdom-info-intersect-preserves-obs-sdom-info-subsetp-2
     (implies (obs-sdom-info-subsetp y z)
              (obs-sdom-info-subsetp int z)))
@@ -1494,7 +1494,7 @@
            :hints(("Goal" :use ((:instance cube-contradictionp-when-subsetp
                                  (x (set::intersect x y))
                                  (y x)))))))
-  
+
   (defret obs-sdom-info-intersect-idempotent
     (equal (obs-sdom-info-intersect (obs-sdom-info-intersect x y) y)
            (obs-sdom-info-intersect x y)))
@@ -1585,7 +1585,7 @@
   (defret aignet-lit-listp-of-<fn>
     (implies (aignet-lit-listp x aignet)
              (aignet-lit-listp new-x aignet))))
-                                          
+
 
 (define obs-sdom-info-store-intersections ((super lit-listp)
                                            (sdominfo obs-sdom-info-p)
@@ -1680,7 +1680,7 @@
              (obs-sdom-fanins-ok lits fanout-sdominfo new-obs-sdom-array))
     :hints (("goal" :in-theory (enable obs-sdom-fanins-ok)
              :induct (obs-sdom-fanins-ok lits fanout-sdominfo obs-sdom-array))))
-  
+
   (defret obs-sdom-fanins-ok-of-obs-sdom-info-store-intersections-self
     (implies (subsetp-equal lits super)
              (obs-sdom-fanins-ok lits sdominfo new-obs-sdom-array))
@@ -1741,7 +1741,7 @@
            (implies (< (lits-max-id-val lits) i)
                     (not (member-equal i (lit-list-vars lits))))
            :hints(("Goal" :in-theory (enable lits-max-id-val lit-list-vars)))))
-  
+
   (defret <fn>-preserves-correct
     (implies (and (< (nfix n) (nfix i))
                   (obs-sdom-fanout-ok i obs-sdom-array refcounts aignet))
@@ -1762,7 +1762,7 @@
            (equal (set::intersect nil x) nil)
            :hints(("Goal" :use ((:instance set::double-containment
                                  (x (set::intersect nil x)) (y nil)))))))
-  
+
   (defret <fn>-preserves-empty-dominators
     (implies (equal (nth i obs-sdom-array)
                     (make-obs-sdom-info-reached nil))
@@ -1801,7 +1801,7 @@
   (defret <fn>-sets-correct
     (implies (< (nfix i) (nfix n))
              (obs-sdom-fanout-ok i new-obs-sdom-array refcounts aignet)))
-  
+
   (defret <fn>-preserves-empty-dominators
     (implies (equal (nth i obs-sdom-array)
                     (make-obs-sdom-info-reached nil))
@@ -1937,7 +1937,7 @@
 
 
 (defsection obs-sdom-array-correct
-  
+
   (defun-sk obs-sdom-array-correct (obs-sdom-array refcounts aignet)
     (forall fanout
             (obs-sdom-fanout-ok fanout obs-sdom-array refcounts aignet))
@@ -1954,7 +1954,7 @@
                                       obs-sdom-fanout-ok-out-of-bounds)
             :cases ((<= (nfix
                          (obs-sdom-array-correct-witness
-                          (obs-sdom-info-sweep-nodes (+ 1 (fanin-count aignet)) 
+                          (obs-sdom-info-sweep-nodes (+ 1 (fanin-count aignet))
                                                     obs-sdom-array refcounts aignet-levels aignet)
                           refcounts
                           aignet))
@@ -1987,7 +1987,7 @@
   (defret len-of-<fn>
     (implies (consp x)
              (equal (len prefix) (+ -1 (len x)))))
-  
+
   (defret spath-exists-of-spath-butlast
     (implies (spath-existsp sink x refcounts aignet)
              (spath-existsp sink prefix refcounts aignet))
@@ -2298,8 +2298,3 @@
         nil))
     (cons (get-sdominfo n obs-sdom-array)
           (obs-sdom-array-collect (1+ (lnfix n)) obs-sdom-array))))
-
-
-
-
-

--- a/books/centaur/depgraph/transdeps.lisp
+++ b/books/centaur/depgraph/transdeps.lisp
@@ -95,7 +95,7 @@ an overapproximation because of shadowed pairs in the graph.</p>"
   :parents (transdeps)
   :short "Get the set of direct dependencies for a set of nodes."
   :verify-guards nil
-  (if (empty nodes)
+  (if (emptyp nodes)
       nil
     (union (transdeps-direct-for-node (head nodes) graph)
            (transdeps-direct-for-nodes (tail nodes) graph)))

--- a/books/centaur/esim/stv/stv2c/stv2c.lisp
+++ b/books/centaur/esim/stv/stv2c/stv2c.lisp
@@ -288,7 +288,7 @@
        (used-vars            (4v-sexpr-vars-1pass-list sexprs))  ;; a set
        (bound-vars           (set::mergesort (alist-keys onoff)))
        (unbound-vars         (set::difference used-vars bound-vars))
-       ((unless (set::empty unbound-vars))
+       ((unless (set::emptyp unbound-vars))
         (raise "variables used in relevant sexprs, but not bound in onoff: ~x0."
                unbound-vars))
        ;; Else looks okay, go ahead and translate.  We'll at least do

--- a/books/centaur/esim/vltoe/preliminary.lisp
+++ b/books/centaur/esim/vltoe/preliminary.lisp
@@ -483,10 +483,10 @@ versa.  We extend @('X') with a fatal warning if this doesn't hold.</p>"
                                  nil)))
                :hints(("Goal" :in-theory (enable (:ruleset set::primitive-rules))))))
 
-      (defthm empty-intersect-to-intersectp-equal
+      (defthm emptyp-intersect-to-intersectp-equal
         (implies (and (setp x)
                       (setp y))
-                 (equal (empty (set::intersect x y))
+                 (equal (emptyp (set::intersect x y))
                         (not (intersectp-equal x y))))
         :hints(("Goal"
                 :induct (set::intersect x y)
@@ -981,4 +981,3 @@ instances."
                     (force (vl-ealist-p eal)))
                (good-esim-occsp (mv-nth 2 ret))))
     :hints(("Goal" :in-theory (enable good-esim-occsp)))))
-

--- a/books/centaur/misc/alist-canonicalize.lisp
+++ b/books/centaur/misc/alist-canonicalize.lisp
@@ -168,7 +168,7 @@
                      :in-theory (disable member-of-hons-assoc-equal))))
                `(:use ((:instance duplicates-p-by-member
                         (k ,(hq pair1))
-                        (x (set::mergesort x)))                     
+                        (x (set::mergesort x)))
                        (:instance mark-clause-is-true (x 'pairs-equal)))))))
     :otf-flg t))
 
@@ -227,7 +227,7 @@
   (local (defthm member-atom-when-maybe-improper-alistp
            (implies (and (maybe-improper-alistp x) (atom k))
                     (not (member k x)))))
-                    
+
 
 
 
@@ -363,22 +363,22 @@
 (define set-diff-witness ((x set::setp) (y set::setp))
   :guard (not (equal x y))
   :returns (memb)
-  
+
   :prepwork ((local (in-theory (enable set::double-containment)))
              (local (defthm member-equal-when-setp
                       (implies (set::setp x)
                                (iff (member-equal k x)
                                     (set::in k x)))
-                      :hints(("Goal" :in-theory (enable set::in set::tail Set::head set::setp set::empty)))))
+                      :hints(("Goal" :in-theory (enable set::in set::tail Set::head set::setp set::emptyp)))))
              (local (defthm head-of-difference-in-y
-                      (implies (not (set::empty (set::difference x y)))
+                      (implies (not (set::emptyp (set::difference x y)))
                                (not (set::in (set::head (set::difference x y)) y)))
                       :hints(("Goal" :use ((:instance set::difference-in
                                             (a (set::head (set::difference x y)))
                                             (x x) (y y)))
                               :in-theory (disable set::difference-in)))))
              (local (defthm head-of-difference-in-x
-                      (implies (not (set::empty (set::difference x y)))
+                      (implies (not (set::emptyp (set::difference x y)))
                                (set::in (set::head (set::difference x y)) x))
                       :hints(("Goal" :use ((:instance set::difference-in
                                             (a (set::head (set::difference x y)))
@@ -486,5 +486,3 @@
               (set::setp x)
               (no-duplicatesp-equal (alist-keys x))))
   :hints(("Goal" :cases ((canonical-alist-p x)))))
-
-

--- a/books/centaur/misc/osets-witnessing.lisp
+++ b/books/centaur/misc/osets-witnessing.lisp
@@ -51,7 +51,7 @@
 ;;  (set::use-osets-reasoning)
 
 ;; What does this strategy do?  We think of the set predicates subset,
-;; intersectp, empty, and equal as involving quantifiers.  For example,
+;; intersectp, emptyp, and equal as involving quantifiers.  For example,
 ;; (subset x y) really means (forall a (implies (in a x) (in a y))).
 
 ;; We do two things with this quantifier-based interpretation of each
@@ -77,7 +77,7 @@
 ;;  (intersectp x y)         (and (in a x) (in a y))
 ;;  (not (equal x y))        (implies (and (setp x) (setp y))
 ;;                                    (xor (in a x) (in a y)))
-;;  (not (empty x))          (not (in a x)).
+;;  (not (emptyp x))         (not (in a x)).
 
 ;; For a positive occurrence -- think of a (subset a b) hypothesis -- we may
 ;; instantiate the implicit quantified formula one or more times, depending
@@ -105,7 +105,7 @@
 ;; (subset x y)               (implies (in a x) (in a y))
 ;; (not (intersectp x y))     (not (and (in a x) (in a y)))
 ;; (equal x y)                (iff (in a x) (in a y))
-;; (empty x)                  (not (in a x))
+;; (emptyp x)                 (not (in a x))
 
 ;; After we do these replacements, we're done.  What does this get us?
 ;; Basically, we've reduced all our implicit quantifiers to a bunch of IN
@@ -171,7 +171,7 @@
 
 (defun nonsubset-witness (x y)
   (declare (xargs :guard (and (setp x) (setp y))))
-  (if (empty x)
+  (if (emptyp x)
       nil
     (if (in (head x) y)
         (nonsubset-witness (tail x) y)
@@ -189,7 +189,7 @@
 
 (defun intersectp-witness (x y)
   (declare (xargs :guard (and (setp x) (setp y))))
-  (if (empty x)
+  (if (emptyp x)
       nil
     (if (in (head x) y)
         (head x)
@@ -221,10 +221,10 @@
 
 (defun nonempty-witness (x)
   (declare (xargs :guard (setp x)))
-  (if (empty x) nil (head x)))
+  (if (emptyp x) nil (head x)))
 
 (defthmd nonempty-witness-correct
-  (iff (empty x)
+  (iff (emptyp x)
        (not (in (nonempty-witness x) x))))
 
 
@@ -257,7 +257,7 @@
   :generalize (((osets-unequal-witness x y) . uneqw)))
 
 (acl2::defwitness empty-witnessing
-  :predicate (not (empty x))
+  :predicate (not (emptyp x))
   :expr (in (nonempty-witness x) x)
   :hints ('(:in-theory '(nonempty-witness-correct)))
   :generalize (((nonempty-witness x) . nempw)))
@@ -285,7 +285,7 @@
   :hints ('(:in-theory nil)))
 
 (acl2::definstantiate empty-instancing
-  :predicate (empty x)
+  :predicate (emptyp x)
   :vars (a)
   :expr (not (in a x))
   :hints ('(:in-theory '(never-in-empty))))
@@ -402,7 +402,7 @@
 
 (defthmd nonempty-when-in
   (implies (in a x)
-           (not (empty x))))
+           (not (emptyp x))))
 
 (defthmd in-tail-to-in-x
   (equal (in a (tail x))
@@ -418,11 +418,11 @@
 (defthmd in-of-cons
   (equal (in a (cons b y))
          (and (setp y)
-              (or (empty y)
+              (or (emptyp y)
                   (<< b (head y)))
               (or (equal a b)
                   (in a y))))
-  :hints(("Goal" :in-theory (enable setp head tail empty)
+  :hints(("Goal" :in-theory (enable setp head tail emptyp)
           :expand ((in a (cons b y)))
           :do-not-induct t)))
 
@@ -435,11 +435,11 @@
     insert-head-tail
     repeated-insert
     insert-sfix-cancel
-    head-when-empty
-    insert-when-empty
+    head-when-emptyp
+    insert-when-emptyp
     head-of-insert-a-nil
     tail-of-insert-a-nil
-    sfix-when-empty
+    sfix-when-emptyp
     subset-membership-tail
     in-tail-or-head
     insert-identity
@@ -449,13 +449,13 @@
     subset-sfix-cancel-y
     subset-in
     subset-in-2
-    empty-subset
-    empty-subset-2
+    emptyp-subset
+    emptyp-subset-2
     subset-reflexive
     subset-insert
     subset-tail
     delete-delete
-    delete-preserves-empty
+    delete-preserves-emptyp
     delete-sfix-cancel
     delete-nonmember-cancel
     repeated-delete
@@ -470,9 +470,9 @@
     union-delete-y
     union-sfix-cancel-x
     union-sfix-cancel-y
-    union-empty-x
-    union-empty-y
-    union-empty
+    union-emptyp-x
+    union-emptyp-y
+    union-emptyp
     union-subset-x
     union-subset-y
     union-self
@@ -485,8 +485,8 @@
     intersect-delete-y
     intersect-sfix-cancel-x
     intersect-sfix-cancel-y
-    intersect-empty-x
-    intersect-empty-y
+    intersect-emptyp-x
+    intersect-emptyp-y
     intersect-subset-x
     intersect-subset-y
     intersect-self
@@ -497,8 +497,8 @@
     intersect-outer-cancel
     difference-sfix-x
     difference-sfix-y
-    difference-empty-x
-    difference-empty-y
+    difference-emptyp-x
+    difference-emptyp-y
     difference-subset-x
     subset-difference
     difference-over-union
@@ -513,7 +513,7 @@
     in-tail))
 
 (acl2::def-ruleset! osets-defs
-  '(setp in empty subset
+  '(setp in emptyp subset
          insert delete intersect union difference
          head tail))
 
@@ -585,15 +585,15 @@
 
    ;; lemmas from sets.lisp
    (defthmd insert-never-empty-lemma
-     (not (empty (insert a X))))
+     (not (emptyp (insert a X))))
 
    (defthmd insert-head-lemma
-     (implies (not (empty X))
+     (implies (not (emptyp X))
               (equal (insert (head X) X)
                      X)))
 
    (defthmd insert-head-tail-lemma
-     (implies (not (empty X))
+     (implies (not (emptyp X))
               (equal (insert (head X) (tail X))
                      X)))
 
@@ -607,14 +607,14 @@
 
    ;; this one doesn't really fit with these -- it's more of an
    ;; implementation detail than a property of sets
-   ;;(defthmd head-when-empty-lemma
-   ;;  (implies (empty X)
+   ;;(defthmd head-when-emptyp-lemma
+   ;;  (implies (emptyp X)
    ;;           (equal (head X)
    ;;                  nil)))
 
-   (defthmd insert-when-empty-lemma
+   (defthmd insert-when-emptyp-lemma
      (implies (and (syntaxp (not (equal X ''nil)))
-                   (empty X))
+                   (emptyp X))
               (equal (insert a X)
                      (insert a nil))))
 
@@ -630,8 +630,8 @@
    ;;         nil))
 
    ;; ;;same thing here
-   ;;(defthmd sfix-when-empty-lemma
-   ;;  (implies (empty X)
+   ;;(defthmd sfix-when-emptyp-lemma
+   ;;  (implies (emptyp X)
    ;;           (equal (sfix X)
    ;;                  nil)))
 
@@ -695,14 +695,14 @@
                         (subset X Y))
                    (not (in a X)))))
 
-   (defthmd empty-subset-lemma
-     (implies (empty X)
+   (defthmd emptyp-subset-lemma
+     (implies (emptyp X)
               (subset X Y)))
 
-   (defthmd empty-subset-2-lemma
-     (implies (empty Y)
+   (defthmd emptyp-subset-2-lemma
+     (implies (emptyp Y)
               (iff (subset X Y)
-                   (empty X))))
+                   (emptyp X))))
 
    (defthmd subset-reflexive-lemma
      (subset X X))
@@ -721,9 +721,9 @@
             (delete b (delete a X)))
      :rule-classes ((:rewrite :loop-stopper ((a b)))))
 
-   (defthmd delete-preserves-empty-lemma
-     (implies (empty X)
-              (empty (delete a X))))
+   (defthmd delete-preserves-emptyp-lemma
+     (implies (emptyp X)
+              (emptyp (delete a X))))
 
    (defthmd delete-in-lemma
      (equal (in a (delete b X))
@@ -788,17 +788,17 @@
    (defthmd union-sfix-cancel-Y-lemma
      (equal (union X (sfix Y)) (union X Y)))
 
-   (defthmd union-empty-X-lemma
-     (implies (empty X)
+   (defthmd union-emptyp-X-lemma
+     (implies (emptyp X)
               (equal (union X Y) (sfix Y))))
 
-   (defthmd union-empty-Y-lemma
-     (implies (empty Y)
+   (defthmd union-emptyp-Y-lemma
+     (implies (emptyp Y)
               (equal (union X Y) (sfix X))))
 
-   (defthmd union-empty-lemma
-     (iff (empty (union X Y))
-          (and (empty X) (empty Y))))
+   (defthmd union-emptyp-lemma
+     (iff (emptyp (union X Y))
+          (and (emptyp X) (emptyp Y))))
 
    (defthmd union-in-lemma
      (iff (in a (union X Y))
@@ -849,11 +849,11 @@
    (defthmd intersect-sfix-cancel-Y-lemma
      (equal (intersect X (sfix Y)) (intersect X Y)))
 
-   (defthmd intersect-empty-X-lemma
-     (implies (empty X) (empty (intersect X Y))))
+   (defthmd intersect-emptyp-X-lemma
+     (implies (emptyp X) (emptyp (intersect X Y))))
 
-   (defthmd intersect-empty-Y-lemma
-     (implies (empty Y) (empty (intersect X Y))))
+   (defthmd intersect-emptyp-Y-lemma
+     (implies (emptyp Y) (emptyp (intersect X Y))))
 
    (defthmd intersect-in-lemma
      (equal (in a (intersect X Y))
@@ -895,12 +895,12 @@
    (defthmd difference-sfix-Y-lemma
      (equal (difference X (sfix Y)) (difference X Y)))
 
-   (defthmd difference-empty-X-lemma
-     (implies (empty X)
+   (defthmd difference-emptyp-X-lemma
+     (implies (emptyp X)
               (equal (difference X Y) (sfix X))))
 
-   (defthmd difference-empty-Y-lemma
-     (implies (empty Y)
+   (defthmd difference-emptyp-Y-lemma
+     (implies (emptyp Y)
               (equal (difference X Y) (sfix X))))
 
    (defthmd difference-in-lemma
@@ -912,7 +912,7 @@
      (subset (difference X Y) X))
 
    (defthmd subset-difference-lemma
-     (iff (empty (difference X Y))
+     (iff (emptyp (difference X Y))
           (subset X Y)))
 
    (defthmd difference-over-union-lemma
@@ -951,7 +951,7 @@
    (defthmd insert-induction-case-lemma
      (implies (and (not (<< a (head X)))
                    (not (equal a (head X)))
-                   (not (empty X)))
+                   (not (emptyp X)))
               (equal (insert (head X) (insert a (tail X)))
                      (insert a X))))
 
@@ -965,4 +965,3 @@
    (defthmd in-tail-lemma
      (implies (in a (tail x))
               (in a x)))))
-

--- a/books/centaur/sv/svex/override-syntax-check.lisp
+++ b/books/centaur/sv/svex/override-syntax-check.lisp
@@ -53,7 +53,7 @@
        (key (svar-change-override key nil))
        ((unless (and (svar-equiv-nonoverride test.name key)
                      (svar-override-p test.name :test)))
-        nil) 
+        nil)
        ((unless (svex-case then :var))
         ;; bad
         key)
@@ -88,7 +88,7 @@
        ((unless (and (svarlist-member-nonoverride test.name keys)
                      (svar-override-p test.name :test)))
         nil)
-       (key (svar-change-override test.name nil)) 
+       (key (svar-change-override test.name nil))
        ((unless (svex-case then :var))
         ;; bad
         key)
@@ -151,7 +151,7 @@
                               equal-of-svar-change-override
                               svar-equiv-nonoverride)
                              (<fn>))))))
- 
+
 
 
 (defines svex-overridekey-syntax-check
@@ -207,7 +207,7 @@
       (or (svex-overridekey-syntax-check (car x) key value)
           (svexlist-overridekey-syntax-check (cdr x) key value))))
   ///
-  
+
 
   (fty::deffixequiv-mutual svex-overridekey-syntax-check)
 
@@ -300,11 +300,11 @@
   (local (in-theory (disable svex-overridekeys-syntax-check
                              svex-call-overridekeys-syntax-check
                              svexlist-overridekeys-syntax-check)))
-  
+
   (local (defthm setp-of-singleton
            (setp (list x))
            :hints(("Goal" :in-theory (enable setp)))))
-  
+
   (std::defret-mutual setp-of-<fn>
     :mutual-recursion svex-overridekeys-syntax-check
     (defret setp-of-<fn>
@@ -324,7 +324,7 @@
 
   (verify-guards svex-overridekeys-syntax-check)
 
-  
+
 
   (local (defthm svex-eval-when-var
            (implies (svex-case x :var)
@@ -343,7 +343,7 @@
                            (svex-eval (svex-lookup v x) env)))))
 
   (local (in-theory (disable svex-env-lookup-of-svex-alist-eval)))
-  
+
   (local (defthm overridekeys-transparent-p-when-bit?!-overridekeys-syntax-check
            (implies (and (svex-case x :call)
                          (equal (svex-call->fn x) 'bit?!)
@@ -383,7 +383,7 @@
                 (or (sfix a) (sfix b)))
            :hints(("Goal" :in-theory (enable union)))))
 
-    
+
   (std::defret-mutual overridekeys-transparent-p-when-<fn>
     (defret overridekeys-transparent-p-when-<fn>
       (b* (((overridekey-syntaxcheck-data data)))
@@ -403,7 +403,7 @@
       :hints ('(:expand (<call>))
               (and stable-under-simplificationp
                    '(:expand ((:free (env) (svex-eval x env)))
-                     :in-theory (enable svexlist-vars 
+                     :in-theory (enable svexlist-vars
                                         svex-overridekey-transparent-p-when-args-transparent
                                         ;; svex-override-triple-check
                                         ))))
@@ -437,14 +437,14 @@
   (local (defthm in-of-singleton
            (iff (in b (list a))
                 (equal a b))
-           :hints(("Goal" :in-theory (enable in empty head tail)))))
+           :hints(("Goal" :in-theory (enable in emptyp head tail)))))
 
   (local (defthm insert-nil
            (equal (insert a nil) (list a))
            :hints(("Goal" :in-theory (enable set::pick-a-point-subset-strategy
                                              double-containment)))))
-           
-  
+
+
   (local (defthm set-lemma4
            (equal (insert a (list a)) (list a))
            :hints(("Goal" :in-theory (enable set::pick-a-point-subset-strategy
@@ -527,7 +527,7 @@
                             (svexlist-overridekey-syntax-check (cddr args)  key value)
                             (svexlist-overridekey-syntax-check (cdddr args) key value))))))
 
-  
+
   (std::defret-mutual <fn>-in-terms-of-overridekey-syntax-check
     (defretd <fn>-in-terms-of-overridekey-syntax-check
       (equal <call>
@@ -632,7 +632,7 @@
                                                                  keys values))))))))
 
     (fty::deffixequiv-mutual svex-overridekeys-syntax-check)
-    
+
     (defthm svexlist-override-syntax-check-subsetp-of-keys
       (subsetp-equal
        (svexlist-overridekeys-syntax-check x data)
@@ -642,7 +642,3 @@
                              (values (overridekey-syntaxcheck-data->values data)))))))
 
     (memoize 'svex-call-overridekeys-syntax-check))
-
-
-
-

--- a/books/centaur/sv/svex/override-types.lisp
+++ b/books/centaur/sv/svex/override-types.lisp
@@ -31,7 +31,7 @@
 (local (include-book "std/lists/sets" :dir :system))
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 (local (include-book "data-structures/no-duplicates" :dir :system))
-(local (std::add-default-post-define-hook :fix))  
+(local (std::add-default-post-define-hook :fix))
 
 
 (define svar->override-val ((x svar-p))
@@ -76,7 +76,7 @@
       (:test (eql bits 2))
       (t (eql bits type))))
   ///
-  
+
 
   (defthmd svar-override-p-when-other
     (implies (and (svar-override-p x type2)
@@ -179,7 +179,7 @@
                                     (acl2::element-list-p (lambda (x) (svarlist-nonoverride-p* x types))))
                          (x x) (y x-equiv)))
            :in-theory (enable svarlist-nonoverride-p*)))))
-  
+
 
 (define svar-change-override ((x svar-p)
                               (type svar-overridetype-p))
@@ -202,7 +202,7 @@
                          (integerp x))
                     (unsigned-byte-p 3 x))
            :hints(("Goal" :in-theory (enable unsigned-byte-p)))))
-  
+
   (defret svar-override-p-of-<fn>
     (iff (svar-override-p new-x other-type)
          (svar-overridetype-equiv other-type type))
@@ -228,7 +228,7 @@
                        (equal (ifix y) (logtail n z))))
            :hints(("Goal" :in-theory (enable* bitops::ihsext-inductions
                                               bitops::ihsext-recursive-redefs)))))
-  
+
   (defthmd equal-of-svar-change-override
     (implies (syntaxp (not (and (equal type ''nil))))
              (equal (equal v1 (svar-change-override v2 type))
@@ -266,7 +266,7 @@
              (svar-overridetype-equiv other-type type)))
     :hints(("Goal" :in-theory (enable svarlist-override-p))))
 
-  
+
   (defthm svarlist-change-override-when-override-p
     (implies (svarlist-override-p x type)
              (equal (svarlist-change-override x type) (svarlist-fix x)))
@@ -474,7 +474,7 @@
                     (equal (svar-fix testvar1) (svar-fix testvar2)))))
 
 
-  
+
 
   (local (Defthm member-vars-when-member-has-test-var
            (implies (and (member-equal trip (svex-override-triplelist-fix x))
@@ -528,7 +528,7 @@
                     (svex-override-triplelist-lookup var x)))
     :hints (("goal" :use ((:instance lookup-test-when-set-equiv-and-no-duplicate-vars
                            (y (mergesort x)))))))
-  
+
 
 
   (local (Defthm member-vars-when-member-has-val-var
@@ -582,7 +582,7 @@
                       (equal k trip.valvar)
                       (member k (svex-override-triplelist-vars (sfix x))))))
            :hints(("Goal" :in-theory (enable svex-override-triplelist-vars
-                                             insert head empty tail sfix setp)))))
+                                             insert head emptyp tail sfix setp)))))
 
   (local (defthm insert-preserves-no-duplicate-vars
            (implies (b* (((svex-override-triple trip))
@@ -594,7 +594,7 @@
                     (no-duplicatesp-equal (svex-override-triplelist-vars (insert trip x))))
            :hints(("Goal" :in-theory (enable insert
                                              svex-override-triplelist-vars
-                                             head empty tail)))))
+                                             head emptyp tail)))))
 
   (defthm mergesort-preserves-member-vars
     (iff (member k (svex-override-triplelist-vars (mergesort x)))
@@ -669,8 +669,8 @@
                   (or (equal k trip.testvar)
                       (member k (svex-override-triplelist-testvars (sfix x))))))
            :hints(("Goal" :in-theory (enable svex-override-triplelist-testvars
-                                             insert head empty tail sfix setp)))))
-  
+                                             insert head emptyp tail sfix setp)))))
+
   (defthm mergesort-preserves-member-testvars
     (iff (member k (svex-override-triplelist-testvars (mergesort x)))
          (member k (svex-override-triplelist-testvars x)))
@@ -793,7 +793,7 @@
                                       svar->svex-override-triplelist
                                       svar->svex-override-triple))))
 
-  
+
   (defthm svar-override-triplelist->testvars-subset-of-override-vars
     (subsetp-equal (svar-override-triplelist->testvars x) (svar-override-triplelist-override-vars x))
     :hints(("Goal" :in-theory (enable svar-override-triplelist-override-vars svar-override-triplelist->testvars)))))

--- a/books/centaur/sv/svex/override.lisp
+++ b/books/centaur/sv/svex/override.lisp
@@ -64,7 +64,7 @@
     (implies (4vec-no-1s-p x)
              (equal (4vec-1mask x) 0))
     :hints(("Goal" :in-theory (enable 4vec-1mask))))
-  
+
   (defthm bit?!-when-4vec-no-1s-p
     (implies (4vec-no-1s-p test)
              (equal (4vec-bit?! test override-val real-val)
@@ -74,8 +74,8 @@
 
 
 
-     
-      
+
+
 
 (local
  (defthm bit?!-when-branches-same
@@ -83,7 +83,7 @@
           (4vec-fix real-val))
    :hints(("Goal" :in-theory (enable 4vec-bit?! 4vec-bitmux))
           (bitops::logbitp-reasoning))))
- 
+
 (local (defthm equal-of-4vec-bit?!-by-example
          (implies (equal (4vec-bit?! test then1 else1) (4vec-bit?! test then2 else1))
                   (equal (equal (4vec-bit?! test then1 else2) (4vec-bit?! test then2 else2))
@@ -101,7 +101,7 @@
          :hints (("goal" :use ((:instance equal-of-4vec-bit?!-by-example
                                 (else2 then2)))
                   :in-theory (disable equal-of-4vec-bit?!-by-example)))))
-       
+
 
 (local (defthm svex-env-lookup-of-cons
          (equal (svex-env-lookup key (cons pair rest))
@@ -130,7 +130,7 @@
              (4vec-no-1s-p (svex-env-lookup var env)))))
 
 
-                               
+
 
 (define svex-env-removekey ((key svar-p) (env svex-env-p))
   :returns (new-env svex-env-p)
@@ -269,7 +269,7 @@
 
   (defthm svex-override-triplelist-env-ok-of-nil
     (equal (svex-override-triplelist-env-ok nil env prev-env) t)))
-                              
+
 (define svex-override-triple-check ((test svex-p)
                                     (then svex-p)
                                     (else svex-p)
@@ -308,7 +308,7 @@
     t)
 
   ///
-  
+
   (defthm svex-override-triple-check-cdr-when-nil
     (implies (and (equal (svex-override-triple-check test then else x) nil)
                   (no-duplicatesp-equal (svex-override-triplelist-vars x)))
@@ -338,7 +338,7 @@
                     (or (svex-override-triple-check test then else trips1)
                         (svex-override-triple-check test then else trips2))))
     :hints (("goal" :do-not-induct t))))
-             
+
 
 
 
@@ -378,7 +378,7 @@
 ;;   2. The test variable's binding in the rest of the env is "false" (in this case, not 1)
 ;;      on all bits
 ;;   3. The override value's current binding in the env matches
-;;      (on the bits where test's binding is 1) the evaluation of the triple's value 
+;;      (on the bits where test's binding is 1) the evaluation of the triple's value
 ;;      expression on the rest of the env.
 
 ;; This test is probably efficient enough, and could be changed to use fast
@@ -387,9 +387,9 @@
 ;;   1 -- Syntactically, the theorem just says we can take two pairs out of the env.
 ;;        Of course, the envs here occur under a svex-envs-similar context so this is
 ;;        relatively easy to expand.
-;;   2 -- In practice we're going to have an evaluation involving an environment where 
+;;   2 -- In practice we're going to have an evaluation involving an environment where
 ;;        several overrides are added to a previous environment, and each of the override
-;;        values is an evaluation of the corresponding variable's expression 
+;;        values is an evaluation of the corresponding variable's expression
 ;;        using the previous environment.  This doesn't quite
 ;;        correspond to an iterative application of this theorem -- we need to whow that
 ;;        these expressions are independent of the other overrides, or at least can be
@@ -442,7 +442,7 @@
         (if first
             (cons (lnfix n) first)
           (svex-args-check-overridetriples (1+ (lnfix n)) (cdr x) triples)))))
-  
+
   (define svexlist-check-overridetriples ((x svexlist-p)
                                           (triples svex-override-triplelist-p))
     :measure (two-nats-measure (svexlist-count x) 0)
@@ -459,7 +459,7 @@
            (if (atom x)
                n
              (count-up-cdr-down (1+ (nfix n)) (cdr x)))))
-  
+
   (defthm svex-args-check-overridetriples-under-iff
     (iff (svex-args-check-overridetriples n x triples)
          (svexlist-check-overridetriples x triples))
@@ -519,7 +519,7 @@
                 (equal (4vec-bit?! testval valval exprval)
                        exprval)))))
 
-  
+
   (std::defret-mutual remove-override-vars-when-check-overridetriples
     (defret remove-override-vars-when-<fn>
       (b* ((vars  (svex-override-triplelist-vars triples))
@@ -569,7 +569,7 @@
                         (svexlist-eval x env))))
       :hints ('(:expand <call>))
       :fn svex-args-check-overridetriples))
-  
+
 
 
   ;; )
@@ -742,8 +742,8 @@
       :fn svex-args-check-overridetriples))
 
 
-  
-  
+
+
   (local (defthm svexlist-check-overridetriples-when-svex-override-triple-check-is-t
            (implies (and (equal (svex-override-triple-check (car args)
                                                             (cadr args)
@@ -855,7 +855,7 @@
            (implies (and (equal (svex-override-triple-check test then else triples)
                                 t)
                          ;; (svex-override-triple-check test then else trips2)
-                         (not (intersectp-equal 
+                         (not (intersectp-equal
                                (svex-override-triplelist-vars triples)
                                (svex-override-triplelist-vars trips2))))
                     (not (svex-override-triple-check test then else trips2)))
@@ -868,7 +868,7 @@
                                                             (caddr args)
                                                             triples)
                                 t)
-                         (not (intersectp-equal 
+                         (not (intersectp-equal
                                (svex-override-triplelist-vars triples)
                                (svex-override-triplelist-vars trips2)))
                          (equal (len args) 3))
@@ -899,11 +899,11 @@
                 x
               (list (svex-check-overridetriples-ind (car x))
                     (svexlist-check-overridetriples-ind (cdr x)))))))
-  
+
   (flag::make-flag svex-check-overridetriples-ind-flag
                    svex-check-overridetriples-ind
                    :local t)
-                      
+
 
   (defthm-svex-check-overridetriples-ind-flag
     (defthm svex-check-overridetriples-of-append
@@ -969,7 +969,7 @@
      :hints (("goal" :use ((:instance svex-override-triplelist-env-ok-implies-lookup
                             (override-env override-env1)))
               :in-theory (disable svex-override-triplelist-env-ok-implies-lookup)))))
-  
+
 
   (std::defret-mutual un-append-override-vars-when-check-overridetriples
     (defret un-append-override-vars-when-<fn>
@@ -1035,7 +1035,7 @@
                               (svexlist-eval (svex-alist-vals x) env)))
              :hints(("Goal" :in-theory (enable svex-alist-vals svex-alist-keys svex-alist-eval
                                                svexlist-eval)))))
-    
+
     (defthm un-append-override-vars-from-svex-alist-eval-when-svexlist-check-overridetriples
       (b* ((vars  (svex-override-triplelist-vars triples))
            (env (append (svex-env-extract vars override-env) prev-env)))
@@ -1046,13 +1046,13 @@
                       (svex-override-triplelist-env-ok triples env prev-env))
                  (equal (svex-alist-eval x env)
                         (svex-alist-eval x prev-env))))))
-  
-  
+
+
   (fty::deffixequiv-mutual svex-check-overridetriples))
 
 
 (defsection overridekey-transparent-p-when-check-overridetriples
-  
+
 
   (local (defthm open-nth
            (implies (syntaxp (quotep n))
@@ -1060,7 +1060,7 @@
                            (if (zp n)
                                (car x)
                              (nth (1- n) (cdr x)))))))
-  
+
   (local (defthm svex-override-triplelist-lookup-of-svar->svex
            (equal (svex-override-triplelist-lookup test (svar->svex-override-triplelist (svarlist-to-override-triples overridekeys) values))
                   (and (svar-override-p test :test)
@@ -1099,7 +1099,7 @@
                            (svex-env-lookup (svex-var->name x) env)))
            :hints(("Goal" :in-theory (enable svex-eval)))))
 
-  
+
   (local (defthm overridekeys-transparent-p-when-svex-override-triple-check
            (implies (and (svex-overridekey-transparent-p else overridekeys values)
                          (equal (svex-override-triple-check
@@ -1123,8 +1123,8 @@
 
   (local (defthm sfix-of-singleton
            (equal (sfix (list x)) (list x))
-           :hints(("Goal" :in-theory (enable sfix empty setp)))))
-  
+           :hints(("Goal" :in-theory (enable sfix emptyp setp)))))
+
   (local (defthm overridekeys-transparent-p-when-svex-override-triple-check-special
            ;; ugh
            (implies (and (svex-case x :call)
@@ -1155,7 +1155,7 @@
                     ))
            :otf-flg t))
 
-  
+
   (std::defret-mutual overridekeys-transparent-p-when-check-overridetriples
     (defret overridekeys-transparent-p-when-<fn>
       :pre-bind ((svar-triples (svarlist-to-override-triples overridekeys))
@@ -1176,7 +1176,7 @@
       :hints ('(:expand ((:free (triples) <call>)))
               (and stable-under-simplificationp
                    '(:expand ((:free (env) (svex-eval x env)))
-                     :in-theory (enable svexlist-vars 
+                     :in-theory (enable svexlist-vars
                                         svex-overridekey-transparent-p-when-args-transparent
                                         ;; svex-override-triple-check
                                         ))))
@@ -1246,7 +1246,7 @@
                             (svexlist-eval (svex-alist-vals x) env)))
            :hints(("Goal" :in-theory (enable svex-alist-vals svex-alist-keys svex-alist-eval
                                              svexlist-eval)))))
-    
+
   (defthmd svex-alist-eval-when-svexlist-check-overridetriples-and-svex-envs-agree-except-overrides
     (b* ((vars  (svex-override-triplelist-vars triples)))
       (implies (and (svex-override-triplelist-env-ok triples env prev-env)
@@ -1300,7 +1300,7 @@
                              (svexlist-check-overridetriples x b)
                              (svexlist-check-overridetriples x c))))
            :hints(("Goal" :in-theory (enable svex-override-triplelist-vars-of-append)))))
-  
+
   (defthmd svexlist-check-overridetriples-of-singleton
     (implies (and (not (svexlist-check-overridetriples x triples))
                   (no-duplicatesp-equal (svex-override-triplelist-vars triples))
@@ -1363,7 +1363,7 @@
              (svexlist-check-overridetriples x triples))
     :hints(("Goal" :in-theory (enable svexlist-check-overridetriples-expand-consp)
             :expand ((svex-override-triplelist-vars triples))))))
-             
+
 
 (defthmd svexlist-check-overridetriples-when-subset
   (implies (and (not (svexlist-check-overridetriples x triples))
@@ -1406,7 +1406,7 @@
              (local (Defthm intersect-single
                       (equal (intersect (list k) x)
                              (and (set::in k x) (list k)))
-                      :hints(("Goal" :in-theory (enable intersect empty head tail setp insert)
+                      :hints(("Goal" :in-theory (enable intersect emptyp head tail setp insert)
                               :expand ((intersect (list k) x))))))
 
              (local (defthm hons-assoc-equal-under-iff
@@ -1477,7 +1477,7 @@
            (equal (4vec-bit?! testval valval 0)
                   (4vec-bit?! testval refval 0)))
          (svar-override-triplelist-env-ok (cdr x) override-env ref-env)))
-      
+
   ///
   (defthm svar-override-triplelist-env-ok-in-terms-of-svex-override-triplelist-env-ok
     (equal (svar-override-triplelist-env-ok x override-env (svex-alist-eval values prev-env))
@@ -1489,7 +1489,7 @@
                                       svar->svex-override-triplelist))))
 
   (local (in-theory (enable svex-env-boundp-iff-member-alist-keys)))
-  
+
   (defthm svar-override-triplelist-env-ok-of-append-ref-envs-when-subsetp-first
     (implies (subsetp-equal (svar-override-triplelist->refvars x)
                             (alist-keys (svex-env-fix ref-env)))
@@ -1674,11 +1674,11 @@
            (4vec-<<= (4vec-bit?! testval valval 0)
                      (4vec-bit?! testval refval 0)))
          (svar-override-triplelist-env-ok-<<= (cdr x) override-env ref-env)))
-      
+
   ///
 
   (local (in-theory (enable svex-env-boundp-iff-member-alist-keys)))
-  
+
   (defthm svar-override-triplelist-env-ok-<<=-of-append-ref-envs-when-subsetp-first
     (implies (subsetp-equal (svar-override-triplelist->refvars x)
                             (alist-keys (svex-env-fix ref-env)))
@@ -1725,7 +1725,7 @@
                              bitops::logior-<-0-linear-1
                              bitops::logand->=-0-linear-2
                              bitops::logior->=-0-linear)))
-  
+
   (local (defthm 4vec-<<=-of-bit?!
            (implies (4vec-<<= then1 then2)
                     (4vec-<<= (4vec-bit?! test then1 else) (4vec-bit?! test then2 else)))
@@ -1743,7 +1743,7 @@
                     (not (member-equal v (svar-override-triplelist->valvars x))))
            :hints(("Goal" :in-theory (enable svar-override-triplelist-override-vars
                                              svar-override-triplelist->valvars)))))
-  
+
   (defthm svar-override-triplelist-env-ok-<<=-when-valvars-<<=-map
     (implies (and (no-duplicatesp-equal (svar-override-triplelist-override-vars x))
                   (svex-env-<<=
@@ -1816,7 +1816,7 @@
                                   (svar-override-triplelist->valvars triples)))
            :hints(("Goal" :in-theory (enable svar-override-triplelist->valvars
                                              svar-override-triplelist-fix)))))
-  
+
   (local (defthm lookup-valvar-of-valvar-when-member
            (implies (and (member-equal (svar-override-triple-fix trip)
                                        (svar-override-triplelist-fix triples))
@@ -1838,7 +1838,7 @@
            :hints(("Goal" :in-theory (enable svar-override-triplelist->testvars
                                              svar-override-triplelist-fix)))))
 
-  
+
   (defret svar-override-triplelist-env-ok-of-<fn>
     (implies (and (subsetp-equal (svar-override-triplelist->refvars triples)
                                  (alist-keys (svex-env-fix spec-run)))
@@ -1855,7 +1855,7 @@
                                       svar-override-triplelist-fix)
             :induct (len trips))))
 
-  
+
   (defret intermediate-override-env-=>>-lemma-env
     (implies (and (svex-env-<<= (svex-env-removekeys
                                  (svar-override-triplelist-override-vars triples)
@@ -1961,7 +1961,7 @@
                                   (svar-override-triplelist->valvars triples)))
            :hints(("Goal" :in-theory (enable svar-override-triplelist->valvars
                                              svar-override-triplelist-fix)))))
-  
+
   (local (defthm lookup-valvar-of-valvar-when-member
            (implies (and (member-equal (svar-override-triple-fix trip)
                                        (svar-override-triplelist-fix triples))
@@ -2013,13 +2013,13 @@
                              bitops::logior-<-0-linear-1
                              bitops::logand->=-0-linear-2
                              bitops::logior->=-0-linear)))
-  
+
   (local (defthm 4vec-<<=-of-bit?!-lemma
            (implies (4vec-<<= (4vec-bit?! test then1 else) (4vec-bit?! test then2 else))
                     (4vec-<<= then1 (4vec-bit?! test then2 then1)))
            :hints(("Goal" :in-theory (enable 4vec-bit?! 4vec-<<= 4vec-bitmux))
                   (bitops::logbitp-reasoning))))
-  
+
   (defret svar-override-triplelist-env-ok-of-<fn>
     (implies (and (subsetp-equal (svar-override-triplelist->refvars triples)
                                  (alist-keys (svex-env-fix spec-run)))
@@ -2043,7 +2043,7 @@
            :hints(("Goal" :in-theory (enable svar-override-triplelist-fix
                                              svar-override-triplelist-lookup-valvar
                                              svar-override-triplelist->valvars)))))
-  
+
   (defret intermediate-override-env2-=>>-lemma-env
     (implies (and (svex-env-<<= (svex-env-removekeys
                                  (svar-override-triplelist-override-vars triples)
@@ -2120,4 +2120,3 @@
              (equal (svex-env-extract vars override-env)
                     (svex-env-extract vars lemma-env)))
     :hints(("Goal" :in-theory (enable svex-env-extract svarlist-fix)))))
-

--- a/books/centaur/sv/svtv/fsm-override-smart-check.lisp
+++ b/books/centaur/sv/svtv/fsm-override-smart-check.lisp
@@ -97,7 +97,7 @@
                   (union (mergesort a) (mergesort b)))
            :hints(("Goal" :in-theory (enable double-containment
                                              set::pick-a-point-subset-strategy)))))
-  
+
   (local (defthm svexlist-overridekeys-syntax-check-of-set-difference
            (equal (svexlist-overridekeys-syntax-check x (overridekey-syntaxcheck-data
                                                          (set-difference-equal (svarlist-change-override keys nil)
@@ -121,26 +121,26 @@
                                (svexlist-overridekeys-syntax-check
                                 x (overridekey-syntaxcheck-data (cons a b) values)))))))))
 
-  
 
-  
+
+
 
   (local (defthmd difference-of-union-lemma
-           (and (empty (difference x (union y x)))
-                (empty (difference x (union x y))))
+           (and (emptyp (difference x (union y x)))
+                (emptyp (difference x (union x y))))
            :hints(("Goal" :in-theory (e/d (double-containment
                                            set::pick-a-point-subset-strategy)
                                           (not))))))
-  
+
   (local (defthm difference-of-union-2
            (and (equal (difference x (union y x)) nil)
                 (equal (difference x (union x y)) nil))
            :hints (("goal" :use difference-of-union-lemma
-                    :in-theory (e/d (empty)
+                    :in-theory (e/d (emptyp)
                                     (set::union-subset-y
                                      set::subset-difference))))))
-  
-  
+
+
   (defret <fn>-correct
     (fsm-overridekey-transparent-p
      x (set-difference-equal (svarlist-change-override keys nil)
@@ -165,7 +165,7 @@
   (local (defthm set-diff-nil
            (set-equiv (set-difference-equal x nil) x)
            :hints(("Goal" :in-theory (enable acl2::set-unequal-witness-rw)))))
-  
+
   (defret <fn>-correct-when-no-bad-keys
     (implies (not bad-keys)
              (fsm-overridekey-transparent-p
@@ -219,7 +219,7 @@
            (iff (svex-alist-eval x env)
                 (svex-alist-keys x))
            :hints(("Goal" :in-theory (enable svex-alist-keys svex-alist-eval)))))
-  
+
   (defret <fn>-correct
     (implies (equal (svex-alist-keys x) (svex-alist-keys y))
              (equal (equal (svex-alist-eval new-x env)
@@ -242,7 +242,7 @@
 
   (defret len-of-<fn>
     (equal (len new-y) (len new-x)))
-  
+
   (local (in-theory (enable svex-alist-fix))))
 
 (define svex-alists-equivalence-prune-top ((x svex-alist-p)
@@ -320,7 +320,7 @@
                                 (pairlis$ keys vals2))))
            :hints (("Goal" :induct (list (pairlis$ keys vals1)
                                          (pairlis$ keys vals2))))))
-  
+
   (local (defthmd svex-alist-eval-in-terms-of-svexlist-eval
            (equal (svex-alist-eval x env)
                   (pairlis$ (svex-alist-keys x)
@@ -329,15 +329,15 @@
                                              svexlist-eval
                                              svex-alist-eval
                                              svex-alist-keys)))))
-  
+
   (local (defthm equal-of-svexlist-eval-svex-alist-vals
            (implies (equal (svex-alist-keys x) (svex-alist-keys y))
                     (equal (equal (svexlist-eval (svex-alist-vals x) env)
                                   (svexlist-eval (svex-alist-vals y) env))
                            (equal (svex-alist-eval x env) (svex-alist-eval y env))))
-           :hints (("goal" 
+           :hints (("goal"
                     :in-theory (enable svex-alist-eval-in-terms-of-svexlist-eval)))))
-                  
+
   (defret <fn>-correct
     (implies (equal (svex-alist-keys x) (svex-alist-keys y))
              (equal equiv
@@ -365,7 +365,7 @@
            (if (atom x)
                x1
              (ind (cdr x) (cdr x1)))))
-  
+
   (local (defthm equal-of-append
            (implies (and (true-listp x) (true-listp x1)
                          (equal (len x) (len x1)))
@@ -391,8 +391,8 @@
 
 (defchoose fsm-override-semantic-check-badguy (env) (x keys)
   (not (fsm-override-semantic-check-on-env x keys env)))
-  
-  
+
+
 
 
 (define fsm-override-semantic-check ((x fsm-p)
@@ -421,7 +421,7 @@
                   (equal (take (len x) y1)
                          (take (len x) y2)))
            :hints(("Goal" :in-theory (enable pairlis$ take)))))
-  
+
   (defthmd fsm-override-semantic-check-in-terms-of-badguy
     (equal (fsm-override-semantic-check x keys)
            (fsm-override-semantic-check-on-env
@@ -467,8 +467,8 @@
     (cw "The following keys failed the override syntax check: ~x0~%" bad-keys)
     (fsm-override-semantic-check-on-env x bad-keys env)))
 
-       
-       
+
+
 (defchoose fsm-override-smart-check-badguy (env) (x keys)
   (not (fsm-override-smart-check-on-env x keys env)))
 
@@ -533,7 +533,7 @@
                         y))
     :hints(("Goal" :in-theory (enable acl2::set-unequal-witness-rw))))
 
-  
+
   (defret fsm-overridekey-transparent-p-when-<fn>
     (b* (((fsm x)))
       (implies ok
@@ -564,7 +564,7 @@
       (& (fsm-overridekey-transparent-p-by-assumptions-collect-args fsm-term (cdr clause))))))
 
 (define nest-binary-appends (lst)
-  
+
   (if (atom lst)
       ''nil
     (if (atom (cdr lst))
@@ -577,7 +577,7 @@
            (xargs :stobjs state))
   (let ((args (fsm-overridekey-transparent-p-by-assumptions-collect-args fsm-term (mfc-clause mfc))))
     `((args . ,(nest-binary-appends args)))))
-    
+
 
 
 (defthm fsm-overridekey-transparent-p-when-subsetp
@@ -597,7 +597,7 @@
                  :use ((:instance overridekeys-envs-agree-implies
                         (overridekeys nil)
                         (v (svex-envs-similar-witness impl-env spec-env))))))))
-                        
+
 (defthm fsm-overridekey-transparent-p-of-empty-keys
   (fsm-overridekey-transparent-p fsm nil)
   :hints(("Goal" :in-theory (enable fsm-overridekey-transparent-p
@@ -669,7 +669,7 @@
             (fgl::disable-definition sv::svex-env-fix$inline)
             (fgl::disable-definition sv::svex-env-lookup)
             (memoize 'svex-mask-alist-p)
-       
+
             (:@ :default-aignet-transforms
              (defun tmp-svtv-generalize-fgl-transforms-config ()
                (declare (xargs :guard t
@@ -693,8 +693,8 @@
                :guard-hints (("goal" :in-theory '((booleanp))))
                (fgl::make-fgl-satlink-monolithic-sat-config :transform t))
              (defattach fgl::fgl-toplevel-sat-check-config tmp-svtv-generalize-monolithic-sat-with-transforms))
-       
-       
+
+
             (fgl::def-fgl-thm tmp-def-override-transparent-smart-check-fgl
               (fsm-override-smart-check-on-env <fsm> (tmp-override-transparent-keys) env)))
 
@@ -710,7 +710,7 @@
                             (syntaxp (quotep fsm-val)))
                        (equal <fsm> fsm-val))
               :hints (("goal" :in-theory '(force-execute)))))
-           
+
            (defthm tmp-def-override-transparent-smart-check
              (fsm-overridekey-transparent-p <fsm> (tmp-override-transparent-keys))
              (:@ :fgl-semantic-check
@@ -735,7 +735,7 @@
        (table def-override-transparent-table '<fsm>
               (cons (cons '<name> '<keys-val>)
                     (cdr (assoc-equal '<fsm> (table-alist 'def-override-transparent-table world))))))))
-       
+
 
 
 (defun def-override-transparent-fn (name fsm-expr keys-expr
@@ -806,8 +806,8 @@ provided, a semantic check using FGL and equivalence checking.</p>
    (defund my-keys1 () '(a b c))
 
    (def-override-transparent fsm-transparent1 :fsm (my-fsm) :keys (my-keys1))
-   
-       
+
+
    (defund my-keys2 () '(d b c))
 
    (def-override-transparent fsm-transparent2 :fsm (my-fsm) :keys (my-keys2))
@@ -816,4 +816,3 @@ provided, a semantic check using FGL and equivalence checking.</p>
    (defund my-keys3 () '(a b c d))
 
    (def-override-transparent fsm-transparent3 :fsm (my-fsm) :keys (my-keys3))))
-

--- a/books/centaur/vl/util/osets.lisp
+++ b/books/centaur/vl/util/osets.lisp
@@ -334,8 +334,7 @@
                            (set::x x)
                            (set::y y)))
           :do-not-induct t
-          :in-theory (e/d (empty)
+          :in-theory (e/d (emptyp)
                           (set::subset-difference
                            set::pick-a-point-subset-strategy))
           )))
-

--- a/books/centaur/vl2014/transforms/always/latchcode.lisp
+++ b/books/centaur/vl2014/transforms/always/latchcode.lisp
@@ -441,7 +441,7 @@ sanity checking."
        ((when warning)
         (mv x cvtregs (vl-warn-delta warning)))
        (lhs-scary (intersect lhs-names scary-regs))
-       ((unless (empty lhs-scary))
+       ((unless (emptyp lhs-scary))
         (mv x cvtregs
             (dwarn :type :vl-latchcode-fail
                    :msg "~a0: cowardly refusing to synthesize always block ~

--- a/books/centaur/vl2014/util/osets.lisp
+++ b/books/centaur/vl2014/util/osets.lisp
@@ -334,8 +334,7 @@
                            (set::x x)
                            (set::y y)))
           :do-not-induct t
-          :in-theory (e/d (empty)
+          :in-theory (e/d (emptyp)
                           (set::subset-difference
                            set::pick-a-point-subset-strategy))
           )))
-

--- a/books/coi/dtrees/base.lisp
+++ b/books/coi/dtrees/base.lisp
@@ -409,7 +409,7 @@
  ()
 
  (local (defun flat-countmap (domain map)
-          (if (set::empty domain)
+          (if (set::emptyp domain)
               1
             (+ (count (map::get (set::head domain) map))
                (flat-countmap (set::tail domain) map)))))
@@ -876,10 +876,10 @@
  ;; things up, so I'm just making it local for this proof.
  (local (defthm in-forward-to-nonempty
           (implies (set::in a x)
-                   (not (set::empty x)))
+                   (not (set::emptyp x)))
           :rule-classes :forward-chaining))
 
  (defthm empty-of-domain
-   (equal (set::empty (domain dtree))
+   (equal (set::emptyp (domain dtree))
           nil))
 )

--- a/books/coi/dtrees/deps.lisp
+++ b/books/coi/dtrees/deps.lisp
@@ -97,7 +97,7 @@
   (declare (xargs :guard (and (set::setp locs)
                               (dtreep dtree))
                   :verify-guards nil))
-  (if (set::empty locs)
+  (if (set::emptyp locs)
       (set::emptyset)
     (set::union (localdeps (get (set::head locs) dtree))
                 (deps1 (set::tail locs) dtree))))
@@ -257,29 +257,29 @@
                           (path nil)))))
 
 (defthm empty-of-localdeps-of-get-when-deps-empty
-  (implies (set::empty (deps dtree))
-           (set::empty (localdeps (get path dtree))))
+  (implies (set::emptyp (deps dtree))
+           (set::emptyp (localdeps (get path dtree))))
   :hints(("Goal"
           :in-theory (disable in-deps-when-in-localdeps-of-get)
           :use (:instance in-deps-when-in-localdeps-of-get
                           (a (set::head (localdeps (get path dtree))))))))
 
 (defthm empty-of-localdeps-when-deps-empty
-  (implies (set::empty (deps dtree))
-           (set::empty (localdeps dtree)))
+  (implies (set::emptyp (deps dtree))
+           (set::emptyp (localdeps dtree)))
   :hints(("Goal"
           :in-theory (disable empty-of-localdeps-of-get-when-deps-empty)
           :use (:instance empty-of-localdeps-of-get-when-deps-empty
                           (path nil)))))
 
 (defthm empty-of-deps-when-nonempty-of-localdeps-of-get
-  (implies (not (set::empty (localdeps (get path dtree))))
-           (equal (set::empty (deps dtree))
+  (implies (not (set::emptyp (localdeps (get path dtree))))
+           (equal (set::emptyp (deps dtree))
                   nil)))
 
 (defthm empty-of-deps-when-nonempty-of-localdeps
-  (implies (not (set::empty (localdeps dtree)))
-           (equal (set::empty (deps dtree))
+  (implies (not (set::emptyp (localdeps dtree)))
+           (equal (set::emptyp (deps dtree))
                   nil)))
 
 (local (in-theory (enable mrdeps)))
@@ -373,7 +373,7 @@
 (defund depsource1 (a locs dtree)
   (declare (xargs :guard (and (set::setp locs)
                               (dtreep dtree))))
-  (if (set::empty locs)
+  (if (set::emptyp locs)
       nil
     (if (set::in a (localdeps (get (set::head locs) dtree)))
         (set::head locs)

--- a/books/coi/dtrees/equiv.lisp
+++ b/books/coi/dtrees/equiv.lisp
@@ -44,7 +44,7 @@
   (declare (xargs :guard (and (set::setp locs)
                               (dtreep sub)
                               (dtreep super))))
-  (or (set::empty locs)
+  (or (set::emptyp locs)
       (and (in (set::head locs) super)
            (set::subset
             (localdeps (get (set::head locs) sub))
@@ -86,7 +86,7 @@
                          (localdeps (get path super)))))
 
 (defthm subtree1-when-empty-locs
-  (implies (set::empty locs)
+  (implies (set::emptyp locs)
            (subtree1 locs sub super))
   :hints(("Goal" :in-theory (enable subtree1))))
 
@@ -200,7 +200,7 @@
 
  (local (defund subtree1-badguy (locs sub super)
           (declare (xargs :verify-guards nil))
-          (cond ((set::empty locs)
+          (cond ((set::emptyp locs)
                  nil)
                 ((and (in (set::head locs) super)
                       (set::subset
@@ -325,7 +325,7 @@
   (declare (xargs :guard (and (set::setp locs)
                               (dtreep sub)
                               (dtreep super))))
-  (or (set::empty locs)
+  (or (set::emptyp locs)
       (and (in (set::head locs) super)
            (set::subset
             (deps (get (set::head locs) sub))
@@ -367,7 +367,7 @@
                          (deps (get path super)))))
 
 (defthm subdeps1-when-empty-locs
-  (implies (set::empty locs)
+  (implies (set::emptyp locs)
            (subdeps1 locs sub super))
   :hints(("Goal" :in-theory (enable subdeps1))))
 
@@ -481,7 +481,7 @@
 
  (local (defund subdeps1-badguy (locs sub super)
           (declare (xargs :verify-guards nil))
-          (cond ((set::empty locs)
+          (cond ((set::emptyp locs)
                  nil)
                 ((and (in (set::head locs) super)
                       (set::subset

--- a/books/coi/dtrees/leafp.lisp
+++ b/books/coi/dtrees/leafp.lisp
@@ -66,7 +66,7 @@
   :hints(("Goal" :in-theory (enable set::sfix
                                     set::setp
                                     set::in
-                                    set::empty
+                                    set::emptyp
                                     set::head
                                     set::tail))))
 
@@ -321,7 +321,7 @@
   (declare (xargs :guard (and (set::setp paths)
                               (dtree::dtreep dtree))
                   :verify-guards nil))
-  (if (set::empty paths)
+  (if (set::emptyp paths)
       (set::emptyset)
     (if (leafp (set::head paths) dtree)
         (set::insert (set::head paths)

--- a/books/coi/dtrees/royalp.lisp
+++ b/books/coi/dtrees/royalp.lisp
@@ -41,12 +41,12 @@
 ;;   (1) p is in the dtree, i.e., (in p dtree)
 ;;
 ;;   (2) the localdeps of p are nonempty, i.e.,
-;;        (not (set::empty (localdeps (get p dtree))))
+;;        (not (set::emptyp (localdeps (get p dtree))))
 ;;
 ;;   (3) for all a, the following is true:
 ;;       (implies (and (in a dtree)
 ;;                     (strictly-dominates a p))
-;;                (set::empty (localdeps (get a dtree))))
+;;                (set::emptyp (localdeps (get a dtree))))
 ;;
 ;; In other words, royal paths are the "first" nodes that actually have
 ;; localdeps in the dtree.  Hence, the deps of the entire dtree can be
@@ -64,10 +64,10 @@
 (defund royalp (path dtree)
   (declare (xargs :guard (dtreep dtree)))
   (if (consp path)
-      (and (set::empty (localdeps dtree))
+      (and (set::emptyp (localdeps dtree))
            (map::in (car path) (children dtree))
            (royalp (cdr path) (map::get (car path) (children dtree))))
-    (not (set::empty (localdeps dtree)))))
+    (not (set::emptyp (localdeps dtree)))))
 
 (encapsulate
  ()
@@ -101,23 +101,23 @@
 (defthm royalp-when-not-consp
   (implies (not (consp path))
            (equal (royalp path dtree)
-                  (not (set::empty (localdeps dtree)))))
+                  (not (set::emptyp (localdeps dtree)))))
   :hints(("Goal" :in-theory (enable royalp))))
 
 (defthm empty-of-localdeps-of-get-when-royalp
   (implies (royalp path dtree)
-           (equal (set::empty (localdeps (get path dtree)))
+           (equal (set::emptyp (localdeps (get path dtree)))
                   nil))
   :hints(("Goal" :in-theory (enable royalp get))))
 
 (defthm empty-of-deps-of-get-when-royalp
   (implies (royalp path dtree)
-           (equal (set::empty (deps (get path dtree)))
+           (equal (set::emptyp (deps (get path dtree)))
                   nil)))
 
 (defthm empty-of-deps-when-royalp
   (implies (royalp path dtree)
-           (equal (set::empty (deps dtree))
+           (equal (set::emptyp (deps dtree))
                   nil))
   :hints(("Goal"
           :in-theory (disable empty-of-deps-when-nonempty-of-localdeps-of-get)
@@ -164,14 +164,14 @@
 
   (defthmd royalp-constraint-localdeps
     (implies (royalp-hyps)
-             (not (set::empty
+             (not (set::emptyp
                    (localdeps (get (royalp-path) (royalp-dtree)))))))
 
   (defthmd royalp-constraint-domination
     (implies (and (royalp-hyps)
                   (in royalp-member (royalp-dtree))
                   (cpath::strictly-dominates royalp-member (royalp-path)))
-             (set::empty (localdeps (get royalp-member (royalp-dtree)))))))
+             (set::emptyp (localdeps (get royalp-member (royalp-dtree)))))))
 
  ;; Suppose that (royalp-hyps) is true, that our constraints are true, and
  ;; suppose towards contradiction that the following is true:
@@ -183,7 +183,7 @@
 
  (local (defund find-royal (path dtree)
           (declare (xargs :guard (dtreep dtree)))
-          (if (not (set::empty (localdeps dtree)))
+          (if (not (set::emptyp (localdeps dtree)))
               nil
             (if (and (consp path)
                      (map::in (car path) (children dtree)))
@@ -212,7 +212,7 @@
 
  (local (defund voidp (path dtree)
           (declare (xargs :guard (dtreep dtree)))
-          (and (set::empty (localdeps dtree))
+          (and (set::emptyp (localdeps dtree))
                (or (atom path)
                    (and (map::in (car path) (children dtree))
                         (voidp (cdr path)
@@ -227,7 +227,7 @@
 
  ;; We observe that any path whose localdeps are nonempty is not void.
  (local (defthm voidp-when-get-of-localdeps-nonempty
-          (implies (not (set::empty (localdeps (get path dtree))))
+          (implies (not (set::emptyp (localdeps (get path dtree))))
                    (equal (voidp path dtree)
                           nil))
           :hints(("Goal" :in-theory (enable voidp get)))))
@@ -263,13 +263,13 @@
  ;;                            (royalp-path))
  ;; exactly when (not (voidp (royalp-path) (royalp-dtree))).  But by our
  ;; localdeps constraint, we know that:
- ;;  (not (set::empty (localdeps (get (royalp-path) (royalp-dtree)))))
+ ;;  (not (set::emptyp (localdeps (get (royalp-path) (royalp-dtree)))))
  ;; which we can use with voidp-when-get-of-localdeps-nonempty to conclude
  ;; that (voidp (royalp-path) (royalp-dtree)) is nil, and we are done.
 
  (local (defthm localdeps-of-find-royal-nonempty-when-input-nonempty
-          (implies (not (set::empty (localdeps (get path dtree))))
-                   (not (set::empty (localdeps
+          (implies (not (set::emptyp (localdeps (get path dtree))))
+                   (not (set::emptyp (localdeps
                                      (get (find-royal path dtree) dtree)))))
           :hints(("Goal" :in-theory (enable find-royal get)))))
 
@@ -297,7 +297,7 @@
   (declare (xargs :guard (and (set::setp paths)
                               (dtree::dtreep dtree))
                   :verify-guards nil))
-  (if (set::empty paths)
+  (if (set::emptyp paths)
       (set::emptyset)
     (if (royalp (set::head paths) dtree)
         (set::insert (set::head paths)

--- a/books/coi/gacc/fr-path-connection.lisp
+++ b/books/coi/gacc/fr-path-connection.lisp
@@ -49,7 +49,7 @@
 
 ;bzo what do we do in the base case? need to know the size of the target record, right?
 (defun mypush-aux (keys r size)
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       (mem::new size) ;nil ;the empty typed record
     (gacc::wr (set::head keys)
               (g (set::head keys) r)
@@ -111,7 +111,7 @@
 ;;                     (MYPUSH-AUX (CONS A RKEYS) R)
 ;;                     (SET::HEAD (CONS A RKEYS))
 ;;                     (SET::SETP (CONS A RKEYS))
-;;                     (SET::EMPTY (CONS A RKEYS))
+;;                     (SET::EMPTYP (CONS A RKEYS))
 ;;                     (SET::TAIL (CONS A RKEYS)))
 ;;            :in-theory (disable GACC::WR==R!)
 ;;            :do-not '(generalize eliminate-destructors))))
@@ -119,7 +119,7 @@
 
 (local
  (defun my-ind (a rkeys r)
-   (if (set::empty rkeys)
+   (if (set::emptyp rkeys)
        (list a rkeys r)
      (if (equal a (set::head (set::insert a rkeys)))
          (list a rkeys r)
@@ -131,7 +131,7 @@
 ;clean up conclusion?
 (defthmd car-of-insert
   (equal (car (set::insert a x))
-         (cond ((set::empty x) a)
+         (cond ((set::emptyp x) a)
                ((equal (set::head x) a) (set::head x))
                ((<< a (set::head x)) a)
                (t (set::head x))))
@@ -152,7 +152,7 @@
                            (SET::SETP (CDR S))
                            (:free (x y) (set::setp (cons x y)))
                            )
-           :in-theory (e/d (car-of-insert SET::EMPTY SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
+           :in-theory (e/d (car-of-insert SET::EMPTYP SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
            :do-not '(generalize eliminate-destructors))))
 
 (defthm set-hack2
@@ -168,7 +168,7 @@
                            (SET::SETP (CDR S))
                            (:free (x y) (set::setp (cons x y)))
                            )
-           :in-theory (e/d (car-of-insert SET::EMPTY SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
+           :in-theory (e/d (car-of-insert SET::EMPTYP SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
            :do-not '(generalize eliminate-destructors))))
 
 
@@ -177,7 +177,7 @@
   (implies (<< a (car s))
            (not (set::in a s)))
   :hints (("Goal" :do-not '(generalize eliminate-destructors)
-           :expand ((set::empty s)
+           :expand ((set::emptyp s)
                     (set::setp s))
            :in-theory (enable set::head set::tail))))
 
@@ -197,7 +197,7 @@
                            (SET::SETP (CDR S))
                            (:free (x y) (set::setp (cons x y)))
                            )
-           :in-theory (e/d (car-of-insert SET::EMPTY SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
+           :in-theory (e/d (car-of-insert SET::EMPTYP SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
            :do-not '(generalize eliminate-destructors))))
 
 
@@ -294,7 +294,7 @@
 ;value for typed records) and so become keys "bound" to nil in the record
 ;(such keys don't show up, since nil is the default value for records).
 (defun mylift-aux (keys tr)
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       nil ;the empty record
     (s (set::head keys)
        (gacc::rd (set::head keys) tr)
@@ -400,10 +400,10 @@
            :do-not '(generalize eliminate-destructors))))
 
 (defthm empty-means-tail-nil
-  (implies (set::empty s)
+  (implies (set::emptyp s)
            (equal (set::tail s)
                   (set::emptyset)))
-  :hints (("Goal" :in-theory (enable set::empty set::tail set::sfix))))
+  :hints (("Goal" :in-theory (enable set::emptyp set::tail set::sfix))))
 
 ;bzo may loop with defn delete or something?
 (defthmd delete-from-tail-when-not-head
@@ -462,7 +462,7 @@
 
 ;bzo bad name? really this checks the values?
 (defun check-fr-keys (keys tr)
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       t
     (and (check-fr-key (set::head keys) tr)
          (check-fr-keys (set::tail keys) tr))))
@@ -977,14 +977,14 @@
 ;; ;bzo dup?
 ;; (defun all-non-nil (lst)
 ;; ;  (declare (xargs :guard t))
-;;   (if (set::empty lst)
+;;   (if (set::emptyp lst)
 ;;       t
 ;;     (and (not (null (set::head lst)))
 ;;          (all-non-nil (set::tail lst)))))
 
 (defthm head-non-nil-when-all-non-nil
   (implies (and (set::all<non-nil> s)
-                (not (set::empty s)))
+                (not (set::emptyp s)))
            (set::head s))
   :hints (("Goal" :in-theory (enable))))
 
@@ -1000,7 +1000,7 @@
                 (set::setp keys))
            (equal (set::rkeys (mylift-aux keys tr))
                   keys))
-  :hints (("Goal" :in-theory (enable SET::EMPTY))))
+  :hints (("Goal" :in-theory (enable SET::EMPTYP))))
 
 ;;bzo wfkeyed should be rewritten to be more abstract.  just call rkeys and check for nils in the result.
 
@@ -1024,16 +1024,16 @@
 ;;            :in-theory (enable wfr WFKEYED))))
 
 (defthm empty-rkeys-when-wfr
-  (equal (set::empty (set::rkeys tr))
+  (equal (set::emptyp (set::rkeys tr))
          (not tr))
   :hints (("Goal" :in-theory (e/d (set::rkeys)
-                                  (SET::EMPTY-WHEN-SETP-MEANS-NIL)))))
+                                  (SET::EMPTYP-WHEN-SETP-MEANS-NIL)))))
 
 (local
  (defun ind (keys tr)
    (declare (xargs :verify-guards nil))
    (if (or (not (set::setp keys))
-           (set::empty keys))
+           (set::emptyp keys))
        (list keys tr)
      (ind (set::tail keys)
           (GACC::MEMORY-CLR (SET::HEAD (mem::domain ;;RKEYS
@@ -1075,7 +1075,7 @@
 
 
 (defthm CHECK-FR-KEYS-when-empty
-  (implies (SET::EMPTY RKEYS)
+  (implies (SET::EMPTYP RKEYS)
            (CHECK-FR-KEYS RKEYS TR))
   :hints (("Goal" :in-theory (enable CHECK-FR-KEYS))))
 
@@ -1083,7 +1083,7 @@
   (implies (and (MEM::LOAD (SET::HEAD RKEYS) TR)
                 (equal 0 (loghead 8 (car (mem::load (set::head rkeys) tr)))))
            (equal (check-fr-keys rkeys tr)
-                  (set::empty rkeys)))
+                  (set::emptyp rkeys)))
   :otf-flg t
   :hints (("Goal" :use (:instance use-check-fr-keys (keys rkeys) (a (set::head rkeys)) (r tr))
            :in-theory (e/d (;CHECK-FR-KEYS
@@ -1263,7 +1263,7 @@
 (defthm load-of-head-of-domain-iff
   (implies (force (GOOD-MEMORYP MEM)) ;drop?
            (iff (mem::load (set::head (mem::domain mem)) mem)
-                (not (set::empty (mem::domain mem)))))
+                (not (set::emptyp (mem::domain mem)))))
   :otf-flg t
   :hints (("Goal" :in-theory (e/d (load-iff)
                                   ( mem::store-of-same-load
@@ -1310,7 +1310,7 @@
 
 (defun typed-fix-aux (keys r)
   (declare (xargs :verify-guards nil))
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       nil ;the empty record
     (s ;mem::store
      (set::head keys)
@@ -1379,7 +1379,7 @@
  (defun ind3 (keys r)
    (declare (xargs :verify-guards nil))
    (if (or (not (set::setp keys))
-           (set::empty keys))
+           (set::emptyp keys))
        (list keys r)
      (ind3 (set::tail keys)
            (CLR (SET::HEAD (SET::RKEYS R)) r) ;
@@ -1538,7 +1538,7 @@
 ;bzo rename?
 (defun all-vals-okay-aux (keys r)
   (declare (xargs :verify-guards nil))
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       t
     (and (unsigned-byte-p 8(g (set::head keys) r))
          (not (equal 0 (g (set::head keys) r)))

--- a/books/coi/gacc/tr-path-connection.lisp
+++ b/books/coi/gacc/tr-path-connection.lisp
@@ -58,7 +58,7 @@
 ;;
 
 (defun mypush-aux (keys r)
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       nil ;the empty typed record
     (gacc::wr (set::head keys)
               (g (set::head keys) r)
@@ -101,14 +101,14 @@
 ;;                     (MYPUSH-AUX (CONS A RKEYS) R)
 ;;                     (SET::HEAD (CONS A RKEYS))
 ;;                     (SET::SETP (CONS A RKEYS))
-;;                     (SET::EMPTY (CONS A RKEYS))
+;;                     (SET::EMPTYP (CONS A RKEYS))
 ;;                     (SET::TAIL (CONS A RKEYS)))
 ;;            :in-theory (disable GACC::WR==R!)
 ;;            :do-not '(generalize eliminate-destructors))))
 
 
 (defun my-ind (a rkeys r)
-  (if (set::empty rkeys)
+  (if (set::emptyp rkeys)
       (list a rkeys r)
     (if (equal a (set::head (set::insert a rkeys)))
         (list a rkeys r)
@@ -119,7 +119,7 @@
 ;clean up conclusion?
 (defthmd car-of-insert
   (equal (CAR (SET::INSERT a x))
-         (COND ((SET::EMPTY X) A)
+         (COND ((SET::EMPTYP X) A)
                ((EQUAL (SET::HEAD X) A) (SET::HEAD X))
                ((<< A (SET::HEAD X)) A)
                (T (SET::HEAD X))))
@@ -140,7 +140,7 @@
                            (SET::SETP (CDR S))
                            (:free (x y) (set::setp (cons x y)))
                            )
-           :in-theory (e/d (car-of-insert SET::EMPTY SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
+           :in-theory (e/d (car-of-insert SET::EMPTYP SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
            :do-not '(generalize eliminate-destructors))))
 
 (defthm set-hack2
@@ -156,7 +156,7 @@
                            (SET::SETP (CDR S))
                            (:free (x y) (set::setp (cons x y)))
                            )
-           :in-theory (e/d (car-of-insert SET::EMPTY SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
+           :in-theory (e/d (car-of-insert SET::EMPTYP SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
            :do-not '(generalize eliminate-destructors))))
 
 
@@ -169,7 +169,7 @@
                )
           (not (set::in a s)))
  :hints (("Goal" :do-not '(generalize eliminate-destructors)
-          :expand ((SET::EMPTY S)
+          :expand ((SET::EMPTYP S)
                    (SET::SETP S))
           :in-theory (enable SET::HEAD set::tail))))
 
@@ -189,7 +189,7 @@
                            (SET::SETP (CDR S))
                            (:free (x y) (set::setp (cons x y)))
                            )
-           :in-theory (e/d (car-of-insert SET::EMPTY SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
+           :in-theory (e/d (car-of-insert SET::EMPTYP SET::HEAD SET::tail SET::SFIX) ( SET::PICK-A-POINT-SUBSET-STRATEGY))
            :do-not '(generalize eliminate-destructors))))
 
 
@@ -283,7 +283,7 @@
 ;value for typed records) and so become keys "bound" to nil in the record
 ;(such keys don't show up, since nil is the default value for records).
 (defun mylift-aux (keys tr)
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       nil ;the empty record
     (s (set::head keys)
        (gacc::rd (set::head keys) tr)
@@ -362,14 +362,14 @@
              (set::tail s)
            nil ;the empty set - is there a function for that?
            ))
-  :hints (("Goal" :in-theory (enable SET::EMPTY))))
+  :hints (("Goal" :in-theory (enable SET::EMPTYP))))
 
 ;could be expensive?
 (defthm empty-means-tail-nil
-  (implies (set::empty s)
+  (implies (set::emptyp s)
            (equal (set::tail s)
                   nil))
-  :hints (("Goal" :in-theory (enable set::empty set::tail set::sfix))))
+  :hints (("Goal" :in-theory (enable set::emptyp set::tail set::sfix))))
 
 ;bzo may loop with defn delete or something?
 (defthmd delete-from-tail-when-not-head
@@ -389,7 +389,7 @@
 
 ;bzo bad name? really this checks the values?
 (defun check-tr-keys (keys tr)
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       t
     (let* ((val (g (set::head keys) tr)))
       (and (equal nil (cdr val)) ;(equal 1 (len val))
@@ -745,14 +745,14 @@
 ;; ;bzo dup?
 ;; (defun all-non-nil (lst)
 ;; ;  (declare (xargs :guard t))
-;;   (if (set::empty lst)
+;;   (if (set::emptyp lst)
 ;;       t
 ;;     (and (not (null (set::head lst)))
 ;;          (all-non-nil (set::tail lst)))))
 
 (defthm head-non-nil-when-all-non-nil
   (implies (and (set::all<non-nil> s)
-                (not (set::empty s)))
+                (not (set::emptyp s)))
            (set::head s))
   :hints (("Goal" :in-theory (enable))))
 
@@ -768,7 +768,7 @@
                 (set::setp keys))
            (equal (set::rkeys (mylift-aux keys tr))
                   keys))
-  :hints (("Goal" :in-theory (enable SET::EMPTY))))
+  :hints (("Goal" :in-theory (enable SET::EMPTYP))))
 
 #+joe
 (defthm wfkeyed-implies-not-nil-memberp
@@ -799,14 +799,14 @@
            :in-theory (enable wfr WFKEYED))))
 
 (defthm empty-list2set
-  (equal (set::empty (list::2set list))
+  (equal (set::emptyp (list::2set list))
          (not (consp list)))
   :hints (("Goal" :in-theory (e/d (list::2set)
                                   (SET::|2SET-REWRAP|)))))
 
 (defthm empty-rkeys-when-wfr
   (IMPLIES (AND  (WFR TR))
-           (equal (SET::EMPTY (SET::RKEYS TR))
+           (equal (SET::EMPTYP (SET::RKEYS TR))
                   (NOT TR)))
   :hints (("Goal" :do-not '(generalize eliminate-destructors))))
 ;;           :in-theory (enable wfr RKEYS))))
@@ -814,7 +814,7 @@
 (defun ind (keys tr)
   (declare (xargs :verify-guards nil))
   (if (or (not (set::setp keys))
-          (set::empty keys))
+          (set::emptyp keys))
       (list keys tr)
     (ind (set::tail keys)
          (GACC::MEMORY-CLR (SET::HEAD (SET::RKEYS TR)) tr);
@@ -852,7 +852,7 @@
 (defthm not-check-tr-keys-1
   (implies (equal (loghead 8 (car (g (set::head rkeys) tr))) 0)
            (equal (check-tr-keys rkeys tr)
-                  (set::empty rkeys))))
+                  (set::emptyp rkeys))))
 
 (defthm check-tr-keys-of-memory-clr-irrel
   (implies (and (not (set::in key keys))
@@ -922,7 +922,7 @@
 
 (defun typed-fix-aux (keys r)
   (declare (xargs :verify-guards nil))
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       nil ;the empty record
     (s (set::head keys)
        (val-fix (g (set::head keys) r))
@@ -979,7 +979,7 @@
 (defun ind3 (keys r)
   (declare (xargs :verify-guards nil))
   (if (or (not (set::setp keys))
-          (set::empty keys))
+          (set::emptyp keys))
       (list keys r)
     (ind3 (set::tail keys)
          (CLR (SET::HEAD (SET::RKEYS R)) r);
@@ -1135,7 +1135,7 @@
 
 (defun all-vals-okay-aux (keys r)
   (declare (xargs :verify-guards nil))
-  (if (set::empty keys)
+  (if (set::emptyp keys)
       t
     (and (unsigned-byte-p 8(g (set::head keys) r))
          (not (equal 0 (g (set::head keys) r)))
@@ -1177,7 +1177,7 @@
 ;; (thm
 ;;  (iff (SET::DELETE A S)
 ;;       (and
-;;       (not (or (set::empty s)
+;;       (not (or (set::emptyp s)
 ;;                (equal s (list a)) ;gross?
 ;;                ))
 
@@ -1192,7 +1192,7 @@
 ;;                        (caddr s))
 ;;                    (car s))))
 ;;  :otf-flg t
-;;  :hints (("Goal" :in-theory (e/d (set::head set::tail SET::SFIX SET::EMPTY
+;;  :hints (("Goal" :in-theory (e/d (set::head set::tail SET::SFIX SET::EMPTYP
 ;;                                  CAR-OF-INSERT
 ;;                                             )
 ;;                                  (set::delete
@@ -1222,7 +1222,7 @@
 ;; ;;                                 (SET::INSERT (CADR KEYS)
 ;; ;;                                              (SET::DELETE A (CDDR KEYS))))
 ;;                    )
-;;           :in-theory (e/d (set::head set::tail SET::SFIX SET::EMPTY
+;;           :in-theory (e/d (set::head set::tail SET::SFIX SET::EMPTYP
 ;;     CAR-OF-INSERT
 ;;                                      )
 ;;                           (set::delete

--- a/books/coi/maps/maps.lisp
+++ b/books/coi/maps/maps.lisp
@@ -66,7 +66,7 @@
 ;;
 ;;   (head map)              returns some arbitrary key from the map
 ;;   (tail map)              macro, abbreviation for (erase (head map) map)
-;;   (empty map)             macro, abbreviation for (set::empty (domain map))
+;;   (empty map)             macro, abbreviation for (set::emptyp (domain map))
 ;;   (empty-exec map)        faster executing function which rewrites to empty
 ;;
 ;;
@@ -190,7 +190,7 @@
 ;; We have not concerned ourselves much with runtime efficiency.  Originally we
 ;; wrote our primitive list-like operations (head, tail) using the set
 ;; operations on the domain of the map.  In other words, (empty map) was
-;; (set::empty (domain map)), (head map) was (set::head (domain map)), and
+;; (set::emptyp (domain map)), (head map) was (set::head (domain map)), and
 ;; (tail map) was (erase (head map) map).  This was very inefficient because we
 ;; had to reconstruct the entire domain for each operation, although at least
 ;; we could define empty-exec to be a faster version of empty that just asked
@@ -485,7 +485,7 @@
 ;; "empty", a simple macro abbreviation for emptiness of its domain.
 
 (defmacro empty (map)
-  `(set::empty (domain ,map)))
+  `(set::emptyp (domain ,map)))
 
 (defund empty-exec (map)
   (declare (xargs :guard (mapp map)
@@ -1091,7 +1091,7 @@
 (ACL2::add-untranslate-pattern (set::in ?key (domain ?map))
                                (in ?key ?map))
 
-(ACL2::add-untranslate-pattern (set::empty (domain ?map))
+(ACL2::add-untranslate-pattern (set::emptyp (domain ?map))
                                (empty ?map))
 
 (ACL2::add-untranslate-pattern (erase (head ?map) ?map)

--- a/books/coi/osets/conversions.lisp
+++ b/books/coi/osets/conversions.lisp
@@ -44,7 +44,7 @@
 
 (defun set::2list (set)
   (declare (type (satisfies setp) set))
-  (if (empty set) nil
+  (if (emptyp set) nil
     (cons (head set)
           (set::2list (tail set)))))
 
@@ -66,20 +66,20 @@
 
 (defthm car-of-2LIST
   (equal (CAR (SET::|2LIST| set))
-         (if (set::empty set)
+         (if (set::emptyp set)
              nil
            (set::head set))))
 
 (defthm cdr-of-2list
   (equal (CDR (SET::|2LIST| set))
-         (if (set::empty set)
+         (if (set::emptyp set)
              nil
            (SET::|2LIST| (set::tail set))))
   :hints (("Goal" :in-theory (enable SET::|2LIST|))))
 
 (defthm consp-of-2list
   (equal (CONSP (SET::|2LIST| set))
-         (not (set::empty set))))
+         (not (set::emptyp set))))
 
 
 ;expensive?
@@ -94,7 +94,7 @@
 (defthm 2set-of-2list
   (equal (list::2set (2list s))
          (sfix s))
-  :hints (("Goal" :in-theory (enable set::empty))))
+  :hints (("Goal" :in-theory (enable set::emptyp))))
 
 
 ;where should this go?
@@ -133,12 +133,11 @@
          (list::2set (list::remove a list))))
 
 (defthm empty-2set
-  (equal (empty (list::2set list))
+  (equal (emptyp (list::2set list))
          (not (consp list)))
   :hints (("Goal" :in-theory (e/d (list::2set)
                                   (|2SET-REWRAP|)))))
 
 (defthm consp-2list
   (equal (consp (2list set))
-         (not (empty set))))
-
+         (not (emptyp set))))

--- a/books/coi/osets/extras.lisp
+++ b/books/coi/osets/extras.lisp
@@ -42,7 +42,7 @@
 
 (defthmd open-set2list
   (implies
-   (not (empty set))
+   (not (emptyp set))
    (equal (2list set)
           (CONS (HEAD SET)
                 (|2LIST| (TAIL SET))))))
@@ -51,7 +51,7 @@
 (defthmd in-implications
   (implies
    (and
-    (not (empty set))
+    (not (emptyp set))
     (in a set)
     (not (equal (head set) a)))
    (acl2::<< (head set) a))
@@ -65,7 +65,7 @@
 (defthmd head-is-least-element
   (implies
    (and
-    (not (empty set))
+    (not (emptyp set))
     (in a (tail set)))
    (acl2::<< (head set) a))
   :hints (("goal" :use in-implications)))
@@ -73,8 +73,8 @@
 (defthm ordering-over-subset
   (implies
    (and
-    (not (empty set1))
-    (not (empty set2))
+    (not (emptyp set1))
+    (not (emptyp set2))
     (subset set2 (tail set1)))
    (acl2::<< (head set1) (head set2)))
   :hints (("goal" :use (:instance head-is-least-element
@@ -84,27 +84,27 @@
 (defthm head-of-insert-under-subset
   (implies
    (and
-    ;(not (empty set2))
-    (not (empty set1))
+    ;(not (emptyp set2))
+    (not (emptyp set1))
     (subset set2 (tail set1)))
    (equal (head (insert (head set1) set2))
           (head set1)))
   :hints (("goal" :in-theory (enable HEAD-INSERT))))
 
-(defthm not-empty-setp
+(defthm not-emptyp-setp
   (implies
    (and
     (setp set)
-    (empty set))
+    (emptyp set))
    (not set))
   :rule-classes (:forward-chaining)
-  :hints (("goal" :in-theory (enable setp empty))))
+  :hints (("goal" :in-theory (enable setp emptyp))))
 
 (defthm tail-of-insert-under-subset
   (implies
    (and
     (setp set2)
-    (not (empty set1))
+    (not (emptyp set1))
     (subset set2 (tail set1)))
    (equal (tail (insert (head set1) set2))
           set2))
@@ -113,13 +113,13 @@
 (defthm consp-of-insert
   (consp (insert a s))
   :rule-classes (:rewrite :type-prescription)
-  :hints (("Goal" :in-theory (enable empty insert setp))))
+  :hints (("Goal" :in-theory (enable emptyp insert setp))))
 
 ;; ;bzo drop because we have consp-of-insert?
 ;; (defthm iff-of-insert
 ;;   (iff (insert a s)
 ;;        t)
-;;   :hints (("Goal" :in-theory (enable empty insert setp))))
+;;   :hints (("Goal" :in-theory (enable emptyp insert setp))))
 
 
 ;these mix car/cdr and insert and perhaps that should never happen.  but it seems to in practice...
@@ -148,25 +148,25 @@
   (in a (list a))
   :hints (("Goal" :in-theory (enable tail
                                      head
-                                     empty)
+                                     emptyp)
            :expand ((in a (list a))))))
 
-(defthm empty-when-setp-means-nil
+(defthm emptyp-when-setp-means-nil
   (implies (setp x)
-           (equal (EMPTY x)
+           (equal (EMPTYP x)
                   (equal x nil)))
-  :hints (("Goal" :in-theory (enable EMPTY))))
+  :hints (("Goal" :in-theory (enable EMPTYP))))
 
 ;bzo expensive?
-(defthm empty-implies-not-sfix
-  (implies (empty set)
+(defthm emptyp-implies-not-sfix
+  (implies (emptyp set)
            (not (sfix set)))
   :hints (("Goal" :in-theory (enable sfix))))
 
 (defthm union-iff
   (iff (union x y)
-       (or (not (empty x))
-           (not (empty y)))))
+       (or (not (emptyp x))
+           (not (emptyp y)))))
 
 (defthmd delete-of-union-push-into-both
   (equal (DELETE A (UNION x y))
@@ -189,8 +189,8 @@
            (insert b (delete a x)))))
 
 ;expensive?
-(defthm head-when-empty
-  (implies (empty x)
+(defthm head-when-emptyp
+  (implies (emptyp x)
            (equal (head x)
                   (emptyset)))
   :hints (("Goal" :in-theory (enable head))))
@@ -205,16 +205,16 @@
 ;trying disabled, since this sort of takes us out of the set world
 
 ;; [jared] something like this is now in std/osets
-;; (defthmd insert-when-empty
-;;   (implies (empty x)
+;; (defthmd insert-when-emptyp
+;;   (implies (emptyp x)
 ;;            (equal (insert a x)
 ;;                   (list a)))
 ;;   :hints (("Goal" :in-theory (enable insert))))
 
 ;this sort of keeps us in the sets world (emptyset is a macro for nil - does that count as being in the sets world?)
-(defthm insert-when-empty-2
+(defthm insert-when-emptyp-2
   (implies (and (syntaxp (not (equal x ''nil))) ;prevents loops
-                (empty x))
+                (emptyp x))
            (equal (insert a x)
                   (insert a (emptyset))))
   :hints (("Goal" :in-theory (enable insert))))
@@ -295,9 +295,9 @@
            (subset x (insert a y)))
   :rule-classes ((:rewrite :backchain-limit-lst 1)))
 
-(defthm not-empty-of-singleton
-  (not (empty (list a)))
-  :hints (("Goal" :in-theory (enable empty))))
+(defthm not-emptyp-of-singleton
+  (not (emptyp (list a)))
+  :hints (("Goal" :in-theory (enable emptyp))))
 
 ;may be expensive?
 (defthm subset-delete-irrel-cheap
@@ -325,33 +325,33 @@
 
 (defthmd subset-of-singleton
   (equal (subset x (insert a nil))
-         (or (empty x)
+         (or (emptyp x)
              ;(equal x (insert a nil))
              (and (equal a (head x)) ;rephrasing...
-                  (empty (tail x))))))
+                  (emptyp (tail x))))))
 
 ;Maybe restrict double-containment to not fire if either argument is a singleton?
 ;(theory-invariant (incompatible (:rewrite subset-of-singleton) (:rewrite double-containment)))
 
 ;semed to be expensive.
-(defthmd empty-of-delete-rewrite
-  (equal (empty (delete a s))
-         (or (empty s)
+(defthmd emptyp-of-delete-rewrite
+  (equal (emptyp (delete a s))
+         (or (emptyp s)
              (equal s (insert a (emptyset))))))
 
 ;; [jared] something like this is now in std/osets/top
-;; (defthmd tail-when-empty
-;;   (implies (empty set)
+;; (defthmd tail-when-emptyp
+;;   (implies (emptyp set)
 ;;            (equal (tail set)
 ;;                   (emptyset)))
 ;;   :hints (("Goal" :in-theory (enable tail))))
 
-(defthm tail-when-empty-cheap
-  (implies (empty set)
+(defthm tail-when-emptyp-cheap
+  (implies (emptyp set)
            (equal (tail set)
                   (emptyset)))
   :rule-classes ((:rewrite :backchain-limit-lst (1)))
-  :hints (("Goal" :in-theory (enable tail-when-empty))))
+  :hints (("Goal" :in-theory (enable tail-when-emptyp))))
 
 (defthm delete-head-of-self
   (equal (delete (head set) set)
@@ -370,6 +370,6 @@
   :rule-classes ((:rewrite :backchain-limit-lst (1)))
   :hints (("Goal" :in-theory (enable tail-when-not-setp))))
 
-(defthm not-empty-when-something-in
+(defthm not-emptyp-when-something-in
   (implies (in a x) ;a is a free variable
-           (not (empty x))))
+           (not (emptyp x))))

--- a/books/coi/osets/fast.lisp
+++ b/books/coi/osets/fast.lisp
@@ -53,7 +53,7 @@
   (equal (setp (cons a X))
          (and (setp X)
               (or (<< a (head X))
-                  (empty X))))
+                  (emptyp X))))
   :hints(("Goal" :in-theory (enable primitives-theory))))
 
 (defthm cons-head
@@ -63,7 +63,7 @@
 
 (defthm cons-to-insert-empty
   (implies (and (setp X)
-                (empty X))
+                (emptyp X))
            (equal (cons a X) (insert a X)))
   :hints(("Goal" :in-theory (enable primitives-theory))))
 

--- a/books/coi/osets/listsets.lisp
+++ b/books/coi/osets/listsets.lisp
@@ -64,8 +64,8 @@
 ;; (local (in-theory (disable map-subset-helper-2))) ;; speed hint
 
 ;; bzo move to sets library
-(defthm sfix-when-empty
-  (implies (empty x)
+(defthm sfix-when-emptyp
+  (implies (emptyp x)
            (equal (sfix x)
                   nil))
   :hints(("Goal" :in-theory (enable sfix))))
@@ -189,8 +189,8 @@
            (setp x))
   :hints(("Goal" :in-theory (enable listsetp))))
 
-(defthm listsetp-when-empty
-  (implies (empty x)
+(defthm listsetp-when-emptyp
+  (implies (emptyp x)
            (equal (listsetp x)
                   (setp x)))
   :hints(("Goal" :in-theory (enable listsetp))))
@@ -469,9 +469,9 @@
 ;;   :hints(("Goal" :in-theory (enable listsetfix))))
 
 ;; ;; TEMP (jcd) - added this rule
-;; (defthm empty-of-listsetfix
-;;   (equal (empty (listsetfix x))
-;;          (empty x))
+;; (defthm emptyp-of-listsetfix
+;;   (equal (emptyp (listsetfix x))
+;;          (emptyp x))
 ;;   :hints(("Goal" :in-theory (enable listsetfix))))
 
 ;; And here are the corresponding theorems using Option 3:
@@ -492,8 +492,8 @@
   :hints(("Goal" :in-theory (enable listsetfix))))
 
 ;; TEMP (jcd) - added this rule
-(defthm empty-of-listsetfix
-  (equal (empty (listsetfix x))
+(defthm emptyp-of-listsetfix
+  (equal (emptyp (listsetfix x))
          (all<not-true-listp> x))
   :hints(("Goal" :in-theory (enable listsetfix))))
 
@@ -597,7 +597,7 @@
 
 (defthmd head-of-insert
   (equal (set::head (set::insert x y))
-         (if (set::empty y) x
+         (if (set::emptyp y) x
            (if (ordered x (set::head y)) x
              (set::head y))))
   :otf-flg t
@@ -606,7 +606,7 @@
                            (acl2::a x)
                            (acl2::x y))
            :expand (set::insert x y)
-           :in-theory (e/d (set::head  SET::EMPTY set::sfix)
+           :in-theory (e/d (set::head  SET::EMPTYP set::sfix)
                            (SET::INSERT-PRODUCES-SET)))
           (and acl2::stable-under-simplificationp
                '(:expand ((SET::SETP (LIST X))
@@ -614,7 +614,7 @@
 
 (defthmd tail-of-insert
   (equal (set::tail (set::insert x y))
-         (if (set::empty y) (set::emptyset)
+         (if (set::emptyp y) (set::emptyset)
            (if (equal x (set::head y)) (set::tail y)
              (if (acl2::<< x (set::head y)) y
                (set::insert x (set::tail y))))))
@@ -624,7 +624,7 @@
                            (acl2::a x)
                            (acl2::x y))
            :expand (set::insert x y)
-           :in-theory (e/d (set::head  set::tail SET::EMPTY set::sfix)
+           :in-theory (e/d (set::head  set::tail SET::EMPTYP set::sfix)
                            (SET::INSERT-PRODUCES-SET)))
           (and acl2::stable-under-simplificationp
                '(:expand ((SET::SETP (LIST X))

--- a/books/coi/osets/membership.lisp
+++ b/books/coi/osets/membership.lisp
@@ -43,22 +43,13 @@
   (implies
    (and
     (syntaxp (quotep x))
-    (not (empty x)))
+    (not (emptyp x)))
    (equal (in a x)
           (or (equal a (head x))
               (in a (tail x))))))
 
 (defun find-not (X)
   (declare (xargs :guard (setp X)))
-  (cond ((empty X) nil)
+  (cond ((emptyp X) nil)
         ((not (predicate (head X))) (head X))
         (t (find-not (tail X)))))
-
-
-
-
-
-
-
-
-

--- a/books/coi/osets/multicons.lisp
+++ b/books/coi/osets/multicons.lisp
@@ -63,7 +63,7 @@
 (defund multicons (a X)
   (declare (xargs :guard (setp X)
                   :verify-guards nil))
-  (mbe :logic (if (empty X)
+  (mbe :logic (if (emptyp X)
                   (emptyset)
                 (insert (cons a (head X))
                         (multicons a (tail X))))
@@ -137,7 +137,7 @@
                  :in-theory (enable setp
                                     tail
                                     sfix
-                                    empty
+                                    emptyp
                                     head
                                     <<
                                     lexorder)))))
@@ -158,10 +158,10 @@
 
 (local (defthm lemma
          (implies (and (setp X)
-                       (empty X))
+                       (emptyp X))
                   (equal X nil))
          :rule-classes nil
-         :hints(("Goal" :in-theory (enable setp empty)))))
+         :hints(("Goal" :in-theory (enable setp emptyp)))))
 
 (local (defthm main-lemma
          (implies (setp X)

--- a/books/coi/osets/outer.lisp
+++ b/books/coi/osets/outer.lisp
@@ -47,7 +47,7 @@
 
 (defun double-delete-induction (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
-  (if (or (empty X) (empty Y))
+  (if (or (emptyp X) (emptyp Y))
       (list X Y)
     (double-delete-induction (delete (head X) X)
                              (delete (head X) Y))))

--- a/books/coi/osets/primitives.lisp
+++ b/books/coi/osets/primitives.lisp
@@ -52,46 +52,46 @@
   (setp (list-to-set X))
   :hints (("Goal" :in-theory (enable insert))))
 
-(defthm head-empty-same
-  (implies (and (empty X)
-                (empty Y))
+(defthm head-emptyp-same
+  (implies (and (emptyp X)
+                (emptyp Y))
            (equal (equal (head X) (head Y)) t)))
 
-(defthm tail-empty-same
-  (implies (and (empty X)
-                (empty Y))
+(defthm tail-emptyp-same
+  (implies (and (emptyp X)
+                (emptyp Y))
            (equal (equal (tail X) (tail Y)) t)))
 
-(defthm insert-empty-same
-  (implies (and (empty X)
-                (empty Y))
+(defthm insert-emptyp-same
+  (implies (and (emptyp X)
+                (emptyp Y))
            (equal (equal (insert a X) (insert a Y)) t)))
 
-(defthm sfix-empty-same
-  (implies (and (empty X)
-                (empty Y))
+(defthm sfix-emptyp-same
+  (implies (and (emptyp X)
+                (emptyp Y))
            (equal (equal (sfix X) (sfix Y)) t)))
 
-(defthm tail-preserves-empty
-  (implies (empty X)
-           (empty (tail X))))
+(defthm tail-preserves-emptyp
+  (implies (emptyp X)
+           (emptyp (tail X))))
 
-(defthm head-insert-empty
-  (implies (empty X)
+(defthm head-insert-emptyp
+  (implies (emptyp X)
            (equal (head (insert a X)) a)))
 
-(defthm tail-insert-empty
-  (implies (empty X)
-           (empty (tail (insert a X)))))
+(defthm tail-insert-emptyp
+  (implies (emptyp X)
+           (emptyp (tail (insert a X)))))
 
 (defthm head-not-whole
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (not (equal (head X) X)))
-  :hints(("Goal" :in-theory (enable head empty))))
+  :hints(("Goal" :in-theory (enable head emptyp))))
 
 (deftheory primitives-theory
   '(setp
-    empty
+    emptyp
     head
     tail
     sfix
@@ -109,4 +109,3 @@
 
 (in-theory (disable primitives-theory
                     primitive-order-theory))
-

--- a/books/coi/osets/set-order.lisp
+++ b/books/coi/osets/set-order.lisp
@@ -79,7 +79,7 @@
 
 (deftheory primitive-reasoning
   '(setp
-    empty
+    emptyp
     head
     tail
     sfix
@@ -118,24 +118,24 @@
 
 (defthmd head-insert
   (equal (head (insert a X))
-         (cond ((empty X) a)
+         (cond ((emptyp X) a)
                ((<< a (head X)) a)
                (t (head X)))))
 
 (defthmd tail-insert
   (equal (tail (insert a X))
-         (cond ((empty X) nil)
+         (cond ((emptyp X) nil)
                ((<< a (head X)) X)
                ((equal a (head X)) (tail X))
                (t (insert a (tail X))))))
 
 (defthmd head-tail-order
-  (implies (not (empty (tail X)))
+  (implies (not (emptyp (tail X)))
            (<< (head X) (head (tail X)))))
 
 (defthmd head-tail-order-contrapositive
   (implies (not (<< (head X) (head (tail X))))
-           (empty (tail X))))
+           (emptyp (tail X))))
 
 (deftheory order-reasoning
   '(; <<-type ; see comment above about svn 1015
@@ -156,7 +156,7 @@
   (equal (setp (cons a X))
          (and (setp X)
               (or (<< a (head X))
-                  (empty X)))))
+                  (emptyp X)))))
 
 (defthmd cons-head
   (implies (setp (cons a X))
@@ -164,7 +164,7 @@
 
 (defthmd cons-to-insert-empty
   (implies (and (setp X)
-                (empty X))
+                (emptyp X))
            (equal (cons a X) (insert a X))))
 
 (defthmd cons-to-insert-nonempty

--- a/books/coi/osets/set-processor.lisp
+++ b/books/coi/osets/set-processor.lisp
@@ -49,7 +49,7 @@
 (defstub process (x) t)
 
 (defund process-set (set)
-  (if (set::empty set)
+  (if (set::emptyp set)
       (set::emptyset)
     (let ((v (set::head set)))
       (if (generic-pred v)
@@ -59,7 +59,7 @@
 
 (defund filter-generic-pred (x)
   ;;  filter-generic-pred(x) = { x | (v \in x) ^ (generic-pred v) }
-  (if (set::empty x)
+  (if (set::emptyp x)
       (set::emptyset)
     (let ((v (set::head x)))
       (if (generic-pred v)
@@ -68,7 +68,7 @@
 
 (defund process-all (x)
   ;; process-all(x) = { (process v) | v \in x }
-  (if (set::empty x)
+  (if (set::emptyp x)
       (set::emptyset)
     (set::insert (process (set::head x))
             (process-all (set::tail x)))))
@@ -125,7 +125,7 @@
 
 (defund has-process-inverse (a x)
   ;; (has-process-inverse a x) = exists b in x such that (process b) = a
-  (if (set::empty x)
+  (if (set::emptyp x)
       nil
     (or (equal a (process (set::head x)))
        (has-process-inverse a (set::tail x)))))
@@ -201,12 +201,12 @@
 (encapsulate
  ()
  (local (defthm terrible-lemma
-          (implies (and (set::empty x)
+          (implies (and (set::emptyp x)
                         (not (equal a (process b))))
                    (not (has-process-inverse a (set::insert b x))))
           :hints(("goal" :in-theory (enable has-process-inverse
                                             set::insert
-                                            set::empty
+                                            set::emptyp
                                             set::sfix
                                             set::head
                                             set::tail)))))
@@ -350,6 +350,6 @@
            (process-set x)))
   :hints (("Goal" :use (:instance goal-both)
            :expand (PROCESS-ALL (SET::INSERT A NIL))
-           :in-theory (e/d (SET::EMPTY
+           :in-theory (e/d (SET::EMPTYP
                             FILTER-GENERIC-PRED
                             MY-PROCESS-SET)(goal-both)))))

--- a/books/coi/osets/sets.lisp
+++ b/books/coi/osets/sets.lisp
@@ -73,17 +73,17 @@
     (or (equal a (car x))
 	(in-list a (cdr x)))))
 
-(defthm tail-preserves-empty
-  (implies (empty X)
-           (empty (tail X))))
+(defthm tail-preserves-emptyp
+  (implies (emptyp X)
+           (emptyp (tail X))))
 
-(defthm head-insert-empty
-  (implies (empty X)
+(defthm head-insert-emptyp
+  (implies (emptyp X)
            (equal (head (insert a X)) a)))
 
-(defthm tail-insert-empty
-  (implies (empty X)
-           (empty (tail (insert a X)))))
+(defthm tail-insert-emptyp
+  (implies (emptyp X)
+           (emptyp (tail (insert a X)))))
 
 
 (defthm intersect-cardinality-subset
@@ -163,4 +163,3 @@
                    insert-cardinality
                    delete-cardinality
                    ))
-

--- a/books/coi/osets/sort.lisp
+++ b/books/coi/osets/sort.lisp
@@ -91,7 +91,7 @@
   (implies (setp X)
            (equal (in-list a X)
                   (in a X)))
-  :hints(("Goal" :in-theory (enable sfix head tail empty setp))))
+  :hints(("Goal" :in-theory (enable sfix head tail emptyp setp))))
 
 ; We now introduce a naive function to split a list into two.
 
@@ -103,4 +103,3 @@
                    (split-list (cddr x))
                    (mv (cons (car x) part1)
                        (cons (cadr x) part2))))))
-

--- a/books/coi/paths/cp-set.lisp
+++ b/books/coi/paths/cp-set.lisp
@@ -44,7 +44,7 @@
 
 (defun cp-set (set st1 st2)
   "Set the value in ST2 of each path P in SET to the value of P in ST1"
-  (if (set::empty set) st2
+  (if (set::emptyp set) st2
     (let ((p (set::head set)))
       (sp p (gp p st1)
 	  (cp-set (set::tail set) st1 st2)))))
@@ -159,7 +159,7 @@
 
 (defthmd open-cp-set
   (implies
-   (not (set::empty set))
+   (not (set::emptyp set))
    (equal (cp-set set st1 st2)
 	  (LET ((P (SET::HEAD SET)))
 	       (SP P (GP P ST1)
@@ -180,7 +180,7 @@
  )
 
 (defun cp-set-equal (set st1 st2)
-  (if (set::empty set) t
+  (if (set::emptyp set) t
     (and (equal (gp (set::head set) st1)
 		(gp (set::head set) st2))
 	 (cp-set-equal (set::tail set) st1 st2))))
@@ -317,20 +317,20 @@
 
 
 (defun clrp-set (set st)
-  (if (set::empty set) st
+  (if (set::emptyp set) st
     (clrp-set (set::tail set) (clrp (set::head set) st))))
 
 (defthm open-clrp-set-on-constants
   (implies (syntaxp (quotep set))
            (equal (clrp-set set st)
-                  (if (set::empty set)
+                  (if (set::emptyp set)
                       st
                     (clrp-set (set::tail set)
                               (clrp (set::head set) st)))))
   :hints (("Goal" :in-theory (enable clrp-set))))
 
 (defun clrp-set-induction (set r1 r2)
-  (if (set::empty set) (cons r1 r2)
+  (if (set::emptyp set) (cons r1 r2)
     (clrp-set-induction (set::tail set)
 			(clrp (set::head set) r1)
 			(clrp (set::head set) r2))))
@@ -365,7 +365,7 @@
 
 (defthmd open-cp-set-equal
   (implies
-   (not (set::empty set))
+   (not (set::emptyp set))
    (equal (cp-set-equal set st1 st2)
 	  (AND (EQUAL (GP (SET::HEAD SET) ST1)
 		      (GP (SET::HEAD SET) ST2))
@@ -373,7 +373,7 @@
 			     ST1 ST2)))))
 
 (defun keep-exposed-elements (a x)
-  (if (set::empty x) (set::emptyset)
+  (if (set::emptyp x) (set::emptyset)
     (let ((head (set::head x)))
       (if (dominates a head)
 	  (set::insert (list::fix (nthcdr (len a) head))
@@ -401,13 +401,13 @@
 
 (defthm multicons-empty
   (implies
-   (set::empty x)
+   (set::emptyp x)
    (equal (set::multicons a x) nil))
   :hints (("goal" :expand (set::multicons a x))))
 
 (defthm multiappend-empty
   (implies
-   (set::empty x)
+   (set::emptyp x)
    (equal (set::multiappend a x) nil))
   :hints (("goal" :in-theory (enable set::multiappend))))
 
@@ -485,7 +485,7 @@
 ;;
 
 (defun clrp-set-equal (set x y)
-  (if (set::empty set) (equal x y)
+  (if (set::emptyp set) (equal x y)
     (clrp-set-equal (set::tail set)
 		    (cpath::clrp (set::head set) x)
 		    (cpath::clrp (set::head set) y))))

--- a/books/coi/records/mem-domain.lisp
+++ b/books/coi/records/mem-domain.lisp
@@ -84,7 +84,7 @@
 
 ;bzo can we make this a set processor?
 (defun cons-onto-all (item set)
-  (if (set::empty set)
+  (if (set::emptyp set)
       (set::emptyset)
     (set::insert (cons item (set::head set))
                  (cons-onto-all item (set::tail set)))))
@@ -92,7 +92,7 @@
 ;bzo do we get this for a set processor?
 (defthm cons-onto-all-iff
   (iff (cons-onto-all a set)
-       (not (set::empty set))))
+       (not (set::emptyp set))))
 
 
 ;if this didn't take a depth, how would we know to stop if an "element" of the tree happened to be another tree
@@ -120,7 +120,7 @@
 ;;                                   (element-processor 'unsupplied)  ;can this be a term?
 ;;                                   (predicate 'unsupplied))
 ;;   `(defun ,processor-name (set) ;can this take more than one arg?
-;;      (if (set::empty set)
+;;      (if (set::emptyp set)
 ;;          (set::emptyset)
 ;;        (if (,predicate (set::head set))
 ;;            (set::insert (,element-processor (set::head set))
@@ -130,14 +130,14 @@
 
 ;bzo use a set processor?
 (defun convert-reversed-bit-lists-to-integers (bit-lists)
-  (if (set::empty bit-lists)
+  (if (set::emptyp bit-lists)
       (set::emptyset)
     (set::insert (convert-reversed-bit-list-to-integer (set::head bit-lists))
                  (convert-reversed-bit-lists-to-integers (set::tail bit-lists)))))
 
 (defthm convert-reversed-bit-lists-to-integers-iff
   (iff (convert-reversed-bit-lists-to-integers bit-lists)
-       (not (set::empty bit-lists))))
+       (not (set::emptyp bit-lists))))
 
 (defthm convert-reversed-bit-lists-to-integers-of-insert
   (equal (convert-reversed-bit-lists-to-integers (set::insert lst lst-of-lsts))
@@ -323,7 +323,7 @@
   (equal (cons-onto-all item (list x))
          (list (cons item x)))
   :hints (("Goal" :in-theory (enable set::head
-                                     set::empty
+                                     set::emptyp
                                      set::tail)
            :expand ((set::setp (list x))
                     (set::insert (cons item x) nil)
@@ -597,7 +597,7 @@
          (not (set::in a x))))
 
 ;; (defun all-have-len (len x)
-;;   (if (set::empty x)
+;;   (if (set::emptyp x)
 ;;       t
 ;;     (and (equal len (len (set::head x)))
 ;;          (all-have-len len (set::tail x)))))
@@ -830,7 +830,7 @@
                 (rationalp len)
                 )
            (equal (len (set::head x))
-                  (if (not (set::empty x))
+                  (if (not (set::emptyp x))
                       len
                   0)))
   :hints (("Goal" :expand ((set::all<len-equal> x len)))))
@@ -854,7 +854,7 @@
                   (CONVERT-REVERSED-BIT-LISTS-TO-INTEGERS
                    (SET::DELETE (CONVERT-INTEGER-TO-REVERSED-BIT-LIST A len)
                                 bit-lists))))
-  :hints (("Subgoal *1/2" :cases ((SET::EMPTY (SET::TAIL BIT-LISTS))))
+  :hints (("Subgoal *1/2" :cases ((SET::EMPTYP (SET::TAIL BIT-LISTS))))
           ("Goal" :in-theory (disable ;test
                               (:type-prescription CONVERT-INTEGER-TO-REVERSED-BIT-LIST) ;had to disable this
                               )
@@ -881,7 +881,7 @@
   (implies (and (natp depth)
                 (mem::_memtree-p mem depth))
            (equal (len (set::head (mem::domain-aux mem depth)))
-                  (if (set::empty (mem::domain-aux mem depth))
+                  (if (set::emptyp (mem::domain-aux mem depth))
                       0
                     (nfix depth))))
   :hints (("Goal" :use (:instance all-len-equal-of-domain-aux (tree mem))
@@ -896,7 +896,7 @@
 ;the need for it arose when i disabled SET::ALL<BIT-LISTP>, since the definition rule was high on accumulated persistence
 (defthm not-all-BIT-LISTP-when-not-head
   (IMPLIES (AND (NOT (BIT-LISTP (SET::HEAD SET::SET-FOR-ALL-REDUCTION)))
-                (NOT (SET::EMPTY SET::SET-FOR-ALL-REDUCTION)))
+                (NOT (SET::EMPTYP SET::SET-FOR-ALL-REDUCTION)))
            (NOT (SET::ALL<BIT-LISTP> SET::SET-FOR-ALL-REDUCTION)))
   :hints (("Goal" :in-theory (enable SET::ALL<BIT-LISTP>))))
 
@@ -951,7 +951,7 @@
                   (set::delete a (mem::domain mem))))
   :otf-flg t
   :hints (("Goal" :do-not-induct t
-           :cases ((SET::EMPTY (MEM::DOMAIN-AUX (CAR (CAR MEM))
+           :cases ((SET::EMPTYP (MEM::DOMAIN-AUX (CAR (CAR MEM))
                                                 (CAR (CDR (CDR MEM))))))
            :do-not '(generalize eliminate-destructors)
            :in-theory (e/d (set::delete-of-union-push-into-both
@@ -1210,7 +1210,7 @@
   :otf-flg t
   :hints (("Goal" :do-not '(generalize eliminate-destructors)
 ;           :use (:instance domain-of-store) ;gross way to prove this...
-           :cases ((SET::EMPTY (MEM::DOMAIN-AUX (CAR (CAR MEM))
+           :cases ((SET::EMPTYP (MEM::DOMAIN-AUX (CAR (CAR MEM))
                                                       (CAR (CDR (CDR MEM))))))
 
            :in-theory (e/d (MEM::DOMAIN

--- a/books/coi/records/set-domain.lisp
+++ b/books/coi/records/set-domain.lisp
@@ -55,12 +55,12 @@
 ;; Is this what we want?  Or should we stick with forward chaining, as
 ;; with (consp (rkeys ..)) ??
 
-(defthm empty-rkeys-not-r
-  (equal (empty (rkeys r))
+(defthm emptyp-rkeys-not-r
+  (equal (emptyp (rkeys r))
          (not r))
   ;;:rule-classes (:forward-chaining)
   :hints (("Goal" :in-theory (e/d nil
-                                  (EMPTY-WHEN-SETP-MEANS-NIL)))))
+                                  (EMPTYP-WHEN-SETP-MEANS-NIL)))))
 
 (defthm rkeys-iff-r
   (iff (set::rkeys r) r)
@@ -239,8 +239,8 @@
 
 ;do we need all of these?
 
-(defthm empty-of-rkeys
-  (equal (set::empty (rkeys r))
+(defthm emptyp-of-rkeys
+  (equal (set::emptyp (rkeys r))
          (equal r nil))
   :hints (("Goal" :in-theory (enable rkeys acl2->rcd))))
 

--- a/books/kestrel/abnf/operations/closure.lisp
+++ b/books/kestrel/abnf/operations/closure.lisp
@@ -1,10 +1,10 @@
 ; ABNF (Augmented Backus-Naur Form) Library
 ;
-; Copyright (C) 2022 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -186,7 +186,7 @@
      or by reducing the size of the work set
      (if no rules are taken out of @('rules')),
      in which case the length of @('rules') stays the same."))
-  (b* (((when (empty workset)) (rulelist-fix accumulator))
+  (b* (((when (set::emptyp workset)) (rulelist-fix accumulator))
        (rulename (head workset))
        (workset (tail workset))
        ((mv rulename-rules other-rules) (rules-of-name rulename rules))

--- a/books/kestrel/acl2pl/functions.lisp
+++ b/books/kestrel/acl2pl/functions.lisp
@@ -1,10 +1,10 @@
 ; ACL2 Programming Language Library
 ;
-; Copyright (C) 2022 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -100,7 +100,7 @@
      is as good as returning any function with that name in the set,
      since there can be at most one."))
   (b* (((when (or (not (mbt (function-setp functions)))
-                  (empty functions)))
+                  (set::emptyp functions)))
         nil)
        (function (head functions))
        ((when (symbol-value-equiv name

--- a/books/kestrel/apt/expdata-tests.lisp
+++ b/books/kestrel/apt/expdata-tests.lisp
@@ -1,10 +1,10 @@
 ; APT (Automated Program Transformations) Library
 ;
-; Copyright (C) 2020 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -228,7 +228,7 @@
  ;; filter oset to keep only its integer elements:
  (define f ((x set::setp))
    :returns (new-x set::setp)
-   (cond ((set::empty x) nil)
+   (cond ((set::emptyp x) nil)
          (t (let ((e (set::head x)))
               (if (integerp e)
                   (set::insert e (f (set::tail x)))

--- a/books/kestrel/apt/schemalg-template-generators.lisp
+++ b/books/kestrel/apt/schemalg-template-generators.lisp
@@ -1,10 +1,10 @@
 ; APT (Automated Program Transformations) Library
 ;
-; Copyright (C) 2020 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -121,7 +121,7 @@
                  :verify-guards t
                  :guard-hints ,guard-hints))
        (cond ((or (not (set::setp ,x))
-                  (set::empty ,x))
+                  (set::emptyp ,x))
               (,?g ,@x-z1...zm))
              (t (,?h ,@z1...
                      (set::head ,x)
@@ -188,7 +188,7 @@
                        :guard-hints ,guard-hints))
        (forall ,x-x1...xn
                (impliez (or (not (set::setp ,x))
-                            (set::empty ,x))
+                            (set::emptyp ,x))
                         (,iorel ,@x-x1...xn (,?g ,@x-a1...am)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -255,7 +255,7 @@
                        :guard-hints ,guard-hints))
        (forall (,@x-x1...xn ,y)
                (impliez (and (set::setp ,x)
-                             (not (set::empty ,x))
+                             (not (set::emptyp ,x))
                              (,iorel ,@x1... (set::tail ,x) ,@...xn ,y))
                         (iorel ,@x-x1...xn
                                (,?h ,@a1... (set::head ,x) ,@...am ,y)))))))

--- a/books/kestrel/apt/schemalg.lisp
+++ b/books/kestrel/apt/schemalg.lisp
@@ -1,10 +1,10 @@
 ; APT (Automated Program Transformations) Library
 ;
-; Copyright (C) 2020 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1104,7 +1104,7 @@
      algo
      :formals x-z1...zm
      :body `(cond ((or (not (set::setp ,x))
-                       (set::empty ,x))
+                       (set::emptyp ,x))
                    (,?g ,@x-z1...zm))
                   (t (,?h ,@head-x-z1...zm
                           (,algo ,@tail-x-z1...zm))))
@@ -1243,7 +1243,7 @@
      :guard t
      :body `(forall ,x-x1...xn
                     (impliez (or (not (set::setp ,x))
-                                 (set::empty ,x))
+                                 (set::emptyp ,x))
                              ,iorel-term))
      :verify-guards verify-guards
      :enable spec-0-enable
@@ -1417,7 +1417,7 @@
      :guard t
      :body `(forall (,@x-x1...xn ,y)
                     (impliez (and (set::setp ,x)
-                                  (not (set::empty ,x))
+                                  (not (set::emptyp ,x))
                                   ,iorel-term1)
                              ,iorel-term2))
      :verify-guards verify-guards

--- a/books/kestrel/axe/jvm/jvm-rules-axe.lisp
+++ b/books/kestrel/axe/jvm/jvm-rules-axe.lisp
@@ -225,7 +225,7 @@
 (def-constant-opener set::delete)
 (def-constant-opener set::tail)
 (def-constant-opener set::head)
-(def-constant-opener set::empty)
+(def-constant-opener set::emptyp)
 (def-constant-opener set::sfix)
 (def-constant-opener set::setp)
 (def-constant-opener FAST-<<)

--- a/books/kestrel/axe/jvm/rule-lists-jvm.lisp
+++ b/books/kestrel/axe/jvm/rule-lists-jvm.lisp
@@ -693,7 +693,7 @@
           '(set::delete-constant-opener ;needed for address calcs
             set::tail-constant-opener   ;needed for address calcs
             set::head-constant-opener   ;needed for address calcs
-            set::empty-constant-opener  ;needed for address calcs
+            set::emptyp-constant-opener ;needed for address calcs
             set::sfix-constant-opener   ;needed for address calcs
             set::setp-constant-opener   ;needed for address calcs
             fast-<<-constant-opener     ;needed for address calcs

--- a/books/kestrel/axe/set-rules.lisp
+++ b/books/kestrel/axe/set-rules.lisp
@@ -50,9 +50,9 @@
 
 ;seems expensive
 (defthmd consp-set-hack
-  (implies (not (set::empty s))
+  (implies (not (set::emptyp s))
            (consp s))
-  :hints (("Goal" :in-theory (enable setp-hack set::empty))))
+  :hints (("Goal" :in-theory (enable setp-hack set::emptyp))))
 
 ;bad to mix sets and lists?
 (defthm consp-of-insert

--- a/books/kestrel/bitcoin/bip32-executable.lisp
+++ b/books/kestrel/bitcoin/bip32-executable.lisp
@@ -1,10 +1,10 @@
 ; Bitcoin Library
 ;
-; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -88,7 +88,7 @@
                                               (all-paths bip32-path-setp))
      :returns (yes/no booleanp)
      (or (not (mbt (bip32-path-setp cur-paths)))
-         (empty cur-paths)
+         (emptyp cur-paths)
          (and (bip32-path-set-closedp-exec-inner (head cur-paths) all-paths)
               (bip32-path-set-closedp-exec-outer (tail cur-paths) all-paths)))
      :no-function t
@@ -264,7 +264,7 @@
      then any member of the set satisfies the key validity condition.
      This fact is used in the correctness proof of the attachment."))
   (or (not (mbt (bip32-path-setp paths)))
-      (empty paths)
+      (emptyp paths)
       (and (b* (((mv error? &) (bip32-ckd* root (head paths))))
              (not error?))
            (bip32-valid-keys-p-exec root (tail paths))))
@@ -367,7 +367,7 @@
      then any member of the set satisfies the depth validity condition.
      This fact is used in the correctness proof of the attachment."))
   (or (not (mbt (bip32-path-setp paths)))
-      (empty paths)
+      (emptyp paths)
       (and (bytep (+ (byte-fix init) (len (head paths))))
            (bip32-valid-depths-p-exec init (tail paths))))
   :no-function t

--- a/books/kestrel/bitcoin/bip32.lisp
+++ b/books/kestrel/bitcoin/bip32.lisp
@@ -1,10 +1,10 @@
 ; Bitcoin Library
 ;
-; Copyright (C) 2020 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -596,7 +596,7 @@
 
   (defrule empty-path-in-closed-nonempty-bip32-path-set
     (implies (and (bip32-path-setp paths)
-                  (not (empty paths))
+                  (not (emptyp paths))
                   (bip32-path-set-closedp paths))
              (in nil paths))
     :use (:instance bip32-path-set-closedp-necc
@@ -646,7 +646,7 @@
     :parents (bip32-index-tree)
     :short "Recognizer for @(tsee bip32-index-tree)."
     (and (bip32-path-setp x)
-         (not (empty x))
+         (not (emptyp x))
          (bip32-path-set-closedp x))
     :no-function t
     ///

--- a/books/kestrel/c/language/static-semantics.lisp
+++ b/books/kestrel/c/language/static-semantics.lisp
@@ -1,11 +1,11 @@
 ; C Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
-; Copyright (C) 2023 Kestrel Technology LLC (http://kestreltechnology.com)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Technology LLC (http://kestreltechnology.com)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -620,11 +620,11 @@
       could just return a set of types (see above).
       However, for uniformity we have all three functions
       return also a possibly updated variable table.")))
-  ((return-types type-set :reqfix (if (set::empty return-types)
+  ((return-types type-set :reqfix (if (set::emptyp return-types)
                                       (set::insert (type-void) nil)
                                     return-types))
    (variables var-table))
-  :require (not (set::empty return-types))
+  :require (not (set::emptyp return-types))
   :pred types+vartab-p)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2672,7 +2672,7 @@
        (vartab (funtab+vartab+tagenv->vars funtab+vartab+tagenv))
        (overlap (set::intersect (omap::keys funtab)
                                 (omap::keys (car vartab))))
-       ((unless (set::empty overlap))
+       ((unless (set::emptyp overlap))
         (reserrf (list :transunit-fun-obj-overlap overlap)))
        ((unless (var-table-add-block vartab))
         (reserrf (list :transunit-has-undef-var vartab)))

--- a/books/kestrel/fty/defset-tests.lisp
+++ b/books/kestrel/fty/defset-tests.lisp
@@ -1,10 +1,11 @@
 ; FTY Library
 ;
-; Copyright (C) 2020 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Authors: Alessandro Coglio (coglio@kestrel.edu) and Stephen Westfold (westfold@kestrel.edu)
+; Authors: Alessandro Coglio (www.alessandrocoglio.info)
+;          Stephen Westfold (westfold@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -29,7 +30,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (must-fail
- (fty::defset nat set 
+ (fty::defset nat set
    :elt-type nat
    :elementp-of-nil nil))
 
@@ -182,7 +183,7 @@
    (define eval-int-term-s-set ((tms int-term-s-set-p))
      :measure (int-term-s-set-count tms)
      :returns (i integerp)
-     (if (or (set::empty tms)
+     (if (or (set::emptyp tms)
              (not (int-term-s-set-p tms)))
          0
        (+ (eval-int-term-s (set::head tms))
@@ -222,4 +223,3 @@
    (fty::defset rec-set-set
      :elt-type rec-set
      :measure (two-nats-measure (acl2-count x) 0))))
-

--- a/books/kestrel/fty/nat-set.lisp
+++ b/books/kestrel/fty/nat-set.lisp
@@ -1,10 +1,10 @@
 ; FTY Library
 ;
-; Copyright (C) 2021 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -26,6 +26,6 @@
 
   (defrule natp-of-head-when-nat-setp-type-prescription
     (implies (and (nat-setp x)
-                  (not (set::empty x)))
+                  (not (set::emptyp x)))
              (natp (set::head x)))
     :rule-classes :type-prescription))

--- a/books/kestrel/fty/string-set.lisp
+++ b/books/kestrel/fty/string-set.lisp
@@ -1,10 +1,10 @@
 ; FTY Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -26,7 +26,7 @@
 
   (defrule stringp-of-head-when-string-setp-type-prescription
     (implies (and (string-setp x)
-                  (not (set::empty x)))
+                  (not (set::emptyp x)))
              (stringp (set::head x)))
     :rule-classes :type-prescription)
 

--- a/books/kestrel/fty/symbol-set.lisp
+++ b/books/kestrel/fty/symbol-set.lisp
@@ -1,10 +1,10 @@
 ; FTY Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -26,7 +26,7 @@
 
   (defrule symbolp-of-head-when-symbol-setp-type-prescription
     (implies (and (symbol-setp x)
-                  (not (set::empty x)))
+                  (not (set::emptyp x)))
              (symbolp (set::head x)))
     :rule-classes :type-prescription)
 

--- a/books/kestrel/hdwallet/wallet.lisp
+++ b/books/kestrel/hdwallet/wallet.lisp
@@ -1,10 +1,10 @@
 ; Cryptocurrency Hierarchical Deterministic Wallet Library
 ;
-; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Main Author: Alessandro Coglio (coglio@kestrel.edu)
+; Main Author: Alessandro Coglio (www.alessandrocoglio.info)
 ; Contributing Author: Eric McCarthy (mccarthy@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -520,7 +520,7 @@
                                (addresses natp))
   :returns (yes/no booleanp)
   :short "Lift @(tsee valid-key-path-p) to sets of paths."
-  (or (empty paths)
+  (or (emptyp paths)
       (and (valid-key-path-p (head paths) addresses)
            (all-valid-key-paths-p (tail paths) addresses)))
   :no-function t

--- a/books/kestrel/jvm/utilities.lisp
+++ b/books/kestrel/jvm/utilities.lisp
@@ -56,7 +56,7 @@
 
 (defthm consp-of-2list-gen
   (equal (CONSP (SET::2LIST set))
-         (not (set::empty set))))
+         (not (set::emptyp set))))
 
 (defthm 2list-of-singleton
   (equal (SET::2LIST (SET::INSERT ITEM NIL))
@@ -64,12 +64,12 @@
   :hints (("Goal" :expand ((SET::2LIST (LIST ITEM))
                            (SET::TAIL (LIST ITEM))
                            (SET::HEAD (LIST ITEM))
-                           (SET::EMPTY (LIST ITEM))
+                           (SET::EMPTYP (LIST ITEM))
                            (SET::SETP (LIST ITEM)))
            :in-theory (enable SET::INSERT SET::2LIST))))
 
 (defthm delete-of-head
-  (IMPLIES (NOT (SET::EMPTY X))
+  (IMPLIES (NOT (SET::EMPTYP X))
            (EQUAL (SET::DELETE (SET::HEAD X) X)
                   (SET::TAIL X))))
 
@@ -78,7 +78,7 @@
          (set::2list (set::tail x))))
 
 (defthm car-of-2-list
-  (implies (not (set::empty x))
+  (implies (not (set::emptyp x))
            (equal (car (set::2list x))
                   (set::head x))))
 
@@ -90,7 +90,7 @@
  (EQUAL (SET::HEAD (SET::INSERT (SET::HEAD X)
                                 (SET::TAIL (SET::TAIL X))))
         (SET::HEAD X))
- :hints (("Goal" :in-theory (enable SET::TAIL SET::INSERT SET::HEAD SET::SFIX SET::EMPTY SET::SETP))))
+ :hints (("Goal" :in-theory (enable SET::TAIL SET::INSERT SET::HEAD SET::SFIX SET::EMPTYP SET::SETP))))
 
 
 ;expensive?
@@ -100,7 +100,7 @@
            (equal (set::head (set::insert item set))
                   item))
   :hints (("Goal" ;:expand ((set::delete item (cdr x)))
-           :in-theory (enable set::tail set::insert set::head set::sfix set::empty set::setp))))
+           :in-theory (enable set::tail set::insert set::head set::sfix set::emptyp set::setp))))
 
 ;expensive?
 (defthm head-of-insert-when-not-smallest
@@ -109,37 +109,37 @@
            (equal (set::head (set::insert item set))
                   (set::head set)))
   :hints (("Goal" ;:expand ((set::delete item (cdr x)))
-           :in-theory (enable set::tail set::insert set::head set::sfix set::empty set::setp))))
+           :in-theory (enable set::tail set::insert set::head set::sfix set::emptyp set::setp))))
 
 (defthm in-of-car
   (equal (SET::IN (CAR SET) SET)
-         (not (set::empty set)))
+         (not (set::emptyp set)))
   :hints (("Goal" ;:expand ((set::delete item (cdr x)))
-           :in-theory (enable set::tail set::insert set::head set::sfix set::empty set::setp set::in))))
+           :in-theory (enable set::tail set::insert set::head set::sfix set::emptyp set::setp set::in))))
 
 (defthm tail-of-insert-when-smallest
   (IMPLIES (AND (EQUAL (SET::HEAD (SET::INSERT ITEM SET)) ;item is smaller than anything in the set
                        ITEM)
-;               (NOT (SET::EMPTY SET))
+;               (NOT (SET::EMPTYP SET))
                 (NOT (SET::IN ITEM SET))
                 (SET::SETP SET) ;drop?
                 )
            (equal (SET::TAIL (SET::INSERT ITEM SET))
                   set))
   :hints (("Goal" ;:expand ((set::delete item (cdr x)))
-           :in-theory (enable set::tail set::insert set::head set::sfix set::empty set::setp))))
+           :in-theory (enable set::tail set::insert set::head set::sfix set::emptyp set::setp))))
 
 (defthm tail-of-insert-when-not-smallest
   (implies (and (equal (set::head (set::insert item set)) ;item is not smaller than anything in the set
                        (set::head set))
                 (not (set::in item set))
-                (not (set::empty set)))
+                (not (set::emptyp set)))
            (equal (set::tail (set::insert item set))
                   (set::insert item (set::tail set))))
   :otf-flg t
   :hints (("Goal" ;:expand ((set::delete item (cdr x)))
            :do-not '(generalize eliminate-destructors)
-           :in-theory (enable set::tail set::insert set::head set::sfix set::empty set::setp set::in)
+           :in-theory (enable set::tail set::insert set::head set::sfix set::emptyp set::setp set::in)
            )))
 
 
@@ -162,16 +162,16 @@
                 (SET::SETP y)
                 )
            (SET::SUBSET (CDR Y) X))
-  :hints (("Goal" :in-theory (e/d (set::subset SET::EMPTY SET::setp set::tail)
+  :hints (("Goal" :in-theory (e/d (set::subset SET::EMPTYP SET::setp set::tail)
                                   (SET::PICK-A-POINT-SUBSET-STRATEGY)))))
 
 (defthm <<-of-head-and-head-of-tail
   (implies (and (set::setp x)
-                (not (set::empty x))
-                (not (set::empty (set::tail x))))
+                (not (set::emptyp x))
+                (not (set::emptyp (set::tail x))))
            (<< (SET::HEAD X)
                (SET::HEAD (SET::TAIL X))))
-  :hints (("Goal" :in-theory (enable set::tail set::insert set::head set::sfix set::empty set::setp set::subset))))
+  :hints (("Goal" :in-theory (enable set::tail set::insert set::head set::sfix set::emptyp set::setp set::subset))))
 
 (defthm <<-of-head-when-not-equal-head
   (implies (and (set::in elem x)
@@ -181,31 +181,31 @@
   :hints (("subgoal *1/3" :use (:instance <<-of-head-and-head-of-tail))
           ("Goal" :expand (SET::SETP X)
            :in-theory (enable set::in ;set::head
-                              set::setp set::empty))))
+                              set::setp set::emptyp))))
 
 
 (defthm setp-of-singleton
   (SET::setp (LIST ITEM))
   :hints (("Goal" :in-theory (enable SET::setp))))
 
-(defthm empty-of-singleton
-  (equal (SET::EMPTY (LIST ITEM))
+(defthm emptyp-of-singleton
+  (equal (SET::EMPTYP (LIST ITEM))
          nil)
-  :hints (("Goal" :in-theory (enable SET::EMPTY))))
+  :hints (("Goal" :in-theory (enable SET::EMPTYP))))
 
 (defthm head-of-cons
   (equal (set::head (cons item lst))
          (if (set::setp (cons item lst))
              item
            nil))
-  :hints (("Goal" :in-theory (enable SET::SETP SET::HEAD SET::SFIX SET::EMPTY))))
+  :hints (("Goal" :in-theory (enable SET::SETP SET::HEAD SET::SFIX SET::EMPTYP))))
 
 (defthm head-of-insert-of-head-when-subset
   (implies (set::subset y x)
            (equal (set::head (set::insert (set::head x) y))
                   (set::head x)))
   :hints (("Goal" :in-theory (enable set::tail set::insert ;set::head
-                                     set::sfix set::empty set::setp set::subset))))
+                                     set::sfix set::emptyp set::setp set::subset))))
 
 (defthm subset-of-delete-when-subset
   (implies (set::subset set1 set2)

--- a/books/kestrel/maps/maps.lisp
+++ b/books/kestrel/maps/maps.lisp
@@ -235,7 +235,7 @@
 ;move to sets
 ;expensive?
 (defthm head-when-empty
-  (implies (set::empty ads)
+  (implies (set::emptyp ads)
            (equal (set::head ads)
                   nil))
   :hints (("Goal" :in-theory (enable set::head set::sfix))))

--- a/books/kestrel/sets/sets.lisp
+++ b/books/kestrel/sets/sets.lisp
@@ -30,13 +30,13 @@
            (equal (set::difference x y)
                   (set::emptyset)))
   :hints (("Goal" :do-not '(generalize eliminate-destructors)
-           :in-theory (enable set::empty set::sfix))))
+           :in-theory (enable set::emptyp set::sfix))))
 
 (defthm difference-self
   (equal (set::difference x x)
          (set::emptyset))
   :hints (("Goal" :do-not '(generalize eliminate-destructors)
-           :in-theory (enable set::empty set::sfix))))
+           :in-theory (enable set::emptyp set::sfix))))
 
 (defthm intersect-difference-same
   (implies (and (set::setp s1)
@@ -137,13 +137,13 @@
   :hints (("Goal" :in-theory (e/d (;set::difference
                                                                       )
                                   (set::never-in-empty
-                                   set::empty-subset-2)))))
+                                   set::emptyp-subset-2)))))
 
 (defthm intersect-difference-both-ways
   (equal (set::intersect (set::difference s1 s0)
                          (set::difference s0 s1))
          (set::emptyset))
-  :hints (("Goal" :in-theory (e/d (set::empty) ( helper))
+  :hints (("Goal" :in-theory (e/d (set::emptyp) ( helper))
            :use (:instance helper))))
 
 (defthm union-with-difference-same
@@ -164,12 +164,12 @@
          (set::difference (set::intersect s2 s1) s3)))
 
 (defthm diffence-of-union-lemma
-  (implies (set::empty (set::difference s1 s3))
+  (implies (set::emptyp (set::difference s1 s3))
            (equal (set::difference (set::union s1 s2) s3)
                   (set::difference s2 s3))))
 
 (defthm diffence-of-union-lemma-alt
-  (implies (set::empty (set::difference s1 s3))
+  (implies (set::emptyp (set::difference s1 s3))
            (equal (set::difference (set::union s2 s1) s3)
                   (set::difference s2 s3))))
 
@@ -194,13 +194,13 @@
          (set::difference s1 s0)))
 
 (defthm helper--
-  (implies (set::empty (set::difference s1 s3))
+  (implies (set::emptyp (set::difference s1 s3))
            (set::subset (set::difference (set::difference s1 s2) s3)
                         (set::emptyset)))
-  :hints (("Goal" :in-theory (disable set::empty-subset-2))))
+  :hints (("Goal" :in-theory (disable set::emptyp-subset-2))))
 
 (defthm difference-empty-lemma
-  (implies (set::empty (set::difference s1 s3))
+  (implies (set::emptyp (set::difference s1 s3))
            (equal (set::difference (set::difference s1 s2) s3)
                   (set::emptyset)))
   :hints (("Goal" :use (:instance helper--)
@@ -235,7 +235,7 @@
   (not (equal (set::insert ad x) (set::delete ad y))))
 
 (defthmd head-not
-  (implies (and (not (set::empty ad-set))
+  (implies (and (not (set::emptyp ad-set))
                 (not (set::in ad ad-set)))
            (not (equal ad (set::head ad-set)))))
 
@@ -248,7 +248,7 @@
            (set::subset (set::insert a x) (set::insert a y))))
 
 (defthm insert-head-union-tail
-  (implies (not (set::empty x))
+  (implies (not (set::emptyp x))
            (equal (set::insert (set::head x) (set::union y (set::tail x)))
                   (set::union x y))))
 
@@ -269,7 +269,7 @@
 
 (defthmd subset-singleton-hack
    (equal (set::subset x (set::insert a nil))
-          (or (set::empty x)
+          (or (set::emptyp x)
               (equal x (make-set a))))
    :hints (("Goal" :in-theory (disable ;set::insert-never-empty
                                        ;set::map-subset-helper
@@ -290,7 +290,7 @@
 
 (defthm insert-when-empty
   (implies (and (syntaxp (not (equal y ''nil)))
-                (set::empty y))
+                (set::emptyp y))
            (equal (set::insert a y)
                   (set::insert a nil)))
   :rule-classes ((:rewrite :backchain-limit-lst (nil 1))))
@@ -368,7 +368,7 @@
 ;isn't this defined in some set conversions.lisp book?
 (defun set::2list (set)
   (declare (type (satisfies set::setp) set))
-  (if (set::empty set) nil
+  (if (set::emptyp set) nil
     (cons (set::head set)
           (set::2list (set::tail set)))))
 
@@ -409,7 +409,7 @@
 (defthm consp-of-2list
   (implies (set::setp set)
            (equal (consp (set::2list set))
-                  (not (set::empty set)))))
+                  (not (set::emptyp set)))))
 
 
 (defthm set::mergesort-of-singleton

--- a/books/kestrel/utilities/omaps/core.lisp
+++ b/books/kestrel/utilities/omaps/core.lisp
@@ -1,10 +1,10 @@
 ; Ordered Maps (Omaps) Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Main Author: Alessandro Coglio (coglio@kestrel.edu)
+; Main Author: Alessandro Coglio (www.alessandrocoglio.info)
 ; Contributing Author: Stephen Westfold (westfold@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -199,7 +199,7 @@
   :short "Check if an omap is empty."
   :long
   (xdoc::topstring-p
-   "This is similar to @(tsee set::empty) for osets.")
+   "This is similar to @(tsee set::emptyp) for osets.")
   (null (mfix map))
   ///
 
@@ -581,13 +581,13 @@
   :long
   (xdoc::topstring-p
    "This lifts @(tsee delete) from a single key to a set of keys.")
-  (cond ((set::empty keys) (mfix map))
+  (cond ((set::emptyp keys) (mfix map))
         (t (delete (set::head keys) (delete* (set::tail keys) map))))
   :verify-guards :after-returns
   ///
 
   (defrule delete*-when-left-empty
-    (implies (set::empty keys)
+    (implies (set::emptyp keys)
              (equal (delete* keys map)
                     (mfix map))))
 
@@ -681,19 +681,19 @@
    "This lifts @(tsee in) to sets of keys.
     However, this returns a boolean,
     while @(tsee in) returns a @(tsee listp).")
-  (cond ((set::empty keys) t)
+  (cond ((set::emptyp keys) t)
         (t (and (in (set::head keys) map)
                 (in* (set::tail keys) map))))
   ///
 
   (defrule in*-when-left-empty
-    (implies (set::empty keys)
+    (implies (set::emptyp keys)
              (in* keys map)))
 
   (defrule in*-when-rigth-empty
     (implies (empty map)
              (equal (in* keys map)
-                    (set::empty keys))))
+                    (set::emptyp keys))))
 
   (defrule in*-of-tail
     (implies (in* keys map)
@@ -799,7 +799,7 @@
   :long
   (xdoc::topstring-p
    "This lifts @(tsee lookup) to sets of keys.")
-  (cond ((set::empty keys) nil)
+  (cond ((set::emptyp keys) nil)
         ((mbt (if (in (set::head keys) map) t nil))
          (set::insert (lookup (set::head keys) map)
                       (lookup* (set::tail keys) map)))
@@ -809,7 +809,7 @@
   (verify-guards lookup* :hints (("Goal" :in-theory (enable in*))))
 
   (defrule lookup*-when-left-empty
-    (implies (set::empty keys)
+    (implies (set::emptyp keys)
              (equal (lookup* keys map)
                     nil))
     :rule-classes (:rewrite :type-prescription))
@@ -856,14 +856,14 @@
   :long
   (xdoc::topstring-p
    "This lifts @(tsee rlookup*) to sets of values.")
-  (cond ((set::empty vals) nil)
+  (cond ((set::emptyp vals) nil)
         (t (set::union (rlookup (set::head vals) map)
                        (rlookup* (set::tail vals) map))))
   :verify-guards :after-returns
   ///
 
   (defrule rlookup*-when-left-empty
-    (implies (set::empty vals)
+    (implies (set::emptyp vals)
              (equal (rlookup* vals map) nil))
     :rule-classes (:rewrite :type-prescription))
 
@@ -891,7 +891,7 @@
   ///
 
   (defrule restrict-when-left-empty
-    (implies (set::empty keys)
+    (implies (set::emptyp keys)
              (equal (restrict keys map) nil))
     :rule-classes (:rewrite :type-prescription))
 
@@ -980,7 +980,7 @@
              set::insert
              set::head
              set::tail
-             set::empty
+             set::emptyp
              set::setp))
 
   (defrule keys-of-update*

--- a/books/kestrel/utilities/oset-theorems.lisp
+++ b/books/kestrel/utilities/oset-theorems.lisp
@@ -1,10 +1,10 @@
 ; Theorems about Osets
 ;
-; Copyright (C) 2019 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -30,7 +30,7 @@
 
   (std::defrule cardinality-of-tail
     (equal (cardinality (tail x))
-           (if (empty x)
+           (if (emptyp x)
                0
              (1- (cardinality x))))
     :enable cardinality)
@@ -44,4 +44,4 @@
     (implies (setp x)
              (iff (in a x)
                   (member-equal a x)))
-    :enable (setp in empty head tail)))
+    :enable (setp in emptyp head tail)))

--- a/books/kestrel/utilities/osets.lisp
+++ b/books/kestrel/utilities/osets.lisp
@@ -1,10 +1,10 @@
 ; Oset Utilities
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -71,7 +71,7 @@
   :returns (yes/no booleanp)
   :parents (osets-of-natural-numbers)
   :short "Check if all the elements of a set are natural numbers."
-  (or (empty set)
+  (or (emptyp set)
       (and (natp (head set))
            (set-all-natp (tail set))))
   ///
@@ -121,7 +121,7 @@
   :returns (yes/no booleanp)
   :parents (osets-of-integer-numbers)
   :short "Check if all the elements of a set are integer numbers."
-  (or (empty set)
+  (or (emptyp set)
       (and (integerp (head set))
            (set-all-integerp (tail set))))
   ///

--- a/books/kestrel/yul/language/dynamic-semantics.lisp
+++ b/books/kestrel/yul/language/dynamic-semantics.lisp
@@ -1,10 +1,10 @@
 ; Yul Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -258,7 +258,7 @@
   (b* (((when (endp funenv)) nil)
        (overlap (set::intersect (omap::keys (funscope-fix funscope))
                                 (omap::keys (funscope-fix (car funenv)))))
-       ((unless (set::empty overlap))
+       ((unless (set::emptyp overlap))
         (reserrf (list :duplicate-functions overlap))))
     (ensure-funscope-disjoint funscope (cdr funenv)))
   :hooks (:fix)

--- a/books/kestrel/yul/language/static-safety-checking.lisp
+++ b/books/kestrel/yul/language/static-safety-checking.lisp
@@ -1,10 +1,10 @@
 ; Yul Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -176,7 +176,7 @@
        ((okf funtab1) (funtable-for-fundefs fundefs))
        (overlap (set::intersect (omap::keys funtab1)
                                 (omap::keys funtab)))
-       ((unless (set::empty overlap))
+       ((unless (set::emptyp overlap))
         (reserrf (list :duplicate-functions overlap))))
     (omap::update* funtab1 funtab))
   :hooks (:fix))

--- a/books/kestrel/yul/language/static-shadowing-checking.lisp
+++ b/books/kestrel/yul/language/static-shadowing-checking.lisp
@@ -1,10 +1,10 @@
 ; Yul Library
 ;
-; Copyright (C) 2023 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -94,7 +94,7 @@
      :variable-multi (b* ((declared (set::mergesort stmt.names))
                           (shadowed (set::intersect declared
                                                     (identifier-set-fix vars))))
-                       (if (set::empty shadowed)
+                       (if (set::emptyp shadowed)
                            (set::union declared (identifier-set-fix vars))
                          (reserrf (list :shadowed-vars shadowed))))
      :assign-single (identifier-set-fix vars)
@@ -179,7 +179,8 @@
          (outputs (fundef->outputs fundef))
          (declared (set::mergesort (append inputs outputs)))
          (shadowed (set::intersect declared (identifier-set-fix vars)))
-         ((unless (set::empty shadowed)) (reserrf (list :shadowed-vars shadowed)))
+         ((unless (set::emptyp shadowed))
+          (reserrf (list :shadowed-vars shadowed)))
          (vars (set::union (identifier-set-fix vars) declared)))
       (check-shadow-block (fundef->body fundef) vars))
     :measure (fundef-count fundef))

--- a/books/kestrel/zcash/pedersen-addition-inputs.lisp
+++ b/books/kestrel/zcash/pedersen-addition-inputs.lisp
@@ -1,10 +1,10 @@
 ; Zcash Library
 ;
-; Copyright (C) 2021 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (coglio@kestrel.edu)
+; Author: Alessandro Coglio (www.alessandrocoglio.info)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -65,14 +65,14 @@
 
 (define belowp ((indices nat-setp) (n natp))
   :returns (yes/no booleanp)
-  (or (set::empty indices)
+  (or (set::emptyp indices)
       (and (< (set::head indices) n)
            (belowp (set::tail indices) n)))
   ///
 
   (defruled head-below-when-belowp
     (implies (and (belowp indices n)
-                  (not (set::empty indices)))
+                  (not (set::emptyp indices)))
              (< (set::head indices) n))
     :rule-classes :linear)
 
@@ -100,7 +100,7 @@
   (defrule belowp-of-0
     (implies (nat-setp indices)
              (equal (belowp indices 0)
-                    (set::empty indices)))))
+                    (set::emptyp indices)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -117,7 +117,7 @@
   :guard (and (integerp (/ (len bits) 3))
               (belowp indices (/ (len bits) 3)))
   :returns (sum integerp :rule-classes (:rewrite :type-prescription))
-  (cond ((set::empty indices) 0)
+  (cond ((set::emptyp indices) 0)
         (t (b* ((index (acl2::lnfix (set::head indices))))
              (+ (* (pedersen-enc (take 3 (nthcdr (* 3 index) bits)))
                    (expt 16 index))
@@ -152,7 +152,7 @@
     :use (:instance sum-of-insert (indices (set::delete index indices))))
 
   (defrule sum-of-0
-    (implies (set::empty indices)
+    (implies (set::emptyp indices)
              (equal (sum indices bits)
                     0))))
 
@@ -481,9 +481,9 @@
                         (nat-setp indices2)
                         (belowp indices1 n)
                         (belowp indices2 n)
-                        (not (set::empty indices1))
-                        (not (set::empty indices2))
-                        (set::empty (set::intersect indices1 indices2)))
+                        (not (set::emptyp indices1))
+                        (not (set::emptyp indices2))
+                        (set::emptyp (set::intersect indices1 indices2)))
                    (and (not (equal (sum indices1 bits)
                                     (sum indices2 bits)))
                         (not (equal (sum indices1 bits)
@@ -532,9 +532,9 @@
                 (nat-setp indices2)
                 (belowp indices1 n)
                 (belowp indices2 n)
-                (not (set::empty indices1))
-                (not (set::empty indices2))
-                (set::empty (set::intersect indices1 indices2)))
+                (not (set::emptyp indices1))
+                (not (set::emptyp indices2))
+                (set::emptyp (set::intersect indices1 indices2)))
            (and (not (equal (sum indices1 bits)
                             (sum indices2 bits)))
                 (not (equal (sum indices1 bits)
@@ -561,9 +561,9 @@
                 (nat-setp indices2)
                 (belowp indices1 n)
                 (belowp indices2 n)
-                (not (set::empty indices1))
-                (not (set::empty indices2))
-                (set::empty (set::intersect indices1 indices2)))
+                (not (set::emptyp indices1))
+                (not (set::emptyp indices2))
+                (set::emptyp (set::intersect indices1 indices2)))
            (and (not (equal (sum indices1 bits)
                             (sum indices2 bits)))
                 (not (equal (sum indices1 bits)
@@ -577,9 +577,9 @@
    (:assume (:nat-set2 (nat-setp indices2)))
    (:assume (:below1 (belowp indices1 n)))
    (:assume (:below2 (belowp indices2 n)))
-   (:assume (:nonempty1 (not (set::empty indices1))))
-   (:assume (:nonempty2 (not (set::empty indices2))))
-   (:assume (:disjoint (set::empty (set::intersect indices1 indices2))))
+   (:assume (:nonempty1 (not (set::emptyp indices1))))
+   (:assume (:nonempty2 (not (set::emptyp indices2))))
+   (:assume (:disjoint (set::emptyp (set::intersect indices1 indices2))))
    (:derive (:below1-n-1 (belowp indices1 (1- n)))
     :from (:below1 :pos :nat-set1 :not-in-set1)
     :hints (("Goal" :use (:instance belowp-of-n-minus-1-when-not-in-set
@@ -668,9 +668,9 @@
                 (nat-setp indices2)
                 (belowp indices1 n)
                 (belowp indices2 n)
-                (not (set::empty indices1))
-                (not (set::empty indices2))
-                (set::empty (set::intersect indices1 indices2)))
+                (not (set::emptyp indices1))
+                (not (set::emptyp indices2))
+                (set::emptyp (set::intersect indices1 indices2)))
            (and (not (equal (sum indices1 bits)
                             (sum indices2 bits)))
                 (not (equal (sum indices1 bits)
@@ -683,9 +683,9 @@
    (:assume (:nat-set2 (nat-setp indices2)))
    (:assume (:below1 (belowp indices1 n)))
    (:assume (:below2 (belowp indices2 n)))
-   (:assume (:nonempty1 (not (set::empty indices1))))
-   (:assume (:nonempty2 (not (set::empty indices2))))
-   (:assume (:disjoint (set::empty (set::intersect indices1 indices2))))
+   (:assume (:nonempty1 (not (set::emptyp indices1))))
+   (:assume (:nonempty2 (not (set::emptyp indices2))))
+   (:assume (:disjoint (set::emptyp (set::intersect indices1 indices2))))
    (:let (indices1-1 (set::delete (1- n) indices1)))
    (:derive (:decompose
              (equal (sum indices1 bits)
@@ -777,9 +777,9 @@
                 (nat-setp indices2)
                 (belowp indices1 n)
                 (belowp indices2 n)
-                (not (set::empty indices1))
-                (not (set::empty indices2))
-                (set::empty (set::intersect indices1 indices2)))
+                (not (set::emptyp indices1))
+                (not (set::emptyp indices2))
+                (set::emptyp (set::intersect indices1 indices2)))
            (and (not (equal (sum indices1 bits)
                             (sum indices2 bits)))
                 (not (equal (sum indices1 bits)
@@ -834,9 +834,9 @@
                 (nat-setp indices2)
                 (belowp indices1 n)
                 (belowp indices2 n)
-                (not (set::empty indices1))
-                (not (set::empty indices2))
-                (set::empty (set::intersect indices1 indices2)))
+                (not (set::emptyp indices1))
+                (not (set::emptyp indices2))
+                (set::emptyp (set::intersect indices1 indices2)))
            (and (not (equal (sum indices1 bits)
                             (sum indices2 bits)))
                 (not (equal (sum indices1 bits)

--- a/books/projects/pfcs/lifting.lisp
+++ b/books/projects/pfcs/lifting.lisp
@@ -162,7 +162,7 @@
   ((define lift-thm-def-hyps-aux ((crels constrel-setp) (tab alistp))
      :returns (more-hyps true-listp)
      :parents nil
-     (b* (((when (set::empty crels)) nil)
+     (b* (((when (set::emptyp crels)) nil)
           (crel (set::head crels))
           (name (constrel->name crel))
           (info (cdr (assoc-equal name tab)))
@@ -188,7 +188,7 @@
      This instantiation is used in a lemma instance (see @(tsee lift-thm)).
      The instantiation replaces each variable
      with its lookup in the witness term of the @(tsee defun-sk)."))
-  (cond ((set::empty free) nil)
+  (cond ((set::emptyp free) nil)
         (t (b* ((var (set::head free)))
              (cons `(,(name-to-symbol var state) (cdr (omap::in ,var ,witness)))
                    (lift-thm-free-inst (set::tail free) witness state)))))
@@ -324,7 +324,7 @@
        (thm-name (acl2::packn-pos (list 'constraint-satp-of- pred-name)
                                   pred-name))
        (thm-event
-        (if (set::empty (definition-free-vars def))
+        (if (set::emptyp (definition-free-vars def))
             `(defruledl ,thm-name
                (implies (and (assignmentp asg)
                              (assignment-wfp asg p)
@@ -334,7 +334,7 @@
                         (b* ((args (constraint-relation->args constr))
                              (def (lookup-definition ,def-name defs)))
                           (implies (and def
-                                        (set::empty (definition-free-vars def)))
+                                        (set::emptyp (definition-free-vars def)))
                                    (equal (constraint-satp constr defs asg p)
                                           (constraint-relation-nofreevars-satp
                                            ,def-name args defs asg p)))))
@@ -378,7 +378,7 @@
      so that we can apply the lifting theorems for those relations.
      So here we go through all the relations called by @('def')
      and we generate one specialized theorem for each."))
-  (b* (((when (set::empty rels)) (mv nil nil))
+  (b* (((when (set::emptyp rels)) (mv nil nil))
        (rel (set::head rels))
        (pred-name (name-to-symbol rel state))
        (thm-name (acl2::packn-pos
@@ -563,7 +563,7 @@
                          fty::consp-when-reserrp
                          acl2::natp-compound-recognizer
                          (:e nat-listp)
-                         (:e set::empty)
+                         (:e set::emptyp)
                          car-cons
                          cdr-cons
                          omap::in-of-update
@@ -647,7 +647,7 @@
                         fty::consp-when-reserrp
                         acl2::natp-compound-recognizer
                         (:e nat-listp)
-                        (:e set::empty)
+                        (:e set::emptyp)
                         car-cons
                         cdr-cons
                         omap::in-of-update*

--- a/books/projects/pfcs/oset-lib-ext.lisp
+++ b/books/projects/pfcs/oset-lib-ext.lisp
@@ -26,4 +26,4 @@
            (not (set::difference a b)))
   :use (:instance set::subset-difference (x a) (y b))
   :disable set::subset-difference
-  :enable set::empty)
+  :enable set::emptyp)

--- a/books/projects/pfcs/proof-support.lisp
+++ b/books/projects/pfcs/proof-support.lisp
@@ -466,7 +466,7 @@
      In this case, we can avoid the existential quantification."))
   (b* ((def (lookup-definition name defs)))
     (and def
-         (set::empty (definition-free-vars def))
+         (set::emptyp (definition-free-vars def))
          (b* (((definition def) def))
            (and (equal (len args) (len def.para))
                 (b* ((vals (eval-expr-list args asg p)))
@@ -498,7 +498,7 @@
                 (args (constraint-relation->args constr))
                 (def (lookup-definition name defs)))
              (implies (and def
-                           (set::empty (definition-free-vars def)))
+                           (set::emptyp (definition-free-vars def)))
                       (equal (constraint-satp constr defs asg p)
                              (constraint-relation-nofreevars-satp name
                                                                   args
@@ -517,7 +517,7 @@
                    (args (constraint-relation->args constr))
                    (def (lookup-definition name defs)))
                 (implies (and def
-                              (set::empty (definition-free-vars def)))
+                              (set::emptyp (definition-free-vars def)))
                          (implies (constraint-satp constr defs asg p)
                                   (constraint-relation-nofreevars-satp name
                                                                        args
@@ -528,7 +528,7 @@
      :enable (constraint-satp-of-relation
               constraint-relation-satp
               constraint-relation-nofreevars-satp
-              set::empty
+              set::emptyp
               omap::keys-iff-not-empty))
 
    (defrule if-direction
@@ -539,7 +539,7 @@
                    (args (constraint-relation->args constr))
                    (def (lookup-definition name defs)))
                 (implies (and def
-                              (set::empty (definition-free-vars def)))
+                              (set::emptyp (definition-free-vars def)))
                          (implies (constraint-relation-nofreevars-satp name
                                                                        args
                                                                        defs

--- a/books/projects/pfcs/semantics-shallow.lisp
+++ b/books/projects/pfcs/semantics-shallow.lisp
@@ -123,7 +123,7 @@
    (xdoc::p
     "The order of the list is according to
      the total order that osets are based on."))
-  (cond ((set::empty names) nil)
+  (cond ((set::emptyp names) nil)
         (t (cons (name-to-symbol (set::head names) state)
                  (name-set-to-symbol-list (set::tail names) state)))))
 

--- a/books/projects/x86isa/proofs/popcount/popcount-general.lisp
+++ b/books/projects/x86isa/proofs/popcount/popcount-general.lisp
@@ -715,7 +715,7 @@
                    (:type-prescription set::setp-type)
                    (:type-prescription acl2::nonnil-symbol-listp)
                    (:type-prescription acl2::hons-duplicity-alist-p)
-                   (:type-prescription set::empty-type)
+                   (:type-prescription set::emptyp-type)
                    (:linear bsf-posp-strict-upper-bound)
                    (:rewrite signed-byte-p-limits-thm)
                    (:rewrite acl2::posp-redefinition)

--- a/books/projects/x86isa/proofs/zeroCopy/marking-view/zeroCopy-init.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-view/zeroCopy-init.lisp
@@ -489,7 +489,7 @@
     (:rewrite bitops::logbitp-when-bitmaskp)
     (:type-prescription all-xlation-governing-entries-paddrs)
     (:type-prescription set::setp-type)
-    (:type-prescription set::empty-type)
+    (:type-prescription set::emptyp-type)
     (:rewrite acl2::equal-constant-+)
     (:definition byte-listp)
     (:rewrite unsigned-byte-p-of-ash)

--- a/books/projects/x86isa/proofs/zeroCopy/non-marking-view/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/non-marking-view/zeroCopy.lisp
@@ -786,7 +786,7 @@
     (:rewrite bitops::logbitp-when-bitmaskp)
     (:type-prescription all-xlation-governing-entries-paddrs)
     (:type-prescription set::setp-type)
-    (:type-prescription set::empty-type)
+    (:type-prescription set::emptyp-type)
     (:rewrite acl2::equal-constant-+)
     (:definition byte-listp)
     (:rewrite unsigned-byte-p-of-ash)

--- a/books/std/bitsets/sbitsets.lisp
+++ b/books/std/bitsets/sbitsets.lisp
@@ -676,9 +676,9 @@ block size.</p>"
     :hints(("Goal" :use ((:instance member-equal-is-in
                                     (x (sbitset-pair-members x)))))))
 
-  (defthm empty-of-sbitset-pair-members
+  (defthm emptyp-of-sbitset-pair-members
     (implies (force (sbitset-pairp x))
-             (not (set::empty (sbitset-pair-members x))))
+             (not (set::emptyp (sbitset-pair-members x))))
     :hints(("Goal" :in-theory (e/d* ((:ruleset set::primitive-rules))
                                     (sbitset-pair-members))))))
 
@@ -969,8 +969,8 @@ is not performed for other block sizes.</p>"
 
   (local (defthm union-under-iff
            (iff (set::union x y)
-                (or (not (set::empty x))
-                    (not (set::empty y))))
+                (or (not (set::emptyp x))
+                    (not (set::emptyp y))))
            :hints(("Goal" :in-theory (enable* (:ruleset set::primitive-rules))))))
 
   (defthm sbitset-members-of-cons
@@ -1793,7 +1793,7 @@ only member is @('a')."
 
 (local (defthm c2
            (implies (sbitset-pairp x)
-                    (not (empty (sbitset-pair-members x))))))
+                    (not (emptyp (sbitset-pair-members x))))))
 
 (local (defthm equal-of-sbitset-pairs
            (implies (and (sbitset-pairp x)

--- a/books/std/obags/core.lisp
+++ b/books/std/obags/core.lisp
@@ -168,7 +168,7 @@
   :short "Check if an obag is empty."
   :long
   (xdoc::topstring-p
-   "This is similar to @(tsee set::empty) for osets.")
+   "This is similar to @(tsee set::emptyp) for osets.")
   (null (bfix bag))
   ///
 

--- a/books/std/osets/cardinality.lisp
+++ b/books/std/osets/cardinality.lisp
@@ -44,7 +44,7 @@ always returns 0 for ill-formed sets.</p>"
   (defun cardinality (X)
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
-    (mbe :logic (if (empty X)
+    (mbe :logic (if (emptyp X)
                     0
                   (1+ (cardinality (tail X))))
          :exec  (length (the list X))))
@@ -52,7 +52,7 @@ always returns 0 for ill-formed sets.</p>"
   (verify-guards cardinality
     ;; Normally we would never want to enable the primitives theory.  However,
     ;; here we need to show that cardinality is equal to length, and for this
-    ;; we need to be able to reason about tail and empty.  Think of this as a
+    ;; we need to be able to reason about tail and emptyp.  Think of this as a
     ;; tiny extension of "fast.lisp"
     :hints(("Goal" :in-theory (enable (:ruleset primitive-rules)))))
 
@@ -61,9 +61,9 @@ always returns 0 for ill-formed sets.</p>"
          (<= 0 (cardinality X)))
     :rule-classes :type-prescription)
 
-  (defthm cardinality-zero-empty
+  (defthm cardinality-zero-emptyp
     (equal (equal (cardinality x) 0)
-           (empty x)))
+           (emptyp x)))
 
   (defthm cardinality-sfix-cancel
     (equal (cardinality (sfix X)) (cardinality X)))
@@ -71,7 +71,7 @@ always returns 0 for ill-formed sets.</p>"
   (encapsulate ()
 
     (local (defthm cardinality-insert-empty
-             (implies (empty X)
+             (implies (emptyp X)
                       (equal (cardinality (insert a X)) 1))
              :hints(("Goal" :use (:instance cardinality (x (insert a nil)))))))
 
@@ -95,7 +95,7 @@ always returns 0 for ill-formed sets.</p>"
 
   (local (defun double-delete-induction (X Y)
            (declare (xargs :guard (and (setp X) (setp Y))))
-           (if (or (empty X) (empty Y))
+           (if (or (emptyp X) (emptyp Y))
                (list X Y)
              (double-delete-induction (delete (head X) X)
                                       (delete (head X) Y)))))
@@ -109,7 +109,7 @@ always returns 0 for ill-formed sets.</p>"
   (encapsulate
     ()
     (local (defthm subset-cardinality-lemma
-             (implies (and (not (or (empty x) (empty y)))
+             (implies (and (not (or (emptyp x) (emptyp y)))
                            (implies (subset (delete (head x) x)
                                             (delete (head x) y))
                                     (<= (cardinality (delete (head x) x))
@@ -156,5 +156,3 @@ always returns 0 for ill-formed sets.</p>"
             :use ((:instance equal-cardinality-subset-is-equality
                              (X (sfix x))
                              (Y (sfix y))))))))
-
-

--- a/books/std/osets/delete.lisp
+++ b/books/std/osets/delete.lisp
@@ -53,7 +53,7 @@ difference) or @(see intersect).</p>
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
     (mbe :logic
-         (cond ((empty X) nil)
+         (cond ((emptyp X) nil)
                ((equal a (head X)) (tail X))
                (t (insert (head X) (delete a (tail X)))))
          :exec
@@ -67,9 +67,9 @@ difference) or @(see intersect).</p>
   (verify-guards delete
     :hints(("Goal" :in-theory (enable (:ruleset primitive-rules)))))
 
-  (defthm delete-preserves-empty
-    (implies (empty X)
-             (empty (delete a X))))
+  (defthm delete-preserves-emptyp
+    (implies (emptyp X)
+             (emptyp (delete a X))))
 
   (defthm delete-in
     (equal (in a (delete b X))

--- a/books/std/osets/difference.lisp
+++ b/books/std/osets/difference.lisp
@@ -169,7 +169,7 @@ exploiting the set order.</p>"
   (defun difference (X Y)
     (declare (xargs :guard (and (setp X) (setp Y))
                     :verify-guards nil))
-    (mbe :logic (cond ((empty X) (sfix X))
+    (mbe :logic (cond ((emptyp X) (sfix X))
                       ((in (head X) Y) (difference (tail X) Y))
                       (t (insert (head X) (difference (tail X) Y))))
          :exec (fast-difference X Y nil)))
@@ -183,12 +183,12 @@ exploiting the set order.</p>"
   (defthm difference-sfix-Y
     (equal (difference X (sfix Y)) (difference X Y)))
 
-  (defthm difference-empty-X
-    (implies (empty X)
+  (defthm difference-emptyp-X
+    (implies (emptyp X)
              (equal (difference X Y) (sfix X))))
 
-  (defthm difference-empty-Y
-    (implies (empty Y)
+  (defthm difference-emptyp-Y
+    (implies (emptyp Y)
              (equal (difference X Y) (sfix X))))
 
   (encapsulate ()
@@ -210,7 +210,7 @@ exploiting the set order.</p>"
     ()
     ;; bozo shouldn't really need this
     (local (defthm l0
-             (implies (and (setp y) (setp x) (empty x))
+             (implies (and (setp y) (setp x) (emptyp x))
                       (not (fast-difference x y nil)))
              :hints(("Goal" :in-theory (enable fast-difference
                                                (:ruleset low-level-rules))))))
@@ -223,7 +223,7 @@ exploiting the set order.</p>"
     (subset (difference X Y) X))
 
   (defthm subset-difference
-    (equal (empty (difference X Y))
+    (equal (emptyp (difference X Y))
            (subset X Y))
     :hints(("Goal" :in-theory (enable subset))))
 

--- a/books/std/osets/element-list.lisp
+++ b/books/std/osets/element-list.lisp
@@ -38,13 +38,13 @@
   (iff (element-list-p (set::sfix x))
        (or (element-list-p x)
            (not (set::setp x))))
-  :hints(("Goal" :in-theory (enable set::empty set::sfix)))
+  :hints(("Goal" :in-theory (enable set::emptyp set::sfix)))
   :tags (:osets))
 
 ;; (local (defthm element-list-p-of-insert-implies-element-list-p-list-fix
 ;;          (implies (not (element-list-p (set::sfix x)))
 ;;                   (not (element-list-p (set::insert a x))))
-;;          :hints(("Goal" :in-theory (e/d (set::insert set::tail set::head set::empty
+;;          :hints(("Goal" :in-theory (e/d (set::insert set::tail set::head set::emptyp
 ;;                                                      set::setp)
 ;;                                         (iff))
 ;;                  :induct (len x)))))
@@ -53,7 +53,7 @@
   (iff (element-list-p (set::insert a x))
        (and (element-list-p (set::sfix x))
             (element-p a)))
-  :hints(("Goal" :in-theory (e/d (set::insert set::tail set::head set::empty
+  :hints(("Goal" :in-theory (e/d (set::insert set::tail set::head set::emptyp
                                               set::setp)
                                  (iff))
           :induct (len x)))
@@ -62,7 +62,7 @@
 (def-listp-rule element-list-p-of-delete
   (implies (element-list-p x)
            (element-list-p (set::delete k x)))
-  :hints(("Goal" :in-theory (enable set::delete set::head set::tail set::empty)))
+  :hints(("Goal" :in-theory (enable set::delete set::head set::tail set::emptyp)))
   :tags (:osets))
 
 (def-listp-rule element-list-p-of-mergesort
@@ -75,7 +75,7 @@
   (iff (element-list-p (set::union x y))
        (and (element-list-p (set::sfix x))
             (element-list-p (set::sfix y))))
-  :hints(("Goal" :in-theory (enable set::union set::head set::tail set::empty
+  :hints(("Goal" :in-theory (enable set::union set::head set::tail set::emptyp
                                     set::setp)
           :induct (len x)))
   :tags (:osets))
@@ -83,25 +83,23 @@
 (def-listp-rule element-list-p-of-intersect-1
   (implies (element-list-p x)
            (element-list-p (set::intersect x y)))
-  :hints(("Goal" :in-theory (enable set::intersect set::head set::tail set::empty set::setp)))
+  :hints(("Goal" :in-theory (enable set::intersect set::head set::tail set::emptyp set::setp)))
   :tags (:osets))
 
 (local (defthm element-p-when-in-element-list-p
          (implies (and (set::in a x)
                        (element-list-p x))
                   (element-p a))
-         :hints(("Goal" :in-theory (enable set::in set::head set::tail set::empty)))))
+         :hints(("Goal" :in-theory (enable set::in set::head set::tail set::emptyp)))))
 
 (def-listp-rule element-list-p-of-intersect-2
   (implies (element-list-p y)
            (element-list-p (set::intersect x y)))
-  :hints(("Goal" :in-theory (enable set::intersect set::head set::tail set::empty set::setp)))
+  :hints(("Goal" :in-theory (enable set::intersect set::head set::tail set::emptyp set::setp)))
   :tags (:osets))
 
 (def-listp-rule element-list-p-of-difference
   (implies (element-list-p x)
            (element-list-p (set::difference x y)))
-  :hints(("Goal" :in-theory (enable set::difference set::head set::tail set::empty set::setp)))
+  :hints(("Goal" :in-theory (enable set::difference set::head set::tail set::emptyp set::setp)))
   :tags (:osets))
-
-

--- a/books/std/osets/intersect.lisp
+++ b/books/std/osets/intersect.lisp
@@ -141,7 +141,7 @@
      (implies (and (setp X)
                    (setp Y))
               (equal (fast-intersectp X Y)
-                     (not (empty (fast-intersect-old X Y)))))
+                     (not (emptyp (fast-intersect-old X Y)))))
      :hints(("Goal" :in-theory (enable (:ruleset low-level-rules)))))))
 
 
@@ -188,7 +188,7 @@
   (defthm fast-intersectp-correct
     (implies (and (setp X) (setp Y))
              (equal (fast-intersectp X Y)
-                    (not (empty (fast-intersect X Y nil))))))
+                    (not (emptyp (fast-intersect X Y nil))))))
 
   (in-theory (disable fast-intersect
                       fast-intersect-set
@@ -216,7 +216,7 @@ consing.</p>"
   (defun intersect (X Y)
     (declare (xargs :guard (and (setp X) (setp Y))
                     :verify-guards nil))
-    (mbe :logic (cond ((empty X) (sfix X))
+    (mbe :logic (cond ((emptyp X) (sfix X))
                       ((in (head X) Y)
                        (insert (head X) (intersect (tail X) Y)))
                       (t (intersect (tail X) Y)))
@@ -231,11 +231,11 @@ consing.</p>"
   (defthm intersect-sfix-cancel-Y
     (equal (intersect X (sfix Y)) (intersect X Y)))
 
-  (defthm intersect-empty-X
-    (implies (empty X) (empty (intersect X Y))))
+  (defthm intersect-emptyp-X
+    (implies (emptyp X) (emptyp (intersect X Y))))
 
-  (defthm intersect-empty-Y
-    (implies (empty Y) (empty (intersect X Y))))
+  (defthm intersect-emptyp-Y
+    (implies (emptyp Y) (emptyp (intersect X Y))))
 
   (encapsulate ()
 
@@ -318,7 +318,7 @@ consing.</p>"
 members."
 
   :long "<p>Logically we just check whether the @(see intersect) of @('X') and
-@('Y') is @(see empty).</p>
+@('Y') is @(see emptyp).</p>
 
 <p>In the execution, we use a faster function that checks for any common
 members and doesn't build any new sets.</p>"
@@ -326,5 +326,5 @@ members and doesn't build any new sets.</p>"
   (defun intersectp (X Y)
     (declare (xargs :guard (and (setp X) (setp Y))
                     :guard-hints(("Goal" :in-theory (enable fast-intersectp-correct)))))
-    (mbe :logic (not (empty (intersect X Y)))
+    (mbe :logic (not (emptyp (intersect X Y)))
          :exec (fast-intersectp X Y))))

--- a/books/std/osets/map.lisp
+++ b/books/std/osets/map.lisp
@@ -143,7 +143,7 @@
 ;; (defthm map-subset-helper-2
 ;;   (implies (not (in (head X) Y))
 ;;            (equal (subset X Y)
-;;                   (empty X))))
+;;                   (emptyp X))))
 
 
 ; We will map an arbitrary transformation function across the set.  We don't
@@ -173,7 +173,7 @@
   (defun map (X)
     (declare (xargs :guard (setp X)))
     (declare (xargs :verify-guards nil))
-    (mbe :logic (if (empty X)
+    (mbe :logic (if (emptyp X)
 		    nil
 		  (insert (transform (head X))
 			  (map (tail X))))
@@ -461,5 +461,3 @@
 		      inversep)))
 
 (in-theory (disable generic-map-theory))
-
-

--- a/books/std/osets/membership.lisp
+++ b/books/std/osets/membership.lisp
@@ -118,7 +118,7 @@ in the future to obtain something along these lines.</p>"
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
     (mbe :logic
-         (and (not (empty X))
+         (and (not (emptyp X))
               (or (equal a (head X))
                   (in a (tail X))))
          :exec
@@ -139,7 +139,7 @@ in the future to obtain something along these lines.</p>"
   (encapsulate ()
 
     (local (defthm head-not-whole
-             (implies (not (empty X))
+             (implies (not (emptyp X))
                       (not (equal (head X) X)))
              :hints(("Goal" :in-theory (enable (:ruleset primitive-rules))))))
 
@@ -155,7 +155,7 @@ in the future to obtain something along these lines.</p>"
            (in a X)))
 
   (defthm never-in-empty
-    (implies (empty X)
+    (implies (emptyp X)
              (not (in a X))))
 
   (defthm in-set
@@ -174,7 +174,7 @@ in the future to obtain something along these lines.</p>"
   (defthm in-head
     ;; BOZO seems redundant with never-in-empty
     (equal (in (head X) X)
-           (not (empty X)))))
+           (not (emptyp X)))))
 
 
 ; We now begin to move away from set order.
@@ -183,14 +183,14 @@ in the future to obtain something along these lines.</p>"
   :extension head
 
   (local (defthm lemma
-	   (implies (and (not (empty X))
+	   (implies (and (not (emptyp X))
 			 (not (equal a (head X)))
 			 (not (<< a (head (tail X))))
 			 (<< a (head X)))
 		    (not (in a X)))
 	   :hints(("Goal"
 		   :in-theory (enable (:ruleset order-rules))
-		   :cases ((empty (tail X)))))))
+		   :cases ((emptyp (tail X)))))))
 
   (defthm head-minimal
     (implies (<< a (head X))
@@ -206,11 +206,11 @@ in the future to obtain something along these lines.</p>"
 
 
   (local (defthm lemma2
-	   (implies (empty (tail X))
+	   (implies (emptyp (tail X))
 		    (not (in (head X) (tail X))))))
 
   (local (defthm lemma3
-	   (implies (not (empty (tail X)))
+	   (implies (not (emptyp (tail X)))
 		    (not (in (head X) (tail X))))
 	   :hints(("Goal" :in-theory (enable (:ruleset order-rules))))))
 
@@ -287,7 +287,7 @@ automatically be used instead.</p>"
 
   (defun weak-insert-induction (a X)
     (declare (xargs :guard (setp X)))
-    (cond ((empty X) nil)
+    (cond ((emptyp X) nil)
           ((in a X) nil)
           ((equal (head (insert a X)) a) nil)
           (t (list (weak-insert-induction a (tail X))))))
@@ -326,8 +326,8 @@ galloping.</p>"
     (declare (xargs :guard (and (setp X) (setp Y))
                     :guard-hints(("Goal" :in-theory (enable (:ruleset primitive-rules) <<)))))
     (mbe :logic
-         (cond ((empty X) t)
-               ((empty Y) nil)
+         (cond ((emptyp X) t)
+               ((emptyp Y) nil)
                ((<< (head X) (head Y)) nil)
                ((equal (head X) (head Y)) (fast-subset (tail X) (tail Y)))
                (t (fast-subset X (tail Y))))
@@ -344,7 +344,7 @@ galloping.</p>"
     (declare (xargs :guard (and (setp X) (setp Y))
                     :verify-guards nil))
     (mbe :logic
-         (if (empty X)
+         (if (emptyp X)
                     t
                   (and (in (head X) Y)
                        (subset (tail X) Y)))
@@ -363,8 +363,8 @@ galloping.</p>"
                              (subset X (tail Y))))))
 
     (local (defthm case-1
-             (implies (and (not (empty X))
-                           (not (empty Y))
+             (implies (and (not (emptyp X))
+                           (not (emptyp Y))
                            (not (<< (head X) (head Y)))
                            (not (equal (head X) (head Y)))
                            (implies (and (setp X) (setp (tail Y)))
@@ -377,8 +377,8 @@ galloping.</p>"
                      :use (:instance lemma)))))
 
     (local (defthm case-2
-             (implies (and (not (empty x))
-                           (not (empty y))
+             (implies (and (not (emptyp x))
+                           (not (emptyp y))
                            (not (<< (head x) (head y)))
                            (equal (head x) (head y))
                            (implies (and (setp (tail x)) (setp (tail y)))
@@ -542,7 +542,7 @@ instantiated to reduce a proof of @('(all X)') to a proof of</p>
 
   (defun all (set-for-all-reduction)
     (declare (xargs :guard (setp set-for-all-reduction)))
-    (if (empty set-for-all-reduction)
+    (if (emptyp set-for-all-reduction)
         t
       (and (predicate (head set-for-all-reduction))
            (all (tail set-for-all-reduction)))))
@@ -561,7 +561,7 @@ instantiated to reduce a proof of @('(all X)') to a proof of</p>
 
   (local (defun find-not (X)
            (declare (xargs :guard (setp X)))
-           (cond ((empty X) nil)
+           (cond ((emptyp X) nil)
                  ((not (predicate (head X))) (head X))
                  (t (find-not (tail X))))))
 
@@ -641,7 +641,7 @@ if you do not want to use the pick-a-point method to solve your goal.</p>"
     ;; only this very special case to solve such goals.
     (implies (syntaxp (equal set-for-all-reduction 'set-for-all-reduction))
              (equal (subset set-for-all-reduction rhs)
-                    (cond ((empty set-for-all-reduction) t)
+                    (cond ((emptyp set-for-all-reduction) t)
                           ((in (head set-for-all-reduction) rhs)
                            (subset (tail set-for-all-reduction) rhs))
                           (t nil))))))
@@ -661,13 +661,13 @@ if you do not want to use the pick-a-point method to solve your goal.</p>"
            (subset X Y)))
 
   (defthm empty-subset
-    (implies (empty X)
+    (implies (emptyp X)
              (subset X Y)))
 
   (defthm empty-subset-2
-    (implies (empty Y)
+    (implies (emptyp Y)
              (equal (subset X Y)
-                    (empty X))))
+                    (emptyp X))))
 
   (defthm subset-in
     (and (implies (and (subset X Y)
@@ -795,12 +795,12 @@ directed by @(see accumulated-persistence).</p>"
 
   (local (defun double-tail-induction (X Y)
 	   (declare (xargs :guard (and (setp X) (setp Y))))
-	   (if (or (empty X) (empty Y))
+	   (if (or (emptyp X) (emptyp Y))
 	       (list X Y)
 	     (double-tail-induction (tail X) (tail Y)))))
 
   (local (defthm double-containment-is-equality-lemma
-	   (IMPLIES (AND (NOT (OR (EMPTY X) (EMPTY Y)))
+	   (IMPLIES (AND (NOT (OR (EMPTYP X) (EMPTYP Y)))
 			 (IMPLIES (AND (SUBSET (TAIL X) (TAIL Y))
 				       (SUBSET (TAIL Y) (TAIL X)))
 				  (EQUAL (EQUAL (TAIL X) (TAIL Y)) T))
@@ -866,7 +866,7 @@ directed by @(see accumulated-persistence).</p>"
     (equal (setp (cons a X))
            (and (setp X)
                 (or (<< a (head X))
-                    (empty X)))))
+                    (emptyp X)))))
 
   (defthm in-to-member
     (implies (setp X)

--- a/books/std/osets/primitives.lisp
+++ b/books/std/osets/primitives.lisp
@@ -78,7 +78,7 @@ convention.  These primitives are:</p>
  <li>@('(head X)') - the first element of a set, nil for non/empty sets</li>
  <li>@('(tail X)') - all rest of the set, nil for non/empty sets</li>
  <li>@('(insert a X)') - ordered insert of @('a') into @('X')</li>
- <li>@('(empty X)') - recognizer for non/empty sets.</li>
+ <li>@('(emptyp X)') - recognizer for non/empty sets.</li>
 </ul>
 
 <p>The general idea is that set operations should be written in terms of these
@@ -136,26 +136,26 @@ elements are in order.  Its cost is linear in the size of @('n').</p>"
               (true-listp X))
      :rule-classes ((:rewrite :backchain-limit-lst (1)))))
 
-(defsection empty
+(defsection emptyp
   :parents (primitives)
-  :short "@(call empty) recognizes empty sets."
+  :short "@(call emptyp) recognizes empty sets."
 
   :long "<p>This function is like @(see endp) for lists, but it respects the
 non-set convention and always returns true for ill-formed sets.</p>"
 
-  (defun empty (X)
+  (defun emptyp (X)
     (declare (xargs :guard (setp X)))
     (mbe :logic (or (null X)
                     (not (setp X)))
          :exec  (null X)))
 
-  (defthm empty-type
-    (or (equal (empty X) t)
-        (equal (empty X) nil))
+  (defthm emptyp-type
+    (or (equal (emptyp X) t)
+        (equal (emptyp X) nil))
     :rule-classes :type-prescription)
 
   (defthm nonempty-means-set
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (setp X))))
 
 (defthm empty-set-unique
@@ -163,8 +163,8 @@ non-set convention and always returns true for ill-formed sets.</p>"
   ;; it out of the docs above.
   (implies (and (setp X)
                 (setp Y)
-                (empty X)
-                (empty Y))
+                (emptyp X)
+                (emptyp Y))
            (equal (equal X Y)
                   t)))
 
@@ -183,7 +183,7 @@ operation to ensure that an ordered set is always produced.</p>"
 
   (defun sfix (X)
     (declare (xargs :guard (setp X)))
-    (mbe :logic (if (empty X) nil X)
+    (mbe :logic (if (emptyp X) nil X)
          :exec  X))
 
   (defthm sfix-produces-set
@@ -198,22 +198,22 @@ operation to ensure that an ordered set is always produced.</p>"
   ;; rewriting it to NIL is a lot nicer.
   ;;
   ;; (defthm sfix-empty-same
-  ;;   (implies (and (empty X)
-  ;;                 (empty Y))
+  ;;   (implies (and (emptyp X)
+  ;;                 (emptyp Y))
   ;;            (equal (equal (sfix X) (sfix Y))
   ;;                   t)))
 
-  (defthm sfix-when-empty
-    (implies (empty X)
+  (defthm sfix-when-emptyp
+    (implies (emptyp X)
              (equal (sfix X)
                     nil))))
 
 
-(defthm empty-sfix-cancel
-  (equal (empty (sfix X))
-         (empty X)))
+(defthm emptyp-sfix-cancel
+  (equal (emptyp (sfix X))
+         (emptyp X)))
 
-(xdoc::xdoc-extend empty "@(def empty-sfix-cancel)")
+(xdoc::xdoc-extend emptyp "@(def emptyp-sfix-cancel)")
 
 
 
@@ -226,32 +226,32 @@ always returns @('nil') for ill-formed sets.</p>"
 
   (defun head (X)
     (declare (xargs :guard (and (setp X)
-                                (not (empty X)))))
+                                (not (emptyp X)))))
     (mbe :logic (car (sfix X))
          :exec  (car X)))
 
   (defthm head-count
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (< (acl2-count (head X)) (acl2-count X)))
     :rule-classes ((:rewrite) (:linear)))
 
   (defthm head-count-built-in
     ;; BOZO probably should remove this
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (o< (acl2-count (head X)) (acl2-count X)))
     :rule-classes :built-in-clause)
 
-  ;; I historically did this instead of head-when-empty, but now I think just
+  ;; I historically did this instead of head-when-emptyp, but now I think just
   ;; rewriting it to NIL is a lot nicer.
   ;;
-  ;; (defthm head-empty-same
-  ;;   (implies (and (empty X)
-  ;;                 (empty Y))
+  ;; (defthm head-emptyp-same
+  ;;   (implies (and (emptyp X)
+  ;;                 (emptyp Y))
   ;;            (equal (equal (head X) (head Y))
   ;;                   t)))
 
-  (defthm head-when-empty
-    (implies (empty X)
+  (defthm head-when-emptyp
+    (implies (emptyp X)
              (equal (head X)
                     nil)))
 
@@ -271,41 +271,41 @@ always returns @('nil') for ill-formed sets.</p>"
 
   (defun tail (X)
     (declare (xargs :guard (and (setp X)
-                                (not (empty X)))))
+                                (not (emptyp X)))))
     (mbe :logic (cdr (sfix X))
          :exec  (cdr X)))
 
   (defthm tail-count
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (< (acl2-count (tail X)) (acl2-count X)))
     :rule-classes ((:rewrite) (:linear)))
 
   (defthm tail-count-built-in
     ;; BOZO probably should remove this
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (o< (acl2-count (tail X)) (acl2-count X)))
     :rule-classes :built-in-clause)
 
   (defthm tail-produces-set
     (setp (tail X)))
 
-  ;; I historically did this instead of tail-when-empty, but now I think just
+  ;; I historically did this instead of tail-when-emptyp, but now I think just
   ;; rewriting it to NIL is a lot nicer.
   ;;
-  ;; (defthm tail-empty-same
-  ;;   (implies (and (empty X)
-  ;;                 (empty Y))
+  ;; (defthm tail-emptyp-same
+  ;;   (implies (and (emptyp X)
+  ;;                 (emptyp Y))
   ;;            (equal (equal (tail X) (tail Y))
   ;;                   t)))
 
-  ;; This was also subsumed by tail-when-empty:
+  ;; This was also subsumed by tail-when-emptyp:
   ;;
-  ;; (defthm tail-preserves-empty
-  ;;   (implies (empty X)
-  ;;            (empty (tail X))))
+  ;; (defthm tail-preserves-emptyp
+  ;;   (implies (emptyp X)
+  ;;            (emptyp (tail X))))
 
-  (defthm tail-when-empty
-    (implies (empty X)
+  (defthm tail-when-emptyp
+    (implies (emptyp X)
              (equal (tail X)
                     nil)))
 
@@ -318,8 +318,8 @@ always returns @('nil') for ill-formed sets.</p>"
   ;; BOZO probably expensive
   (implies (and (equal (head X) (head Y))
                 (equal (tail X) (tail Y))
-                (not (empty X))
-                (not (empty Y)))
+                (not (emptyp X))
+                (not (emptyp Y)))
            (equal (equal X Y)
                   t)))
 
@@ -349,9 +349,9 @@ following loop:</p>
 
   (local (in-theory (disable nonempty-means-set
                              empty-set-unique
-                             head-when-empty
-                             tail-when-empty
-                             sfix-when-empty
+                             head-when-emptyp
+                             tail-when-emptyp
+                             sfix-when-emptyp
                              default-car
                              default-cdr
                              )))
@@ -360,7 +360,7 @@ following loop:</p>
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
     (mbe :logic
-         (cond ((empty X) (list a))
+         (cond ((emptyp X) (list a))
                ((equal (head X) a) X)
                ((<< a (head X)) (cons a X))
                (t (cons (head X) (insert a (tail X)))))
@@ -386,34 +386,34 @@ following loop:</p>
            (insert a X)))
 
   (defthm insert-never-empty
-    (not (empty (insert a X))))
+    (not (emptyp (insert a X))))
 
   ;; I historically did this instead of insert-when-empty, but now I think that
   ;; canonicalizing bad inserts into (insert a NIL) seems nicer.
   ;;
   ;; (defthm insert-empty-same
-  ;;   (implies (and (empty X)
-  ;;                 (empty Y))
+  ;;   (implies (and (emptyp X)
+  ;;                 (emptyp Y))
   ;;            (equal (equal (insert a X) (insert a Y))
   ;;                   t)))
 
   ;; The following also became unnecessary after switching to (insert a NIL).
   ;;
   ;; (defthm head-insert-empty
-  ;;   (implies (empty X)
+  ;;   (implies (emptyp X)
   ;;            (equal (head (insert a X)) a)))
   ;;
   ;; (defthm tail-insert-empty
-  ;;   (implies (empty X)
-  ;;  	      (empty (tail (insert a X)))))
+  ;;   (implies (emptyp X)
+  ;;  	      (emptyp (tail (insert a X)))))
 
-  (defthm insert-when-empty
+  (defthm insert-when-emptyp
     (implies (and (syntaxp (not (equal X ''nil)))
-                  (empty X))
+                  (emptyp X))
              (equal (insert a X)
                     (insert a nil))))
 
-  ;; These special cases can come up after insert-when-empty applies, so it's
+  ;; These special cases can come up after insert-when-emptyp applies, so it's
   ;; nice to have rules to target them.
 
   (defthm head-of-insert-a-nil
@@ -426,18 +426,18 @@ following loop:</p>
 
   ;; Historic Note: We used to require that nil was "greater than" everything else
   ;; in our order.  This had the advantage that the following theorems could have
-  ;; a combined case for (empty X) and (<< a (head X)).  Starting in Version 0.9,
+  ;; a combined case for (emptyp X) and (<< a (head X)).  Starting in Version 0.9,
   ;; we remove this restriction in order to be more flexible about our order.
 
   (defthm head-insert
     (equal (head (insert a X))
-           (cond ((empty X) a)
+           (cond ((emptyp X) a)
                  ((<< a (head X)) a)
                  (t (head X)))))
 
   (defthm tail-insert
     (equal (tail (insert a X))
-           (cond ((empty X) nil)
+           (cond ((emptyp X) nil)
                  ((<< a (head X)) X)
                  ((equal a (head X)) (tail X))
                  (t (insert a (tail X))))))
@@ -456,7 +456,7 @@ following loop:</p>
              :rule-classes ((:rewrite :backchain-limit-lst 0))))
 
     (local (in-theory (disable sfix-set-identity
-                               insert-when-empty
+                               insert-when-emptyp
                                (:definition insert)
                                <<-trichotomy
                                <<-asymmetric)))
@@ -502,12 +502,12 @@ following loop:</p>
                        (:free (k1 k2 k3) (insert k1 (cons k2 k3))))))))
 
   (defthm insert-head
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (equal (insert (head X) X)
                     X)))
 
   (defthm insert-head-tail
-    (implies (not (empty X))
+    (implies (not (emptyp X))
              (equal (insert (head X) (tail X))
                     X)))
 
@@ -520,7 +520,7 @@ following loop:</p>
   (defthm insert-induction-case
     (implies (and (not (<< a (head X)))
                   (not (equal a (head X)))
-                  (not (empty X)))
+                  (not (emptyp X)))
              (equal (insert (head X) (insert a (tail X)))
                     (insert a X)))))
 
@@ -533,15 +533,15 @@ following loop:</p>
 ;; book, these are the only facts which membership.lisp will be able to use.
 
 (defthm head-tail-order
-  (implies (not (empty (tail X)))
+  (implies (not (emptyp (tail X)))
            (<< (head X) (head (tail X)))))
 
 (defthm head-tail-order-contrapositive
   (implies (not (<< (head X) (head (tail X))))
-           (empty (tail X))))
+           (emptyp (tail X))))
 
 (defthm head-not-head-tail
-  (implies (not (empty (tail X)))
+  (implies (not (emptyp (tail X)))
            (not (equal (head X) (head (tail X))))))
 
 
@@ -557,7 +557,7 @@ following loop:</p>
 ; but are needed for some theorems in the membership level.
 
 (def-ruleset primitive-rules
-  '(setp empty head tail sfix insert))
+  '(setp emptyp head tail sfix insert))
 
 (def-ruleset order-rules
   '(<<-irreflexive

--- a/books/std/osets/quantify.lisp
+++ b/books/std/osets/quantify.lisp
@@ -209,7 +209,7 @@
   (defun all (set-for-all-reduction)
     (declare (xargs :guard (setp set-for-all-reduction)
                     :verify-guards nil))
-    (if (empty set-for-all-reduction)
+    (if (emptyp set-for-all-reduction)
 	t
       (and (predicate (head set-for-all-reduction))
 	   (all (tail set-for-all-reduction)))))
@@ -217,21 +217,21 @@
   (defun exists (X)
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
-    (cond ((empty X) nil)
+    (cond ((emptyp X) nil)
 	  ((predicate (head X)) t)
 	  (t (exists (tail X)))))
 
   (defun find (X)
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
-    (cond ((empty X) nil)
+    (cond ((emptyp X) nil)
 	  ((predicate (head X)) (head X))
 	  (t (find (tail X)))))
 
   (defun filter (X)
     (declare (xargs :guard (setp X)
                     :verify-guards nil))
-    (cond ((empty X) (sfix X))
+    (cond ((emptyp X) (sfix X))
 	  ((predicate (head X))
 	   (insert (head X) (filter (tail X))))
 	  (t (filter (tail X)))))
@@ -386,8 +386,8 @@
     (implies (all X)
 	     (all (tail X))))
 
-  (defthm all-empty
-    (implies (empty X)
+  (defthm all-emptyp
+    (implies (emptyp X)
 	     (all X)))
 
   (defthm all-in
@@ -492,7 +492,7 @@
     (implies (setp X)
 	     (equal (all-list X)
 		    (all X)))
-    :hints(("Goal" :in-theory (enable setp empty sfix head tail))))
+    :hints(("Goal" :in-theory (enable setp emptyp sfix head tail))))
 
 ))
 
@@ -809,7 +809,7 @@
 	(instance-*theorems*
 	 :subs ,subs
 	 :suffix ,(mksym wrap in-package))
-	 ;:extra-defs (empty))
+	 ;:extra-defs (emptyp))
 
 
 	;; Automating the computed hints is a pain in the ass.  We
@@ -943,7 +943,7 @@
 	(instance-*final-theorems*
 	 :subs ,subs
 	 :suffix ,(mksym wrap in-package))
-	 ;:extra-defs (empty))
+	 ;:extra-defs (emptyp))
 
 
         ,@(and verify-guards
@@ -1031,4 +1031,3 @@
     all-list<not> exists-list<not> find-list<not> filter-list<not>))
 
 (in-theory (disable generic-quantification-theory))
-

--- a/books/std/osets/top.lisp
+++ b/books/std/osets/top.lisp
@@ -144,37 +144,37 @@ from the accompanying talk.</p>")
       (equal (setp X) nil))
   :rule-classes :type-prescription)
 
-(defund empty (X)
+(defund emptyp (X)
   (declare (xargs :guard (setp X)))
   (mbe :logic (or (null X)
                   (not (setp X)))
        :exec  (null X)))
 
-(defthm empty-type
-  (or (equal (empty X) t)
-      (equal (empty X) nil))
+(defthm emptyp-type
+  (or (equal (emptyp X) t)
+      (equal (emptyp X) nil))
   :rule-classes :type-prescription)
 
 (defund sfix (X)
   (declare (xargs :guard (setp X)))
-  (mbe :logic (if (empty X) nil X)
+  (mbe :logic (if (emptyp X) nil X)
        :exec  X))
 
 (defund head (X)
   (declare (xargs :guard (and (setp X)
-                              (not (empty X)))))
+                              (not (emptyp X)))))
   (mbe :logic (car (sfix X))
        :exec  (car X)))
 
 (defund tail (X)
   (declare (xargs :guard (and (setp X)
-                              (not (empty X)))))
+                              (not (emptyp X)))))
   (mbe :logic (cdr (sfix X))
        :exec  (cdr X)))
 
 (defund insert (a X)
   (declare (xargs :guard (setp X)))
-  (mbe :logic (cond ((empty X) (list a))
+  (mbe :logic (cond ((emptyp X) (list a))
                     ((equal (head X) a) X)
                     ((<< a (head X)) (cons a X))
                     (t (cons (head X) (insert a (tail X)))))
@@ -190,7 +190,7 @@ from the accompanying talk.</p>")
 (defun in (a X)
   (declare (xargs :guard (setp X)))
   (mbe :logic
-       (and (not (empty X))
+       (and (not (emptyp X))
             (or (equal a (head X))
                 (in a (tail X))))
        :exec
@@ -208,8 +208,8 @@ from the accompanying talk.</p>")
 (defund fast-subset (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
   (mbe :logic
-       (cond ((empty X) t)
-             ((empty Y) nil)
+       (cond ((emptyp X) t)
+             ((emptyp Y) nil)
              ((<< (head X) (head Y)) nil)
              ((equal (head X) (head Y)) (fast-subset (tail X) (tail Y)))
              (t (fast-subset X (tail Y))))
@@ -224,7 +224,7 @@ from the accompanying talk.</p>")
 
 (defun subset (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
-  (mbe :logic (if (empty X)
+  (mbe :logic (if (emptyp X)
 		  t
 		(and (in (head X) Y)
 		     (subset (tail X) Y)))
@@ -300,7 +300,7 @@ from the accompanying talk.</p>")
 (defun delete (a X)
   (declare (xargs :guard (setp X)))
   (mbe :logic
-       (cond ((empty X) nil)
+       (cond ((emptyp X) nil)
              ((equal a (head X)) (tail X))
              (t (insert (head X) (delete a (tail X)))))
        :exec
@@ -310,14 +310,14 @@ from the accompanying talk.</p>")
 
 (defun union (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
-  (mbe :logic (if (empty X)
+  (mbe :logic (if (emptyp X)
                   (sfix Y)
                 (insert (head X) (union (tail X) Y)))
        :exec  (fast-union X Y nil)))
 
 (defun intersect (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
-  (mbe :logic (cond ((empty X) (sfix X))
+  (mbe :logic (cond ((emptyp X) (sfix X))
                     ((in (head X) Y)
                      (insert (head X) (intersect (tail X) Y)))
                     (t (intersect (tail X) Y)))
@@ -325,19 +325,19 @@ from the accompanying talk.</p>")
 
 (defun intersectp (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
-  (mbe :logic (not (empty (intersect X Y)))
+  (mbe :logic (not (emptyp (intersect X Y)))
        :exec (fast-intersectp X Y)))
 
 (defun difference (X Y)
   (declare (xargs :guard (and (setp X) (setp Y))))
-  (mbe :logic (cond ((empty X) (sfix X))
+  (mbe :logic (cond ((emptyp X) (sfix X))
                     ((in (head X) Y) (difference (tail X) Y))
                     (t (insert (head X) (difference (tail X) Y))))
        :exec (fast-difference X Y nil)))
 
 (defun cardinality (X)
   (declare (xargs :guard (setp X)))
-  (mbe :logic (if (empty X)
+  (mbe :logic (if (emptyp X)
                   0
                 (1+ (cardinality (tail X))))
        :exec  (length (the list X))))
@@ -389,7 +389,7 @@ from the accompanying talk.</p>")
 
 (defun all (set-for-all-reduction)
   (declare (xargs :guard (setp set-for-all-reduction)))
-  (if (empty set-for-all-reduction)
+  (if (emptyp set-for-all-reduction)
       t
     (and (predicate (head set-for-all-reduction))
 	 (all (tail set-for-all-reduction)))))
@@ -441,7 +441,7 @@ from the accompanying talk.</p>")
   ;; only this very special case to solve such goals.
   (implies (syntaxp (equal set-for-all-reduction 'set-for-all-reduction))
            (equal (subset set-for-all-reduction rhs)
-                  (cond ((empty set-for-all-reduction) t)
+                  (cond ((emptyp set-for-all-reduction) t)
                         ((in (head set-for-all-reduction) rhs)
                          (subset (tail set-for-all-reduction) rhs))
                         (t nil)))))
@@ -482,22 +482,22 @@ from the accompanying talk.</p>")
   :rule-classes ((:rewrite :backchain-limit-lst (1))))
 
 (defthm tail-count
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (< (acl2-count (tail X)) (acl2-count X)))
   :rule-classes ((:rewrite) (:linear)))
 
 (defthm head-count
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (< (acl2-count (head X)) (acl2-count X)))
   :rule-classes ((:rewrite) (:linear)))
 
 (defthm tail-count-built-in
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (o< (acl2-count (tail X)) (acl2-count X)))
   :rule-classes :built-in-clause)
 
 (defthm head-count-built-in
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (o< (acl2-count (head X)) (acl2-count X)))
   :rule-classes :built-in-clause)
 
@@ -516,10 +516,10 @@ from the accompanying talk.</p>")
   (setp (insert a X)))
 
 (defthm insert-never-empty
-  (not (empty (insert a X))))
+  (not (emptyp (insert a X))))
 
 (defthm nonempty-means-set
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (setp X)))
 
 (defthm sfix-set-identity
@@ -527,9 +527,9 @@ from the accompanying talk.</p>")
            (equal (sfix X)
                   X)))
 
-(defthm empty-sfix-cancel
-  (equal (empty (sfix X))
-         (empty X)))
+(defthm emptyp-sfix-cancel
+  (equal (emptyp (sfix X))
+         (emptyp X)))
 
 (defthm head-sfix-cancel
   (equal (head (sfix X))
@@ -540,12 +540,12 @@ from the accompanying talk.</p>")
          (tail X)))
 
 (defthm insert-head
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (equal (insert (head X) X)
                   X)))
 
 (defthm insert-head-tail
-  (implies (not (empty X))
+  (implies (not (emptyp X))
            (equal (insert (head X) (tail X))
                   X)))
 
@@ -557,19 +557,19 @@ from the accompanying talk.</p>")
   (equal (insert a (sfix X))
          (insert a X)))
 
-(defthm head-when-empty
-  (implies (empty X)
+(defthm head-when-emptyp
+  (implies (emptyp X)
            (equal (head X)
                   nil)))
 
-(defthm tail-when-empty
-  (implies (empty X)
+(defthm tail-when-emptyp
+  (implies (emptyp X)
            (equal (tail X)
                   nil)))
 
-(defthm insert-when-empty
+(defthm insert-when-emptyp
   (implies (and (syntaxp (not (equal X ''nil)))
-                (empty X))
+                (emptyp X))
            (equal (insert a X)
                   (insert a nil))))
 
@@ -581,8 +581,8 @@ from the accompanying talk.</p>")
   (equal (tail (insert a nil))
          nil))
 
-(defthm sfix-when-empty
-  (implies (empty X)
+(defthm sfix-when-emptyp
+  (implies (emptyp X)
            (equal (sfix X)
                   nil)))
 
@@ -608,7 +608,7 @@ from the accompanying talk.</p>")
          (in a X)))
 
 (defthm never-in-empty
-  (implies (empty X)
+  (implies (emptyp X)
            (not (in a X))))
 
 (defthm in-set
@@ -627,7 +627,7 @@ from the accompanying talk.</p>")
 
 (defthm in-head
   (equal (in (head X) X)
-         (not (empty X))))
+         (not (emptyp X))))
 
 (defthm head-unique
   (not (in (head X) (tail X))))
@@ -679,14 +679,14 @@ from the accompanying talk.</p>")
                      (subset X Y))
                 (not (in a X)))))
 
-(defthm empty-subset
-  (implies (empty X)
+(defthm emptyp-subset
+  (implies (emptyp X)
            (subset X Y)))
 
-(defthm empty-subset-2
-  (implies (empty Y)
+(defthm emptyp-subset-2
+  (implies (emptyp Y)
 	   (equal (subset X Y)
-                  (empty X))))
+                  (emptyp X))))
 
 (defthm subset-reflexive
   (subset X X))
@@ -721,7 +721,7 @@ from the accompanying talk.</p>")
 
 (defun weak-insert-induction (a X)
   (declare (xargs :guard (setp X)))
-  (cond ((empty X) nil)
+  (cond ((emptyp X) nil)
         ((in a X) nil)
         ((equal (head (insert a X)) a) nil)
         (t (list (weak-insert-induction a (tail X))))))
@@ -745,9 +745,9 @@ from the accompanying talk.</p>")
 (defthm delete-set
   (setp (delete a X)))
 
-(defthm delete-preserves-empty
-  (implies (empty X)
-           (empty (delete a X))))
+(defthm delete-preserves-emptyp
+  (implies (emptyp X)
+           (emptyp (delete a X))))
 
 (defthm delete-in
   (equal (in a (delete b X))
@@ -817,17 +817,17 @@ from the accompanying talk.</p>")
 (defthm union-sfix-cancel-Y
   (equal (union X (sfix Y)) (union X Y)))
 
-(defthm union-empty-X
-  (implies (empty X)
+(defthm union-emptyp-X
+  (implies (emptyp X)
            (equal (union X Y) (sfix Y))))
 
-(defthm union-empty-Y
-  (implies (empty Y)
+(defthm union-emptyp-Y
+  (implies (emptyp Y)
            (equal (union X Y) (sfix X))))
 
-(defthm union-empty
-  (equal (empty (union X Y))
-         (and (empty X) (empty Y))))
+(defthm union-emptyp
+  (equal (emptyp (union X Y))
+         (and (emptyp X) (emptyp Y))))
 
 (defthm union-in
   (equal (in a (union X Y))
@@ -895,11 +895,11 @@ from the accompanying talk.</p>")
 (defthm intersect-sfix-cancel-Y
   (equal (intersect X (sfix Y)) (intersect X Y)))
 
-(defthm intersect-empty-X
-  (implies (empty X) (empty (intersect X Y))))
+(defthm intersect-emptyp-X
+  (implies (emptyp X) (emptyp (intersect X Y))))
 
-(defthm intersect-empty-Y
-  (implies (empty Y) (empty (intersect X Y))))
+(defthm intersect-emptyp-Y
+  (implies (emptyp Y) (emptyp (intersect X Y))))
 
 (defthm intersect-in
   (equal (in a (intersect X Y))
@@ -958,12 +958,12 @@ from the accompanying talk.</p>")
 (defthm difference-sfix-Y
   (equal (difference X (sfix Y)) (difference X Y)))
 
-(defthm difference-empty-X
-  (implies (empty X)
+(defthm difference-emptyp-X
+  (implies (emptyp X)
            (equal (difference X Y) (sfix X))))
 
-(defthm difference-empty-Y
-  (implies (empty Y)
+(defthm difference-emptyp-Y
+  (implies (emptyp Y)
            (equal (difference X Y) (sfix X))))
 
 (defthm difference-in
@@ -975,7 +975,7 @@ from the accompanying talk.</p>")
   (subset (difference X Y) X))
 
 (defthm subset-difference
-  (equal (empty (difference X Y))
+  (equal (emptyp (difference X Y))
          (subset X Y)))
 
 (defthm difference-over-union
@@ -1017,9 +1017,9 @@ from the accompanying talk.</p>")
        (<= 0 (cardinality X)))
   :rule-classes :type-prescription)
 
-(defthm cardinality-zero-empty
+(defthm cardinality-zero-emptyp
   (equal (equal (cardinality x) 0)
-	 (empty x)))
+	 (emptyp x)))
 
 (defthm cardinality-sfix-cancel
   (equal (cardinality (sfix X))
@@ -1119,30 +1119,30 @@ from the accompanying talk.</p>")
 (defthmd insert-induction-case
   (implies (and (not (<< a (head X)))
                 (not (equal a (head X)))
-                (not (empty X)))
+                (not (emptyp X)))
            (equal (insert (head X) (insert a (tail X)))
                   (insert a X))))
 
 (defthmd head-insert
   (equal (head (insert a X))
-	 (cond ((empty X) a)
+	 (cond ((emptyp X) a)
 	       ((<< a (head X)) a)
 	       (t (head X)))))
 
 (defthmd tail-insert
   (equal (tail (insert a X))
-	 (cond ((empty X) nil)
+	 (cond ((emptyp X) nil)
 	       ((<< a (head X)) X)
                ((equal a (head X)) (tail X))
                (t (insert a (tail X))))))
 
 (defthmd head-tail-order
-  (implies (not (empty (tail X)))
+  (implies (not (emptyp (tail X)))
            (<< (head X) (head (tail X)))))
 
 (defthmd head-tail-order-contrapositive
   (implies (not (<< (head X) (head (tail X))))
-           (empty (tail X))))
+           (emptyp (tail X))))
 
 (defthmd head-minimal
   (implies (<< a (head X))
@@ -1156,7 +1156,7 @@ from the accompanying talk.</p>")
   (equal (setp (cons a X))
          (and (setp X)
               (or (<< a (head X))
-                  (empty X)))))
+                  (emptyp X)))))
 
 (defthmd in-to-member
   (implies (setp X)

--- a/books/std/osets/union.lisp
+++ b/books/std/osets/union.lisp
@@ -145,7 +145,7 @@ the set order.</p>"
   (defun union (X Y)
     (declare (xargs :guard (and (setp X) (setp Y))
                     :verify-guards nil))
-    (mbe :logic (if (empty X)
+    (mbe :logic (if (emptyp X)
                     (sfix Y)
                   (insert (head X) (union (tail X) Y)))
          :exec  (fast-union X Y nil)))
@@ -159,17 +159,17 @@ the set order.</p>"
   (defthm union-sfix-cancel-Y
     (equal (union X (sfix Y)) (union X Y)))
 
-  (defthm union-empty-X
-    (implies (empty X)
+  (defthm union-emptyp-X
+    (implies (emptyp X)
              (equal (union X Y) (sfix Y))))
 
-  (defthm union-empty-Y
-    (implies (empty Y)
+  (defthm union-emptyp-Y
+    (implies (emptyp Y)
              (equal (union X Y) (sfix X))))
 
-  (defthm union-empty
-    (equal (empty (union X Y))
-           (and (empty X) (empty Y))))
+  (defthm union-emptyp
+    (equal (emptyp (union X Y))
+           (and (emptyp X) (emptyp Y))))
 
   (defthm union-in
     (equal (in a (union X Y))

--- a/books/std/package.lsp
+++ b/books/std/package.lsp
@@ -136,7 +136,7 @@
   ;; that frequently need to be enabled/disabled.
   '(<<
     setp
-    empty
+    emptyp
     sfix
     head
     tail

--- a/books/std/util/deflist.lisp
+++ b/books/std/util/deflist.lisp
@@ -165,13 +165,13 @@
   (defthmd deflist-lemma-sfix-when-not-setp
     (implies (not (setp x))
              (equal (sfix x) nil))
-    :hints(("Goal" :in-theory (enable sfix empty))))
+    :hints(("Goal" :in-theory (enable sfix emptyp))))
 
   (defthmd deflist-lemma-sfix-when-setp
     (implies (setp x)
              (equal (sfix x)
                     x))
-    :hints(("Goal" :in-theory (enable sfix empty))))
+    :hints(("Goal" :in-theory (enable sfix emptyp))))
 
   (defthmd deflist-lemma-subsetp-of-difference
     (subsetp-equal (difference x y) x))

--- a/books/workshops/2023/coglio-mccarthy-smith/pfcs.lisp
+++ b/books/workshops/2023/coglio-mccarthy-smith/pfcs.lisp
@@ -958,7 +958,7 @@
            set::mergesort))
 
 (defrule definition-free-vars-of-boolean-assert-list-gadget
-  (set::empty (definition-free-vars (boolean-assert-list-gadget n)))
+  (set::emptyp (definition-free-vars (boolean-assert-list-gadget n)))
   :enable (boolean-assert-list-gadget
            definition-free-vars))
 


### PR DESCRIPTION
The new name is in line with the typical Lisp/ACL2 convention for predicates. The old name has caused confusion to some users/readers.

This change was proposed some time ago on the ACL2 Books mailing list, and there were no objections.