### PR TITLE
x86isa: implement pcmpgt and some instruction bugfixes

### DIFF
--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -10413,8 +10413,8 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-AND*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VPAND"
           (OP :OP #xFDB
@@ -10423,8 +10423,8 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-AND*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX2)))))
     (INST "VPANDD"
           (OP :OP #xFDB
@@ -10628,8 +10628,8 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-ANDN*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VPANDN"
           (OP :OP #xFDF
@@ -10638,8 +10638,8 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-ANDN*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX2)))))
     (INST "VPANDND"
           (OP :OP #xFDF

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -5033,8 +5033,8 @@
           (ARG :OP1 '(V PD)
                :OP2 '(H PD)
                :OP3 '(W PD))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-OR*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VORPD"
           (OP :OP #xF56
@@ -5043,8 +5043,8 @@
           (ARG :OP1 '(V PD)
                :OP2 '(H PD)
                :OP3 '(W PD))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-OR*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VORPS"
           (OP :OP #xF56
@@ -5053,8 +5053,8 @@
           (ARG :OP1 '(V PS)
                :OP2 '(H PS)
                :OP3 '(W PS))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-OR*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VORPS"
           (OP :OP #xF56
@@ -5063,8 +5063,8 @@
           (ARG :OP1 '(V PS)
                :OP2 '(H PS)
                :OP3 '(W PS))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-OR*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VORPD"
           (OP :OP #xF56

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -2765,12 +2765,12 @@
     (INST "MOVSLDUP"
           (OP :OP #xF12 :PFX :F3 :FEAT '(:SSE3))
           (ARG :OP1 '(V X) :OP2 '(W X))
-          '(X86-MOVLPS/MOVLPD-OP/EN-RM)
+          'NIL
           '((:EX (CHK-EXC :TYPE-4 (:SSE3)))))
     (INST "MOVDDUP"
           (OP :OP #xF12 :PFX :F2 :FEAT '(:SSE3))
           (ARG :OP1 '(V X) :OP2 '(W X))
-          '(X86-MOVLPS/MOVLPD-OP/EN-RM)
+          'NIL
           '((:EX (CHK-EXC :TYPE-5 (:SSE3)))))
     (INST "VMOVDDUP"
           (OP :OP #xF12

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -6407,7 +6407,7 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          'NIL
+          '(X86-PCMPGT-SSE)
           '((:EX (CHK-EXC :TYPE-4 (:SSE2)))))
     (INST "VPCMPGTB"
           (OP :OP #xF64
@@ -6455,7 +6455,7 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          'NIL
+          '(X86-PCMPGT-SSE)
           '((:EX (CHK-EXC :TYPE-4 (:SSE2)))))
     (INST "VPCMPGTW"
           (OP :OP #xF65
@@ -6503,7 +6503,7 @@
           (ARG :OP1 '(V X)
                :OP2 '(H X)
                :OP3 '(W X))
-          'NIL
+          '(X86-PCMPGT-SSE)
           '((:EX (CHK-EXC :TYPE-4 (:SSE2)))))
     (INST "VPCMPGTD"
           (OP :OP #xF66

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -7074,7 +7074,7 @@
           (ARG :OP1 '(V X)
                :OP2 '(W X)
                :OP3 '(I B))
-          '(X86-PSHUFHW)
+          '(X86-PSHUFLW)
           '((:EX (CHK-EXC :TYPE-4 (:SSE2)))))
     (INST "VPSHUFD"
           (OP :OP #xF70

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -4845,8 +4845,8 @@
           (ARG :OP1 '(V PD)
                :OP2 '(H PD)
                :OP3 '(W PD))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-AND*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDPD"
           (OP :OP #xF54
@@ -4855,8 +4855,8 @@
           (ARG :OP1 '(V PD)
                :OP2 '(H PD)
                :OP3 '(W PD))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-AND*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDPS"
           (OP :OP #xF54
@@ -4865,8 +4865,8 @@
           (ARG :OP1 '(V PS)
                :OP2 '(H PS)
                :OP3 '(W PS))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-AND*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDPS"
           (OP :OP #xF54
@@ -4939,8 +4939,8 @@
           (ARG :OP1 '(V PD)
                :OP2 '(H PD)
                :OP3 '(W PD))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-ANDN*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDNPD"
           (OP :OP #xF55
@@ -4949,8 +4949,8 @@
           (ARG :OP1 '(V PD)
                :OP2 '(H PD)
                :OP3 '(W PD))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-ANDN*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDNPS"
           (OP :OP #xF55
@@ -4959,8 +4959,8 @@
           (ARG :OP1 '(V PS)
                :OP2 '(H PS)
                :OP3 '(W PS))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-ANDN*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDNPS"
           (OP :OP #xF55
@@ -4969,8 +4969,8 @@
           (ARG :OP1 '(V PS)
                :OP2 '(H PS)
                :OP3 '(W PS))
-          '(x86-vandp?/vandnp?/vorp?/vxorp?/vpand/vpandn/vpor/vpxor-vex
-            (operation . #x5))
+          '(X86-VANDP?/VANDNP?/VORP?/VXORP?/VPAND/VPANDN/VPOR/VPXOR-VEX
+            (OPERATION . #.*OP-ANDN*))
           '((:EX (CHK-EXC :TYPE-4 (:AVX)))))
     (INST "VANDNPD"
           (OP :OP #xF55

--- a/books/projects/x86isa/machine/instructions/arith-and-logic.lisp
+++ b/books/projects/x86isa/machine/instructions/arith-and-logic.lisp
@@ -738,7 +738,9 @@
        ((the (integer 1 8) operand-size)
         (select-operand-size
          proc-mode byte-operand? rex-byte t prefixes nil nil nil x86))
-       (rAX-size (if (logbitp #.*w* rex-byte)
+       ;; rex does not promote byte opcodes to 64-bit
+       (rAX-size (if (and (not byte-operand?)
+                          (logbitp #.*w* rex-byte))
                      8
                    operand-size))
 

--- a/books/projects/x86isa/machine/instructions/exchange.lisp
+++ b/books/projects/x86isa/machine/instructions/exchange.lisp
@@ -245,7 +245,7 @@
        ((mv result
             (the (unsigned-byte 32) output-rflags)
             (the (unsigned-byte 32) undefined-flags))
-        (gpr-arith/logic-spec reg/mem-size #.*OP-CMP* reg/mem rAX input-rflags))
+        (gpr-arith/logic-spec reg/mem-size #.*OP-CMP* rAX reg/mem input-rflags))
 
        ;; Update the x86 state:
        (x86 (write-user-rflags output-rflags undefined-flags x86))

--- a/books/projects/x86isa/machine/instructions/fp/simd-integer.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/simd-integer.lisp
@@ -421,11 +421,11 @@
             (operand-size 16)
 
             ;; The first source operand (Operand 1 in the Intel manual)
-            ;; is the XMM register specified in Reg.
+            ;; is the XMM register specified in r/m.
             ;; This is also the destination operand,
             ;; and thus we obtain the index for later use.
             ((the (unsigned-byte 4) src1/dst-index)
-             (reg-index reg rex-byte #.*r*))
+             (reg-index r/m rex-byte #.*b*))
             ((the (unsigned-byte 128) src1)
              (xmmi-size operand-size src1/dst-index x86))
 

--- a/books/projects/x86isa/machine/instructions/fp/simd-integer.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/simd-integer.lisp
@@ -317,6 +317,7 @@
        :modr/m t
 
        :returns (x86 x86p :hyp (x86p x86))
+       :guard (member opcode ',(strip-cdrs width-opcode-alist))
        :guard-hints (("Goal" :in-theory (disable unsigned-byte-p)))
 
        :body
@@ -379,16 +380,14 @@
                     (loghead 64 src2) ;; Memory operand
                     src2)) ;; Register operand
 
-            (result (case opcode
-                      (,(cdr (assoc 16 width-opcode-alist))
-                        (,name (* 8 operand-size) 16 src1 src2))
-                      (,(cdr (assoc 32 width-opcode-alist))
-                        (,name (* 8 operand-size) 32 src1 src2))
-                      ,@(if (assoc 64 width-opcode-alist)
-                          `((,(cdr (assoc 64 width-opcode-alist))
-                              (,name (* 8 operand-size) 64 src1 src2)))
-                          nil)
-                      (t 0))) ; unreachable
+            (el-width (car (rassoc opcode ',width-opcode-alist)))
+            ;; Clamp to el-width because src2 may be huge; it comes from an xmm
+            ;; reg, so it may be up to 128-bits long. This may cause the host
+            ;; lisp to throw an error
+            (src2 (if (> src2 el-width)
+                    el-width
+                    src2))
+            (result (,name (* 8 operand-size) el-width src1 src2))
 
             ;; Store the result into the destination register.
             (x86 (!xmmi-size operand-size src1/dst-index result x86))
@@ -412,6 +411,7 @@
        :modr/m t
 
        :returns (x86 x86p :hyp (x86p x86))
+       :guard (member opcode '(#x71 #x72 #x73))
        :guard-hints (("Goal" :in-theory (e/d (rme-size-of-1-to-rme08)
                                              (unsigned-byte-p))))
 
@@ -450,13 +450,11 @@
             ;; Calculate the result.
             ;; Note: these opcodes are always the same; the reg field specifies
             ;; which type of shift and that's handled at decode time
-            (result (case opcode
-                      (#x71 (,name (* 8 operand-size) 16 src1 imm))
-                      (#x72 (,name (* 8 operand-size) 32 src1 imm))
-                      ,@(if (assoc 64 width-opcode-alist)
-                          `((#x73 (,name (* 8 operand-size) 64 src1 imm)))
-                          nil)
-                      (t 0))) ; unreachable
+            (el-width (case opcode
+                        (#x71 16)
+                        (#x72 32)
+                        (#x73 64)))
+            (result (,name (* 8 operand-size) el-width src1 imm))
 
             ;; Store the result into the destination register.
             (x86 (!xmmi-size operand-size src1/dst-index result x86))

--- a/books/projects/x86isa/machine/instructions/pcmp.lisp
+++ b/books/projects/x86isa/machine/instructions/pcmp.lisp
@@ -147,3 +147,108 @@
        ;; Update the instruction pointer.
        (x86 (write-*ip proc-mode temp-rip x86)))
       x86))
+
+(define pcmpgt ((result-width natp)
+                (el-width posp)
+                (a natp)
+                (b natp))
+  :prepwork ((local (include-book "arithmetic-5/top" :dir :system)))
+  :guard (equal (mod result-width el-width) 0)
+  :returns (result (unsigned-byte-p result-width result)
+                   :hyp (and (natp result-width)
+                             (<= (pos-fix el-width) result-width)
+                             (equal (mod result-width (pos-fix el-width)) 0))
+                   :hints (("Goal" :in-theory (disable unsigned-byte-p
+                                                       bitops::logapp-of-i-0
+                                                       acl2::prefer-positive-addends-<))))
+  :measure (nfix result-width)
+  (b* ((result-width (nfix result-width))
+       (el-width (pos-fix el-width))
+       (a (nfix a))
+       (b (nfix b))
+       ((when (zp result-width)) 0)
+       (el-greater? (> (logext el-width a)
+                     (logext el-width b))))
+      (logapp el-width (if el-greater? -1 0)
+              (pcmpgt (- result-width el-width) el-width
+                      (logtail el-width a) (logtail el-width b)))))
+
+(def-inst x86-pcmpgt-sse
+  :parents (two-byte-opcodes)
+  :long
+  "<code>
+  PCMPGTB xmm1, xmm2/m128
+  PCMPGTW xmm1, xmm2/m128
+  PCMPGTD xmm1, xmm2/m128
+  </code>"
+
+  :modr/m t
+
+  :returns (x86 x86p :hyp (x86p x86))
+  :guard-hints (("Goal" :in-theory (disable unsigned-byte-p)))
+
+  :body
+
+  (b* ((p2 (prefixes->seg prefixes))
+       (p4? (eql #.*addr-size-override* (prefixes->adr prefixes)))
+       (seg-reg (select-segment-register proc-mode p2 p4? mod r/m sib x86))
+
+       ;; The operand size is always 128 bits, i.e. 16 bytes.
+       (operand-size 16)
+
+       ;; The first source operand (Operand 1 in the Intel manual)
+       ;; is the XMM register specified in Reg.
+       ;; This is also the destination operand,
+       ;; and thus we obtain the index for later use.
+       ((the (unsigned-byte 4) src1/dst-index)
+        (reg-index reg rex-byte #.*r*))
+       ((the (unsigned-byte 128) src1)
+        (xmmi-size operand-size src1/dst-index x86))
+
+       ;; The second source operand (Operand 2 in the Intel manual)
+       ;; is the XMM register, or memory operand, specified in Mod and R/M.
+       (inst-ac? t) ; Intel Manual Volume 2 Table 2-21 (Dec 2023)
+       ((mv flg
+            (the (unsigned-byte 128) src2)
+            (the (integer 0 4) increment-rip-by)
+            ?addr
+            x86)
+        (x86-operand-from-modr/m-and-sib-bytes proc-mode
+                                               #.*xmm-access*
+                                               operand-size
+                                               inst-ac?
+                                               nil ; not a memory operand
+                                               seg-reg
+                                               p4?
+                                               temp-rip
+                                               rex-byte
+                                               r/m
+                                               mod
+                                               sib
+                                               0 ; no immediate operand
+                                               x86))
+       ((when flg) (!!ms-fresh :x86-operand-from-modr/m-and-sib-bytes flg))
+
+       ;; Increment the instruction pointer in the temp-rip variable.
+       ((mv flg (the (signed-byte #.*max-linear-address-size*) temp-rip))
+        (add-to-*ip proc-mode temp-rip increment-rip-by x86))
+       ((when flg) (!!ms-fresh :rip-increment-error flg))
+
+       ;; Ensure the instruction is not too long.
+       (badlength? (check-instruction-length start-rip temp-rip 0))
+       ((when badlength?)
+        (!!fault-fresh :gp 0 :instruction-length badlength?)) ;; #GP(0)
+
+       ;; Calculate the result.
+       (result (case opcode
+                 (#x64 (pcmpgt (* 8 operand-size) 08 src1 src2))
+                 (#x65 (pcmpgt (* 8 operand-size) 16 src1 src2))
+                 (#x66 (pcmpgt (* 8 operand-size) 32 src1 src2))
+                 (t 0))) ; unreachable
+
+       ;; Store the result into the destination register.
+       (x86 (!xmmi-size operand-size src1/dst-index result x86))
+
+       ;; Update the instruction pointer.
+       (x86 (write-*ip proc-mode temp-rip x86)))
+      x86))

--- a/books/projects/x86isa/machine/instructions/rotate-and-shift.lisp
+++ b/books/projects/x86isa/machine/instructions/rotate-and-shift.lisp
@@ -563,7 +563,7 @@
   (b* (;; The index of the XMM register
        ;; is in the R/M portion of the ModR/M byte.
        ;; It can be extended by one bit via the REX byte.
-       (reg-index (reg-index r/m rex-byte #.*r*))
+       (reg-index (reg-index r/m rex-byte #.*b*))
 
        ;; Read the 128-bit (i.e. 16-byte) operand from the XMM register.
        (operand (xmmi-size 16 reg-index x86))

--- a/books/projects/x86isa/machine/instructions/rotate-and-shift.lisp
+++ b/books/projects/x86isa/machine/instructions/rotate-and-shift.lisp
@@ -189,7 +189,9 @@
        ((when flg1)
         (!!ms-fresh :rme-size-error flg1))
 
-       (countMask (if (logbitp #.*w* rex-byte)
+       ;; REX does not promote to 64-bits for byte-operand opcodes
+       (countMask (if (and (not byte-operand?)
+                           (logbitp #.*w* rex-byte))
                       #x3F
                     #x1F))
        (shift/rotate-by (logand countMask shift/rotate-by))

--- a/books/projects/x86isa/machine/instructions/shifts-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/shifts-spec.lisp
@@ -149,7 +149,7 @@
                       (mbe
                        :logic (part-select
                                dst
-                               :low ,size-1 ;; (- ,size src)
+                               :low ,size-1
                                :width 1)
                        :exec
                        (the (unsigned-byte 1)
@@ -664,16 +664,6 @@ set to the most-significant bit of the original operand.</p>"
 
 ;;;;;;;;;; SAR:
 
-;; (local
-;;  (defthm logand-identity
-;;    (implies (and (equal 2^size-1 (1- (expt 2 size)))
-;;                  (unsigned-byte-p size i))
-;;             (equal (logand 2^size-1 i) i))
-;;    :hints (("Goal" :in-theory (e/d ()
-;;                                    (loghead-to-logand))
-;;             :use ((:instance loghead-to-logand
-;;                              (n size) (x i)))))))
-
 (define sar-spec-gen ((size :type (member 8 16 32 64)))
   :verify-guards nil
 
@@ -692,12 +682,16 @@ set to the most-significant bit of the original operand.</p>"
         (input-rflags :type (unsigned-byte 32)))
 
        :parents (sar-spec)
-       :guard-hints (("Goal" :in-theory (e/d* (rflag-RoWs-enables)
-                                              (unsigned-byte-p
-                                               (tau-system)))))
+       :guard-hints
+       (("Goal" :in-theory (e/d* (rflag-RoWs-enables)
+                                 (unsigned-byte-p
+                                  bitops::logbit-to-logbitp
+                                  (tau-system))))
+        (and stable-under-simplificationp
+             '(:in-theory (enable bitops::logbit-to-logbitp))))
        :prepwork
        ((local
-         (defthm sar-spec-helper
+          (defthm sar-spec-helper
            (implies (unsigned-byte-p ,size dst)
                     (equal (logand ,(1- (expt 2 size)) (logtail src dst))
                            (logtail src dst)))
@@ -709,7 +703,18 @@ set to the most-significant bit of the original operand.</p>"
                                      (i dst)))
                     :in-theory (e/d* ()
                                      (unsigned-byte-p
-                                      unsigned-byte-p-of-logtail)))))))
+                                      unsigned-byte-p-of-logtail))))))
+
+        (local
+          (defthm sar-spec-helper-2
+                  (implies (unsigned-byte-p (1+ n) x)
+                           (equal (logbit n x)
+                                  (logtail n x)))
+                  :hints (("Goal" :in-theory
+                           (e/d (bitops::logbitp** bitops::logbitp-induct
+                                                   bitops::logtail** bitops::logtail-induct
+                                                   bitops::unsigned-byte-p**)
+                                (unsigned-byte-p)))))))
 
        (b* ((dst (mbe :logic (n-size ,size dst)
                       :exec dst))
@@ -726,11 +731,10 @@ set to the most-significant bit of the original operand.</p>"
                    (the (signed-byte ,size+1) neg-src))))
             (raw-result
              (if (eql (mbe :logic (logbit ,size-1 dst)
-                           :exec (logand 1
-                                         (the (unsigned-byte 1)
-                                              (ash (the (unsigned-byte ,size)
-                                                        dst)
-                                                   ,neg-size-1))))
+                           :exec (the (unsigned-byte 1)
+                                      (ash (the (unsigned-byte ,size)
+                                                dst)
+                                           ,neg-size-1)))
                       1)
                  (loghead ,size
                           (ash
@@ -790,96 +794,62 @@ set to the most-significant bit of the original operand.</p>"
                   (mv output-rflags undefined-flags)))
 
                (otherwise
-                (if (<= ,size src)
-                    (b* (
-                         ;; CF is undefined.
-                         (pf (general-pf-spec ,size result))
-                         ;; AF is undefined.
-                         (zf (zf-spec result))
-                         (sf (general-sf-spec ,size result))
-                         ;; OF is undefined.
-                         (output-rflags (mbe :logic
-                                             (change-rflagsBits
-                                              input-rflags
-                                              :pf pf
-                                              :zf zf
-                                              :sf sf)
-                                             :exec
-                                             (the (unsigned-byte 32)
-                                                  (!rflagsBits->pf
-                                                   pf
-                                                   (!rflagsBits->zf
-                                                    zf
-                                                    (!rflagsBits->sf
-                                                     sf
-                                                     input-rflags))))))
-
-                         (undefined-flags (mbe :logic
-                                               (change-rflagsBits
-                                                0
-                                                :cf 1
-                                                :af 1
-                                                :of 1)
-                                               :exec
-                                               (the (unsigned-byte 32)
-                                                    (!rflagsBits->cf
-                                                     1
-                                                     (!rflagsBits->af
-                                                      1
-                                                      (!rflagsBits->of
-                                                       1
-                                                       0)))))))
-                      (mv output-rflags undefined-flags))
-
-                  (b* ((cf (mbe :logic (part-select dst :low (1- src) :width 1)
-                                :exec (let* ((shft
-                                              (the (signed-byte ,size)
-                                                   (- 1
-                                                      (the (unsigned-byte ,size) src)))))
-                                        (the (unsigned-byte 1)
-                                             (logand
-                                              1
-                                              (the (unsigned-byte ,size)
-                                                   (ash
-                                                    (the (unsigned-byte ,size) dst)
-                                                    (the (signed-byte ,size) shft))))))))
-                       (pf (general-pf-spec ,size result))
-                       ;; AF is undefined.
-                       (zf (zf-spec result))
-                       (sf (general-sf-spec ,size result))
-                       ;; OF is undefined.
-
-                       (output-rflags (mbe :logic
-                                           (change-rflagsBits
+                 (b* ((cf (if (<= ,size src)
+                            (mbe :logic (part-select dst :low ,size-1 :width 1)
+                                 :exec (let* ((shft (the (signed-byte ,size) ,neg-size-1)))
+                                         (the (unsigned-byte 1)
+                                              (ash
+                                                (the (unsigned-byte ,size) dst)
+                                                (the (signed-byte ,size) shft)))))
+                            (mbe :logic (part-select dst :low (1- src) :width 1)
+                                 :exec (let* ((shft
+                                                (the (signed-byte ,size)
+                                                     (- 1
+                                                        (the (unsigned-byte ,size) src)))))
+                                         (the (unsigned-byte 1)
+                                              (logand
+                                                1
+                                                (the (unsigned-byte ,size)
+                                                     (ash
+                                                       (the (unsigned-byte ,size) dst)
+                                                       (the (signed-byte ,size) shft)))))))))
+                      (pf (general-pf-spec ,size result))
+                      ;; AF is undefined.
+                      (zf (zf-spec result))
+                      (sf (general-sf-spec ,size result))
+                      ;; OF is undefined.
+                      (output-rflags (mbe :logic
+                                          (change-rflagsBits
                                             input-rflags
                                             :cf cf
                                             :pf pf
                                             :zf zf
                                             :sf sf)
-                                           :exec
-                                           (the (unsigned-byte 32)
-                                                (!rflagsBits->cf
+                                          :exec
+                                          (the (unsigned-byte 32)
+                                               (!rflagsBits->cf 
                                                  cf
                                                  (!rflagsBits->pf
-                                                  pf
-                                                  (!rflagsBits->zf
-                                                   zf
-                                                   (!rflagsBits->sf
-                                                    sf
-                                                    input-rflags)))))))
+                                                   pf
+                                                   (!rflagsBits->zf
+                                                     zf
+                                                     (!rflagsBits->sf
+                                                       sf
+                                                       input-rflags)))))))
 
-                       (undefined-flags (mbe
-                                         :logic
-                                         (change-rflagsBits
-                                          0
-                                          :af 1
-                                          :of 1)
-                                         :exec
-                                         (!rflagsBits->af
-                                          1
-                                          (!rflagsBits->of
-                                           1 0)))))
-                    (mv output-rflags undefined-flags))))))
+                      (undefined-flags (mbe :logic
+                                            (change-rflagsBits
+                                              0
+                                              :af 1
+                                              :of 1)
+                                            :exec
+                                            (the (unsigned-byte 32)
+                                                 (!rflagsBits->af
+                                                   1
+                                                   (!rflagsBits->of
+                                                     1
+                                                     0))))))
+                     (mv output-rflags undefined-flags)))))
 
             (output-rflags (mbe :logic (n32 output-rflags)
                                 :exec output-rflags))

--- a/books/projects/x86isa/machine/rflags-spec.lisp
+++ b/books/projects/x86isa/machine/rflags-spec.lisp
@@ -666,12 +666,12 @@ positive value and 1 indicates a negative value.)</p>"
            (mbe :logic (part-select src   :low 0 :width 4)
                 :exec  (logand #xF src)))
 
-          (sbb
-           (- (the (unsigned-byte 4) dst-3-0)
-              (+ (the (unsigned-byte 4) src-3-0)
-                 (the (unsigned-byte 4) cf))))
+          ((the (unsigned-byte 6) sbb)
+           (logand #x3F (- (the (unsigned-byte 4) dst-3-0)
+                           (+ (the (unsigned-byte 4) src-3-0)
+                              (the (unsigned-byte 4) cf)))))
 
-          (af (the (unsigned-byte 1) (bool->bit (< sbb 0)))))
+          (af (the (unsigned-byte 1) (bool->bit (> sbb #xF)))))
 
          af)
 


### PR DESCRIPTION
- **Fix some x86isa shifts**
  The flag computation for SAR treated the CF as undefined when the shift
  count was greater than the operand size, but that is incorrect.
  
  Additionally, the count mask was computed incorrectly for byte operands
  with a REX prefix
  

- **Fix x86isa cmpxchg computing incorrect flags**
  

- **x86isa Fix large SSE2 shift counts causing Lisp errors**
  The SSE2 packed shift instructions which take the count as an XMM
  register could have a huge (128-bit wide) shift count. These cause CCL
  to throw when passed to `ash`.
  
  Clamping the shift count to the el-width resolves this issue. This
  commit also cleans up some of the SSE2 shift implementation code.
  

- **x86isa Implement pcmpgt(b/w/d) instructions**
  