### PR TITLE
Make some stobjs non-executable

### DIFF
--- a/books/centaur/bigmems/bigmem/bigmem.lisp
+++ b/books/centaur/bigmems/bigmem/bigmem.lisp
@@ -197,6 +197,7 @@
 
 (acl2::defabsstobj-events mem
 
+    :non-executable t
     :attachable t
     :foundation mem$c
 

--- a/books/centaur/bigmems/bigmem/concrete.lisp
+++ b/books/centaur/bigmems/bigmem/concrete.lisp
@@ -191,7 +191,8 @@
     (level1 :type (array l1 (,*num-level-entries*))
 	    :resizable nil)
     :inline t
-    :non-memoizable t))
+    :non-memoizable t
+    :non-executable t))
 
 ;; ----------------------------------------------------------------------
 

--- a/books/centaur/defrstobj2/defrstobj.lisp
+++ b/books/centaur/defrstobj2/defrstobj.lisp
@@ -780,7 +780,8 @@ accessor on a stobj's creator function returns the default value.</li>
     `(defstobj ,x.concrete-stobj
        ,@(rstobj-concrete-stobj-fields x.fields)
        :inline ,x.inline
-       :non-memoizable ,x.non-memoizable)))
+       :non-memoizable ,x.non-memoizable
+       :non-executable t)))
 
 (defun rstobj-concrete-stobj-field-child-stobj-accessor/updater-def (x.concrete-stobj field)
   (b* (((rstobj-field field)))


### PR DESCRIPTION
- **Make the concrete stobj generated by defrstobj2 non-executable**
  The concrete stobj generated by defrstobj2 is abstracted away from the
  user. Thus, it is never directly used. Making it non-executable saves
  memory.
  

- **Make bigmem::mem and bigmem::mem$c non-executable**
  While bigmem::mem itself doesn't use much memory, if one attaches the
  bigmem-asymmetric::mem to it, the memory usage can be substantial.
  bigmem::mem is generally not used directly, so making it non-executable
  to save on memory makes sense and if needed one can use
  `add-global-stobj` to use it at the top level.
  
  bigmem::mem$c is only used to back bigmem::mem so making it
  non-executable as well shouldn't be an issue and saves some (although
  probably insignificant) memory.
  