### PR TITLE
Fix `make-flag`-generated macro for mutual recursions with single-function cliques

### DIFF
--- a/books/tools/flag-tests.lisp
+++ b/books/tools/flag-tests.lisp
@@ -450,3 +450,26 @@
                           (IF (ATOM X)
                               'NIL
                               (FLAG4-EVENLP 'EVENLP (CDR X)))))))
+
+;;;;;;;;;;
+;;; Test of application to a single-function mutual-recursion
+;;; (by Grant Jurgensen).
+;;;;;;;;;;
+
+(mutual-recursion
+ (defun my-nat-listp (x)
+   (if (consp x)
+       (and (natp (car x))
+            (my-nat-listp (cdr x)))
+     (eq x nil))))
+
+(flag::make-flag flag-my-nat-listp
+                 my-nat-listp)
+
+(defthm-flag-my-nat-listp
+  (defthm type-of-my-nat-listp
+    (booleanp (my-nat-listp x))
+    :flag my-nat-listp
+    :hints ('(:in-theory '(booleanp)
+              :expand ((my-nat-listp x)))))
+  :hints (("Goal" :in-theory '((:i flag-my-nat-listp)))))

--- a/books/tools/flag.lisp
+++ b/books/tools/flag.lisp
@@ -878,6 +878,9 @@ one such form may affect what you might think of as the proof of another.</p>
                :hints(("Goal"
                        :in-theory (theory 'minimal-theory)
                        :use ((:instance ,lemma-name
+                                        ;; This avoids errors for the case
+                                        ;; where the mutually recursive clique
+                                        ;; consists of a single function.
                                         :extra-bindings-ok
                                         (,flag-var ',flag)))))))
           (flag-defthm-corollaries lemma-name explicit-name flag-var (cdr thmparts)))))

--- a/books/tools/flag.lisp
+++ b/books/tools/flag.lisp
@@ -877,7 +877,9 @@ one such form may affect what you might think of as the proof of another.</p>
                ;; :doc ,doc ; Removed by Matt K.; see comment above
                :hints(("Goal"
                        :in-theory (theory 'minimal-theory)
-                       :use ((:instance ,lemma-name (,flag-var ',flag)))))))
+                       :use ((:instance ,lemma-name
+                                        :extra-bindings-ok
+                                        (,flag-var ',flag)))))))
           (flag-defthm-corollaries lemma-name explicit-name flag-var (cdr thmparts)))))
 
 (defun find-first-thm-name (thmparts)


### PR DESCRIPTION
When `make-flag` is invoked on a trivial mutual recursion with just one function in the clique, the generated defthm-flag macro fails on subsequent theorems due to a generated lemma being instantiated with the flag variable, but the lemma not actually containing said flag variable. (The lemma would normally be a case statement on the flag variable, but since the clique has just one member, the case statement only has the final "otherwise" condition.)

This PR fixes the issue by adding the `:extra-bindings-ok` keyword, telling the system to just ignore the extra binding when it would otherwise trigger an error.

I also added a test to `flag-tests.lisp` which demonstrates the use case where `make-flag`'s generated defthm macro was previously failing.

(I should probably acknowledge that it is strange to be using `mutual-recursion` and `make-flag` for just a single function, but such a case could be generated by a macro.)