### PR TITLE
Add test cases for c$ preprocessing utility

### DIFF
--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -409,6 +409,11 @@ $(info Excluding books that need STP: [$(CERT_PL_USES_STP)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_STP), $(OK_CERTS))
 endif
 
+ifeq ($(USE_PREPROCESSOR), )
+$(info Excluding books that invoke an external C preprocessor: [$(CERT_PL_USES_PREPROCESSOR)])
+OK_CERTS := $(filter-out $(CERT_PL_USES_PREPROCESSOR), $(OK_CERTS))
+endif
+
 ifeq ($(ACL2_HAS_REALS), )
 $(info Excluding ACL2(r)-only books: [$(CERT_PL_USES_ACL2R)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_ACL2R), $(OK_CERTS))

--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -409,9 +409,9 @@ $(info Excluding books that need STP: [$(CERT_PL_USES_STP)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_STP), $(OK_CERTS))
 endif
 
-ifeq ($(USE_C_PREPROCESSOR), )
-$(info Excluding books that invoke an external C preprocessor: [$(CERT_PL_USES_C_PREPROCESSOR)])
-OK_CERTS := $(filter-out $(CERT_PL_USES_C_PREPROCESSOR), $(OK_CERTS))
+ifeq ($(OS_HAS_CPP), )
+$(info Excluding books that invoke cpp: [$(CERT_PL_USES_CPP)])
+OK_CERTS := $(filter-out $(CERT_PL_USES_CPP), $(OK_CERTS))
 endif
 
 ifeq ($(ACL2_HAS_REALS), )

--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -409,9 +409,9 @@ $(info Excluding books that need STP: [$(CERT_PL_USES_STP)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_STP), $(OK_CERTS))
 endif
 
-ifeq ($(USE_PREPROCESSOR), )
-$(info Excluding books that invoke an external C preprocessor: [$(CERT_PL_USES_PREPROCESSOR)])
-OK_CERTS := $(filter-out $(CERT_PL_USES_PREPROCESSOR), $(OK_CERTS))
+ifeq ($(USE_C_PREPROCESSOR), )
+$(info Excluding books that invoke an external C preprocessor: [$(CERT_PL_USES_C_PREPROCESSOR)])
+OK_CERTS := $(filter-out $(CERT_PL_USES_C_PREPROCESSOR), $(OK_CERTS))
 endif
 
 ifeq ($(ACL2_HAS_REALS), )

--- a/books/build/cert.pl
+++ b/books/build/cert.pl
@@ -77,22 +77,22 @@ use Cygwin_paths;
 # (do "$RealBin/certlib.pl") or die ("Error loading $RealBin/certlib.pl:\n!: $!\n\@: $@\n");
 # (do "$RealBin/paths.pl") or die ("Error loading $RealBin/paths.pl:\n!: $!\n\@: $@\n");
 
-my %reqparams = ("uses-glucose"        => "USES_GLUCOSE",
-                 "uses-ipasir"         => "USES_IPASIR",
-                 "uses-abc"            => "USES_ABC",
-                 "uses-smtlink"        => "USES_SMTLINK",
-                 "uses-stp"            => "USES_STP",
-                 "uses-quicklisp"      => "USES_QUICKLISP",
-                 "uses-c-preprocessor" => "USES_C_PREPROCESSOR",
-                 "ansi-only"           => "ANSI_ONLY",
-                 "uses-acl2r"          => "USES_ACL2R",
-                 "non-acl2r"           => "NON_ACL2R",
-                 "ccl-only"            => "CCL_ONLY",
-                 'non-cmucl'           => "NON_CMUCL",
-                 'non-lispworks'       => "NON_LISPWORKS",
-                 'non-allegro'         => "NON_ALLEGRO",
-                 'non-sbcl'            => "NON_SBCL",
-                 'non-gcl'             => "NON_GCL"
+my %reqparams = ("uses-glucose"   => "USES_GLUCOSE",
+                 "uses-ipasir"    => "USES_IPASIR",
+                 "uses-abc"       => "USES_ABC",
+                 "uses-smtlink"   => "USES_SMTLINK",
+                 "uses-stp"       => "USES_STP",
+                 "uses-quicklisp" => "USES_QUICKLISP",
+                 "uses-cpp"       => "USES_CPP",
+                 "ansi-only"      => "ANSI_ONLY",
+                 "uses-acl2r"     => "USES_ACL2R",
+                 "non-acl2r"      => "NON_ACL2R",
+                 "ccl-only"       => "CCL_ONLY",
+                 'non-cmucl'      => "NON_CMUCL",
+                 'non-lispworks'  => "NON_LISPWORKS",
+                 'non-allegro'    => "NON_ALLEGRO",
+                 'non-sbcl'       => "NON_SBCL",
+                 'non-gcl'        => "NON_GCL"
     );
 
 # use lib "/usr/lib64/perl5/5.8.8/x86_64-linux-thread-multi/Devel";

--- a/books/build/cert.pl
+++ b/books/build/cert.pl
@@ -77,22 +77,22 @@ use Cygwin_paths;
 # (do "$RealBin/certlib.pl") or die ("Error loading $RealBin/certlib.pl:\n!: $!\n\@: $@\n");
 # (do "$RealBin/paths.pl") or die ("Error loading $RealBin/paths.pl:\n!: $!\n\@: $@\n");
 
-my %reqparams = ("uses-glucose"      => "USES_GLUCOSE",
-                 "uses-ipasir"       => "USES_IPASIR",
-                 "uses-abc"          => "USES_ABC",
-                 "uses-smtlink"      => "USES_SMTLINK",
-                 "uses-stp"          => "USES_STP",
-                 "uses-quicklisp"    => "USES_QUICKLISP",
-                 "uses-preprocessor" => "USES_PREPROCESSOR",
-                 "ansi-only"         => "ANSI_ONLY",
-                 "uses-acl2r"        => "USES_ACL2R",
-                 "non-acl2r"         => "NON_ACL2R",
-                 "ccl-only"          => "CCL_ONLY",
-                 'non-cmucl'         => "NON_CMUCL",
-                 'non-lispworks'     => "NON_LISPWORKS",
-                 'non-allegro'       => "NON_ALLEGRO",
-                 'non-sbcl'          => "NON_SBCL",
-                 'non-gcl'           => "NON_GCL"
+my %reqparams = ("uses-glucose"        => "USES_GLUCOSE",
+                 "uses-ipasir"         => "USES_IPASIR",
+                 "uses-abc"            => "USES_ABC",
+                 "uses-smtlink"        => "USES_SMTLINK",
+                 "uses-stp"            => "USES_STP",
+                 "uses-quicklisp"      => "USES_QUICKLISP",
+                 "uses-c-preprocessor" => "USES_C_PREPROCESSOR",
+                 "ansi-only"           => "ANSI_ONLY",
+                 "uses-acl2r"          => "USES_ACL2R",
+                 "non-acl2r"           => "NON_ACL2R",
+                 "ccl-only"            => "CCL_ONLY",
+                 'non-cmucl'           => "NON_CMUCL",
+                 'non-lispworks'       => "NON_LISPWORKS",
+                 'non-allegro'         => "NON_ALLEGRO",
+                 'non-sbcl'            => "NON_SBCL",
+                 'non-gcl'             => "NON_GCL"
     );
 
 # use lib "/usr/lib64/perl5/5.8.8/x86_64-linux-thread-multi/Devel";

--- a/books/build/cert.pl
+++ b/books/build/cert.pl
@@ -77,21 +77,22 @@ use Cygwin_paths;
 # (do "$RealBin/certlib.pl") or die ("Error loading $RealBin/certlib.pl:\n!: $!\n\@: $@\n");
 # (do "$RealBin/paths.pl") or die ("Error loading $RealBin/paths.pl:\n!: $!\n\@: $@\n");
 
-my %reqparams = ("uses-glucose"   => "USES_GLUCOSE",
-                 "uses-ipasir"    => "USES_IPASIR",
-                 "uses-abc"       => "USES_ABC",
-                 "uses-smtlink"   => "USES_SMTLINK",
-                 "uses-stp"       => "USES_STP",
-                 "uses-quicklisp" => "USES_QUICKLISP",
-                 "ansi-only"      => "ANSI_ONLY",
-                 "uses-acl2r"     => "USES_ACL2R",
-                 "non-acl2r"      => "NON_ACL2R",
-                 "ccl-only"       => "CCL_ONLY",
-                 'non-cmucl'      => "NON_CMUCL",
-                 'non-lispworks'  => "NON_LISPWORKS",
-                 'non-allegro'    => "NON_ALLEGRO",
-                 'non-sbcl'       => "NON_SBCL",
-                 'non-gcl'        => "NON_GCL"
+my %reqparams = ("uses-glucose"      => "USES_GLUCOSE",
+                 "uses-ipasir"       => "USES_IPASIR",
+                 "uses-abc"          => "USES_ABC",
+                 "uses-smtlink"      => "USES_SMTLINK",
+                 "uses-stp"          => "USES_STP",
+                 "uses-quicklisp"    => "USES_QUICKLISP",
+                 "uses-preprocessor" => "USES_PREPROCESSOR",
+                 "ansi-only"         => "ANSI_ONLY",
+                 "uses-acl2r"        => "USES_ACL2R",
+                 "non-acl2r"         => "NON_ACL2R",
+                 "ccl-only"          => "CCL_ONLY",
+                 'non-cmucl'         => "NON_CMUCL",
+                 'non-lispworks'     => "NON_LISPWORKS",
+                 'non-allegro'       => "NON_ALLEGRO",
+                 'non-sbcl'          => "NON_SBCL",
+                 'non-gcl'           => "NON_GCL"
     );
 
 # use lib "/usr/lib64/perl5/5.8.8/x86_64-linux-thread-multi/Devel";

--- a/books/build/doc.lisp
+++ b/books/build/doc.lisp
@@ -1433,7 +1433,7 @@ certification using @('make')."
 
  <li>@('uses-quicklisp'): only certify when quicklisp is available</li>
 
- <li>@('uses-preprocessor'): only certify when an external C preprocessor is
+ <li>@('uses-c-preprocessor'): only certify when an external C preprocessor is
  available. See @(see c$::preprocessing).</li>
 
  </ul>

--- a/books/build/doc.lisp
+++ b/books/build/doc.lisp
@@ -1433,6 +1433,9 @@ certification using @('make')."
 
  <li>@('uses-quicklisp'): only certify when quicklisp is available</li>
 
+ <li>@('uses-preprocessor'): only certify when an external C preprocessor is
+ available. See @(see c$preprocessing).</li>
+
  </ul>
 
  <p>There is currently no @('cert_param') related to ACL2(p) (see @(see

--- a/books/build/doc.lisp
+++ b/books/build/doc.lisp
@@ -1433,8 +1433,8 @@ certification using @('make')."
 
  <li>@('uses-quicklisp'): only certify when quicklisp is available</li>
 
- <li>@('uses-c-preprocessor'): only certify when an external C preprocessor is
- available. See @(see c$::preprocessing).</li>
+ <li>@('uses-cpp'): only certify when cpp is available. See @(see
+ c$::preprocessing).</li>
 
  </ul>
 
@@ -1462,6 +1462,8 @@ certification using @('make')."
 (acl2::defpointer uses-smtlink cert_param)
 (acl2::defpointer uses-stp cert_param)
 (acl2::defpointer uses-quicklisp cert_param)
+
+(acl2::defpointer uses-cpp cert_param)
 
 ;; Added by Eric Smith
 (acl2::defpointer cert-flags custom-certify-book-commands)

--- a/books/build/doc.lisp
+++ b/books/build/doc.lisp
@@ -1434,7 +1434,7 @@ certification using @('make')."
  <li>@('uses-quicklisp'): only certify when quicklisp is available</li>
 
  <li>@('uses-preprocessor'): only certify when an external C preprocessor is
- available. See @(see c$preprocessing).</li>
+ available. See @(see c$::preprocessing).</li>
 
  </ul>
 

--- a/books/build/features.sh
+++ b/books/build/features.sh
@@ -170,6 +170,15 @@ EXPORTED_VARS += OS_HAS_STP
 EOF
 fi
 
+echo "Determining whether cpp is installed" 1>&2
+if cpp --version 2>/dev/null;
+then
+    cat >> Makefile-features <<EOF
+export OS_HAS_CPP ?= 1
+EXPORTED_VARS += OS_HAS_CPP
+EOF
+fi
+
 cat >> Makefile-features <<EOF
 EXPORT_SHELL_ENV := \$(foreach v,\$(EXPORTED_VARS),\$(v)='\$(\$(v))')
 EOF

--- a/books/kestrel/c/syntax/cert.acl2
+++ b/books/kestrel/c/syntax/cert.acl2
@@ -10,4 +10,4 @@
 
 (include-book "portcullis")
 
-; cert-flags: ? t :ttags ((:quicklisp) (:quicklisp.shellpool) (:tshell))
+; cert-flags: ? t :ttags ((:quicklisp) (:quicklisp.shellpool) (:tshell) (:quicklisp.osicat) (:oslib))

--- a/books/kestrel/c/syntax/package.lsp
+++ b/books/kestrel/c/syntax/package.lsp
@@ -13,6 +13,7 @@
 (include-book "centaur/fty/portcullis" :dir :system)
 (include-book "kestrel/c/portcullis" :dir :system)
 (include-book "kestrel/utilities/omaps/portcullis" :dir :system)
+(include-book "oslib/portcullis" :dir :system)
 (include-book "std/portcullis" :dir :system)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -54,8 +54,8 @@
    (xdoc::p
      "These tools appeal to a configurable C preprocessor, and the prerequisite
       dependencies may not be present on all systems. For books which use the
-      default preprocessor \"cpp\", certification may controlled with the the
-      @(see build::uses-cpp) @(see build::cert_param) flag.")
+      default preprocessor \"cpp\", certification may be controlled with the
+      the @(see build::uses-cpp) @(see build::cert_param) flag.")
    (xdoc::p
      "The community books Makefile will autodetect whether \"cpp\" is
       available, and exclude books appropriately. Certification of such books

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -163,8 +163,8 @@
    ((out (or (not out)
              (stringp out))
          "This specifies the output file to which the preprocessed file is
-          saved. If @('nil'), a file will be created suitable with a name and
-          directory typical of temporary files (using the mktemp utility).")
+          saved. If @('nil'), a file will be created with a name and directory
+          typical of temporary files (see @(see oslib::tempfile)).")
     'nil)
    ((save "If @('t'), the output file is saved. If @('nil'), the file is
            removed after reading it in. If @(':auto'), the default value, the
@@ -305,8 +305,8 @@
    ((out-dir (or (not out-dir)
                  (stringp out-dir))
              "This specifies the directory that preprocessed output files are
-              saved to with posfix \".preprocessed\". If @('nil'), files will
-              be created with mktemp.")
+              saved to with posfix \".preprocessed\". If @('nil'), temporary
+              files will be created (see @(see oslib::tempfile))).")
     'nil)
    ((save "If @('t'), the output files are saved. If @('nil'), the files are
            removed after reading them in. If @(':auto'), the default value,

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -52,16 +52,17 @@
    (xdoc::p
      "A collection of tools to invoke an external C preprocessor.")
    (xdoc::p
-     "These tools appeal to a configurable C preprocessor, and the
-     prerequisite dependencies may not be present on all systems. Certification
-     of books which invoke these tools should therefore be predicated on the
-     @('uses-preprocessor') @(see build::cert_param) flag.")
+     "These tools appeal to a configurable C preprocessor, and the prerequisite
+     dependencies may not be present on all systems. Certification of books
+     which invoke these tools should therefore be predicated on the
+     @('uses-c-preprocessor') @(see build::cert_param) flag.")
    (xdoc::p
      "By default, the community books Makefile does not build such books.
-     Certification can be enabled by defining the \"USE_PREPROCESSOR\" Makefile
-     variable. E.g., to run a regression including preprocessing books:")
+     Certification can be enabled by defining the \"USE_C_PREPROCESSOR\"
+     Makefile variable. E.g., to run a regression including preprocessing
+     books:")
    (xdoc::code
-     "USE_PREPROCESSOR=1 make regression"))
+     "USE_C_PREPROCESSOR=1 make regression"))
   :order-subtopics t)
 
 

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -141,19 +141,6 @@
       (concatenate 'string cbd filepath))))
 
 
-(define basename
-  ((filename stringp))
-  :returns (filename stringp)
-  :parents (preprocess-file)
-  :short "Extract the basename of a file path, assuming a Unix-style \"/\"
-          directory separator."
-  (b* (((mv success left right)
-        (acl2::split-string-last filename #\/)))
-    (if success
-        right
-      left)))
-
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define preprocess-file

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -39,8 +39,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(in-theory (disable acl2::tshell-call
-                    (:e acl2::tshell-call)))
+(in-theory (disable (:e acl2::tshell-call)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -223,9 +222,10 @@
                    \"clang\", \"cc\", etc.")
     '"cpp")
    ((extra-args string-listp
-                "Arguments to pass to the C preprocessor, in addition to \"-E\"
-                 and \"-P\".")
-    'nil)
+                "Arguments to pass to the C preprocessor, in addition to
+                 \"-E\". The default value is @('(list \"-P\")') (the flag
+                 @('\"-P\"') suppresses the generation of linemarkers).")
+    ''("-P"))
    (state 'state))
   :returns (mv erp
                (pair "A pair whose first value is the output file (if it is
@@ -240,7 +240,11 @@
    (xdoc::p
      "This function preprocesses a @(see filepathp) using the system's C
       preprocessor. See @(see preprocess-files) for a simlilar utility which
-      handles a set of files."))
+      handles a set of files.")
+   (xdoc::p
+     "By default, we pass the @('\"-P\"') flag to the preprocessor to disable
+      linemarkers. This behavior may be overriden by explicitly providing a
+      @(':extra-args') value."))
   (macrolet
    ((iferr () '(cons "" (filepath nil))))
    (b* ((filename (filepath->unwrap file))
@@ -257,7 +261,7 @@
              (value (absolute-filepath out))
            (mktemp (basename filename))))
         (preprocess-cmd
-          (str::join (append (list* preprocessor "-o" out "-E" "-P" extra-args)
+          (str::join (append (list* preprocessor "-o" out "-E" extra-args)
                              (list filename))
                      " "))
         ((mv exit-status -)
@@ -344,9 +348,10 @@
                    \"clang\", \"cc\", etc.")
     '"cpp")
    ((extra-args string-listp
-                "Arguments to pass to the C preprocessor, in addition to \"-E\"
-                 and \"-P\".")
-    'nil)
+                "Arguments to pass to the C preprocessor, in addition to
+                 \"-E\". The default value is @('(list \"-P\")') (the flag
+                 @('\"-P\"') suppresses the generation of linemarkers).")
+    ''("-P"))
    (state 'state))
   :returns (mv erp
                (map filesetp

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -50,7 +50,18 @@
   :long
   (xdoc::topstring
    (xdoc::p
-     "A collection of tools to invoke an external C preprocessor."))
+     "A collection of tools to invoke an external C preprocessor.")
+   (xdoc::p
+     "These tools appeal to a configurable C preprocessor, and the
+     prerequisite dependencies may not be present on all systems. Certification
+     of books which invoke these tools should therefore be predicated on the
+     @('uses-preprocessor') @(see build::cert_param) flag.")
+   (xdoc::p
+     "By default, the community books Makefile does not build such books.
+     Certification can be enabled by defining the \"USE_PREPROCESSOR\" Makefile
+     variable. E.g., to run a regression including preprocessing books:")
+   (xdoc::code
+     "USE_PREPROCESSOR=1 make regression"))
   :order-subtopics t)
 
 

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -53,16 +53,19 @@
      "A collection of tools to invoke an external C preprocessor.")
    (xdoc::p
      "These tools appeal to a configurable C preprocessor, and the prerequisite
-     dependencies may not be present on all systems. Certification of books
-     which invoke these tools should therefore be predicated on the
-     @('uses-c-preprocessor') @(see build::cert_param) flag.")
+      dependencies may not be present on all systems. For books which use the
+      default preprocessor \"cpp\", certification may controlled with the the
+      @(see build::uses-cpp) @(see build::cert_param) flag.")
    (xdoc::p
-     "By default, the community books Makefile does not build such books.
-     Certification can be enabled by defining the \"USE_C_PREPROCESSOR\"
-     Makefile variable. E.g., to run a regression including preprocessing
-     books:")
+     "The community books Makefile will autodetect whether \"cpp\" is
+      available, and exclude books appropriately. Certification of such books
+      may be suppressed by manually undefining the Makefile variable
+      \"OS_HAS_CPP\". E.g., to run a regression excluding books calling cpp:")
    (xdoc::code
-     "USE_C_PREPROCESSOR=1 make regression"))
+     "OS_HAS_CPP= make regression")
+   (xdoc::p
+     "Further @(see build::cert_param) flags may need to be defined if using a
+      C preprocessor other than \"cpp\"."))
   :order-subtopics t)
 
 

--- a/books/kestrel/c/syntax/tests/acl2-customization.lsp
+++ b/books/kestrel/c/syntax/tests/acl2-customization.lsp
@@ -1,0 +1,17 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(ld "~/acl2-customization.lsp" :ld-missing-input-ok t)
+
+(ld "../package.lsp")
+
+(reset-prehistory)
+
+(in-package "C$")

--- a/books/kestrel/c/syntax/tests/cert.acl2
+++ b/books/kestrel/c/syntax/tests/cert.acl2
@@ -1,0 +1,13 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(include-book "../portcullis")
+
+; cert-flags: ? t :ttags ((:quicklisp) (:quicklisp.shellpool) (:tshell))

--- a/books/kestrel/c/syntax/tests/cert.acl2
+++ b/books/kestrel/c/syntax/tests/cert.acl2
@@ -10,4 +10,4 @@
 
 (include-book "../portcullis")
 
-; cert-flags: ? t :ttags ((:quicklisp) (:quicklisp.shellpool) (:tshell))
+; cert-flags: ? t :ttags ((:quicklisp) (:quicklisp.shellpool) (:tshell) (:quicklisp.osicat) (:oslib))

--- a/books/kestrel/c/syntax/tests/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/tests/preprocess-file.lisp
@@ -10,7 +10,7 @@
 
 (in-package "C$")
 
-; cert_param: (uses-c-preprocessor)
+; cert_param: (uses-cpp)
 
 
 (include-book "std/testing/must-eval-to" :dir :system)

--- a/books/kestrel/c/syntax/tests/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/tests/preprocess-file.lisp
@@ -10,7 +10,7 @@
 
 (in-package "C$")
 
-; cert_param: (uses-preprocessor)
+; cert_param: (uses-c-preprocessor)
 
 
 (include-book "std/testing/must-eval-to" :dir :system)

--- a/books/kestrel/c/syntax/tests/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/tests/preprocess-file.lisp
@@ -1,0 +1,111 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "C$")
+
+; cert_param: (uses-preprocessor)
+
+
+(include-book "std/testing/must-eval-to" :dir :system)
+(include-book "std/testing/must-eval-to-t" :dir :system)
+(include-book "std/testing/must-fail" :dir :system)
+(include-book "std/testing/must-succeed" :dir :system)
+
+(include-book "../preprocess-file")
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(local (include-book "kestrel/built-ins/disable" :dir :system))
+(local (acl2::disable-most-builtin-logic-defuns))
+(local (acl2::disable-builtin-rewrite-rules-for-defaults))
+(set-induction-depth-limit 0)
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define bytes-to-string
+  ((bytes byte-listp))
+  :returns (str stringp)
+  (coerce (bytes-to-characters bytes) 'string)
+  :prepwork
+  ((define bytes-to-characters
+     ((bytes byte-listp))
+     :returns (chars character-listp
+                     :hints (("Goal" :in-theory (enable character-listp)
+                                     :induct (bytes-to-characters bytes))))
+     (if (endp bytes)
+         nil
+       (cons (code-char (first bytes))
+             (bytes-to-characters (rest bytes))))
+     :guard-hints (("Goal" :in-theory (enable byte-listp
+                                              bytep
+                                              unsigned-byte-p))))))
+
+
+(defmacro preprocess-file-to-string (filepath &rest args)
+  `(b* (((er (cons out bytes))
+         (preprocess-file ,filepath ,@args)))
+     (value (cons out
+                  (bytes-to-string (filedata->unwrap bytes))))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(acl2::must-succeed
+  (acl2::must-eval-to
+    (preprocess-file-to-string (filepath "stdbool.c"))
+    (cons nil "int main(void) {
+  return (int)0;
+}
+")))
+
+(acl2::must-succeed
+  (acl2::must-eval-to-t
+    (b* (((er (cons out str))
+          (preprocess-file-to-string (filepath "stdbool.c") :out "stdbool.c.preprocessed")))
+      (value (and (stringp out)
+                  (equal str "int main(void) {
+  return (int)0;
+}
+"))))))
+
+(acl2::must-succeed
+  (acl2::must-eval-to
+    ;; Idempotence
+    (preprocess-file-to-string (filepath "stdbool.c.preprocessed"))
+    (cons nil "int main(void) {
+  return (int)0;
+}
+")))
+
+(acl2::must-succeed
+  (acl2::must-eval-to
+    (preprocess-file-to-string (filepath "stdbool.c") :out "stdbool.c.preprocessed" :save nil)
+    (cons nil "int main(void) {
+  return (int)0;
+}
+")))
+
+(acl2::must-fail
+  (preprocess-file (filepath "nonexistent-file.c")))
+
+(acl2::must-succeed
+  (preprocess-file-to-string (filepath "stdint.c")))
+
+(acl2::must-succeed
+  (preprocess-files
+    (mergesort (list (filepath "stdbool.c")
+                     (filepath "stdint.c")))))
+
+(acl2::must-succeed
+  (acl2::must-eval-to
+    (preprocess-files nil)
+    (fileset nil)))

--- a/books/kestrel/c/syntax/tests/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/tests/preprocess-file.lisp
@@ -13,7 +13,6 @@
 ; cert_param: (uses-cpp)
 
 
-(include-book "std/testing/must-eval-to" :dir :system)
 (include-book "std/testing/must-eval-to-t" :dir :system)
 (include-book "std/testing/must-fail" :dir :system)
 (include-book "std/testing/must-succeed" :dir :system)
@@ -23,82 +22,26 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(local (include-book "kestrel/built-ins/disable" :dir :system))
-(local (acl2::disable-most-builtin-logic-defuns))
-(local (acl2::disable-builtin-rewrite-rules-for-defaults))
-(set-induction-depth-limit 0)
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define bytes-to-string
-  ((bytes byte-listp))
-  :returns (str stringp)
-  (coerce (bytes-to-characters bytes) 'string)
-  :prepwork
-  ((define bytes-to-characters
-     ((bytes byte-listp))
-     :returns (chars character-listp
-                     :hints (("Goal" :in-theory (enable character-listp)
-                                     :induct (bytes-to-characters bytes))))
-     (if (endp bytes)
-         nil
-       (cons (code-char (first bytes))
-             (bytes-to-characters (rest bytes))))
-     :guard-hints (("Goal" :in-theory (enable byte-listp
-                                              bytep
-                                              unsigned-byte-p))))))
-
-
-(defmacro preprocess-file-to-string (filepath &rest args)
-  `(b* (((er (cons out bytes))
-         (preprocess-file ,filepath ,@args)))
-     (value (cons out
-                  (bytes-to-string (filedata->unwrap bytes))))))
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (acl2::must-succeed
-  (acl2::must-eval-to
-    (preprocess-file-to-string (filepath "stdbool.c"))
-    (cons nil "int main(void) {
-  return (int)0;
-}
-")))
+  (preprocess-file (filepath "stdbool.c")))
 
 (acl2::must-succeed
   (acl2::must-eval-to-t
-    (b* (((er (cons out str))
-          (preprocess-file-to-string (filepath "stdbool.c") :out "stdbool.c.preprocessed")))
-      (value (and (stringp out)
-                  (equal str "int main(void) {
-  return (int)0;
-}
-"))))))
+    (b* (((er (cons out -))
+          (preprocess-file (filepath "stdbool.c") :out "stdbool.c.preprocessed")))
+      (value (stringp out)))))
 
 (acl2::must-succeed
-  (acl2::must-eval-to
-    ;; Idempotence
-    (preprocess-file-to-string (filepath "stdbool.c.preprocessed"))
-    (cons nil "int main(void) {
-  return (int)0;
-}
-")))
+  (preprocess-file (filepath "stdbool.c.preprocessed")))
 
 (acl2::must-succeed
-  (acl2::must-eval-to
-    (preprocess-file-to-string (filepath "stdbool.c") :out "stdbool.c.preprocessed" :save nil)
-    (cons nil "int main(void) {
-  return (int)0;
-}
-")))
+  (preprocess-file (filepath "stdbool.c") :out "stdbool.c.preprocessed" :save nil))
 
 (acl2::must-fail
   (preprocess-file (filepath "nonexistent-file.c")))
 
 (acl2::must-succeed
-  (preprocess-file-to-string (filepath "stdint.c")))
+  (preprocess-file (filepath "stdint.c")))
 
 (acl2::must-succeed
   (preprocess-files

--- a/books/kestrel/c/syntax/tests/stdbool.c
+++ b/books/kestrel/c/syntax/tests/stdbool.c
@@ -1,0 +1,6 @@
+// #include <stdbooh.h>
+#include <stdbool.h>
+
+int main(void) {
+  return (int)false;
+}

--- a/books/kestrel/c/syntax/tests/stdbool.c
+++ b/books/kestrel/c/syntax/tests/stdbool.c
@@ -1,4 +1,3 @@
-// #include <stdbooh.h>
 #include <stdbool.h>
 
 int main(void) {

--- a/books/kestrel/c/syntax/tests/stdint.c
+++ b/books/kestrel/c/syntax/tests/stdint.c
@@ -1,0 +1,6 @@
+#include <stdint.h>
+
+int main(void) {
+  uint32_t x = 0;
+  return 0;
+}


### PR DESCRIPTION
Since the preprocessing utility is open-ended in its system dependencies, I've added the cert_param flag "uses-preprocessor" as well as the Makefile variable "USE_PREPROCESSOR" to control certification of books using the tool, such as this new test book.

The feature does not attempt to auto-detect dependencies, and defaults to "off". Thus, you must explicitly set `USE_PREPROCESSOR=1` when invoking make to build the relevant books.

The names of these variables is easy to change. We might consider renaming it to "USE_C_PREPROCESSOR" to be more specific. Or "USE_C_UTILITIES" if we expect other similar utilities to require conditional certification.