### PR TITLE
Update `x86isa` debugging tools and fix bt(s/r) instructions

### DIFF
--- a/books/projects/x86isa/machine/instructions/bit.lisp
+++ b/books/projects/x86isa/machine/instructions/bit.lisp
@@ -150,7 +150,7 @@
             (mv nil
                 (mod bitOffset (ash operand-size 3))
                 (rgfi-size operand-size
-                           (reg-index r/m rex-byte #.*r*)
+                           (reg-index r/m rex-byte #.*b*)
                            rex-byte
                            x86)
                 x86)
@@ -271,7 +271,7 @@
             (mv nil
                 (mod bitOffset (ash operand-size 3))
                 (rgfi-size operand-size
-                           (reg-index r/m rex-byte #.*r*)
+                           (reg-index r/m rex-byte #.*b*)
                            rex-byte
                            x86)
                 nil
@@ -313,7 +313,7 @@
         (if (equal mod #b11)
             ;; bitBase is a register operand
             (let ((x86 (!rgfi-size operand-size
-                                   (reg-index r/m rex-byte #.*r*)
+                                   (reg-index r/m rex-byte #.*b*)
                                    (loghead operand-size val)
                                    rex-byte
                                    x86)))
@@ -410,7 +410,7 @@
                   (mv nil
                       (mod bitOffset (ash operand-size 3))
                       (rgfi-size operand-size
-                                 (reg-index r/m rex-byte #.*r*)
+                                 (reg-index r/m rex-byte #.*b*)
                                  rex-byte
                                  x86)
                       nil
@@ -452,7 +452,7 @@
                 (if (equal mod #b11)
                   ;; bitBase is a register operand
                   (let ((x86 (!rgfi-size operand-size
-                                         (reg-index r/m rex-byte #.*r*)
+                                         (reg-index r/m rex-byte #.*b*)
                                          (loghead operand-size val)
                                          rex-byte
                                          x86)))


### PR DESCRIPTION
- Before this fix, if the RIP pointed to unmapped memory the virtualization based
debugging tool would segfault.
- `bt`, `bts`, and `btr` instructions now decode their operand properly when the
bitBase is one of the r8-15(d) registers.

See the relevant commit messages for more information.
