### PR TITLE
[c$] Change preprocessing-related flags in tools

### DIFF
--- a/books/kestrel/c/syntax/read-and-parse-files.lisp
+++ b/books/kestrel/c/syntax/read-and-parse-files.lisp
@@ -215,7 +215,7 @@
        ((unless (or (not preprocessor)
                     (eq :auto preprocessor)
                     (stringp preprocessor)))
-        (reterr (msg "The :PREPROCESSOR input must be a STRINGP or NIL, ~
+        (reterr (msg "The :PREPROCESSOR input must be NIL, :AUTO, or a string, ~
                       but it is ~x0 instead."
                      preprocessor))))
     (retok const paths preprocessor))

--- a/books/kestrel/c/syntax/read-and-parse-files.lisp
+++ b/books/kestrel/c/syntax/read-and-parse-files.lisp
@@ -110,12 +110,12 @@
      (xdoc::p
       "Flag indicating the preprocessor to use, if any.")
      (xdoc::p
-      "This must be @('nil'), @(':auto') or a @(tsee stringp).")
+      "This must be @('nil'), @(':auto'), or a @(tsee stringp).")
      (xdoc::p
       "If this is a @(tsee stringp), the @(tsee preprocess-file) tool is called
        on the files read at the file paths using the indicated preprocesser. If
-       it is @(':auto'), we use the \"cpp\" preprocessor. If it is @('nil'), we
-       do not preprocess the files.")))
+       it is @(':auto'), we use the @('\"cpp\"') preprocessor. If it is
+       @('nil'), we do not preprocess the files.")))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/syntax/read-files.lisp
+++ b/books/kestrel/c/syntax/read-files.lisp
@@ -112,12 +112,12 @@
      (xdoc::p
       "Flag indicating the preprocessor to use, if any.")
      (xdoc::p
-      "This must be @('nil'), @(':auto') or a @(tsee stringp).")
+      "This must be @('nil'), @(':auto'), or a @(tsee stringp).")
      (xdoc::p
       "If this is a @(tsee stringp), the @(tsee preprocess-file) tool is called
        on the files read at the file paths using the indicated preprocesser. If
-       it is @(':auto'), we use the \"cpp\" preprocessor. If it is @('nil'), we
-       do not preprocess the files.")))
+       it is @(':auto'), we use the @('\"cpp\"') preprocessor. If it is
+       @('nil'), we do not preprocess the files.")))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/syntax/read-files.lisp
+++ b/books/kestrel/c/syntax/read-files.lisp
@@ -65,7 +65,7 @@
       containing a file set (see @(tsee fileset))
       with the content of the given files.
       Optionally, this macro can use the @(tsee preprocess-files) tool
-      to preprocess the given files prior to generate the constant,
+      to preprocess the given files prior to generating the constant,
       so that the constant will contain the preprocessed files.")
 
     (xdoc::p
@@ -77,9 +77,9 @@
    (xdoc::evmac-section-form
 
     (xdoc::codeblock
-     "(read-files :const      ...  ; no default"
-     "            :files      ...  ; no default"
-     "            :preprocess ...  ; default nil"
+     "(read-files :const        ...  ; no default"
+     "            :files        ...  ; no default"
+     "            :preprocessor ...  ; default \"cpp\""
      "  )"))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -108,15 +108,14 @@
       "This input to this macro is not evaluated."))
 
     (xdoc::desc
-     "@(':preprocess') &mdash; default @('nil')"
+     "@(':preprocessor') &mdash; default @('\"cpp\"')"
      (xdoc::p
-      "Flag saying whether the files must be preprocessed or not.")
+      "Flag indicating the preprocessor to use, if any.")
      (xdoc::p
-      "This must be @('t') or @('nil').")
+      "This must be @('nil') or a @(tsee stringp).")
      (xdoc::p
-      "If this is @('t'), the @(tsee preprocess-file) tool
-       is called on the files read at the file paths,
-       obtaining a file set that is stored in the generated named constant.")))
+      "If this is a @(tsee stringp), the @(tsee preprocess-file) tool is called
+       on the files read at the file paths using the indicated preprocesser.")))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -143,7 +142,7 @@
   :short "Keyword options accepted by @(tsee read-files)."
   (list :const
         :files
-        :preprocess)
+        :preprocessor)
   ///
   (assert-event (keyword-listp *read-files-allowed-options*))
   (assert-event (no-duplicatesp-eq *read-files-allowed-options*)))
@@ -161,7 +160,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define read-files-process-inputs ((args true-listp))
-  :returns (mv erp (const symbolp) (paths filepath-setp) (preprocess booleanp))
+  :returns (mv erp
+               (const symbolp)
+               (paths filepath-setp)
+               (preprocessor (or (not preprocessor)
+                                 (stringp preprocessor))
+                             :rule-classes (:rewrite :type-prescription)))
   :short "Process the inputs."
   (b* (((reterr) nil nil nil)
        ;; Check and obtain options.
@@ -203,15 +207,16 @@
                      files)))
        (paths (read-files-strings-to-paths files))
        ;; Process :PREPROCESS input.
-       (preprocess-option (assoc-eq :preprocess options))
-       (preprocess (if preprocess-option
-                       (cdr preprocess-option)
-                     nil))
-       ((unless (booleanp preprocess))
-        (reterr (msg "The :PREPROCESS input must be T or NIL, ~
+       (preprocessor-option (assoc-eq :preprocessor options))
+       (preprocessor (if preprocessor-option
+                         (cdr preprocessor-option)
+                       "cpp"))
+       ((unless (or (not preprocessor)
+                    (stringp preprocessor)))
+        (reterr (msg "The :PREPROCESSOR input must be a STRINGP or NIL, ~
                       but it is ~x0 instead."
-                     preprocess))))
-    (retok const paths preprocess))
+                     preprocessor))))
+    (retok const paths preprocessor))
   :guard-hints (("Goal" :in-theory (enable acl2::alistp-when-symbol-alistp))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -245,7 +250,9 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define read-files-read-and-preprocess ((paths filepath-setp) state)
+(define read-files-read-and-preprocess ((paths filepath-setp)
+                                        (preprocessor stringp)
+                                        state)
   :returns (mv erp (fileset filesetp) state)
   :short "Read and preprocess a file set from a given set of paths."
   :long
@@ -257,7 +264,7 @@
    (xdoc::p
     "We tell the preprocessing tool not to save any files."))
   (b* (((reterr) (fileset nil) state)
-       ((mv erp fileset state) (preprocess-files paths))
+       ((mv erp fileset state) (preprocess-files paths :preprocessor preprocessor))
        ((when erp)
         (reterr (msg "Preprocessing of ~x0 failed." paths))))
     (retok fileset state)))
@@ -266,22 +273,23 @@
 
 (define read-files-gen-defconst ((const symbolp)
                                  (paths filepath-setp)
-                                 (preprocess booleanp)
+                                 (preprocessor (or (not preprocessor)
+                                                   (stringp preprocessor)))
                                  state)
   :returns (mv erp (event pseudo-event-formp) state)
   :short "Generate the named constant event."
   :long
   (xdoc::topstring
    (xdoc::p
-    "Based on the @(':proprocess') flag,
+    "Based on the @(':proprocessor') flag,
      either we read the files directly,
      or we read and preprocess them.
      We put the file set into a quoted constant
      to define the named constant."))
   (b* (((reterr) '(_) state)
        ((erp fileset state)
-        (if preprocess
-            (read-files-read-and-preprocess paths state)
+        (if preprocessor
+            (read-files-read-and-preprocess paths preprocessor state)
           (read-files-read paths state)))
        (event `(defconst ,const ',fileset)))
     (retok event state)))
@@ -296,10 +304,10 @@
                state)
   :short "Process the inputs and generate the constant event."
   (b* (((reterr) '(_) state)
-       ((erp const paths preprocess)
+       ((erp const paths preprocessor)
         (read-files-process-inputs args))
        ((erp event state)
-        (read-files-gen-defconst const paths preprocess state)))
+        (read-files-gen-defconst const paths preprocessor state)))
     (retok event state)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/c/syntax/read-files.lisp
+++ b/books/kestrel/c/syntax/read-files.lisp
@@ -216,7 +216,7 @@
        ((unless (or (not preprocessor)
                     (eq :auto preprocessor)
                     (stringp preprocessor)))
-        (reterr (msg "The :PREPROCESSOR input must be NIL, :AUTO, or a STRINGP, ~
+        (reterr (msg "The :PREPROCESSOR input must be NIL, :AUTO, or a string, ~
                       but it is ~x0 instead."
                      preprocessor))))
     (retok const paths preprocessor))

--- a/books/kestrel/c/syntax/read-files.lisp
+++ b/books/kestrel/c/syntax/read-files.lisp
@@ -79,7 +79,7 @@
     (xdoc::codeblock
      "(read-files :const        ...  ; no default"
      "            :files        ...  ; no default"
-     "            :preprocessor ...  ; default \"cpp\""
+     "            :preprocessor ...  ; default nil"
      "  )"))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -108,14 +108,16 @@
       "This input to this macro is not evaluated."))
 
     (xdoc::desc
-     "@(':preprocessor') &mdash; default @('\"cpp\"')"
+     "@(':preprocessor') &mdash; default @('nil')"
      (xdoc::p
       "Flag indicating the preprocessor to use, if any.")
      (xdoc::p
-      "This must be @('nil') or a @(tsee stringp).")
+      "This must be @('nil'), @(':auto') or a @(tsee stringp).")
      (xdoc::p
       "If this is a @(tsee stringp), the @(tsee preprocess-file) tool is called
-       on the files read at the file paths using the indicated preprocesser.")))
+       on the files read at the file paths using the indicated preprocesser. If
+       it is @(':auto'), we use the \"cpp\" preprocessor. If it is @('nil'), we
+       do not preprocess the files.")))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -164,8 +166,8 @@
                (const symbolp)
                (paths filepath-setp)
                (preprocessor (or (not preprocessor)
-                                 (stringp preprocessor))
-                             :rule-classes (:rewrite :type-prescription)))
+                                 (equal :auto preprocessor)
+                                 (stringp preprocessor))))
   :short "Process the inputs."
   (b* (((reterr) nil nil nil)
        ;; Check and obtain options.
@@ -210,14 +212,20 @@
        (preprocessor-option (assoc-eq :preprocessor options))
        (preprocessor (if preprocessor-option
                          (cdr preprocessor-option)
-                       "cpp"))
+                       nil))
        ((unless (or (not preprocessor)
+                    (eq :auto preprocessor)
                     (stringp preprocessor)))
-        (reterr (msg "The :PREPROCESSOR input must be a STRINGP or NIL, ~
+        (reterr (msg "The :PREPROCESSOR input must be NIL, :AUTO, or a STRINGP, ~
                       but it is ~x0 instead."
                      preprocessor))))
     (retok const paths preprocessor))
-  :guard-hints (("Goal" :in-theory (enable acl2::alistp-when-symbol-alistp))))
+  :guard-hints (("Goal" :in-theory (enable acl2::alistp-when-symbol-alistp)))
+  ///
+  (defret stringp-of-read-files-process-inputs.preprocessor
+    (equal (stringp preprocessor)
+           (and preprocessor
+                (not (equal :auto preprocessor))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -274,6 +282,7 @@
 (define read-files-gen-defconst ((const symbolp)
                                  (paths filepath-setp)
                                  (preprocessor (or (not preprocessor)
+                                                   (equal :auto preprocessor)
                                                    (stringp preprocessor)))
                                  state)
   :returns (mv erp (event pseudo-event-formp) state)
@@ -288,9 +297,12 @@
      to define the named constant."))
   (b* (((reterr) '(_) state)
        ((erp fileset state)
-        (if preprocessor
-            (read-files-read-and-preprocess paths preprocessor state)
-          (read-files-read paths state)))
+        (cond ((not preprocessor)
+               (read-files-read paths state))
+              ((eq :auto preprocessor)
+               (read-files-read-and-preprocess paths "cpp" state))
+              (t
+                (read-files-read-and-preprocess paths preprocessor state))))
        (event `(defconst ,const ',fileset)))
     (retok event state)))
 

--- a/books/kestrel/c/syntax/tests/read-and-parse-files.lisp
+++ b/books/kestrel/c/syntax/tests/read-and-parse-files.lisp
@@ -17,4 +17,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (read-and-parse-files :const *stdbool-ast*
-                      :files ("stdbool.c"))
+                      :files ("stdbool.c")
+                      :preprocessor :auto)

--- a/books/kestrel/c/syntax/tests/read-and-parse-files.lisp
+++ b/books/kestrel/c/syntax/tests/read-and-parse-files.lisp
@@ -17,5 +17,4 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (read-and-parse-files :const *stdbool-ast*
-                      :files ("stdbool.c")
-                      :preprocess t)
+                      :files ("stdbool.c"))

--- a/books/kestrel/c/syntax/tests/read-files.lisp
+++ b/books/kestrel/c/syntax/tests/read-files.lisp
@@ -24,17 +24,14 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 (read-files :const *stdbool*
-            :files ("stdbool.c")
-            :preprocessor nil)
+            :files ("stdbool.c"))
 
 (read-files :const *stdint*
-            :files ("stdint.c")
-            :preprocessor nil)
+            :files ("stdint.c"))
 
 (read-files :const *stdbool-stdint*
             :files ("stdbool.c"
-                     "stdint.c")
-            :preprocessor nil)
+                    "stdint.c"))
 
 ;;;;;;;;;;;;;;;;;;;;
 
@@ -70,11 +67,14 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;
 
 (read-files :const *stdbool-pp*
-            :files ("stdbool.c"))
+            :files ("stdbool.c")
+            :preprocessor :auto)
 
 (read-files :const *stdint-pp*
-            :files ("stdint.c"))
+            :files ("stdint.c")
+            :preprocessor :auto)
 
 (read-files :const *stdbool-stdint-pp*
             :files ("stdbool.c"
-                    "stdint.c"))
+                    "stdint.c")
+            :preprocessor :auto)

--- a/books/kestrel/c/syntax/tests/read-files.lisp
+++ b/books/kestrel/c/syntax/tests/read-files.lisp
@@ -24,14 +24,17 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 (read-files :const *stdbool*
-            :files ("stdbool.c"))
+            :files ("stdbool.c")
+            :preprocessor nil)
 
 (read-files :const *stdint*
-            :files ("stdint.c"))
+            :files ("stdint.c")
+            :preprocessor nil)
 
 (read-files :const *stdbool-stdint*
             :files ("stdbool.c"
-                    "stdint.c"))
+                     "stdint.c")
+            :preprocessor nil)
 
 ;;;;;;;;;;;;;;;;;;;;
 
@@ -67,14 +70,11 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;
 
 (read-files :const *stdbool-pp*
-            :files ("stdbool.c")
-            :preprocess t)
+            :files ("stdbool.c"))
 
 (read-files :const *stdint-pp*
-            :files ("stdint.c")
-            :preprocess t)
+            :files ("stdint.c"))
 
 (read-files :const *stdbool-stdint-pp*
             :files ("stdbool.c"
-                    "stdint.c")
-            :preprocess t)
+                    "stdint.c"))


### PR DESCRIPTION
This changes the boolean `:preprocess` flag in `read-files` and `read-and-parse-files` to `:preprocessor`, which may be either `nil` or a string. If it is a string, it indicates the name of the preprocessor to be used. The default is `"cpp"` (in contrast to the old flag which defaulted to `nil`).