### PR TITLE
[c2c] Add `split-fn` transformation

### DIFF
--- a/books/kestrel/c/syntax/abstract-syntax-symbols.lisp
+++ b/books/kestrel/c/syntax/abstract-syntax-symbols.lisp
@@ -26,6 +26,9 @@
 
     ident-listp
 
+    ident-setp
+    ident-set-fix
+
     dec/oct/hex-const-case
     dec/oct/hex-const-oct
 
@@ -340,6 +343,9 @@
     fundef-fix
     make-fundef
     fundef->declor
+
+    fundef-optionp
+    fundef-option-case
 
     extdeclp
     extdecl-fix

--- a/books/kestrel/c/syntax/abstract-syntax-symbols.lisp
+++ b/books/kestrel/c/syntax/abstract-syntax-symbols.lisp
@@ -20,6 +20,7 @@
   '(
 
     identp
+    ident
     ident-fix
     ident->unwrap
 
@@ -34,6 +35,8 @@
     const-fix
     const-case
     const-int->unwrap
+
+    tyqual-list-listp
 
     exprp
     expr-fix
@@ -292,6 +295,8 @@
     initdeclor-list-fix
 
     declp
+    decl
+    decl-fix
     decl-case
     make-decl-decl
     decl-statassert
@@ -327,20 +332,24 @@
     block-item-stmt
 
     block-item-listp
+    block-item-list-fix
     block-item-list-count
 
     fundefp
     fundef
+    fundef-fix
     make-fundef
     fundef->declor
 
     extdeclp
+    extdecl-fix
     extdecl-case
     extdecl-fundef
     extdecl-fundef->unwrap
     extdecl-decl
 
     extdecl-listp
+    extdecl-list-fix
 
     transunitp
     transunit

--- a/books/kestrel/c/syntax/abstract-syntax.lisp
+++ b/books/kestrel/c/syntax/abstract-syntax.lisp
@@ -159,6 +159,18 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(fty::defset ident-set
+  :short "Fixtype of sets of identifiers."
+  :long
+  (xdoc::topstring
+    (xdoc::p
+      "Identifiers are defined in @(tsee ident)."))
+  :elt-type ident
+  :elementp-of-nil nil
+  :pred ident-setp)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (fty::defoption ident-option
   ident
   :short "Fixtype of optional identifiers."
@@ -2722,6 +2734,17 @@
    (decls decl-list)
    (body stmt))
   :pred fundefp)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fty::defoption fundef-option
+  fundef
+  :short "Fixtype of optional function definitions."
+  :long
+  (xdoc::topstring
+    (xdoc::p
+      "Function definitions are defined in @(tsee fundef)."))
+  :pred fundef-optionp)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/transformation/package.lsp
+++ b/books/kestrel/c/transformation/package.lsp
@@ -26,4 +26,7 @@
                                   '())
                c$::*abstract-syntax-symbols*
                '(defxdoc+
-                 index-of)))
+                 erp
+                 index-of
+                 reterr
+                 retok)))

--- a/books/kestrel/c/transformation/rename.lisp
+++ b/books/kestrel/c/transformation/rename.lisp
@@ -37,8 +37,8 @@
   (xdoc::topstring
    (xdoc::p
      "This transformation will rename all identifiers according to a provided
-     alist. Note, it does nothing to ensure substitutions preserve semantic
-     equivalence. For instance, a substitution might introduce variable names
+      alist. Note, it does nothing to ensure substitutions preserve semantic
+      equivalence. For instance, a substitution might introduce variable names
       which conflict with existing variables.")
    (xdoc::p
      "Eventually we may wish for a renaming transformation with options to

--- a/books/kestrel/c/transformation/split-fn.lisp
+++ b/books/kestrel/c/transformation/split-fn.lisp
@@ -32,7 +32,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defxdoc+ split-fn
-  :parents (utilities)
+  :parents (transformation-tools)
   :short "A C-to-C transformation to split a function in two."
   :long
   (xdoc::topstring

--- a/books/kestrel/c/transformation/split-fn.lisp
+++ b/books/kestrel/c/transformation/split-fn.lisp
@@ -86,7 +86,7 @@
 
 (define expr-ident-list
   ((idents ident-listp))
-  :short "Map @(tsee expr-list) over a list."
+  :short "Map @(tsee c$::expr-list) over a list."
   :returns (exprs expr-listp)
   (if (endp idents)
       nil
@@ -204,7 +204,7 @@
       declarations of the original function which appear free in the block
       items, which will constitute the body of the new function. (Note that
       arguments are not currently taken by reference, but this may be necessary
-      for general correctness. It may be sufficient to take an argument by
+      for general equivalence. It may be sufficient to take an argument by
       reference when its address is taken in an expression of the new function
       body.)"))
   :returns (mv er

--- a/books/kestrel/c/transformation/split-fn.lisp
+++ b/books/kestrel/c/transformation/split-fn.lisp
@@ -69,6 +69,13 @@
     :val-type decl
     :pred ident-decl-mapp))
 
+(defrulel ident-listp-of-strip-cars-when-ident-decl-mapp
+  (implies (ident-decl-mapp map)
+           (ident-listp (strip-cars map)))
+  :induct t
+  :enable (strip-cars
+           ident-decl-mapp))
+
 (defrulel decl-listp-of-strip-cdrs-when-ident-decl-mapp
   (implies (ident-decl-mapp map)
            (decl-listp (strip-cdrs map)))
@@ -158,6 +165,7 @@
   (b* (((reterr) nil (c$::irr-fundef))
        (idents (free-vars-block-item-list items nil))
        (decls (ident-decls-map-filter decls idents))
+       (idents (strip-cars decls))
        (params (decl-list-to-paramdecl-list (strip-cdrs decls))))
     (retok
       idents

--- a/books/kestrel/c/transformation/split-fn.lisp
+++ b/books/kestrel/c/transformation/split-fn.lisp
@@ -1,0 +1,441 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "C2C")
+
+(include-book "std/util/bstar" :dir :system)
+(include-book "std/util/define" :dir :system)
+(include-book "std/util/defrule" :dir :system)
+(include-book "xdoc/defxdoc-plus" :dir :system)
+(include-book "xdoc/constructors" :dir :system)
+
+(include-book "centaur/fty/deftypes" :dir :system)
+(include-book "kestrel/std/util/defirrelevant" :dir :system)
+(include-book "kestrel/std/util/error-value-tuples" :dir :system)
+
+(include-book "../syntax/abstract-syntax-operations")
+(include-book "deftrans")
+(include-book "utilities/free-vars")
+
+(local (include-book "kestrel/built-ins/disable" :dir :system))
+(local (acl2::disable-most-builtin-logic-defuns))
+(local (acl2::disable-builtin-rewrite-rules-for-defaults))
+(set-induction-depth-limit 0)
+
+(local (include-book "kestrel/alists-light/remove-assoc-equal" :dir :system))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defxdoc+ split-fn
+  :parents (utilities)
+  :short "A C-to-C transformation to split a function in two."
+  :long
+  (xdoc::topstring
+    (xdoc::p
+      "This transformation takes the identifier of the function it is to split,
+       the name of the new function to be generated, and the location of the
+       split, represented as a natural number corresponding to the number of
+       statements in the function body before the split.")
+    )
+  :order-subtopics t
+  :default-parent t)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(encapsulate ()
+  (set-induction-depth-limit 1)
+
+  (fty::defomap ident-decl-map
+    :key-type C$::ident
+    :val-type C$::decl
+    :pred ident-decl-mapp))
+
+(defrulel decl-listp-of-strip-cdrs-when-ident-decl-mapp
+  (implies (ident-decl-mapp map)
+           (decl-listp (strip-cdrs map)))
+  :induct t
+  :enable (strip-cdrs
+           ident-decl-mapp))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; MOVE
+(fty::defoption fundef-option
+  fundef
+  :short "Fixtype of optional function definitions."
+  :pred fundef-optionp)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; MOVE
+(acl2::defirrelevant irr-fundef
+  :short "An irrelevant function definition."
+  :type c$::fundefp
+  :body (make-fundef
+          :extension nil
+          :spec nil
+          :declor (c$::irr-declor)
+          :decls nil
+          :body (c$::irr-stmt)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define ident-decls-map-filter
+  ((map ident-decl-mapp)
+   (idents ident-setp))
+  :returns (new-map ident-decl-mapp)
+  (b* ((map (ident-decl-map-fix map))
+       ((when (omap::emptyp map))
+        nil)
+       ((mv key val)
+        (omap::head map)))
+    (if (in key idents)
+        (omap::update key
+                      val
+                      (ident-decls-map-filter (omap::tail map) idents))
+      (ident-decls-map-filter
+        (omap::tail map)
+        idents)))
+  :measure (acl2-count (ident-decl-map-fix map))
+  :hints (("Goal" :in-theory (enable o< o-finp)))
+  :verify-guards :after-returns)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define decl-to-paramdecl
+  ((decl declp))
+  :returns (mv erp
+               (paramdecl paramdeclp))
+  (b* (((reterr) (c$::irr-paramdecl)))
+    (decl-case
+      decl
+      :decl (b* (((when (endp decl.init))
+                  (reterr t))
+                 ((initdeclor initdeclor) (first decl.init)))
+              (retok
+                (make-paramdecl
+                  ;; TODO: spec vs specs
+                  :spec decl.specs
+                  :decl (paramdeclor-declor initdeclor.declor))))
+      :statassert (reterr t))))
+
+(define decl-list-to-paramdecl-list
+  ((decls decl-listp))
+  :returns (paramdecls paramdecl-listp)
+  (b* (((when (endp decls))
+        nil)
+       ((mv erp paramdecl)
+        (decl-to-paramdecl (first decls))))
+    (if erp
+        (decl-list-to-paramdecl-list (rest decls))
+      (cons paramdecl
+            (decl-list-to-paramdecl-list (rest decls))))))
+
+(define paramdecl-to-decl
+  ((paramdecl paramdeclp))
+  :returns (mv erp
+               (decl declp))
+  (b* (((reterr) (c$::irr-decl))
+       ((paramdecl paramdecl) paramdecl))
+    (paramdeclor-case
+      paramdecl.decl
+      :declor (retok (make-decl-decl
+                       :specs paramdecl.spec
+                       :init (list (make-initdeclor
+                                     :declor paramdecl.decl.unwrap))))
+      :otherwise (reterr t))))
+
+(define paramdecl-list-to-decl-list
+  ((paramdecls paramdecl-listp))
+  :returns (decls decl-listp)
+  (b* (((when (endp paramdecls))
+        nil)
+       ((mv erp decl)
+        (paramdecl-to-decl (first paramdecls))))
+    (if erp
+        (paramdecl-list-to-decl-list (rest paramdecls))
+      (cons decl
+            (paramdecl-list-to-decl-list (rest paramdecls))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define abstract-fn
+  ((new-fn-name identp)
+   (spec declspec-listp)
+   (pointers c$::tyqual-list-listp)
+   (items block-item-listp)
+   (decls ident-decl-mapp))
+  :returns (mv er
+               (idents ident-listp)
+               (new-fn fundefp))
+  (b* (((reterr) nil (irr-fundef))
+       (idents (free-vars-block-item-list items nil))
+       (decls (ident-decls-map-filter decls idents))
+       (params (decl-list-to-paramdecl-list (strip-cdrs decls))))
+    (retok
+      idents
+      (make-fundef
+        :spec spec
+        :declor (make-declor
+                  :pointers pointers
+                  :decl (make-dirdeclor-function-params
+                          :decl (dirdeclor-ident new-fn-name)
+                          :params params))
+        :body (stmt-compound items)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define initdeclor-get-idents
+  ((initdeclor initdeclorp))
+  :returns (idents ident-setp)
+  (b* (((initdeclor initdeclor) initdeclor)
+       (ident? (declor-get-ident initdeclor.declor)))
+    (if ident?
+        (insert ident? nil)
+      nil)))
+
+(define initdeclor-list-get-idents
+  ((initdeclors initdeclor-listp))
+  :returns (idents ident-setp)
+  (if (endp initdeclors)
+      nil
+    (union (initdeclor-get-idents (first initdeclors))
+           (initdeclor-list-get-idents (rest initdeclors))))
+  :verify-guards :after-returns)
+
+(define decl-get-idents
+  ((decl declp))
+  :returns (idents ident-setp)
+  (decl-case
+   decl
+   :decl (initdeclor-list-get-idents decl.init)
+   :statassert nil))
+
+(define split-fn-decl
+  ((decl declp)
+   (map ident-decl-mapp))
+  :returns (mv er
+               (new-map ident-decl-mapp))
+  (b* ((map (ident-decl-map-fix map))
+       ((reterr) map)
+       (idents (decl-get-idents decl)))
+    (if (emptyp idents)
+        (retok map)
+      ;; TODO: either reterr on more than one ident, or else add all to the alist
+      (retok (omap::update (head idents)
+                           (c$::decl-fix decl)
+                           map)))))
+
+(define split-fn-decl-list
+  ((decls decl-listp)
+   (map ident-decl-mapp))
+  :returns (new-map ident-decl-mapp)
+  (b* (((when (endp decls))
+        (ident-decl-map-fix map))
+       ((mv er split-map)
+        (split-fn-decl (first decls) map)))
+    (split-fn-decl-list (rest decls)
+                        (if er
+                            map
+                          split-map))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define expr-ident-list
+  ((idents ident-listp))
+  :returns (exprs expr-listp)
+  (if (endp idents)
+      nil
+    (cons (expr-ident (first idents))
+          (expr-ident-list (rest idents)))))
+
+(define split-fn-block-item-list
+  ((new-fn-name identp)
+   (items block-item-listp)
+   (spec declspec-listp)
+   (pointers c$::tyqual-list-listp)
+   (decls ident-decl-mapp)
+   (split-point natp))
+  :returns (mv er
+               (new-fn fundefp)
+               (truncated-items block-item-listp))
+  (b* ((items (c$::block-item-list-fix items))
+       ((reterr) (irr-fundef) items)
+       ((when (zp split-point))
+        (b* (((erp idents new-fn)
+              (abstract-fn new-fn-name spec pointers items decls)))
+          (retok new-fn
+                 (list
+                   (block-item-stmt
+                     (stmt-return
+                       (make-expr-funcall
+                         :fun (expr-ident new-fn-name)
+                         :args (expr-ident-list idents))))))))
+       ((when (endp items))
+        (reterr (msg "Bad split point specifier")))
+       (item (first items))
+       ((erp decls)
+        (block-item-case
+          item
+          :decl (split-fn-decl item.unwrap decls)
+          :otherwise (mv nil decls)))
+       ((erp new-fn truncated-items)
+        (split-fn-block-item-list new-fn-name
+                              (rest items)
+                              spec
+                              pointers
+                              decls
+                              (- split-point 1))))
+    (retok new-fn
+           (cons (first items)
+                 truncated-items)))
+  :measure (block-item-list-count items)
+  :hints (("Goal" :in-theory (enable o<
+                                     o-finp
+                                     c$::block-item-list-fix))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define split-fn-fundef
+  ((target-fn identp)
+   (new-fn-name identp)
+   (fundef fundefp)
+   (split-point natp))
+  :returns (mv er
+               (fundef1 fundefp)
+               (fundef2 fundef-optionp))
+  (b* (((reterr) (irr-fundef) nil)
+       ((fundef fundef) fundef)
+       ((declor fundef.declor) fundef.declor))
+    (stmt-case
+      fundef.body
+      :compound
+      (dirdeclor-case
+        fundef.declor.decl
+        :function-params
+        (b* (((unless (equal target-fn (dirdeclor-get-ident fundef.declor.decl.decl)))
+              (retok (c$::fundef-fix fundef) nil))
+             ((erp new-fn truncated-items)
+              (split-fn-block-item-list
+                new-fn-name
+                fundef.body.items
+                fundef.spec
+                fundef.declor.pointers
+                (split-fn-decl-list
+                  (paramdecl-list-to-decl-list fundef.declor.decl.params)
+                  nil)
+                split-point)))
+          (retok new-fn
+                 (make-fundef
+                   :extension fundef.extension
+                   :spec fundef.spec
+                   :declor fundef.declor
+                   :decls fundef.decls
+                   :body (stmt-compound truncated-items))))
+        :otherwise (retok (c$::fundef-fix fundef) nil))
+      :otherwise (retok (c$::fundef-fix fundef) nil))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define split-fn-extdecl
+  ((target-fn identp)
+   (new-fn-name identp)
+   (extdecl extdeclp)
+   (split-point natp))
+  :returns (mv er
+               (target-found booleanp)
+               (extdecls extdecl-listp))
+  (b* (((reterr) nil nil))
+    (extdecl-case
+      extdecl
+      :fundef (b* (((erp fundef1 fundef2)
+                    (split-fn-fundef
+                      target-fn
+                      new-fn-name
+                      extdecl.unwrap
+                      split-point)))
+                (fundef-option-case
+                  fundef2
+                  :some (retok t (list (extdecl-fundef fundef1)
+                                       (extdecl-fundef fundef2.val)))
+                  :none (retok nil (list (extdecl-fundef fundef1)))))
+      :decl (retok nil (list (c$::extdecl-fix extdecl))))))
+
+(define split-fn-extdecl-list
+  ((target-fn identp)
+   (new-fn-name identp)
+   (extdecls extdecl-listp)
+   (split-point natp))
+  :returns (mv er
+               (new-extdecls extdecl-listp))
+  (b* (((reterr) nil)
+       ((when (endp extdecls))
+        (retok nil))
+       ((erp target-found extdecls1)
+        (split-fn-extdecl target-fn new-fn-name (first extdecls) split-point))
+       ((when target-found)
+        (retok (append extdecls1 (c$::extdecl-list-fix (rest extdecls)))))
+       ((erp extdecls2)
+        (split-fn-extdecl-list target-fn new-fn-name (rest extdecls) split-point)))
+    (retok (append extdecls1 extdecls2))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define split-fn-transunit
+  ((target-fn identp)
+   (new-fn-name identp)
+   (tunit transunitp)
+   (split-point natp))
+  :returns (mv er
+               (new-tunit transunitp))
+  (b* (((transunit tunit) tunit)
+       ((mv er extdecls)
+        (split-fn-extdecl-list target-fn new-fn-name tunit.decls split-point)))
+    (mv er (transunit extdecls))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define split-fn-filepath-transunit-map
+  ((target-fn identp)
+   (new-fn-name identp)
+   (map filepath-transunit-mapp)
+   (split-point natp))
+  :returns (mv er
+               (new-map filepath-transunit-mapp
+                        :hyp (filepath-transunit-mapp map)))
+  (b* (((reterr) nil)
+       ((when (omap::emptyp map))
+        (retok nil))
+       ((mv path tunit) (omap::head map))
+       (new-path (deftrans-filepath path "SPLIT-FN"))
+       ((erp new-tunit)
+        (split-fn-transunit target-fn new-fn-name tunit split-point))
+       ((erp new-map)
+        (split-fn-filepath-transunit-map target-fn
+                                         new-fn-name
+                                         (omap::tail map)
+                                         split-point)))
+    (retok (omap::update new-path new-tunit new-map)))
+  :verify-guards :after-returns)
+
+(define split-fn-transunit-ensemble
+  ((target-fn identp)
+   (new-fn-name identp)
+   (tunits transunit-ensemblep)
+   (split-point natp))
+  :returns (mv er
+               (new-tunits transunit-ensemblep))
+  (b* (((transunit-ensemble tunits) tunits)
+       ((mv er map)
+        (split-fn-filepath-transunit-map target-fn
+                                         new-fn-name
+                                         tunits.unwrap
+                                         split-point)))
+    (mv er (transunit-ensemble map))))

--- a/books/kestrel/c/transformation/split-fn.lisp
+++ b/books/kestrel/c/transformation/split-fn.lisp
@@ -41,9 +41,23 @@
        the name of the new function to be generated, and the location of the
        split, represented as a natural number corresponding to the number of
        statements in the function body before the split.")
-    )
+    (xdoc::p
+      "This transformation is a work in progress, and may fail in certain
+       cases. For one, it does not currently recognize multiple variables
+       declared at once (e.g. @('int x, y;')). It may also fail on variables
+       which have been declared but not yet initialized at the split point."))
   :order-subtopics t
   :default-parent t)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defruled ident-listp-when-ident-setp
+  (implies (ident-setp set)
+           (ident-listp set))
+  :induct t
+  :enable ident-setp)
+
+(local (in-theory (enable ident-listp-when-ident-setp)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -61,14 +75,6 @@
   :induct t
   :enable (strip-cdrs
            ident-decl-mapp))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-;; MOVE
-(fty::defoption fundef-option
-  fundef
-  :short "Fixtype of optional function definitions."
-  :pred fundef-optionp)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -106,7 +112,6 @@
                  ((initdeclor initdeclor) (first decl.init)))
               (retok
                 (make-paramdecl
-                  ;; TODO: spec vs specs
                   :spec decl.specs
                   :decl (paramdeclor-declor initdeclor.declor))))
       :statassert (reterr t))))

--- a/books/kestrel/c/transformation/split-fn.lisp
+++ b/books/kestrel/c/transformation/split-fn.lisp
@@ -40,7 +40,7 @@
       "This transformation takes the identifier of the function it is to split,
        the name of the new function to be generated, and the location of the
        split, represented as a natural number corresponding to the number of
-       statement block items in the function body before the split.")
+       block items in the function body before the split.")
     (xdoc::p
       "This transformation is a work in progress, and may fail in certain
        cases. For instance, it may fail given variables which have been
@@ -116,7 +116,7 @@
 
 (define paramdecl-list-to-ident-paramdecl-map
   ((paramdecls paramdecl-listp))
-  :short "Fold @(tsee decl-to-ident-paramdecl-map) over a list."
+  :short "Fold @(tsee paramdecl-to-ident-paramdecl-map) over a list."
   :returns (map ident-paramdecl-mapp)
   (if (endp paramdecls)
         nil

--- a/books/kestrel/c/transformation/tests/split-fn.lisp
+++ b/books/kestrel/c/transformation/tests/split-fn.lisp
@@ -1,0 +1,142 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "C2C")
+
+(include-book "../split-fn")
+
+(include-book "../../syntax/parser")
+(include-book "../../syntax/printer")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defconst *old-filepath*
+  (filepath "file.c"))
+
+(defconst *filepath-split-fn*
+  (filepath "file.SPLIT-FN.c"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defconst *old-filedata1*
+  (filedata
+   (acl2::string=>nats
+    "int foo(int y) {
+  int x = 5;
+  return x + y;
+}
+")))
+
+(defconst *old-fileset1*
+  (fileset
+   (omap::update *old-filepath*
+                 *old-filedata1*
+                 nil)))
+
+(defconst *old-transunits1*
+  (b* (((mv erp transunits) (c$::parse-fileset *old-fileset1* nil)))
+    (if erp
+        (cw "~@0" erp)
+      transunits)))
+
+(defconst *transunits-split-fn1*
+  (b* (((mv er ensemble)
+        (split-fn-transunit-ensemble (c$::ident "foo")
+                                     (c$::ident "bar")
+                                     *old-transunits1*
+                                     1)))
+    (if er
+        (cw "~@0" er)
+      ensemble)))
+
+(defconst *fileset-split-fn1*
+  (c$::print-fileset *transunits-split-fn1*))
+
+(defconst *filedata-split-fn1*
+  (omap::lookup *filepath-split-fn*
+                (fileset->unwrap *fileset-split-fn1*)))
+
+(assert-event
+ (equal
+   (acl2::nats=>string
+     (filedata->unwrap *filedata-split-fn1*))
+  "int bar(int x, int y) {
+  return x + y;
+}
+int foo(int y) {
+  int x = 5;
+  return bar(x, y);
+}
+"))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defconst *old-filedata2*
+  (filedata
+   (acl2::string=>NATS
+    "unsigned long add_and_sub_all(long arr[], unsigned int len) {
+  long total = 0l;
+  for (unsigned int i = 0; i < len; i++) {
+    total += arr[i];
+  }
+  for (unsigned int i = 0; i < len; i++) {
+    total -= arr[i];
+  }
+  return (unsigned long)total;
+}
+")))
+
+(defconst *old-fileset2*
+  (fileset
+   (omap::update *old-filepath*
+                 *old-filedata2*
+                 nil)))
+
+(defconst *old-transunits2*
+  (b* (((mv erp transunits) (c$::parse-fileset *old-fileset2* nil)))
+    (if erp
+        (cw "~@0" erp)
+      transunits)))
+
+(defconst *transunits-split-fn2*
+  (b* (((mv er ensemble)
+        (split-fn-transunit-ensemble (c$::ident "add_and_sub_all")
+                                     (c$::ident "sub_all")
+                                     *old-transunits2*
+                                     2)))
+    (if er
+        (cw "~@0" er)
+      ensemble)))
+
+(defconst *fileset-split-fn2*
+  (c$::print-fileset *transunits-split-fn2*))
+
+(defconst *filedata-split-fn2*
+  (omap::lookup *filepath-split-fn*
+                (fileset->unwrap *fileset-split-fn2*)))
+
+(assert-event
+ (equal
+   (acl2::nats=>string
+     (filedata->unwrap *filedata-split-fn2*))
+  "unsigned long sub_all(long arr[], unsigned int len, long total) {
+  for (unsigned int i = 0; i < len; i++) {
+    total -= arr[i];
+  }
+  return (unsigned long) total;
+}
+unsigned long add_and_sub_all(long arr[], unsigned int len) {
+  long total = 0l;
+  for (unsigned int i = 0; i < len; i++) {
+    total += arr[i];
+  }
+  return sub_all(arr, len, total);
+}
+"))

--- a/books/kestrel/c/transformation/tests/split-fn.lisp
+++ b/books/kestrel/c/transformation/tests/split-fn.lisp
@@ -147,11 +147,11 @@ unsigned long add_and_sub_all(long arr[], unsigned int len) {
   (filedata
    (acl2::string=>nats
      "
-int z = 42;
+int w = 42;
 
-int foo(int y) {
-  int x = 5;
-  x = bar(x);
+int foo(int x) {
+  long y = 0, z = 5;
+  y = bar(x);
   return x + y + z;
 }
 ")))
@@ -189,13 +189,13 @@ int foo(int y) {
  (equal
    (acl2::nats=>string
      (filedata->unwrap *filedata-split-fn3*))
-  "int z = 42;
-int baz(int x, int y) {
-  x = bar(x);
+  "int w = 42;
+int baz(int x, long y, long z) {
+  y = bar(x);
   return x + y + z;
 }
-int foo(int y) {
-  int x = 5;
-  return baz(x, y);
+int foo(int x) {
+  long y = 0, z = 5;
+  return baz(x, y, z);
 }
 "))

--- a/books/kestrel/c/transformation/tests/split-fn.lisp
+++ b/books/kestrel/c/transformation/tests/split-fn.lisp
@@ -140,3 +140,62 @@ unsigned long add_and_sub_all(long arr[], unsigned int len) {
   return sub_all(arr, len, total);
 }
 "))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defconst *old-filedata3*
+  (filedata
+   (acl2::string=>nats
+     "
+int z = 42;
+
+int foo(int y) {
+  int x = 5;
+  x = bar(x);
+  return x + y + z;
+}
+")))
+
+(defconst *old-fileset3*
+  (fileset
+   (omap::update *old-filepath*
+                 *old-filedata3*
+                 nil)))
+
+(defconst *old-transunits3*
+  (b* (((mv erp transunits) (c$::parse-fileset *old-fileset3* nil)))
+    (if erp
+        (cw "~@0" erp)
+      transunits)))
+
+(defconst *transunits-split-fn3*
+  (b* (((mv er ensemble)
+        (split-fn-transunit-ensemble (c$::ident "foo")
+                                     (c$::ident "baz")
+                                     *old-transunits3*
+                                     1)))
+    (if er
+        (cw "~@0" er)
+      ensemble)))
+
+(defconst *fileset-split-fn3*
+  (c$::print-fileset *transunits-split-fn3*))
+
+(defconst *filedata-split-fn3*
+  (omap::lookup *filepath-split-fn*
+                (fileset->unwrap *fileset-split-fn3*)))
+
+(assert-event
+ (equal
+   (acl2::nats=>string
+     (filedata->unwrap *filedata-split-fn3*))
+  "int z = 42;
+int baz(int x, int y) {
+  x = bar(x);
+  return x + y + z;
+}
+int foo(int y) {
+  int x = 5;
+  return baz(x, y);
+}
+"))

--- a/books/kestrel/c/transformation/top.lisp
+++ b/books/kestrel/c/transformation/top.lisp
@@ -14,7 +14,7 @@
 (include-book "rename")
 (include-book "simpadd0-proofs")
 (include-book "split-fn")
-(include-book "utilities/free-vars")
+(include-book "utilities/top")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/transformation/top.lisp
+++ b/books/kestrel/c/transformation/top.lisp
@@ -13,6 +13,7 @@
 (include-book "deftrans")
 (include-book "rename")
 (include-book "simpadd0-proofs")
+(include-book "split-fn")
 (include-book "utilities/free-vars")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/c/transformation/top.lisp
+++ b/books/kestrel/c/transformation/top.lisp
@@ -13,6 +13,7 @@
 (include-book "deftrans")
 (include-book "rename")
 (include-book "simpadd0-proofs")
+(include-book "utilities/free-vars")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/transformation/utilities/acl2-customization.lsp
+++ b/books/kestrel/c/transformation/utilities/acl2-customization.lsp
@@ -1,0 +1,16 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(ld "~/acl2-customization.lsp" :ld-missing-input-ok t)
+(ld "../package.lsp")
+
+(reset-prehistory)
+
+(in-package "C2C")

--- a/books/kestrel/c/transformation/utilities/cert.acl2
+++ b/books/kestrel/c/transformation/utilities/cert.acl2
@@ -1,0 +1,11 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(include-book "../portcullis")

--- a/books/kestrel/c/transformation/utilities/free-vars.lisp
+++ b/books/kestrel/c/transformation/utilities/free-vars.lisp
@@ -45,12 +45,14 @@
 (defines declor/dirdeclor-get-ident
   (define declor-get-ident
     ((declor declorp))
+    :short "Get the identifier described by a declarator."
     :returns (ident (or (not ident) (identp ident)))
     (b* (((declor declor) declor))
       (dirdeclor-get-ident declor.decl))
     :measure (declor-count declor))
 
   (define dirdeclor-get-ident
+    :short "Get the identifier described by a direct declarator."
     ((dirdeclor dirdeclorp))
     :returns (ident (or (not ident) (identp ident)))
     (dirdeclor-case
@@ -81,6 +83,7 @@
   (define free-vars-expr
     ((expr exprp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in an expression."
     :returns (free-vars ident-setp)
     (expr-case
      expr
@@ -110,6 +113,7 @@
   (define free-vars-expr-list
     ((exprs expr-listp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in an expression list."
     :returns (free-vars ident-setp)
     (if (endp exprs)
         nil
@@ -120,6 +124,7 @@
   (define free-vars-expr-option
     ((expr? expr-optionp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in an optional expression."
     :returns (free-vars ident-setp)
     (expr-option-case
      expr?
@@ -130,6 +135,7 @@
   (define free-vars-genassoc
     ((genassoc genassocp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in a generic association."
     :returns (free-vars ident-setp)
     (genassoc-case
      genassoc
@@ -140,6 +146,7 @@
   (define free-vars-genassoc-list
     ((genassocs genassoc-listp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in a generic association list."
     :returns (free-vars ident-setp)
     (if (endp genassocs)
         nil
@@ -150,6 +157,7 @@
   (define free-vars-initer
     ((initer initerp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in an initializer."
     :returns (free-vars ident-setp)
     (initer-case
      initer
@@ -160,6 +168,7 @@
   (define free-vars-initer-option
     ((initer? initer-optionp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in an optional initializer."
     :returns (free-vars ident-setp)
     (initer-option-case
      initer?
@@ -170,6 +179,8 @@
   (define free-vars-desiniter
     ((desiniter desiniterp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in an initializer with optional
+            designations."
     :returns (free-vars ident-setp)
     (b* (((desiniter desiniter) desiniter))
       (free-vars-initer desiniter.init bound-vars))
@@ -178,6 +189,8 @@
   (define free-vars-desiniter-list
     ((desiniters desiniter-listp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in a list of initializers with
+            optional designations."
     :returns (free-vars ident-setp)
     (if (endp desiniters)
         nil
@@ -193,6 +206,7 @@
 (define free-vars-initdeclor
   ((initdeclor initdeclorp)
    (bound-vars ident-setp))
+  :short "Collect free variables appearing in an initializer declarator."
   :returns (mv (free-vars ident-setp)
                (bound-vars ident-setp))
   (b* ((bound-vars (ident-set-fix bound-vars))
@@ -206,6 +220,8 @@
 (define free-vars-initdeclor-list
   ((initdeclors initdeclor-listp)
    (bound-vars ident-setp))
+  :short "Collect free variables appearing in a list of initializer
+          declarators."
   :returns (mv (free-vars ident-setp)
                (bound-vars ident-setp))
   (b* ((bound-vars (ident-set-fix bound-vars))
@@ -222,6 +238,7 @@
 (define free-vars-decl
   ((decl declp)
    (bound-vars ident-setp))
+  :short "Collect free variables appearing in a declaration."
   :returns (mv (free-vars ident-setp)
                (bound-vars ident-setp))
   (b* ((bound-vars (ident-set-fix bound-vars)))
@@ -233,6 +250,7 @@
 (define free-vars-decl-list
   ((decls decl-listp)
    (bound-vars ident-setp))
+  :short "Collect free variables appearing in a list of declarations."
   :returns (mv (free-vars ident-setp)
                (bound-vars ident-setp))
   (b* ((bound-vars (ident-set-fix bound-vars))
@@ -252,6 +270,7 @@
   (define free-vars-stmt
     ((stmt stmtp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in a statement."
     :returns (free-vars ident-setp)
     (stmt-case
      stmt
@@ -286,6 +305,7 @@
   (define free-vars-block-item
     ((item block-itemp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in a block item."
     :returns (mv (free-vars ident-setp)
                  (bound-vars ident-setp))
     (b* ((bound-vars (ident-set-fix bound-vars)))
@@ -300,6 +320,7 @@
   (define free-vars-block-item-list
     ((items block-item-listp)
      (bound-vars ident-setp))
+    :short "Collect free variables appearing in a list of block item."
     :returns (free-vars ident-setp)
     (b* (((when (endp items))
           nil)
@@ -317,6 +338,7 @@
 (define free-vars-fundef
   ((fundef fundefp)
    (bound-vars ident-setp))
+  :short "Collect free variables appearing in a function function definition."
   :returns (free-vars ident-setp)
   (b* (((fundef fundef) fundef)
        ((mv free-vars bound-vars)

--- a/books/kestrel/c/transformation/utilities/free-vars.lisp
+++ b/books/kestrel/c/transformation/utilities/free-vars.lisp
@@ -44,7 +44,7 @@
 
 (fty::defset ident-set
   :short "Fixtype of sets of identifiers."
-  :elt-type c$::ident
+  :elt-type ident
   :elementp-of-nil nil
   :pred ident-setp)
 
@@ -83,11 +83,13 @@
 
   :hints (("Goal" :in-theory (enable o< o-finp))))
 
-(defrule identp-of-declor-get-ident-under-iff
+(defruled identp-of-declor-get-ident-under-iff
   (iff (identp (declor-get-ident declor))
        (declor-get-ident declor))
   :use return-type-of-declor-get-ident.ident
   :disable return-type-of-declor-get-ident.ident)
+
+(local (in-theory (enable identp-of-declor-get-ident-under-iff)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/transformation/utilities/free-vars.lisp
+++ b/books/kestrel/c/transformation/utilities/free-vars.lisp
@@ -1,0 +1,339 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "C2C")
+
+(include-book "std/util/bstar" :dir :system)
+(include-book "std/util/define" :dir :system)
+(include-book "std/util/defrule" :dir :system)
+(include-book "xdoc/defxdoc-plus" :dir :system)
+(include-book "xdoc/constructors" :dir :system)
+
+(include-book "../../syntax/abstract-syntax")
+
+(local (include-book "kestrel/built-ins/disable" :dir :system))
+(local (acl2::disable-most-builtin-logic-defuns))
+(local (acl2::disable-builtin-rewrite-rules-for-defaults))
+(set-induction-depth-limit 0)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defxdoc+ free-vars
+  :parents (utilities)
+  :short "A utility to collect free variables over a C AST."
+  :long
+  (xdoc::topstring
+    (xdoc::p
+      "This returns a set of all identifiers used as variables within the AST,
+       excluding those variables which have first been declared, i.e. in a
+       statement declaration or as a function parameter.")
+    (xdoc::p
+      "It only considers variables of regular data object, not other types of
+       named language constructs, such as @('typedef') type names."))
+  :order-subtopics t
+  :default-parent t)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fty::defset ident-set
+  :short "Fixtype of sets of identifiers."
+  :elt-type c$::ident
+  :elementp-of-nil nil
+  :pred ident-setp)
+
+(defruled ident-listp-when-ident-setp-cheap
+  (implies (ident-setp set)
+           (ident-listp set))
+  :induct t
+  :enable ident-setp)
+
+(local (in-theory (enable ident-listp-when-ident-setp-cheap)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defines declor/dirdeclor-get-ident
+  (define declor-get-ident
+    ((declor declorp))
+    :returns (ident (or (not ident) (identp ident)))
+    (b* (((declor declor) declor))
+      (dirdeclor-get-ident declor.decl))
+    :measure (declor-count declor))
+
+  (define dirdeclor-get-ident
+    ((dirdeclor dirdeclorp))
+    :returns (ident (or (not ident) (identp ident)))
+    (dirdeclor-case
+     dirdeclor
+     :ident dirdeclor.unwrap
+     :paren (declor-get-ident dirdeclor.unwrap)
+     :array (dirdeclor-get-ident dirdeclor.decl)
+     :array-static1 (dirdeclor-get-ident dirdeclor.decl)
+     :array-static2 (dirdeclor-get-ident dirdeclor.decl)
+     :array-star (dirdeclor-get-ident dirdeclor.decl)
+     :function-params (dirdeclor-get-ident dirdeclor.decl)
+     :function-names (dirdeclor-get-ident dirdeclor.decl))
+    :measure (dirdeclor-count dirdeclor))
+
+  :hints (("Goal" :in-theory (enable o< o-finp))))
+
+(defrule identp-of-declor-get-ident-under-iff
+  (iff (identp (declor-get-ident declor))
+       (declor-get-ident declor))
+  :use return-type-of-declor-get-ident.ident
+  :disable return-type-of-declor-get-ident.ident)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defines free-vars-exprs/decls
+  (define free-vars-expr
+    ((expr exprp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (expr-case
+     expr
+     :ident (if (in expr.unwrap bound-vars)
+                nil
+              (insert expr.unwrap nil))
+     :paren (free-vars-expr expr.unwrap bound-vars)
+     :gensel (union (free-vars-expr expr.control bound-vars)
+                    (free-vars-genassoc-list expr.assoc bound-vars))
+     :arrsub (union (free-vars-expr expr.arg1 bound-vars)
+                    (free-vars-expr expr.arg2 bound-vars))
+     :funcall (union (free-vars-expr expr.fun bound-vars)
+                     (free-vars-expr-list expr.args bound-vars))
+     :complit (free-vars-desiniter-list expr.elems bound-vars)
+     :unary (free-vars-expr expr.arg bound-vars)
+     :cast (free-vars-expr expr.arg bound-vars)
+     :binary (union (free-vars-expr expr.arg1 bound-vars)
+                    (free-vars-expr expr.arg2 bound-vars))
+     :cond (union (free-vars-expr expr.test bound-vars)
+                  (union (free-vars-expr expr.then bound-vars)
+                         (free-vars-expr expr.else bound-vars)))
+     :comma (union (free-vars-expr expr.first bound-vars)
+                   (free-vars-expr expr.next bound-vars))
+     :otherwise nil)
+    :measure (expr-count expr))
+
+  (define free-vars-expr-list
+    ((exprs expr-listp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (if (endp exprs)
+        nil
+      (union (free-vars-expr (first exprs) bound-vars)
+             (free-vars-expr-list (rest exprs) bound-vars)))
+    :measure (expr-list-count exprs))
+
+  (define free-vars-expr-option
+    ((expr? expr-optionp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (expr-option-case
+     expr?
+     :some (free-vars-expr expr?.val bound-vars)
+     :none nil)
+    :measure (expr-option-count expr?))
+
+  (define free-vars-genassoc
+    ((genassoc genassocp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (genassoc-case
+     genassoc
+     :type (free-vars-expr genassoc.expr bound-vars)
+     :default (free-vars-expr genassoc.expr bound-vars))
+    :measure (genassoc-count genassoc))
+
+  (define free-vars-genassoc-list
+    ((genassocs genassoc-listp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (if (endp genassocs)
+        nil
+      (union (free-vars-genassoc (first genassocs) bound-vars)
+             (free-vars-genassoc-list (rest genassocs) bound-vars)))
+    :measure (genassoc-list-count genassocs))
+
+  (define free-vars-initer
+    ((initer initerp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (initer-case
+     initer
+     :single (free-vars-expr initer.expr bound-vars)
+     :list (free-vars-desiniter-list initer.elems bound-vars))
+    :measure (initer-count initer))
+
+  (define free-vars-initer-option
+    ((initer? initer-optionp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (initer-option-case
+     initer?
+     :some (free-vars-initer initer?.val bound-vars)
+     :none nil)
+    :measure (initer-option-count initer?))
+
+  (define free-vars-desiniter
+    ((desiniter desiniterp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (b* (((desiniter desiniter) desiniter))
+      (free-vars-initer desiniter.init bound-vars))
+    :measure (desiniter-count desiniter))
+
+  (define free-vars-desiniter-list
+    ((desiniters desiniter-listp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (if (endp desiniters)
+        nil
+      (union (free-vars-desiniter (first desiniters) bound-vars)
+             (free-vars-desiniter-list (rest desiniters) bound-vars)))
+    :measure (desiniter-list-count desiniters))
+
+  :hints (("Goal" :in-theory (enable o< o-finp)))
+  :verify-guards :after-returns)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define free-vars-initdeclor
+  ((initdeclor initdeclorp)
+   (bound-vars ident-setp))
+  :returns (mv (free-vars ident-setp)
+               (bound-vars ident-setp))
+  (b* ((bound-vars (ident-set-fix bound-vars))
+       ((initdeclor initdeclor) initdeclor)
+       (ident (declor-get-ident initdeclor.declor)))
+    (mv (free-vars-initer-option initdeclor.init? bound-vars)
+        (if ident
+            (insert (ident-fix ident) bound-vars)
+          bound-vars))))
+
+(define free-vars-initdeclor-list
+  ((initdeclors initdeclor-listp)
+   (bound-vars ident-setp))
+  :returns (mv (free-vars ident-setp)
+               (bound-vars ident-setp))
+  (b* ((bound-vars (ident-set-fix bound-vars))
+       ((when (endp initdeclors))
+        (mv nil bound-vars))
+       ((mv free-vars1 bound-vars)
+        (free-vars-initdeclor (first initdeclors) bound-vars))
+       ((mv free-vars2 bound-vars)
+        (free-vars-initdeclor-list (rest initdeclors) bound-vars)))
+    (mv (union free-vars1 free-vars2)
+        bound-vars))
+  :verify-guards :after-returns)
+
+(define free-vars-decl
+  ((decl declp)
+   (bound-vars ident-setp))
+  :returns (mv (free-vars ident-setp)
+               (bound-vars ident-setp))
+  (b* ((bound-vars (ident-set-fix bound-vars)))
+    (decl-case
+      decl
+      :decl (free-vars-initdeclor-list decl.init bound-vars)
+      :statassert (mv nil bound-vars))))
+
+(define free-vars-decl-list
+  ((decls decl-listp)
+   (bound-vars ident-setp))
+  :returns (mv (free-vars ident-setp)
+               (bound-vars ident-setp))
+  (b* ((bound-vars (ident-set-fix bound-vars))
+       ((when (endp decls))
+        (mv nil bound-vars))
+       ((mv free-vars1 bound-vars)
+        (free-vars-decl (first decls) bound-vars))
+       ((mv free-vars2 bound-vars)
+        (free-vars-decl-list (rest decls) bound-vars)))
+    (mv (union free-vars1 free-vars2)
+        bound-vars))
+  :verify-guards :after-returns)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defines free-vars-stmts/blocks
+  (define free-vars-stmt
+    ((stmt stmtp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (stmt-case
+     stmt
+     :labeled (free-vars-stmt stmt.stmt bound-vars)
+     :compound (free-vars-block-item-list stmt.items bound-vars)
+     :expr (free-vars-expr-option stmt.expr? bound-vars)
+     :if (union (free-vars-expr stmt.test bound-vars)
+                (free-vars-stmt stmt.then bound-vars))
+     :ifelse (union (free-vars-expr stmt.test bound-vars)
+                    (union (free-vars-stmt stmt.then bound-vars)
+                           (free-vars-stmt stmt.else bound-vars)))
+     :switch (union (free-vars-expr stmt.target bound-vars)
+                    (free-vars-stmt stmt.body bound-vars))
+     :while (union (free-vars-expr stmt.test bound-vars)
+                   (free-vars-stmt stmt.body bound-vars))
+     :dowhile (union (free-vars-stmt stmt.body bound-vars)
+                     (free-vars-expr stmt.test bound-vars))
+     :for (union (free-vars-expr-option stmt.init bound-vars)
+                 (union (free-vars-expr-option stmt.test bound-vars)
+                        (union (free-vars-expr-option stmt.next bound-vars)
+                               (free-vars-stmt stmt.body bound-vars))))
+     :fordecl (b* (((mv free-vars for-bound-vars)
+                    (free-vars-decl stmt.init bound-vars)))
+                (union free-vars
+                       (union (free-vars-expr-option stmt.test for-bound-vars)
+                              (union (free-vars-expr-option stmt.next for-bound-vars)
+                                     (free-vars-stmt stmt.body for-bound-vars)))))
+     :return (free-vars-expr-option stmt.expr? bound-vars)
+     :otherwise nil)
+    :measure (stmt-count stmt))
+
+  (define free-vars-block-item
+    ((item block-itemp)
+     (bound-vars ident-setp))
+    :returns (mv (free-vars ident-setp)
+                 (bound-vars ident-setp))
+    (b* ((bound-vars (ident-set-fix bound-vars)))
+      (block-item-case
+        item
+        :decl (free-vars-decl item.unwrap bound-vars)
+        :stmt (mv (free-vars-stmt item.unwrap bound-vars)
+                  bound-vars)
+        :ambig (mv nil bound-vars)))
+    :measure (block-item-count item))
+
+  (define free-vars-block-item-list
+    ((items block-item-listp)
+     (bound-vars ident-setp))
+    :returns (free-vars ident-setp)
+    (b* (((when (endp items))
+          nil)
+         ((mv free-vars1 bound-vars)
+          (free-vars-block-item (first items) bound-vars)))
+      (union free-vars1
+             (free-vars-block-item-list (rest items) bound-vars)))
+    :measure (block-item-list-count items))
+
+  :hints (("Goal" :in-theory (enable o< o-finp)))
+  :verify-guards :after-returns)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define free-vars-fundef
+  ((fundef fundefp)
+   (bound-vars ident-setp))
+  :returns (free-vars ident-setp)
+  (b* (((fundef fundef) fundef)
+       ((mv free-vars bound-vars)
+        (free-vars-decl-list fundef.decls bound-vars)))
+    (union free-vars
+           (free-vars-stmt fundef.body bound-vars))))

--- a/books/kestrel/c/transformation/utilities/free-vars.lisp
+++ b/books/kestrel/c/transformation/utilities/free-vars.lisp
@@ -42,22 +42,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(fty::defset ident-set
-  :short "Fixtype of sets of identifiers."
-  :elt-type ident
-  :elementp-of-nil nil
-  :pred ident-setp)
-
-(defruled ident-listp-when-ident-setp-cheap
-  (implies (ident-setp set)
-           (ident-listp set))
-  :induct t
-  :enable ident-setp)
-
-(local (in-theory (enable ident-listp-when-ident-setp-cheap)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (defines declor/dirdeclor-get-ident
   (define declor-get-ident
     ((declor declorp))

--- a/books/kestrel/c/transformation/utilities/top.lisp
+++ b/books/kestrel/c/transformation/utilities/top.lisp
@@ -1,0 +1,22 @@
+; C Library
+;
+; Copyright (C) 2024 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "C2C")
+
+(include-book "xdoc/defxdoc-plus" :dir :system)
+(include-book "xdoc/constructors" :dir :system)
+
+(include-book "free-vars")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defxdoc+ utilities
+  :parents (transformation-tools)
+  :short "Utilities for C transformations")

--- a/books/kestrel/c/transformation/utilities/top.lisp
+++ b/books/kestrel/c/transformation/utilities/top.lisp
@@ -19,4 +19,4 @@
 
 (defxdoc+ utilities
   :parents (transformation-tools)
-  :short "Utilities for C transformations")
+  :short "Utilities for C transformations.")


### PR DESCRIPTION
This transformation splits a function after a certain number of block items, factoring out the remainder of the function into a new function.

It also provides a couple test cases. The transformation is not yet fully robust. I expect it may currently fail when multiple variables are declared at once, when variables are declared but not immediately initialized, or when variables are declared with type/storage specifiers that cannot or should not be duplicated in the new function's parameter declarations.