### PR TITLE
[acl2s] Replace ACL2s' PRNG with the Thrust PRNG

### DIFF
--- a/books/acl2s/defdata/random-state-basis1.lisp
+++ b/books/acl2s/defdata/random-state-basis1.lisp
@@ -8,18 +8,16 @@
 (set-verify-guards-eagerness 2)
 (include-book "std/util/bstar" :dir :system)
 (include-book "acl2s/utilities" :dir :system)
+(include-book "ihs/basic-definitions" :dir :system)
+(local (include-book "ihs/logops-definitions" :dir :system))
+(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 (local (include-book "arithmetic-3/floor-mod/floor-mod" :dir :system))
-;(local (include-book "arithmetic-5/top" :dir :system))
-
-(def-const *M63* (1- (expt 2 63))) ;1 less than 2^63
-(def-const *P1* 16807)
 
 (make-event
  (er-progn
   (assign random-seed 1382728371)
   (value '(value-triple (@ random-seed))))
  :check-expansion t)
-
 
 (defun getseed (state)
   (declare (xargs :stobjs (state)))
@@ -38,10 +36,6 @@
   (natp (getseed state))
   :rule-classes :type-prescription)
 
-(defthm getseed-<-*m63*
-  (<= (getseed state) *M63*)
-  :rule-classes :linear)
-
 (in-theory (disable getseed))
  
 (defun putseed (s state)
@@ -50,38 +44,54 @@
   (declare (type (unsigned-byte 63) s))
   (acl2::f-put-global 'random-seed s state))
 
-
-(defun genrandom-seed (max seed.)
-  "generates a pseudo-random number less than max, given that the
+;; This is the Thrust PRNG. I used it here as it only requires 63 bits
+;; of seed/state, and ACL2s is currently using seeds of that length.
+;;
+;; I (Andrew Walter) converted this from Tommy Ettinger's C implementation:
+;; https://gist.github.com/tommyettinger/e6d3e8816da79b45bfe582384c2fe14a#file-thrust-c
+;; The C implementation was released into the public domain using the CC0 Deed:
+;; http://creativecommons.org/publicdomain/zero/1.0/
+;;
+;; Internally, there are a number of places where full 64-bit unsigned
+;; values are used. However, on my machine this still ends up being
+;; faster than the previous implementation. Performance will likely
+;; vary depending on the Lisp implementation used.
+(defun genrandom-seed (max raw-seed)
+    "generates a pseudo-random number less than max, given that the
 current random seed is seed. and also returns the new seed."
   (declare (type (unsigned-byte 63) max)
-           (type (unsigned-byte 63) seed.))
-  (declare (xargs :guard (and (unsigned-byte-p 63 seed.)
-                              (unsigned-byte-p 63 max)
+           (type (unsigned-byte 63) raw-seed))
+  (declare (xargs :guard (and (unsigned-byte-p 63 max)
+                              (unsigned-byte-p 63 raw-seed)
                               (posp max))))
-  (mbe :logic (if (and (posp max)
-                       (unsigned-byte-p 63 seed.))
-                       
-                  (b* (((the (unsigned-byte 63) seed.) (mod (* *P1* seed.) *M63*)))
-                    (mv (the (unsigned-byte 63) (mod seed. max)) seed.))
-                (mv 0 1382728371))
-       :exec (b* (((the (unsigned-byte 63) seed.) (mod (* *P1* seed.) *M63*)))
-               (mv (the (unsigned-byte 63) (mod seed. max)) (the (unsigned-byte 63) seed.)))))
+  ;; reconstitute the real seed
+  (b* (((the (unsigned-byte 64) seed) (acl2::logcons 1 raw-seed))
+       ((the (unsigned-byte 64) next-seed) (acl2::loghead 64 (+ seed #x6A5D39EAE12657AA)))
+       ((the (unsigned-byte 64) z) (acl2::loghead 64 (* (logxor seed (acl2::loghead 64 (ash seed -25))) next-seed)))
+       ((the (unsigned-byte 64) z) (logxor z (acl2::loghead 64 (ash z -22)))))
+    ;; lop off the low-order bit of the seed, since it should always be odd.
+    (mv (acl2::loghead 63 (mod z max)) (acl2::loghead 63 (ash next-seed -1)))))
 
+(defthm genrandom-seed-res-size
+  (implies (and (unsigned-byte-p 63 max) (posp max)
+                (unsigned-byte-p 63 seed))
+           (unsigned-byte-p 63 (mv-nth 0 (genrandom-seed max seed))))
+  :rule-classes :type-prescription)
 
 (defun genrandom-state (max state)
   "generates a pseudo-random number less than max"
   (declare (type (unsigned-byte 63) max))
   (declare (xargs :stobjs (state)
-                  :guard (and  (unsigned-byte-p 63 max)
-                               (posp max))))
-  (b* (((the (unsigned-byte 63) old-seed) (getseed state))
-       ((the (unsigned-byte 63) new-seed) (mod (* *P1* old-seed) *M63*))
-       (state (acl2::f-put-global 'random-seed new-seed state)))
-    (mv (if (zp max)
-          0
-          (the (unsigned-byte 63) (mod new-seed max)))
-        state)))
+                  :guard (and (unsigned-byte-p 63 max) (posp max))))
+  (b* ((raw-seed (getseed state))
+       ((mv res next-seed) (genrandom-seed max raw-seed))
+       (state (putseed next-seed state)))
+    (mv res state)))
+
+(defthm genrandom-state-res-size
+  (implies (and (unsigned-byte-p 63 max) (posp max))
+           (unsigned-byte-p 63 (mv-nth 0 (genrandom-state max state))))
+  :rule-classes :type-prescription)
 
 (encapsulate nil
 
@@ -103,8 +113,8 @@ current random seed is seed. and also returns the new seed."
  
 (defthm genrandom-natural1
   (implies (and (posp max)) ;(natp seed))
-           (and (integerp (car (genrandom-seed max seed)))
-                (>= (car (genrandom-seed max seed)) 0))
+           (and (integerp (mv-nth 0 (genrandom-seed max seed)))
+                (>= (mv-nth 0 (genrandom-seed max seed)) 0))
            )
    :rule-classes :type-prescription)
 
@@ -118,7 +128,7 @@ current random seed is seed. and also returns the new seed."
   (implies (and (<= 1 max)
                 (unsigned-byte-p 63 max) 
                 (natp seed))
-           (unsigned-byte-p 63 (car (genrandom-seed max seed))))
+           (unsigned-byte-p 63 (mv-nth 0 (genrandom-seed max seed))))
    :rule-classes (:type-prescription))
 
 
@@ -131,7 +141,7 @@ current random seed is seed. and also returns the new seed."
  
 (defthm genrandom-minimum1
    (implies (and (posp max) (natp seed))
-            (<= 0 (car (genrandom-seed max seed))))
+            (<= 0 (mv-nth 0 (genrandom-seed max seed))))
    :rule-classes :linear)
 
 (defthm genrandom-minimum2
@@ -139,33 +149,41 @@ current random seed is seed. and also returns the new seed."
             (<= 0 (mv-nth 1 (genrandom-seed max seed))))
    :rule-classes :linear)
 
+(local (defthm loghead-lt-help
+         (implies (and (natp x) (natp y) (posp size)
+                       (< x y))
+                  (< (acl2::loghead size x) y))
+         :hints (("Goal" :in-theory (enable acl2::loghead)))))
+
  (defthm genrandom-maximum1
    (implies (and (posp max))
                  
-            (< (car (genrandom-seed max seed)) max))
+            (< (mv-nth 0 (genrandom-seed max seed)) max))
    :rule-classes (:linear))
- 
- (defthm genrandom-maximum2
+
+  (defthm genrandom-maximum2
    (implies (and (posp max)
                  (unsigned-byte-p 63 seed))
-            (< (mv-nth 1 (genrandom-seed max seed)) *M63*))
+            (<= (mv-nth 1 (genrandom-seed max seed)) (1- (expt 2 63))))
    :rule-classes :linear)
- 
- 
-
-
 
  (defthm genrandom-state-natural
-   (natp (car (genrandom-state max state)))
+   (natp (mv-nth 0 (genrandom-state max state)))
    :rule-classes :type-prescription)
 
  (defthm genrandom-state-minimum 
-   (<= 0 (car (genrandom-state max state)))
+   (<= 0 (mv-nth 0 (genrandom-state max state)))
    :rule-classes :linear)
+
+ (local (defthm loghead-lte-help
+         (implies (and (natp x) (natp y) (posp size)
+                       (<= x y))
+                  (<= (acl2::loghead size x) y))
+         :hints (("Goal" :in-theory (enable acl2::loghead)))))
  
  (defthm genrandom-state-maximum
    (implies (posp max)
-            (<= (car (genrandom-state max state)) (1- max)))
+            (<= (mv-nth 0 (genrandom-state max state)) (1- max)))
    :rule-classes :linear)
  
  )

--- a/books/acl2s/defdata/random-state.lisp
+++ b/books/acl2s/defdata/random-state.lisp
@@ -28,7 +28,7 @@
           (mv (= 1 num) state)))
 
 (defthm random-boolean-type
-  (booleanp (car (random-boolean r)))
+  (booleanp (mv-nth 0 (random-boolean r)))
   :rule-classes :type-prescription)
 
 (in-theory (disable random-boolean))
@@ -120,13 +120,13 @@
 
  (defthm random-natural-seed-type-car
   (implies (unsigned-byte-p 63 r)
-           (natp (car (random-natural-seed r))))
+           (natp (mv-nth 0 (random-natural-seed r))))
   :rule-classes (:type-prescription))
 
 (defthm random-natural-seed-type-car-type
   (implies (natp r)
-           (and (integerp (car (random-natural-seed r)))
-                (>= (car (random-natural-seed r)) 0)))
+           (and (integerp (mv-nth 0 (random-natural-seed r)))
+                (>= (mv-nth 0 (random-natural-seed r)) 0)))
   :rule-classes :type-prescription)
 
 (defthm random-natural-seed-type-cadr
@@ -161,8 +161,8 @@
 
 (defthm random-natural-basemax1-type-car
   (implies (and (posp b) (natp d) (natp r))
-           (and (integerp (car (random-natural-basemax1 b d r)))
-                (>= (car (random-natural-basemax1 b d r)) 0)))
+           (and (integerp (mv-nth 0 (random-natural-basemax1 b d r)))
+                (>= (mv-nth 0 (random-natural-basemax1 b d r)) 0)))
   :rule-classes (:type-prescription))
 
 
@@ -187,8 +187,8 @@
 
 (defthm random-natural-basemax2-type-car
   (implies (and (posp b) (natp d) (natp r))
-           (and (integerp (car (random-natural-basemax2 b d r)))
-                (>= (car (random-natural-basemax2 b d r)) 0)))
+           (and (integerp (mv-nth 0 (random-natural-basemax2 b d r)))
+                (>= (mv-nth 0 (random-natural-basemax2 b d r)) 0)))
   :rule-classes (:type-prescription))
 
 
@@ -217,13 +217,13 @@
 
 (defthm random-natural-seed-type/0.5-car
   (implies (unsigned-byte-p 63 r)
-           (natp (car (random-natural-seed/0.5 r))))
+           (natp (mv-nth 0 (random-natural-seed/0.5 r))))
   :rule-classes (:type-prescription))
 
 (defthm random-natural-seed-type/0.5-car-type
   (implies (natp r)
-           (and (integerp (car (random-natural-seed/0.5 r)))
-                (>= (car (random-natural-seed/0.5 r)) 0)))
+           (and (integerp (mv-nth 0 (random-natural-seed/0.5 r)))
+                (>= (mv-nth 0 (random-natural-seed/0.5 r)) 0)))
   :rule-classes :type-prescription)
 
 (defthm random-natural-seed-type/0.5-cadr
@@ -253,13 +253,13 @@
 
 (defthm random-natural-seed-type/0.25-car
   (implies (unsigned-byte-p 63 r)
-           (natp (car (random-natural-seed/0.25 r))))
+           (natp (mv-nth 0 (random-natural-seed/0.25 r))))
   :rule-classes (:type-prescription))
 
 (defthm random-natural-seed-type/0.25-car-type
   (implies (natp r)
-           (and (integerp (car (random-natural-seed/0.25 r)))
-                (>= (car (random-natural-seed/0.25 r)) 0)))
+           (and (integerp (mv-nth 0 (random-natural-seed/0.25 r)))
+                (>= (mv-nth 0 (random-natural-seed/0.25 r)) 0)))
   :rule-classes :type-prescription)
 
 (defthm random-natural-seed-type/0.25-cadr


### PR DESCRIPTION
I replaced the PRNG used by ACL2s with the Thrust PRNG, which is designed to work with 63-bit state (the seed) and 64-bit outputs. My implementation is an adaptation of Tommy Ettinger's C implementation, which Tommy dedicated to the public domain. The implementation is here: https://gist.github.com/tommyettinger/e6d3e8816da79b45bfe582384c2fe14a

Some quick-and-dirty benchmarking indicates that this implementation is about 2x faster than the previous one.

I also needed to update some of the theorems that were being proved about `genrandom-seed` and `genrandom-state`, as they often used `car` to access the first element of the MV that those functions return. I replaced `car` with `mv-nth 0` in those theorems, which eliminated failures that were occurring in random-state.lisp.

I tested this on Linux x86-64 with SBCL 2.4.3. I will mark this PR as a draft until my local regression-all completes.