### PR TITLE
[X86ISA] Reduce dependence on other-non-det.lisp.

### DIFF
--- a/books/projects/x86isa/machine/decoding-and-spec-utils.lisp
+++ b/books/projects/x86isa/machine/decoding-and-spec-utils.lisp
@@ -43,8 +43,12 @@
 
 (in-package "X86ISA")
 
-(include-book "other-non-det"
-              :ttags (:include-raw :undef-flg :syscall-exec :other-non-det))
+(include-book "std/util/def-bound-theorems" :dir :system)
+(include-book "state")
+(include-book "application-level-memory")
+(include-book "segmentation")
+(include-book "top-level-memory")
+(include-book "../utils/segmentation-structures")
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (in-theory (e/d () (mv-nth)))

--- a/books/projects/x86isa/machine/instructions/syscall.lisp
+++ b/books/projects/x86isa/machine/instructions/syscall.lisp
@@ -45,6 +45,7 @@
 
 (include-book "../decoding-and-spec-utils"
               :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+(include-book "../syscalls")
 
 ;; ======================================================================
 ;; INSTRUCTION: SYSCALL

--- a/books/projects/x86isa/machine/instructions/top.lisp
+++ b/books/projects/x86isa/machine/instructions/top.lisp
@@ -352,6 +352,9 @@ writes the final value of the instruction pointer into RIP.</p>")
 ;; INSTRUCTION: RDRAND
 ;; ======================================================================
 
+(include-book "../other-non-det"
+              :ttags (:include-raw :undef-flg :syscall-exec :other-non-det))
+
 (def-inst x86-rdrand
 
   ;; 0F C7:


### PR DESCRIPTION
This reduces the dependence on other-non-det, which has a ttag and is only used for a few instructions that currently live in machine/instructions/top.lisp.  Future commits could reduce mentions of the :other-non-det ttag.  This is a step towards building x86-related tools (e.g., Axe) without needing (so many) ttags.