### PR TITLE
[Std/basic] Remove duplicate rule.

### DIFF
--- a/books/centaur/misc/tarjan.lisp
+++ b/books/centaur/misc/tarjan.lisp
@@ -282,7 +282,7 @@
 
   (fty::deffixequiv-mutual tarjan-sccs)
 
-  (local (in-theory (disable NFIX-POSITIVE-TO-NON-ZP NFIX-GT-0 DEFAULT-<-1)))
+  (local (in-theory (disable NFIX-POSITIVE-TO-NON-ZP DEFAULT-<-1)))
 
   (local (defthm subsetp-when-suffix
            (implies (suffixp a b)

--- a/books/std/basic/arith-equivs.lisp
+++ b/books/std/basic/arith-equivs.lisp
@@ -94,10 +94,6 @@
 
 ;; And there are similar rules we can use to normalize things into ZP, ZIP, etc.
 
-(defthm nfix-gt-0
-  (equal (< 0 (nfix x))
-         (not (zp x))))
-
 (defthm ifix-equal-to-0
   (equal (equal (ifix x) 0)
          (zip x)))


### PR DESCRIPTION
Remove nfix-gt-0 as it is the same as the rule nfix-positive-to-non-zp in the same file.