### PR TITLE
[acl2s] Add ACL2s interface portcullis to docs/cert.acl2

### DIFF
--- a/books/doc/cert.acl2
+++ b/books/doc/cert.acl2
@@ -59,5 +59,6 @@
 (include-book "kestrel/ethereum/semaphore/portcullis" :dir :system)
 (include-book "projects/pfcs/portcullis" :dir :system)
 (include-book "kestrel/zcash/portcullis" :dir :system)
+(include-book "acl2s/interface/portcullis" :dir :system)
 
 ; cert-flags: ? t :ttags :all


### PR DESCRIPTION
This resolves an error that occurs when certifying doc/top.lisp due to packages not being set up right.