### PR TITLE
[C$] Fix a case where a union was parsed as a struct.

### DIFF
--- a/books/kestrel/c/syntax/parser.lisp
+++ b/books/kestrel/c/syntax/parser.lisp
@@ -10693,9 +10693,13 @@
                    ((erp last-span parstate)
                     ;; struct/union ident { structdecls }
                     (read-punctuator "}" parstate)))
-                (retok (type-spec-struct
-                        (make-strunispec :name ident
-                                         :members structdecls))
+                (retok (if structp
+                           (type-spec-struct
+                             (make-strunispec :name ident
+                                              :members structdecls))
+                         (type-spec-union
+                             (make-strunispec :name ident
+                                              :members structdecls)))
                        (span-join struct/union-span last-span)
                        parstate))))
            ;; If token2 is not an open curly brace,


### PR DESCRIPTION
This was found through round-trip testing.  Example input that shows the issue:

union foo { int x; };