### PR TITLE
xdoc: add def? preprocessor directive, use it in defsection to avoid …

### DIFF
--- a/books/xdoc/top.lisp
+++ b/books/xdoc/top.lisp
@@ -288,7 +288,7 @@
         ((and (consp (car entries))
               (symbolp (caar entries)))
          ;; theorems, definitions, defchooses
-         (let* ((acc (list* #\Space #\f #\e #\d #\( #\@ acc)) ;; "@(def "
+         (let* ((acc (list* #\Space #\? #\f #\e #\d #\( #\@ acc)) ;; "@(def? "
                 (acc (revappend-full-escape-symbol (caar entries) acc))
                 (acc (list* #\Newline #\) acc)))
            (formula-info-to-defs1 (cdr entries) acc)))
@@ -307,6 +307,13 @@
                 acc))
          (before-entries acc)
          (acc (formula-info-to-defs1 entries acc)))
+    ;; Bozo (Sol): The above may generate some @(def? ...) directives. If
+    ;; there aren't any, then we'll avoid printing "Definitions and Theorems".
+    ;; But some or all of these may turn out not to print anything
+    ;; (e.g. because the events they referred to were local, in the case of
+    ;; defsection-progn). We'll still print "Definitions and Theorems" in the
+    ;; case where there it turned out that no definitions were printed.  This
+    ;; isn't easy to solve so for now I'll leave it.
     (if (equal acc before-entries)
         ;; Avoid adding empty "Definitions and Theorems" sections.
         original

--- a/books/xdoc/topics.lisp
+++ b/books/xdoc/topics.lisp
@@ -442,6 +442,11 @@ world and insert them into your documentation, you can use:</p>
           (also works for theorems, macros, ...)</td>
 </tr>
 
+<tr>  <td>@('@(def? fn)')</td>
+      <td>Same as @('@(def fn)') but doesn't
+          produce an error if the definition isn't found</td>
+</tr>
+
 <tr> <td>@('@(body fn)')</td>
      <td>just the body of <i>fn</i></td> </tr>
 


### PR DESCRIPTION
…xdoc errors when defsection-progn contains local events