### PR TITLE
[tools] Drop cert-flags for include-raw.

### DIFF
--- a/books/tools/include-raw.acl2
+++ b/books/tools/include-raw.acl2
@@ -1,2 +1,1 @@
 (include-book "std/portcullis" :dir :system)
-; cert-flags: ? t :ttags :all


### PR DESCRIPTION
A ttag is not needed to certify or include include-raw, only to call it.  A comment in include-raw.lisp seems to indicate that previously a ttag was needed.