### PR TITLE
[pdf-parser] Drastically speed up certification of pdf-parser

### DIFF
--- a/books/projects/pdf-parser/pdf-parser.lisp
+++ b/books/projects/pdf-parser/pdf-parser.lisp
@@ -1020,6 +1020,7 @@
 
 (defund parse-objects (prefix contents )
         (declare (xargs :guard (character-listp contents)
+                        ; Updated 7/24/2024 by Drew Walter to speed up CCG analysis
                         :consider-only-ccms ((len contents))))
   (let ((res1 (parse-object-entry contents) ))
     (if (ast-obj-p prefix)
@@ -1142,8 +1143,9 @@
 
 
 (defund parse-trailer-entry-repetition (prefix contents )
-    (declare (xargs :guard (character-listp contents)
-                    :consider-only-ccms ((len contents))))
+  (declare (xargs :guard (character-listp contents)
+                   ; Updated 7/24/2024 by Drew Walter to speed up CCG analysis
+                   :consider-only-ccms ((len contents))))
   (let ((res1 (parse-trailer-entry contents) ))
     (if (ast-obj-p prefix)
       (if (character-listp contents)

--- a/books/projects/pdf-parser/pdf-parser.lisp
+++ b/books/projects/pdf-parser/pdf-parser.lisp
@@ -1019,11 +1019,8 @@
 
 
 (defund parse-objects (prefix contents )
-    (declare (xargs :guard
-                         (and  (character-listp contents)
-                           )
-                            )
-             )
+        (declare (xargs :guard (character-listp contents)
+                        :consider-only-ccms ((len contents))))
   (let ((res1 (parse-object-entry contents) ))
     (if (ast-obj-p prefix)
       (if (character-listp contents)
@@ -1145,11 +1142,8 @@
 
 
 (defund parse-trailer-entry-repetition (prefix contents )
-    (declare (xargs :guard
-                         (and  (character-listp contents)
-                           )
-                            )
-             )
+    (declare (xargs :guard (character-listp contents)
+                    :consider-only-ccms ((len contents))))
   (let ((res1 (parse-trailer-entry contents) ))
     (if (ast-obj-p prefix)
       (if (character-listp contents)


### PR DESCRIPTION
Add hints for CCG that drastically speed up termination analysis for some functions in projects/pdf-parser/pdf-parser. Should resolve regression timeouts related to this book.