### PR TITLE
Fixes for merging updated x86isa model into acl2

### DIFF
--- a/books/centaur/bigmem-asymmetric/bigmem-asymmetric.lisp
+++ b/books/centaur/bigmem-asymmetric/bigmem-asymmetric.lisp
@@ -464,7 +464,9 @@
              :exec  write-mem$c$inline
              :correspondence write-mem{correspondence}
              :guard-thm write-mem{guard-thm}
-             )))
+             ))
+
+  :non-executable t)
 
 #|
 (defthm integerp-read-mem

--- a/books/centaur/bigmem-asymmetric/concrete-asymmetric.lisp
+++ b/books/centaur/bigmem-asymmetric/concrete-asymmetric.lisp
@@ -134,6 +134,7 @@
 
   :inline t
   :non-memoizable t
+  :non-executable t
   :renaming
   ((update-ai !ai)
    (a-length al)

--- a/books/kestrel/axe/x86/support-axe.lisp
+++ b/books/kestrel/axe/x86/support-axe.lisp
@@ -408,6 +408,7 @@
                 ;;                     (read 1 (x86isa::read-*ip proc-mode x86) x86)))
                 ;; (poor-mans-quotep (read 1 (rip x86) x86))
                 (64-bit-modep x86)
+                (app-view x86)
                 (not (ms x86))
                 (not (fault x86)))
            (equal (x86-fetch-decode-execute x86)

--- a/books/projects/x86isa/virtualization/top.lisp
+++ b/books/projects/x86isa/virtualization/top.lisp
@@ -344,5 +344,7 @@ emit those instructions, which can be useful. Of course, if your bug is in the
       (validate-insts (1- n) x86)))
 
 (defttag :virtualization)
+;; The raw file only works with CCL
+; cert_param: (ccl-only)
 ; (depends-on "virtualization-raw.lsp")
 (include-raw "virtualization-raw.lsp")


### PR DESCRIPTION
This has two commits. One updated support-axe.lisp and marks books/projects/x86isa/virtualization/top.lisp as ccl-only. These are necessary to get the regression to succeed.

The other one marks both the concrete and abstract stobjs created by bigmem-asymmetric as non-executable. They each require 6 GB of memory, so this change drastically reduces the amount of memory necessary to certify books. This wasn't done before because :non-executable was not supported on abstract stobjs until recently. I can't certify the doc book on my machine without this change, but it shouldn't be necessary on a machine with more memory.

This has been tested on ACL2 built with CCL.

CC: @solswords @ericwhitmansmith 