### PR TITLE
[c$] Fix tempfile creation in preprocess-file

### DIFF
--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -164,6 +164,12 @@
          (er-soft-with (iferr)
                        "Filepath is not a string: ~x0"
                        filename))
+        (canonical-filename (canonical-pathname filename nil state))
+        ((unless (stringp canonical-filename))
+         (er-soft-with (iferr)
+                       "Filepath does not exist: ~x0"
+                       filename))
+        (filename canonical-filename)
         (- (acl2::tshell-ensure))
         (save (if (eq :auto save)
                   (and out t)

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -268,8 +268,8 @@
    ((out-dir (or (not out-dir)
                  (stringp out-dir))
              "This specifies the directory that preprocessed output files are
-              saved to with posfix \".preprocessed\". If @('nil'), temporary
-              files will be created (see @(see oslib::tempfile))).")
+              saved to with posfix \".i\". If @('nil'), temporary files will be
+              created (see @(see oslib::tempfile))).")
     'nil)
    ((save "If @('t'), the output files are saved. If @('nil'), the files are
            removed after reading them in. If @(':auto'), the default value,
@@ -297,7 +297,7 @@
   (xdoc::topstring
    (xdoc::p
      "This function preprocesses a @(see filepath-setp). See @(see
-      preprocess-files) for a similar utility which operates on individuals
+      preprocess-file) for a similar utility which operates on individuals
       files."))
   (b* (((when (emptyp files))
         (value (fileset nil)))
@@ -308,7 +308,7 @@
                                      out-dir
                                      "/"
                                      filename
-                                     ".preprocessed")))))
+                                     ".i")))))
        ((er (cons - filedata) :iferr (fileset nil))
         (preprocess-file (head files)
                          :out out

--- a/books/kestrel/c/syntax/tests/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/tests/preprocess-file.lisp
@@ -28,20 +28,20 @@
 (acl2::must-succeed
   (acl2::must-eval-to-t
     (b* (((er (cons out -))
-          (preprocess-file (filepath "stdbool.c") :out "stdbool.c.preprocessed")))
+          (preprocess-file (filepath "stdbool.c") :out "stdbool.i")))
       (value (stringp out)))))
 
 (acl2::must-succeed
-  (preprocess-file (filepath "stdbool.c.preprocessed")))
+  (preprocess-file (filepath "stdbool.i")))
 
 (acl2::must-succeed
-  (preprocess-file (filepath "stdbool.c") :out "stdbool.c.preprocessed" :save nil))
+  (preprocess-file (filepath "stdbool.c") :out "stdbool.i" :save nil))
 
 (acl2::must-fail
   (preprocess-file (filepath "nonexistent-file.c")))
 
 (acl2::must-succeed
-  (preprocess-file (filepath "stdint.c")))
+  (preprocess-file (filepath "../tests/stdint.c")))
 
 (acl2::must-succeed
   (preprocess-files


### PR DESCRIPTION
The `oslib::tempfile` utility may return a filepath whose directory does not yet exist. This changes `preprocess-file` to now create said directory before invoking the preprocessor.

This also removes the supporting `absolute-filepath` utility, in favor of the built-in and superior `canonical-filepath`.

Finally, this changes the file extension of files generated by `preprocess-files` to `.i` (which is the expected file extension and understood by compilers).