### PR TITLE
[cowles-flat] Remove legacy certify-book command.

### DIFF
--- a/books/workshops/2002/cowles-flat/support/flat.acl2
+++ b/books/workshops/2002/cowles-flat/support/flat.acl2
@@ -8,4 +8,5 @@
   (union-eq *acl2-exports*
             *common-lisp-symbols-from-main-lisp-package*))
 
-(certify-book "flat" ? t)
+;; Legacy certify-book command commented out by Eric Smith:
+;; (certify-book "flat" ? t)


### PR DESCRIPTION
This lets me get the FLAT package by loading flat.acl2, without causing certification to be attempted.  The build system no-longer requires a .acl2 file to include a certify-book command.