### PR TITLE
Fix read-bytes$ guard for 8-byte reads

### DIFF
--- a/books/std/io/read-ints.lisp
+++ b/books/std/io/read-ints.lisp
@@ -960,7 +960,8 @@ the table below.</p>
                                 (booleanp signed)
                                 (or (equal bytes 1)
                                     (equal bytes 2)
-                                    (equal bytes 4))
+                                    (equal bytes 4)
+                                    (equal bytes 8))
                                 (or (equal end :little)
                                     (equal end :big)))))
     (case end


### PR DESCRIPTION
While the definition of read-bytes$ supports 8 byte reads, the guard
disallowed them. This fixes the guard to allow 8 byte reads.
