### PR TITLE
Fix packed subtraction instructions

### DIFF
--- a/books/projects/x86isa/machine/instructions/psub.lisp
+++ b/books/projects/x86isa/machine/instructions/psub.lisp
@@ -83,7 +83,7 @@
        ((unless (mbt (posp chunk-size))) 0)
        (x-lo (loghead chunk-size x))
        (y-lo (loghead chunk-size y))
-       (result-lo (loghead chunk-size (+ x-lo y-lo)))
+       (result-lo (loghead chunk-size (- x-lo y-lo)))
        (x-hi (logtail chunk-size x))
        (y-hi (logtail chunk-size y))
        (result-hi


### PR DESCRIPTION
Previously, `simd-sub-spec` would perform a packed add rather than a
packed subtraction. This caused the packed subtraction instrctions (PSUB
and its variants) to perform adds instead of subtractions. This fixes
that bug.
