### PR TITLE
[X86ISA] Remove subsumed rule.

### DIFF
--- a/books/kestrel/x86/support-x86.lisp
+++ b/books/kestrel/x86/support-x86.lisp
@@ -61,8 +61,8 @@
   (implies (x86p x86)
            (x86p (xw x86isa::fld x86isa::index value x86))))
 
-(in-theory (disable x86isa::x86p-xw ;does forcing, which causes problems in various places
-                    x86isa::x86p-!rip-when-val-is-canonical-address-p ;todo: remove this rule altogether since it is subsumed by x86p-xw
+(in-theory (disable x86isa::x86p-xw
+                    ;x86isa::x86p-!rip-when-val-is-canonical-address-p ;todo: remove this rule altogether since it is subsumed by x86p-xw  ;does forcing, which causes problems in various places
                     ))
 
 (defthm rflags-is-n32p-unforced

--- a/books/projects/x86isa/proofs/utilities/general-memory-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/general-memory-utils.lisp
@@ -304,11 +304,6 @@
            (integerp (xr :rip index x86)))
   :rule-classes :type-prescription)
 
-(defthm x86p-!rip-when-val-is-canonical-address-p
-  (implies (forced-and (x86p x86)
-                       (canonical-address-p v))
-           (x86p (xw :rip index v x86))))
-
 (defthm canonical-address-p-to-integerp-thm
   (implies (canonical-address-p x)
            (integerp x))


### PR DESCRIPTION
This is subsumed by x86p-xw, which is much more general.  That rule is:

(defthm x86p-xw
  (implies (x86p x86)
           (x86p (xw fld index val x86))))

My only hesitation in removing x86p-!rip-when-val-is-canonical-address-p is that it has a force on the x86p hyp (so x86p-xw may not be strictly better), but the forcing doesn't seem to be needed anywhere.