### PR TITLE
Update `x86isa` book 8.6 relnotes

### DIFF
--- a/books/doc/relnotes.lisp
+++ b/books/doc/relnotes.lisp
@@ -662,7 +662,8 @@
      "VPSUBB, VPSUBW, VPSUBD, VPSUBQ (VEX versions)"))
 
    (xdoc::p
-    "Support has been added for the following instructions:"
+    "Support has been added for the following instructions:")
+   (xdoc::ul
     (xdoc::li
      "MOVDQA")
     (xdoc::li
@@ -674,6 +675,17 @@
 
    (xdoc::p
     "Some memory accessing functions for larger sizes have been added.")
+
+   (xdoc::p
+    "A number of improvements were made to the model in support of booting a
+    slightly modified Linux kernel on it. These include various instruction
+    bug fixes, a handful of new instructions, a translation lookaside buffer
+    (TLB), and support for exception/interrupt handling, a timer peripheral,
+    and a TTY peripheral. Additionally, there is a new validation mechanism
+    that uses co-simulation with a virtual machine running in KVM to find bugs
+    in the model. All these changes, along with instructions on how to boot
+    Linux on the model are documented in the @(tsee x86isa::x86isa)
+    documentation.")
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
The changes to the x86isa books that were made to support booting Linux were not documented in the 8.6 community books changelog. This has been resolved and a small formatting issue was fixed.

Thanks to Eric for mentioning in the Zulip that the community books release notes for 8.6 should be updated.
