### PR TITLE
Speed up certification of x86isa's x87.lisp (fxsave/fxrstor defs)

### DIFF
--- a/books/projects/x86isa/machine/decoding-and-spec-utils.lisp
+++ b/books/projects/x86isa/machine/decoding-and-spec-utils.lisp
@@ -2201,7 +2201,29 @@ reference made from privilege level 3.</blockquote>"
                      (the (unsigned-byte 8) (prefixes->opr prefixes)))))
         (if (= cs.d 1)
             (if p3? 2 4)
-          (if p3? 4 2))))))
+          (if p3? 4 2)))))
+  ///
+  (defthm select-operand-size-range
+          (and (<= 1 (select-operand-size proc-mode byte-operand? rex-byte imm?
+                                          prefixes default64? ignore-rex? ignore-p3-64? x86))
+               (<= (select-operand-size proc-mode byte-operand? rex-byte imm?
+                                        prefixes default64? ignore-rex? ignore-p3-64? x86)
+                   8))
+          :rule-classes :linear)
+
+ (defthm select-operand-size-values
+         (or (equal (select-operand-size proc-mode byte-operand? rex-byte
+                                         imm? prefixes default64? ignore-rex? ignore-p3-64? x86)
+                    1)
+             (equal (select-operand-size proc-mode byte-operand? rex-byte
+                                         imm? prefixes default64? ignore-rex? ignore-p3-64? x86)
+                    2)
+             (equal (select-operand-size proc-mode byte-operand? rex-byte
+                                         imm? prefixes default64? ignore-rex? ignore-p3-64? x86)
+                    4)
+             (equal (select-operand-size proc-mode byte-operand? rex-byte
+                                         imm? prefixes default64? ignore-rex? ignore-p3-64? x86)
+                    8))))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/machine/instructions/x87.lisp
+++ b/books/projects/x86isa/machine/instructions/x87.lisp
@@ -45,6 +45,11 @@
 (include-book "../top-level-memory")
 (include-book "fp/base")
 
+(local (in-theory (disable not
+                           select-operand-size
+                           mv-nth-0-of-add-to-*ip-when-64-bit-modep
+                           mv-nth-1-of-add-to-*ip-when-64-bit-modep)))
+
 (define write-mm-regs ((proc-mode :type (integer 0 #.*num-proc-modes-1*))
                        (inst-ac? booleanp)
                        (seg-reg (integer-range-p 0 *segment-register-names-len* seg-reg))
@@ -123,6 +128,15 @@
                           (unsigned-byte-p 16 (xr :fp-opcode i x86))
                           :hints (("Goal" :use (:instance elem-p-of-xr-fp-opcode (i i) (x86$a x86))
                                    :in-theory (disable elem-p-of-xr-fp-opcode))))))
+
+          :guard-hints
+          (("Goal" :in-theory (disable select-operand-size-values)
+            :use (:instance select-operand-size-values
+                            (byte-operand? nil)
+                            (imm? nil)
+                            (default64? nil)
+                            (ignore-rex? nil)
+                            (ignore-p3-64? nil))))
 
           :body
 
@@ -296,6 +310,15 @@
 
           :prepwork
           ((local (in-theory (disable unsigned-byte-p signed-byte-p))))
+
+          :guard-hints
+          (("Goal" :in-theory (disable select-operand-size-values)
+            :use (:instance select-operand-size-values
+                            (byte-operand? nil)
+                            (imm? nil)
+                            (default64? nil)
+                            (ignore-rex? nil)
+                            (ignore-p3-64? nil))))
 
           :body
 


### PR DESCRIPTION
The x86isa/machine/instructions/x87.lisp book, which contains
definitions for the instructions fxsave and fxrstor, was very slow to
certify (~15 minutes on my machine with CCL). This change disables some
runes and adds some lemmas to make this much faster (~200 seconds).

Thanks to Eric for suggesting I look at the reported splitter runes.
