### PR TITLE
[X86ISA] Remove mentions of the :include-raw ttag.

### DIFF
--- a/books/projects/x86isa/cert.acl2
+++ b/books/projects/x86isa/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :instrument :syscall-exec :other-non-det :undef-flg )
+;; cert-flags: ? t :ttags (:instrument :syscall-exec :other-non-det :undef-flg )
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/cert.acl2
+++ b/books/projects/x86isa/machine/cert.acl2
@@ -41,7 +41,7 @@
 (set-waterfall-parallelism t)
 (include-book "../portcullis/sharp-dot-constants")
 (add-include-book-dir :utils "../utils")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
 
 ; Matt K. mod 7/11/2022 for GCL to avoid exhausting storage, which happened in
 ; the following book before deciding simply to cover all books (including some

--- a/books/projects/x86isa/machine/environment.lisp
+++ b/books/projects/x86isa/machine/environment.lisp
@@ -41,7 +41,7 @@
 
 (in-package "X86ISA")
 
-(include-book "top-level-memory" :ttags (:include-raw :undef-flg))
+(include-book "top-level-memory" :ttags (:undef-flg))
 (local (include-book "std/alists/assoc" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/evex-opcodes-dispatch.lisp
+++ b/books/projects/x86isa/machine/evex-opcodes-dispatch.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "instructions/top"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "prefix-modrm-sib-decoding")
 (include-book "dispatch-macros")
 (include-book "cpuid")

--- a/books/projects/x86isa/machine/instructions/add-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/add-spec.lisp
@@ -42,7 +42,7 @@
 ;; add  adc
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/and-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/and-spec.lisp
@@ -42,7 +42,7 @@
 ;; and
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/arith-and-logic.lisp
+++ b/books/projects/x86isa/machine/instructions/arith-and-logic.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "arith-and-logic-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))

--- a/books/projects/x86isa/machine/instructions/bit.lisp
+++ b/books/projects/x86isa/machine/instructions/bit.lisp
@@ -48,7 +48,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-          :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+          :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "ihs/quotient-remainder-lemmas" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/cache.lisp
+++ b/books/projects/x86isa/machine/instructions/cache.lisp
@@ -41,7 +41,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (def-inst x86-invlpg
 

--- a/books/projects/x86isa/machine/instructions/cert.acl2
+++ b/books/projects/x86isa/machine/instructions/cert.acl2
@@ -42,7 +42,7 @@
 (include-book "../../portcullis/sharp-dot-constants")
 (add-include-book-dir :utils "../../utils")
 ; The book divide-spec.lisp, at least, seems to need :useless-runes nil:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg)  :useless-runes nil
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg)  :useless-runes nil
 
 ; Matt K. mod 7/11/2022 for GCL to avoid exhausting storage, which happened in
 ; the following books before deciding simply to cover all books (including some

--- a/books/projects/x86isa/machine/instructions/conditional.lisp
+++ b/books/projects/x86isa/machine/instructions/conditional.lisp
@@ -44,7 +44,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/cpuid.lisp
+++ b/books/projects/x86isa/machine/instructions/cpuid.lisp
@@ -4,7 +4,7 @@
 
 (include-book "std/util/defaggregate" :dir :system)
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/machine/instructions/divide-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/divide-spec.lisp
@@ -42,7 +42,7 @@
 (in-package "X86ISA")
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "ihs/quotient-remainder-lemmas" :dir :system))

--- a/books/projects/x86isa/machine/instructions/divide.lisp
+++ b/books/projects/x86isa/machine/instructions/divide.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "divide-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/endbranch.lisp
+++ b/books/projects/x86isa/machine/instructions/endbranch.lisp
@@ -41,7 +41,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/projects/x86isa/machine/instructions/exchange.lisp
+++ b/books/projects/x86isa/machine/instructions/exchange.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "arith-and-logic-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/fp/arithmetic.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/arithmetic.lisp
@@ -44,11 +44,11 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "arith-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "sqrt-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/fp/bitscan.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/bitscan.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "base"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ; =============================================================================

--- a/books/projects/x86isa/machine/instructions/fp/cert.acl2
+++ b/books/projects/x86isa/machine/instructions/fp/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (include-book "../../../portcullis/sharp-dot-constants")
 (add-include-book-dir :utils "../../../utils")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/fp/convert.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/convert.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "cvt-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/fp/logical.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/logical.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "cmp-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/fp/mov.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/mov.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "base"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/fp/mxcsr.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/mxcsr.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "base"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ; =============================================================================

--- a/books/projects/x86isa/machine/instructions/fp/non-arith.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/non-arith.lisp
@@ -41,9 +41,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "base"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 ; =============================================================================
 ; INSTRUCTION: AVX Non-Arithmetic Instructions

--- a/books/projects/x86isa/machine/instructions/fp/shuffle-and-unpack.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/shuffle-and-unpack.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "base"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/fp/simd-integer.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/simd-integer.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "../../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "base"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/fp/top.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/top.lisp
@@ -46,23 +46,23 @@
 ;; are unimplemented: MMX, AVX, AVX2, and AVX512.
 
 (include-book "bitscan"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "arithmetic"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "logical"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "shuffle-and-unpack"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "mxcsr"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "simd-integer"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "convert"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "mov"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "non-arith"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 ;; Exception Types and Alignment Checking: A Quick Reference
 ;; (TO-DO: make this into a doc topic or a function later...)

--- a/books/projects/x86isa/machine/instructions/interrupts.lisp
+++ b/books/projects/x86isa/machine/instructions/interrupts.lisp
@@ -41,7 +41,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/jump-and-loop.lisp
+++ b/books/projects/x86isa/machine/instructions/jump-and-loop.lisp
@@ -44,7 +44,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "../guard-helpers"))
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))

--- a/books/projects/x86isa/machine/instructions/move.lisp
+++ b/books/projects/x86isa/machine/instructions/move.lisp
@@ -47,7 +47,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/msrs.lisp
+++ b/books/projects/x86isa/machine/instructions/msrs.lisp
@@ -41,7 +41,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/machine/instructions/multiply-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/multiply-spec.lisp
@@ -42,7 +42,7 @@
 (in-package "X86ISA")
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/multiply.lisp
+++ b/books/projects/x86isa/machine/instructions/multiply.lisp
@@ -44,9 +44,9 @@
 ;; ======================================================================
 
 (include-book "multiply-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/or-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/or-spec.lisp
@@ -42,7 +42,7 @@
 ;; or
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/padd.lisp
+++ b/books/projects/x86isa/machine/instructions/padd.lisp
@@ -41,7 +41,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "arithmetic-3/top" :dir :system))
 (local (include-book "ihs/logops-lemmas" :dir :system))

--- a/books/projects/x86isa/machine/instructions/pcmp.lisp
+++ b/books/projects/x86isa/machine/instructions/pcmp.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/pio.lisp
+++ b/books/projects/x86isa/machine/instructions/pio.lisp
@@ -38,7 +38,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/pshuf.lisp
+++ b/books/projects/x86isa/machine/instructions/pshuf.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/psub.lisp
+++ b/books/projects/x86isa/machine/instructions/psub.lisp
@@ -41,7 +41,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "arithmetic-3/top" :dir :system))
 (local (include-book "ihs/logops-lemmas" :dir :system))

--- a/books/projects/x86isa/machine/instructions/punpck.lisp
+++ b/books/projects/x86isa/machine/instructions/punpck.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/push-and-pop.lisp
+++ b/books/projects/x86isa/machine/instructions/push-and-pop.lisp
@@ -44,7 +44,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ; The Intel and AMD documentation is ambiguous about the determination of the

--- a/books/projects/x86isa/machine/instructions/rotate-and-shift.lisp
+++ b/books/projects/x86isa/machine/instructions/rotate-and-shift.lisp
@@ -44,11 +44,11 @@
 ;; ======================================================================
 
 (include-book "shifts-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "rotates-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/rotates-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/rotates-spec.lisp
@@ -42,7 +42,7 @@
 (in-package "X86ISA")
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (include-book "centaur/bitops/fast-rotate" :dir :system)
 

--- a/books/projects/x86isa/machine/instructions/segmentation.lisp
+++ b/books/projects/x86isa/machine/instructions/segmentation.lisp
@@ -44,7 +44,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "../guard-helpers"))
 
 ;; No alignment check is done for these instructions because they are

--- a/books/projects/x86isa/machine/instructions/shifts-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/shifts-spec.lisp
@@ -47,7 +47,7 @@
 (in-package "X86ISA")
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "centaur/bitops/fast-rotate" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/instructions/signextend.lisp
+++ b/books/projects/x86isa/machine/instructions/signextend.lisp
@@ -44,7 +44,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/string.lisp
+++ b/books/projects/x86isa/machine/instructions/string.lisp
@@ -46,9 +46,9 @@
 ;; ======================================================================
 
 (include-book "arith-and-logic-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/sub-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/sub-spec.lisp
@@ -42,7 +42,7 @@
 ;; sub  sbb
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/instructions/subroutine.lisp
+++ b/books/projects/x86isa/machine/instructions/subroutine.lisp
@@ -47,7 +47,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/syscall.lisp
+++ b/books/projects/x86isa/machine/instructions/syscall.lisp
@@ -44,7 +44,7 @@
 ;; ======================================================================
 
 (include-book "../decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../syscalls")
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/instructions/time.lisp
+++ b/books/projects/x86isa/machine/instructions/time.lisp
@@ -38,7 +38,7 @@
 (in-package "X86ISA")
 
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 
 ;; ======================================================================
 ;; INSTRUCTION: RDTSC

--- a/books/projects/x86isa/machine/instructions/top.lisp
+++ b/books/projects/x86isa/machine/instructions/top.lisp
@@ -42,63 +42,63 @@
 ;; ======================================================================
 
 (include-book "arith-and-logic"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "bit"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "conditional"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "divide"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "endbranch"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "exchange"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "jump-and-loop"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "move"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "multiply"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "padd"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "psub"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "push-and-pop"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "rotate-and-shift"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "segmentation"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "signextend"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "string"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "syscall"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "subroutine"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "fp/top"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "interrupts"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "cpuid"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "msrs"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "x87"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "time"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "pio"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "cache"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "punpck"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "pcmp"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "pshuf"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
@@ -353,7 +353,7 @@ writes the final value of the instruction pointer into RIP.</p>")
 ;; ======================================================================
 
 (include-book "../other-non-det"
-              :ttags (:include-raw :undef-flg :syscall-exec :other-non-det))
+              :ttags (:undef-flg :syscall-exec :other-non-det))
 
 (def-inst x86-rdrand
 

--- a/books/projects/x86isa/machine/instructions/x87.lisp
+++ b/books/projects/x86isa/machine/instructions/x87.lisp
@@ -41,7 +41,7 @@
 (local (include-book "arithmetic-5/top" :dir :system))
 
 (include-book "../decoding-and-spec-utils"
-	      :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+	      :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "../top-level-memory")
 (include-book "fp/base")
 

--- a/books/projects/x86isa/machine/instructions/xor-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/xor-spec.lisp
@@ -42,7 +42,7 @@
 ;; xor
 
 (include-book "../rflags-spec"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/machine/linear-memory.lisp
+++ b/books/projects/x86isa/machine/linear-memory.lisp
@@ -42,7 +42,7 @@
 ; Alessandro Coglio (www.alessandrocoglio.info)
 
 (in-package "X86ISA")
-(include-book "paging" :ttags (:undef-flg :include-raw))
+(include-book "paging" :ttags (:undef-flg))
 (include-book "centaur/bitops/merge" :dir :system)
 
 ;; ======================================================================

--- a/books/projects/x86isa/machine/modes.lisp
+++ b/books/projects/x86isa/machine/modes.lisp
@@ -42,7 +42,7 @@
 
 (include-book "segmentation-structures" :dir :utils)
 (include-book "paging-structures" :dir :utils)
-(include-book "register-readers-and-writers" :ttags (:undef-flg :include-raw))
+(include-book "register-readers-and-writers" :ttags (:undef-flg))
 (include-book "std/bitsets/bignum-extract" :dir :system) ;; For 64-bit-modep
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/new-decode.lisp
+++ b/books/projects/x86isa/machine/new-decode.lisp
@@ -43,7 +43,7 @@
 
 (in-package "X86ISA")
 (include-book "decoding-and-spec-utils"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "std/util/defenum" :dir :system)
 (include-book "inst-structs")
 

--- a/books/projects/x86isa/machine/other-non-det.lisp
+++ b/books/projects/x86isa/machine/other-non-det.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "syscalls"
-              :ttags (:include-raw :undef-flg :syscall-exec))
+              :ttags (:undef-flg :syscall-exec))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/machine/paging.acl2
+++ b/books/projects/x86isa/machine/paging.acl2
@@ -49,4 +49,4 @@
 (set-waterfall-parallelism nil)
 
 ; Copied from cert.acl2:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil

--- a/books/projects/x86isa/machine/paging.lisp
+++ b/books/projects/x86isa/machine/paging.lisp
@@ -43,7 +43,7 @@
 
 (in-package "X86ISA")
 (include-book "paging-structures" :dir :utils)
-(include-book "physical-memory" :ttags (:undef-flg :include-raw))
+(include-book "physical-memory" :ttags (:undef-flg))
 (include-book "clause-processors/find-matching" :dir :system)
 
 ;; [Shilpi]: For now, I've removed nested paging and all paging modes

--- a/books/projects/x86isa/machine/physical-memory.acl2
+++ b/books/projects/x86isa/machine/physical-memory.acl2
@@ -6,4 +6,4 @@
 (set-waterfall-parallelism nil)
 
 ; Copied from cert.acl2:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil

--- a/books/projects/x86isa/machine/prefix-modrm-sib-decoding.acl2
+++ b/books/projects/x86isa/machine/prefix-modrm-sib-decoding.acl2
@@ -1,6 +1,6 @@
 (ld "cert.acl2")
 ; From cert.acl2:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
 
 #+acl2-par
 ; computed hints that modify state

--- a/books/projects/x86isa/machine/segmentation.lisp
+++ b/books/projects/x86isa/machine/segmentation.lisp
@@ -45,7 +45,7 @@
 
 (in-package "X86ISA")
 (include-book "segmentation-structures" :dir :utils)
-(include-book "linear-memory" :ttags (:undef-flg :include-raw))
+(include-book "linear-memory" :ttags (:undef-flg))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/machine/syscalls.lisp
+++ b/books/projects/x86isa/machine/syscalls.lisp
@@ -41,7 +41,7 @@
 (in-package "X86ISA")
 
 (include-book "syscall-numbers")
-(include-book "environment" :ttags (:include-raw :undef-flg))
+(include-book "environment" :ttags (:undef-flg))
 
 (local (include-book "std/lists/nthcdr" :dir :system))
 

--- a/books/projects/x86isa/machine/three-byte-opcodes-dispatch.lisp
+++ b/books/projects/x86isa/machine/three-byte-opcodes-dispatch.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "instructions/top"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "prefix-modrm-sib-decoding")
 (include-book "dispatch-macros")
 (include-book "cpuid")

--- a/books/projects/x86isa/machine/two-byte-opcodes-dispatch.lisp
+++ b/books/projects/x86isa/machine/two-byte-opcodes-dispatch.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "three-byte-opcodes-dispatch"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "dispatch-creator"))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/vex-opcodes-dispatch.lisp
+++ b/books/projects/x86isa/machine/vex-opcodes-dispatch.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "instructions/top"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "prefix-modrm-sib-decoding")
 (include-book "dispatch-macros")
 (include-book "cpuid")

--- a/books/projects/x86isa/machine/x86.lisp
+++ b/books/projects/x86isa/machine/x86.lisp
@@ -45,20 +45,20 @@
 ;; ----------------------------------------------------------------------
 
 (include-book "instructions/top"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "two-byte-opcodes-dispatch"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "three-byte-opcodes-dispatch"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "vex-opcodes-dispatch"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "evex-opcodes-dispatch"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "cpuid")
 (include-book "dispatch-macros")
 (include-book "interrupt-servicing")
 (include-book "catalogue"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg)) ;; for xdoc
+              :ttags (:syscall-exec :other-non-det :undef-flg)) ;; for xdoc
 (include-book "std/strings/hexify" :dir :system)
 
 (local (include-book "dispatch-creator"))

--- a/books/projects/x86isa/proofs/cert.acl2
+++ b/books/projects/x86isa/proofs/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/codewalker-examples/cert.acl2
+++ b/books/projects/x86isa/proofs/codewalker-examples/cert.acl2
@@ -41,6 +41,6 @@
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
 
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/dataCopy/cert.acl2
+++ b/books/projects/x86isa/proofs/dataCopy/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/dissertation-examples/cert.acl2
+++ b/books/projects/x86isa/proofs/dissertation-examples/cert.acl2
@@ -42,6 +42,6 @@
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
 
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/factorial/cert.acl2
+++ b/books/projects/x86isa/proofs/factorial/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/popcount/cert.acl2
+++ b/books/projects/x86isa/proofs/popcount/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/powOfTwo/cert.acl2
+++ b/books/projects/x86isa/proofs/powOfTwo/cert.acl2
@@ -42,6 +42,6 @@
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
 
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/app-view/cert.acl2
+++ b/books/projects/x86isa/proofs/utilities/app-view/cert.acl2
@@ -42,6 +42,6 @@
 (include-book "../../../portcullis/sharp-dot-constants")
 (add-include-book-dir :machine "../../../machine")
 (add-include-book-dir :proof-utils "../")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/cert.acl2
+++ b/books/projects/x86isa/proofs/utilities/cert.acl2
@@ -43,6 +43,6 @@
 (add-include-book-dir :machine "../../machine")
 (add-include-book-dir :proof-utils ".")
 ; The book basics.lisp, at least, seems to need :useless-runes nil:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg)  :useless-runes nil
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg)  :useless-runes nil
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/row-wow-thms.lisp
+++ b/books/projects/x86isa/proofs/utilities/row-wow-thms.lisp
@@ -38,7 +38,7 @@
 
 (in-package "X86ISA")
 
-(include-book "basics" :ttags (:include-raw :undef-flg :syscall-exec :other-non-det))
+(include-book "basics" :ttags (:undef-flg :syscall-exec :other-non-det))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ===================================================================

--- a/books/projects/x86isa/proofs/utilities/sys-view/cert.acl2
+++ b/books/projects/x86isa/proofs/utilities/sys-view/cert.acl2
@@ -42,6 +42,6 @@
 (include-book "../../../portcullis/sharp-dot-constants")
 (add-include-book-dir :machine "../../../machine")
 (add-include-book-dir :proof-utils "../")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/sys-view/paging/cert.acl2
+++ b/books/projects/x86isa/proofs/utilities/sys-view/paging/cert.acl2
@@ -42,6 +42,6 @@
 (include-book "../../../../portcullis/sharp-dot-constants")
 (add-include-book-dir :machine "../../../../machine")
 (add-include-book-dir :proof-utils "../../")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/utilities/sys-view/paging/paging-basics.acl2
+++ b/books/projects/x86isa/proofs/utilities/sys-view/paging/paging-basics.acl2
@@ -49,4 +49,4 @@
 (set-waterfall-parallelism nil)
 
 ; Copied from cert.acl2:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 

--- a/books/projects/x86isa/proofs/utilities/sys-view/paging/top.acl2
+++ b/books/projects/x86isa/proofs/utilities/sys-view/paging/top.acl2
@@ -51,5 +51,5 @@
 (set-waterfall-parallelism nil)
 
 ; Copied from cert.acl2:
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 

--- a/books/projects/x86isa/proofs/wordCount/cert.acl2
+++ b/books/projects/x86isa/proofs/wordCount/cert.acl2
@@ -43,6 +43,6 @@
 (include-book "../../portcullis/sharp-dot-constants")
 
 (include-book "wc-addr-byte")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/wordCount/wc-addr-byte.acl2
+++ b/books/projects/x86isa/proofs/wordCount/wc-addr-byte.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :proof-utils "../utilities")
 (include-book "../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/zeroCopy/marking-view/cert.acl2
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-view/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :proof-utils "../../utilities")
 (include-book "../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/proofs/zeroCopy/non-marking-view/cert.acl2
+++ b/books/projects/x86isa/proofs/zeroCopy/non-marking-view/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :proof-utils "../../utilities")
 (include-book "../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/cert.acl2
+++ b/books/projects/x86isa/tools/execution/cert.acl2
@@ -41,6 +41,6 @@
 (set-waterfall-parallelism t)
 (add-include-book-dir :utils "../../utils")
 (include-book "../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument)
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument)
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument :bignum-extract) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument :bignum-extract) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/dataCopy/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/dataCopy/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/documenting-edge-cases/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/documenting-edge-cases/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/micro-sat/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/micro-sat/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/nop-sequence/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/nop-sequence/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/wc/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/wc/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/examples/zeroCopy/cert.acl2
+++ b/books/projects/x86isa/tools/execution/examples/zeroCopy/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================

--- a/books/projects/x86isa/tools/execution/init-page-tables.lisp
+++ b/books/projects/x86isa/tools/execution/init-page-tables.lisp
@@ -40,7 +40,7 @@
 (in-package "X86ISA")
 
 (include-book "init-state"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "arithmetic/top-with-meta" :dir :system))

--- a/books/projects/x86isa/tools/execution/init-state.lisp
+++ b/books/projects/x86isa/tools/execution/init-state.lisp
@@ -39,7 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "../../machine/x86"
-              :ttags (:include-raw :syscall-exec :other-non-det :undef-flg))
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/tools/execution/instrument/cert.acl2
+++ b/books/projects/x86isa/tools/execution/instrument/cert.acl2
@@ -40,6 +40,6 @@
 
 (set-waterfall-parallelism t)
 (include-book "../../../portcullis/sharp-dot-constants")
-;; cert-flags: ? t :ttags (:include-raw :syscall-exec :other-non-det :undef-flg :instrument) 
+;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg :instrument) 
 
 ;; ======================================================================


### PR DESCRIPTION
There is no ttag with that name, though perhaps there was in the past.