### PR TITLE
[Std/osets] Make two rules more applicable.

### DIFF
--- a/books/std/osets/intersect.lisp
+++ b/books/std/osets/intersect.lisp
@@ -232,10 +232,10 @@ consing.</p>"
     (equal (intersect X (sfix Y)) (intersect X Y)))
 
   (defthm intersect-emptyp-X
-    (implies (emptyp X) (emptyp (intersect X Y))))
+    (implies (emptyp X) (equal (intersect X Y) nil)))
 
   (defthm intersect-emptyp-Y
-    (implies (emptyp Y) (emptyp (intersect X Y))))
+    (implies (emptyp Y) (equal (intersect X Y) nil)))
 
   (encapsulate ()
 

--- a/books/std/osets/top.lisp
+++ b/books/std/osets/top.lisp
@@ -902,10 +902,10 @@ from the accompanying talk.</p>")
   (equal (intersect X (sfix Y)) (intersect X Y)))
 
 (defthm intersect-emptyp-X
-  (implies (emptyp X) (emptyp (intersect X Y))))
+  (implies (emptyp X) (equal (intersect X Y) nil)))
 
 (defthm intersect-emptyp-Y
-  (implies (emptyp Y) (emptyp (intersect X Y))))
+  (implies (emptyp Y) (equal (intersect X Y) nil)))
 
 (defthm intersect-in
   (equal (in a (intersect X Y))


### PR DESCRIPTION
The new rules work with certain proofs where the empty set `nil` is involved, which does not match with the `(emptyp ...)` term.

The old rules rewrite terms of the form `(emptyp (intersect x y))` to `t`. The new rules first rewrite that to `(emptyp nil)`, and then the executable counterpart of `emptyp`, which is normally enabled, should turn that into `t`.

Although the matching terms of these rules are quite generic (i.e. `(intersect x y)`, the Std/osets library has other rules with similarly generic matching terms (e.g. `(union x y)` and `(subset x y)`) that are also enabled by default and have no backchain limits. We should probably make all of these disabled by default at some point, and perhaps add them to the `expensive-rules` rule set in Std/osets, or other rule set that can be easily summoned when needed; however, that is a broader change, which may require adjusting several proofs. The current change helps some proofs, is not inconsistent with other parts of the library, and does not exhibit any slowdown, either in the whole regression or in a specific development that makes heavy use of osets.