### PR TITLE
Remove ACL2s section from installation page

### DIFF
--- a/installation/obtaining-and-installing.html
+++ b/installation/obtaining-and-installing.html
@@ -15,7 +15,6 @@
 <UL>
   <LI><A HREF="#Shortcuts">Pre-built Binary Distributions</A>
   <UL>
-    <LI><A HREF="#Shortcut-acl2s">Linux/Mac/Windows Binaries in ACL2s</A>
     <LI><A HREF="#Shortcut-windows">Windows</A>
     <LI><A HREF="#Shortcut-MacPorts">MacPorts for Mac OS X</A>
     <LI><A HREF="#Shortcut-debian">Debian GNU Linux</A>

--- a/installation/obtaining-and-installing.html
+++ b/installation/obtaining-and-installing.html
@@ -77,34 +77,6 @@ version of ACL2 (Version 8.5).
 
 <UL>
 
-<LI><B><A NAME="Shortcut-acl2s">Linux/Mac/Windows Binaries in ACL2s</A></B>
-
-<p>
-
-The <a href="http://acl2s.ccs.neu.edu/acl2s/doc/">ACL2 Sedan</a>
-(ACL2s) is an Eclipse-based IDE for ACL2 that is distributed with pre-certified
-books and pre-built binaries, though it is not always based on the
-latest ACL2 version.  If you
-  use an alternative development environment (such as Emacs), you
-can still <a href="http://acl2s.ccs.neu.edu/acl2s/src/acl2/">fetch a
-tarball</a> for your x86-based Linux/Mac/Windows system that contains a
-pre-built binary of (pure) ACL2, using the following instructions
-based on information kindly provided by Harsh Raju Chamarthi.
-Just extract the
-appropriate tarball (using <code>tar xfz</code> on Linux or Mac
-and <code>unzip</code> on Windows)
-under a path with <i>no</i> spaces.
-Then run the script you will
-find, <code>run_acl2</code> on Linux or Mac
-and <code>run_acl2.exe</code> on Windows, to start an ACL2 session.
-(Note that The first time you execute that command,
-the certificate (<code>.cert</code>) files are automatically
-fixed, according to the full pathname of your <code>books/</code> directory.)
-Also see
-the <a href="http://www.cs.utexas.edu/users/moore/acl2/v8-5/combined-manual/index.html?topic=ACL2____ACL2-SEDAN">ACL2
-documentation topic on the ACL2 Sedan</a>.
-
-
 <LI><B><A NAME="Shortcut-windows">Windows</A></B>
 
 <p>


### PR DESCRIPTION
ACL2s no longer provides precompiled binaries