### PR TITLE
x86 inst bugfixes

### DIFF
--- a/books/projects/x86isa/machine/instructions/bit.lisp
+++ b/books/projects/x86isa/machine/instructions/bit.lisp
@@ -198,7 +198,7 @@
   :returns (x86 x86p :hyp (x86p x86))
 
   :guard-hints (("Goal" :in-theory (e/d (segment-base-and-bounds)
-                                        ())))
+                                        (bitops::part-install-width-low))))
 
   :modr/m t
 
@@ -314,7 +314,7 @@
             ;; bitBase is a register operand
             (let ((x86 (!rgfi-size operand-size
                                    (reg-index r/m rex-byte #.*b*)
-                                   (loghead operand-size val)
+                                   val
                                    rex-byte
                                    x86)))
               (mv nil x86))
@@ -453,7 +453,7 @@
                   ;; bitBase is a register operand
                   (let ((x86 (!rgfi-size operand-size
                                          (reg-index r/m rex-byte #.*b*)
-                                         (loghead operand-size val)
+                                         val
                                          rex-byte
                                          x86)))
                     (mv nil x86))

--- a/books/projects/x86isa/machine/instructions/shifts-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/shifts-spec.lisp
@@ -1025,10 +1025,13 @@ most-significant bit of the original operand.</p>"
             ;; we shift the juxtaposed dst and src to the left by cnt bits,
             ;; so that the high bits of src go into the low bits of dst:
             (output-dst (the (unsigned-byte ,size)
-                             (n-size ,size (ash (the (unsigned-byte ,size*2)
-                                                     dst-src)
-                                                (the (unsigned-byte ,size)
-                                                     cnt)))))
+                             ;; Our result is in the 2*size-1:size bits
+                             (n-size ,size
+                                     (logtail ,size
+                                              (ash (the (unsigned-byte ,size*2)
+                                                        dst-src)
+                                                   (the (unsigned-byte ,size)
+                                                        cnt))))))
 
             ((mv (the (unsigned-byte 32) output-rflags)
                  (the (unsigned-byte 32) undefined-flags))


### PR DESCRIPTION
- **Fix bts/r instructions truncating results to incorrect number of bits**
- **Fix shld-spec computing incorrect result**
