### PR TITLE
Add `:verify-guards :after-returns` option to `defines`

### DIFF
--- a/books/std/util/defines.lisp
+++ b/books/std/util/defines.lisp
@@ -915,8 +915,12 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
                          `(with-output :stack :pop ,event))
                      (value '(value-triple :invisible))))))
          (with-output :stack :pop (progn . ,rest-events1))
+         ,@(and verify-guards-after-returns
+                returns-induct
+                `((with-output :stack :pop (verify-guards ,name))))
          ,@fn-sections
          ,@(and verify-guards-after-returns
+                (not returns-induct)
                 `((with-output :stack :pop (verify-guards ,name))))
          ,@sections-rest
          (with-output :stack :pop (progn . ,rest-events2)))

--- a/books/std/util/defines.lisp
+++ b/books/std/util/defines.lisp
@@ -770,9 +770,6 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
 
        (verify-guards-after-returns
          (eq (cdr (assoc :verify-guards kwd-alist)) :after-returns))
-       (kwd-alist (if verify-guards-after-returns
-                      (put-assoc :verify-guards 'nil kwd-alist)
-                    kwd-alist))
 
        (short      (getarg :short   nil kwd-alist))
        (long       (getarg :long    nil kwd-alist))
@@ -807,7 +804,10 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
        (macros      (collect-macros gutslist))
        (set-ignores (make-ignore-events name kwd-alist gutslist))
 
-       (extra-xargs (get-xargs-from-kwd-alist kwd-alist))
+       (extra-xargs (get-xargs-from-kwd-alist
+                      (if verify-guards-after-returns
+                          (put-assoc :verify-guards 'nil kwd-alist)
+                        kwd-alist)))
        (ruler-extenders (getarg :ruler-extenders nil kwd-alist))
        (orig-defs   (collect-main-defs gutslist))
        (final-defs  (if extra-xargs

--- a/books/std/util/defines.lisp
+++ b/books/std/util/defines.lisp
@@ -450,7 +450,7 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
                      (and cliquename
                           (not (eq cliquename guts.name))
                           (list cliquename))))
-       (divide-defsections (and process-returns divide-defsections))
+       (divide-defsections (and process-returns divide-defsections guts.rest-events))
        (rest-events
         `(
 ; Matt K. mod, 8/27/2021, for GitHub Issue #1302: allow current-function to be


### PR DESCRIPTION
This mirrors the existing option provided by `define`.

The only notable implementation change is that `make-fn-defsection` is modified to return two sets of events. The produced `defsection` is split right after the returns theorems (if `:returns-no-induct t` and `:verify-guards :after-returns`) to allow for the `verify-guards` event to be place before the functions' additional events.