### PR TITLE
[X86ISA] Reduce inclusion.

### DIFF
--- a/books/projects/x86isa/tools/execution/execloaders.lisp
+++ b/books/projects/x86isa/tools/execution/execloaders.lisp
@@ -45,6 +45,7 @@
 (include-book "init-page-tables" :ttags :all)
 (include-book "projects/execloader/elf-reader" :dir :system)
 (include-book "projects/execloader/mach-o-reader" :dir :system)
+(include-book "../../machine/environment")
 
 (local (xdoc::set-default-parents program-execution))
 

--- a/books/projects/x86isa/tools/execution/init-state.lisp
+++ b/books/projects/x86isa/tools/execution/init-state.lisp
@@ -38,8 +38,7 @@
 
 (in-package "X86ISA")
 
-(include-book "../../machine/x86"
-              :ttags (:syscall-exec :other-non-det :undef-flg))
+(include-book "../../machine/linear-memory" :ttags (:undef-flg))
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 

--- a/books/projects/x86isa/tools/execution/instrument/top.lisp
+++ b/books/projects/x86isa/tools/execution/instrument/top.lisp
@@ -38,6 +38,8 @@
 
 (in-package "X86ISA")
 (include-book "../init-page-tables" :ttags :all)
+(include-book "../../../machine/x86"
+              :ttags (:syscall-exec :other-non-det :undef-flg))
 (include-book "std/strings/hex" :dir :system)
 (include-book "std/strings/decimal" :dir :system)
 


### PR DESCRIPTION
The book about initializing the x86 state doesn't need all the instruction semantic functions.  As is common with this sort of change, include-books had to be added to some downstream books, but overall the dependencies were reduced.

(This change was enabled by an earlier change that collected rules about XR.)