### PR TITLE
Fix clique name bug for `defines` `:verify-guards :after-returns`

### DIFF
--- a/books/std/util/defines.lisp
+++ b/books/std/util/defines.lisp
@@ -770,6 +770,9 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
 
        (verify-guards-after-returns
          (eq (cdr (assoc :verify-guards kwd-alist)) :after-returns))
+       (verify-guards-name
+         (and verify-guards-after-returns
+              (defguts->name-fn (car gutslist))))
 
        (short      (getarg :short   nil kwd-alist))
        (long       (getarg :long    nil kwd-alist))
@@ -917,11 +920,11 @@ encapsulate), and is mainly meant as a tool for macro developers.</dd>
          (with-output :stack :pop (progn . ,rest-events1))
          ,@(and verify-guards-after-returns
                 returns-induct
-                `((with-output :stack :pop (verify-guards ,name))))
+                `((with-output :stack :pop (verify-guards ,verify-guards-name))))
          ,@fn-sections
          ,@(and verify-guards-after-returns
                 (not returns-induct)
-                `((with-output :stack :pop (verify-guards ,name))))
+                `((with-output :stack :pop (verify-guards ,verify-guards-name))))
          ,@sections-rest
          (with-output :stack :pop (progn . ,rest-events2)))
 

--- a/books/std/util/tests/defines.lisp
+++ b/books/std/util/tests/defines.lisp
@@ -265,6 +265,27 @@
   ;; Prevent guard proof from succeeding without returns theorem
   :guard-hints (("Goal" :in-theory (disable acl2::natp-compound-recognizer))))
 
+(defines clique-name-different
+  (define count-vars3 ((term pseudo-termp) (i natp))
+    :returns (count natp :hyp (natp i))
+    (cond ((acl2::variablep term)
+           (+ 1 i))
+          ((acl2::fquotep term)
+           i)
+          ((acl2::flambda-applicationp term)
+           (count-vars3 (acl2::lambda-body (acl2::ffn-symb term))
+                        (count-vars-list (acl2::fargs term) i)))
+          (t
+            (count-vars-list3 (acl2::fargs term) i))))
+
+  (define count-vars-list3 ((terms pseudo-term-listp) (i natp))
+    :returns (count natp :hyp (natp i))
+    (if (endp terms)
+        i
+      (count-vars3 (first terms)
+                   (count-vars-list3 (rest terms) i))))
+  :verify-guards :after-returns)
+
 
 (defines doc-test
   :short "Test of local stuff."


### PR DESCRIPTION
The generated `verify-guards` event was erroneously using the name of the clique, instead of the name of one of the functions.

Thanks @acoglio for reporting.