### PR TITLE
[X86ISA] Collect type theorems about XR.

### DIFF
--- a/books/projects/x86isa/machine/application-level-memory.lisp
+++ b/books/projects/x86isa/machine/application-level-memory.lisp
@@ -147,12 +147,6 @@ memory.</p>" )
 
 ;; Memory Read Functions:
 
-(defthm-unsigned-byte-p n08p-xr-mem
-                        :hyp t
-                        :bound 8
-                        :concl (xr :mem i x86)
-                        :gen-linear t
-                        :gen-type t)
 
 (define rvm08
   ((addr :type (signed-byte #.*max-linear-address-size*))

--- a/books/projects/x86isa/machine/instructions/fp/mxcsr.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/mxcsr.lisp
@@ -53,13 +53,6 @@
 ; INSTRUCTION: MXCSR State Management Instructions
 ; =============================================================================
 
-(defthm-unsigned-byte-p n32p-xr-mxcsr
-  :hyp t
-  :bound 32
-  :concl (xr :mxcsr i x86)
-  :gen-linear t
-  :gen-type t)
-
 (def-inst x86-ldmxcsr/stmxcsr-Op/En-M
 
   :parents (two-byte-opcodes fp-opcodes)

--- a/books/projects/x86isa/machine/instructions/jump-and-loop.lisp
+++ b/books/projects/x86isa/machine/instructions/jump-and-loop.lisp
@@ -285,20 +285,6 @@
  (defthm unsigned-byte-p-96-of-xr-str
    (unsigned-byte-p 96 (xr :str i x86))))
 
-(defthm-unsigned-byte-p n32p-xr-ssr-hidden-limit
-  :hyp t
-  :bound 32
-  :concl (xr :ssr-hidden-limit i x86)
-  :gen-linear t
-  :gen-type t)
-
-(defthm-unsigned-byte-p n64p-xr-ssr-hidden-base
-  :hyp t
-  :bound 64
-  :concl (xr :ssr-hidden-base i x86)
-  :gen-linear t
-  :gen-type t)
-
 (local
  (defthm x86-far-jmp-op/en-d-helper-1
    (unsigned-byte-p

--- a/books/projects/x86isa/machine/instructions/push-and-pop.lisp
+++ b/books/projects/x86isa/machine/instructions/push-and-pop.lisp
@@ -694,13 +694,6 @@
 ;; INSTRUCTION: PUSHF/PUSHFQ
 ;; ======================================================================
 
-(defthm-unsigned-byte-p n32p-xr-rflags
-  :hyp t
-  :bound 32
-  :concl (xr :rflags i x86)
-  :gen-linear t
-  :gen-type t)
-
 (def-inst x86-pushf
 
   ;; #x9C: Op/En: NP

--- a/books/projects/x86isa/machine/instructions/syscall.lisp
+++ b/books/projects/x86isa/machine/instructions/syscall.lisp
@@ -205,14 +205,6 @@
        (x86 (!rip temp-rip x86))) ;; SYSRET
     x86))
 
-(local
- (defthm-unsigned-byte-p n32p-xr-rflags
-   :hyp t
-   :bound 32
-   :concl (xr :rflags i x86)
-   :gen-linear t
-   :gen-type t))
-
 (local (include-book "centaur/bitops/width-find-rule" :dir :system))
 (local (in-theory (e/d (bitops::unsigned-byte-p-by-find-rule) ())))
 

--- a/books/projects/x86isa/machine/paging.lisp
+++ b/books/projects/x86isa/machine/paging.lisp
@@ -216,13 +216,6 @@
                                acl2::ihsext-inductions)
                               ()))))
 
-(defthm-unsigned-byte-p n64p-xr-ctr
-  :hyp t
-  :bound 64
-  :concl (xr :ctr i x86)
-  :gen-linear t
-  :gen-type t)
-
 (define good-lin-addr-p (lin-addr x86)
 
   :parents (ia32e-paging)

--- a/books/projects/x86isa/machine/register-readers-and-writers.lisp
+++ b/books/projects/x86isa/machine/register-readers-and-writers.lisp
@@ -164,13 +164,6 @@ prefix.</p>"
 (local (in-theory (disable bitops::logext-of-logand
                            bitops::logext-of-logior)))
 
-(defthm-signed-byte-p i64p-xr-rgf
-  :hyp t
-  :bound 64
-  :concl (xr :rgf i x86)
-  :gen-linear t
-  :gen-type t)
-
 (defsection GPRs-Reads-and-Writes
 
   :parents (register-readers-and-writers)
@@ -652,13 +645,6 @@ are used to write natural numbers into the GPRs.</p>"
 
 ;; ----------------------------------------------------------------------
 
-(defthm-unsigned-byte-p n80p-xr-fp-data
-  :hyp t
-  :bound 80
-  :concl (xr :fp-data i x86)
-  :gen-linear t
-  :gen-type t)
-
 (defsection MMX-Registers-Reads-and-Writes
 
   :parents (register-readers-and-writers)
@@ -773,13 +759,6 @@ pointer, or opcode registers\).</em></p>"
                      (x86p (mmx-instruction-updates x86))))))
 
 ;; ----------------------------------------------------------------------
-
-(defthm-unsigned-byte-p n512p-xr-zmm
-  :hyp t
-  :bound 512
-  :concl (xr :zmm i x86)
-  :gen-linear t
-  :gen-type t)
 
 (defsection ZMMs-Reads-and-Writes
 

--- a/books/projects/x86isa/machine/segmentation.lisp
+++ b/books/projects/x86isa/machine/segmentation.lisp
@@ -73,27 +73,6 @@
 
 ;; ======================================================================
 
-(defthm-unsigned-byte-p n64p-xr-seg-hidden-base
-  :hyp t
-  :bound 64
-  :concl (xr :seg-hidden-base i x86)
-  :gen-linear t
-  :gen-type t)
-
-(defthm-unsigned-byte-p n32p-xr-seg-hidden-limit
-  :hyp t
-  :bound 32
-  :concl (xr :seg-hidden-limit i x86)
-  :gen-linear t
-  :gen-type t)
-
-(defthm-unsigned-byte-p n16p-xr-seg-visible
-  :hyp t
-  :bound 16
-  :concl (xr :seg-visible i x86)
-  :gen-linear t
-  :gen-type t)
-
 (define segment-base-and-bounds
   ((proc-mode :type (integer 0 #.*num-proc-modes-1*))
    (seg-reg   :type (integer 0 #.*segment-register-names-len-1*))

--- a/books/projects/x86isa/machine/state.lisp
+++ b/books/projects/x86isa/machine/state.lisp
@@ -687,6 +687,97 @@ before including the x86 books:</p>
 
 (globally-disable '(x86p))
 
+(defthm-signed-byte-p i64p-xr-rgf
+  :hyp t
+  :bound 64
+  :concl (xr :rgf i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n32p-xr-rflags
+  :hyp t
+  :bound 32
+  :concl (xr :rflags i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n16p-xr-seg-visible
+  :hyp t
+  :bound 16
+  :concl (xr :seg-visible i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n64p-xr-seg-hidden-base
+  :hyp t
+  :bound 64
+  :concl (xr :seg-hidden-base i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n32p-xr-seg-hidden-limit
+  :hyp t
+  :bound 32
+  :concl (xr :seg-hidden-limit i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n16p-xr-seg-hidden-attr
+  :hyp t
+  :bound 16
+  :concl (xr :seg-hidden-attr i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n64p-xr-ssr-hidden-base
+  :hyp t
+  :bound 64
+  :concl (xr :ssr-hidden-base i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n32p-xr-ssr-hidden-limit
+  :hyp t
+  :bound 32
+  :concl (xr :ssr-hidden-limit i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n64p-xr-ctr
+  :hyp t
+  :bound 64
+  :concl (xr :ctr i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n80p-xr-fp-data
+  :hyp t
+  :bound 80
+  :concl (xr :fp-data i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n32p-xr-mxcsr
+  :hyp t
+  :bound 32
+  :concl (xr :mxcsr i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n512p-xr-zmm
+  :hyp t
+  :bound 512
+  :concl (xr :zmm i x86)
+  :gen-linear t
+  :gen-type t)
+
+(defthm-unsigned-byte-p n08p-xr-mem
+  :hyp t
+  :bound 8
+  :concl (xr :mem i x86)
+  :gen-linear t
+  :gen-type t)
+
 ;; ----------------------------------------------------------------------
 
 (make-event

--- a/books/projects/x86isa/machine/top-level-memory.lisp
+++ b/books/projects/x86isa/machine/top-level-memory.lisp
@@ -125,13 +125,6 @@
 
 ;; Memory Read Functions:
 
-(defthm-unsigned-byte-p n16p-xr-seg-hidden-attr
-  :hyp t
-  :bound 16
-  :concl (xr :seg-hidden-attr i x86)
-  :gen-linear t
-  :gen-type t)
-
 (define gen-read-function (&key
                            (size natp)
                            (signed? booleanp)


### PR DESCRIPTION
Previously these were spread across various books where needed.  Now they all live in the file where XR is defined.

I suspect that this will help us reduce dependencies (specifically, I saw an unrelated guard proof fail when push-and-pop.lisp was not included, seemingly because push-and-pop.lisp is where n32p-xr-rflags happened to be defined).

Perhaps i48p-xr-rip should be moved too, but I held back because that would have taken it out of its enclosing defsection.

I think there is some duplication between the :rewrite rules generated by these forms and the rules generated by defrstobj.  I plan to look into that.