### PR TITLE
[std/io] Speed up file-measure proof.

### DIFF
--- a/books/std/io/file-measure.lisp
+++ b/books/std/io/file-measure.lisp
@@ -41,6 +41,21 @@
 (include-book "xdoc/top" :dir :system)
 (local (include-book "system/f-put-global" :dir :system))
 
+;; This speeds up the proofs (from about 50 seconds to about 1/2 second):
+(local (in-theory (disable default-car
+                           default-cdr
+                           nth
+                           update-nth
+                           array1p
+                           aref1
+                           add-pair
+                           assoc-equal
+                           assoc-keyword
+                           true-list-fix
+                           natp
+                           nfix
+                           mv-nth)))
+
 (defsection file-measure
   :parents (std/io)
   :short "A measure for admitting functions that read from files."


### PR DESCRIPTION
I noticed that this file was slow to certify.  This change speeds the proofs up by about 100x (~50 seconds to ~0.5 seconds on a very fast machine).