### PR TITLE
set global timeouts

### DIFF
--- a/books/workshops/2023/kumar-etal/attacks/cert.acl2
+++ b/books/workshops/2023/kumar-etal/attacks/cert.acl2
@@ -13,6 +13,6 @@
 
 (in-package "ACL2S")
 (acl2s-defaults :set testing-enabled nil)
-(ACL2S::set-acl2s-property-table-proof-timeout 12000)
+(ACL2S::set-acl2s-property-table-proof-timeout 50000)
 
 ; cert-flags: ? t :ttags :all :skip-proofs-okp t

--- a/books/workshops/2023/kumar-etal/cert.acl2
+++ b/books/workshops/2023/kumar-etal/cert.acl2
@@ -16,6 +16,6 @@
 
 (in-package "ACL2S")
 (acl2s-defaults :set testing-enabled nil)
-(set-acl2s-property-table-proof-timeout 12000)
+(set-acl2s-property-table-proof-timeout 50000)
 
 ; cert-flags: ? t :ttags :all :skip-proofs-okp t

--- a/books/workshops/2023/kumar-etal/demo.lsp
+++ b/books/workshops/2023/kumar-etal/demo.lsp
@@ -432,7 +432,7 @@
        s :nat)
   :res1
   :skip-tests t
-  :timeout 600
+  :timeout 12000
   :ic (is-valid-twp twpm)
   :body-contracts-hints (("goal" :do-not-induct t
                           :in-theory (enable nbr-topic-statep evntp twpp wpp)))
@@ -699,7 +699,7 @@
                                        s :nat)
   :res1
   :skip-tests t
-  :timeout 60
+  :timeout 12000
   :ic (is-valid-twp twpm)
   :body-contracts-hints (("Goal" :DO-NOT-INDUCT T
                           :in-theory (enable nbr-topic-statep evntp twpp wpp)))
@@ -809,7 +809,7 @@
                                   twpm :twp)
   :res2
   :skip-tests t
-  :timeout 2000
+  :timeout 12000
   :function-contract-hints (("Goal" :DO-NOT-INDUCT T
                              :in-theory (enable evntp)))
   :body-contracts-hints (("Goal" :DO-NOT-INDUCT T
@@ -898,7 +898,7 @@
 				  twpm :twp)
   :res2
   :skip-tests t
-  :timeout 2000
+  :timeout 12000
   :function-contract-hints (("Goal" :DO-NOT-INDUCT T
 			     :in-theory (enable evntp paramsp)))
   :body-contracts-hints (("Goal" :DO-NOT-INDUCT T
@@ -960,7 +960,7 @@
 (definecd transition
   (self :peer pstate :peer-state evnt :evnt twpm :twp s :nat) :res4
   :skip-tests t
-  :timeout 2000
+  :timeout 12000
   :function-contract-hints (("Goal" :in-theory (enable evntp forward-emission
                                                     update-nbr-topic-state
                                                     update-nbr-topic-state1

--- a/books/workshops/2023/kumar-etal/msgs-state.lisp
+++ b/books/workshops/2023/kumar-etal/msgs-state.lisp
@@ -231,7 +231,6 @@
                                   twpm :twp)
   :res2
   :skip-tests t
-  :timeout 2000
   :function-contract-hints (("Goal" :DO-NOT-INDUCT T
                              :in-theory (enable evntp)))
   :body-contracts-hints (("Goal" :DO-NOT-INDUCT T
@@ -365,7 +364,6 @@
                                    twpm :twp)
    :res2
    :skip-tests t
-   :timeout 2000
    :function-contract-hints (("Goal" :DO-NOT-INDUCT T
                               :in-theory (enable evntp paramsp)))
    :body-contracts-hints (("Goal" :DO-NOT-INDUCT T

--- a/books/workshops/2023/kumar-etal/nbrs-topics-state.lisp
+++ b/books/workshops/2023/kumar-etal/nbrs-topics-state.lisp
@@ -667,7 +667,6 @@
        s :nat)
   :res1
   :skip-tests t
-  :timeout 600
   :ic (is-valid-twp twpm)
   :body-contracts-hints (("goal" :do-not-induct t
                           :in-theory (enable nbr-topic-statep evntp twpp wpp)))
@@ -934,7 +933,6 @@
                                        s :nat)
   :res1
   :skip-tests t
-  :timeout 60
   :ic (is-valid-twp twpm)
   :body-contracts-hints (("Goal" :DO-NOT-INDUCT T
                           :in-theory (enable nbr-topic-statep evntp twpp wpp)))

--- a/books/workshops/2023/kumar-etal/network.lisp
+++ b/books/workshops/2023/kumar-etal/network.lisp
@@ -32,7 +32,6 @@
 (definecd network-propagator (evnts acc :loev) :loev
   :skip-tests t
   :body-contracts-hints (("Goal" :in-theory (enable evntp)))
-  :timeout 2000
   (match evnts
     (() (reverse acc))
     (((p1 'SND p2 x y) . rst)
@@ -101,7 +100,6 @@
   :ic (is-valid-twp twpm)
   :body-contracts-hints
   (("Goal" :do-not-induct t :in-theory (enable transition)))
-  :timeout 600
   :skip-tests t
   (cdr (car (reverse (run-network gr evnts i twpm s)))))
 

--- a/books/workshops/2023/kumar-etal/peer-state.lisp
+++ b/books/workshops/2023/kumar-etal/peer-state.lisp
@@ -46,7 +46,6 @@
 ;;emit gossip to d random nbrs
 (definecd gossip-emission (p :peer ps :peer-state d :nat params :params s :nat) :loev
   :skip-tests t
-  :timeout 600
   (b* (((mv k &) (defdata::genrandom-seed
                    (1- (expt 2 31))
                    (mod s (expt 2 31))))
@@ -184,7 +183,6 @@
  ;; TODO : add all other decays as well, including global decays
  (definecd decay-ctrs (pts :lopt hbmint :pos-rational twpm :twp ptc :pt-tctrs-map ) :pt-tctrs-map
    :skip-tests t
-   :timeout 600
    :function-contract-hints (("Goal" :in-theory (enable pt-tctrs-mapp)))
    :body-contracts-hints (("Goal" :in-theory (enable pt-tctrs-mapp)))
    (match pts
@@ -319,7 +317,6 @@
 (definecd transition
   (self :peer pstate :peer-state evnt :evnt twpm :twp s :nat) :res4
   :skip-tests t
-  :timeout 2000
   :function-contract-hints (("Goal" :in-theory (enable evntp forward-emission
                                                     update-nbr-topic-state
                                                     update-nbr-topic-state1

--- a/books/workshops/2023/kumar-etal/scoring.lisp
+++ b/books/workshops/2023/kumar-etal/scoring.lisp
@@ -660,7 +660,6 @@
   :ic (is-valid-twp twpm)
   :skip-tests t
   :body-contracts-hints (("Goal" :in-theory (enable wpp)))
-  :timeout 100
   (match pt-ctrs
     (() acc)
     ((((p . top) . &) . rst)

--- a/books/workshops/2023/kumar-etal/utils.lisp
+++ b/books/workshops/2023/kumar-etal/utils.lisp
@@ -1,8 +1,7 @@
 (in-package "ACL2S")
 ;; Some utility functions
 
-(set-acl2s-property-table-proof-timeout 1000)
-(set-defunc-timeout 1000)
+(set-defunc-timeout 100000)
 
 (defdata lol (listof tl))
 (defdata lor (listof rational))


### PR DESCRIPTION
Setting global timeout values and getting rid of overriding timeouts on properties, which were causing issues on slow machines.