### PR TITLE
Fix doc not building on non-CCL lisps

### DIFF
--- a/books/projects/x86isa/virtualization/top.lisp
+++ b/books/projects/x86isa/virtualization/top.lisp
@@ -344,7 +344,8 @@ emit those instructions, which can be useful. Of course, if your bug is in the
       (validate-insts (1- n) x86)))
 
 (defttag :virtualization)
-;; The raw file only works with CCL
-; cert_param: (ccl-only)
+
 ; (depends-on "virtualization-raw.lsp")
+;; The the raw file only works on CCL
+#+ccl
 (include-raw "virtualization-raw.lsp")


### PR DESCRIPTION
This resolves the issue introduced in 651623a77e. In an attempt to prevent build failures on non-CCL lisps, the books/projects/x86isa/virtualization/top.lisp book was marked CCL-only because the raw lisp it includes only works on CCL. This causes cert.pl to not build the book when the host lisp isn't CCL. However, this book is a dependency of the doc, so this prevented the doc from building.

This was resolved by, instead of marking the book CCL-only, using #+ccl to only include the raw lisp if the host lisp is CCL. Thus, the virtualization/top.lisp book can and is built when using non-CCL lisps, allowing for the doc to be built, but the raw lisp is not included.

CC: @ericwhitmansmith 