### PR TITLE
[X86ISA] Standardize includes of proofs.

### DIFF
--- a/books/projects/x86isa/proofs/codewalker-examples/base.lisp
+++ b/books/projects/x86isa/proofs/codewalker-examples/base.lisp
@@ -39,7 +39,8 @@
 (in-package "X86ISA")
 
 (include-book "../../../codewalker/codewalker")
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))

--- a/books/projects/x86isa/proofs/dataCopy/dataCopy.lisp
+++ b/books/projects/x86isa/proofs/dataCopy/dataCopy.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "loop-base" :ttags :all)
 (include-book "loop-recur" :ttags :all)
 (include-book "centaur/bitops/ihs-extensions" :dir :system)

--- a/books/projects/x86isa/proofs/dataCopy/init.lisp
+++ b/books/projects/x86isa/proofs/dataCopy/init.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "centaur/bitops/ihs-extensions" :dir :system)
 
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))

--- a/books/projects/x86isa/proofs/dataCopy/loop-base.lisp
+++ b/books/projects/x86isa/proofs/dataCopy/loop-base.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "init" :ttags :all)
 (include-book "centaur/bitops/ihs-extensions" :dir :system)
 

--- a/books/projects/x86isa/proofs/dataCopy/loop-recur.lisp
+++ b/books/projects/x86isa/proofs/dataCopy/loop-recur.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "init" :ttags :all)
 (include-book "centaur/bitops/ihs-extensions" :dir :system)
 

--- a/books/projects/x86isa/proofs/dissertation-examples/clc-stc-app-view.lisp
+++ b/books/projects/x86isa/proofs/dissertation-examples/clc-stc-app-view.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 
 (include-book "centaur/bitops/ihs-extensions" :dir :system)
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))

--- a/books/projects/x86isa/proofs/factorial/fact-inductive-assertions.lisp
+++ b/books/projects/x86isa/proofs/factorial/fact-inductive-assertions.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (local (include-book "centaur/gl/gl" :dir :system))
 
 (set-irrelevant-formals-ok t)

--- a/books/projects/x86isa/proofs/factorial/fact-wormhole-abstraction.lisp
+++ b/books/projects/x86isa/proofs/factorial/fact-wormhole-abstraction.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 
 (set-irrelevant-formals-ok t)
 

--- a/books/projects/x86isa/proofs/popcount/popcount-general.lisp
+++ b/books/projects/x86isa/proofs/popcount/popcount-general.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 
 (local (include-book "centaur/gl/gl" :dir :system))
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))

--- a/books/projects/x86isa/proofs/popcount/popcount.lisp
+++ b/books/projects/x86isa/proofs/popcount/popcount.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "../../tools/execution/init-state" :ttags :all)
 (include-book "centaur/gl/gl" :dir :system)
 (include-book "std/testing/must-fail" :dir :system)

--- a/books/projects/x86isa/proofs/powOfTwo/powOfTwo.lisp
+++ b/books/projects/x86isa/proofs/powOfTwo/powOfTwo.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 
 (local (include-book "centaur/gl/gl" :dir :system))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/proofs/wordCount/wc.lisp
+++ b/books/projects/x86isa/proofs/wordCount/wc.lisp
@@ -41,8 +41,8 @@
 
 (in-package "X86ISA")
 
-(include-book "app-view/user-level-memory-utils" :dir :proof-utils :ttags :all)
-(include-book "app-view/environment-utils" :dir :proof-utils :ttags :all)
+;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
+(include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "centaur/gl/gl" :dir :system)
 ;; Including the WC program binary and other misc. stuff:
 (include-book "wc-addr-byte")


### PR DESCRIPTION
The app-view proofs now include the app-view/top proof-utilities book, which is the official book to include for such proofs.