### PR TITLE
[X86ISA] Reduce dependencies of proof utils.

### DIFF
--- a/books/kestrel/x86/support-x86.lisp
+++ b/books/kestrel/x86/support-x86.lisp
@@ -19,7 +19,7 @@
 (include-book "projects/x86isa/proofs/utilities/row-wow-thms" :dir :system) ; for X86ISA::WRITE-USER-RFLAGS-AND-XW
 (include-book "projects/x86isa/proofs/utilities/app-view/user-level-memory-utils" :dir :system) ; for rb-rb-subset
 (include-book "projects/x86isa/machine/state" :dir :system)
-;(include-book "projects/x86isa/machine/x86" :dir :system)
+(include-book "projects/x86isa/machine/x86" :dir :system) ; for ONE-BYTE-OPCODE-EXECUTE, etc.
 (include-book "projects/x86isa/machine/get-prefixes" :dir :system)
 ;(include-book "projects/x86isa/machine/state-field-thms" :dir :system)
 (include-book "projects/x86isa/machine/application-level-memory" :dir :system) ;for canonical-address-p

--- a/books/projects/x86isa/proofs/utilities/app-view/environment-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/app-view/environment-utils.lisp
@@ -40,6 +40,7 @@
 
 (in-package "X86ISA")
 (include-book "row-wow-thms" :ttags :all :dir :proof-utils)
+(include-book "../../../machine/syscalls")
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/proofs/utilities/app-view/top.lisp
+++ b/books/projects/x86isa/proofs/utilities/app-view/top.lisp
@@ -41,6 +41,8 @@
 ;; This is the top-level book to include when reasoning about code in
 ;; the application-level view.
 
+(include-book "x86" :ttags :all :dir :machine)
+(include-book "../basics" :ttags :all)
 (include-book "environment-utils" :ttags :all)
 (include-book "user-level-memory-utils" :ttags :all)
 

--- a/books/projects/x86isa/proofs/utilities/app-view/user-level-memory-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/app-view/user-level-memory-utils.lisp
@@ -38,6 +38,7 @@
 
 (in-package "X86ISA")
 
+(include-book "basics" :ttags :all :dir :proof-utils)
 (include-book "row-wow-thms" :ttags :all :dir :proof-utils)
 (include-book "general-memory-utils" :ttags :all :dir :proof-utils)
 (include-book "clause-processors/find-subterms" :dir :system)

--- a/books/projects/x86isa/proofs/utilities/basics.lisp
+++ b/books/projects/x86isa/proofs/utilities/basics.lisp
@@ -39,7 +39,7 @@
 ;; ===================================================================
 
 (in-package "X86ISA")
-(include-book "x86" :ttags :all :dir :machine)
+(include-book "ihs/basic-definitions" :dir :system)
 (include-book "../../portcullis/utils")
 (include-book "tools/mv-nth" :dir :system)
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/proofs/utilities/general-memory-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/general-memory-utils.lisp
@@ -38,8 +38,10 @@
 
 (in-package "X86ISA")
 
-(include-book "basics" :ttags :all :dir :proof-utils)
+(include-book "../../portcullis/utils")
 (include-book "disjoint" :dir :proof-utils)
+(include-book "../../machine/linear-memory")
+(include-book "../../machine/decoding-and-spec-utils")
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "arithmetic/top-with-meta" :dir :system))

--- a/books/projects/x86isa/proofs/utilities/row-wow-thms.lisp
+++ b/books/projects/x86isa/proofs/utilities/row-wow-thms.lisp
@@ -38,7 +38,9 @@
 
 (in-package "X86ISA")
 
-(include-book "basics" :ttags (:undef-flg :syscall-exec :other-non-det))
+(include-book "../../machine/state")
+(include-book "../../machine/environment")
+(include-book "../../machine/decoding-and-spec-utils")
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ===================================================================

--- a/books/projects/x86isa/proofs/utilities/sys-view/marking-view-top.lisp
+++ b/books/projects/x86isa/proofs/utilities/sys-view/marking-view-top.lisp
@@ -41,6 +41,9 @@
 ; Yahya Sohail        <yahya.sohail@intel.com>
 
 (in-package "X86ISA")
+
+(include-book "x86" :ttags :all :dir :machine)
+(include-book "../basics" :ttags :all)
 (include-book "marking-view-utils")
 
 (local (include-book "gl-lemmas"))

--- a/books/projects/x86isa/proofs/utilities/sys-view/marking-view-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/sys-view/marking-view-utils.lisp
@@ -41,6 +41,7 @@
 ; Yahya Sohail        <yahya.sohail@intel.com>
 
 (in-package "X86ISA")
+(include-book "../../../machine/get-prefixes")
 (include-book "common-system-level-utils")
 (include-book "paging/top")
 (include-book "clause-processors/find-subterms" :dir :system)
@@ -1195,8 +1196,8 @@
       (in-theory (e/d ()
                       ((:definition member-equal)
                        (:definition rme08$inline)
-                       (:linear mv-nth-1-idiv-spec)
-                       (:linear mv-nth-1-div-spec)
+                       ; (:linear mv-nth-1-idiv-spec)
+                       ; (:linear mv-nth-1-div-spec)
                        (:rewrite ia32e-la-to-pa-in-app-view)
                        (:type-prescription 64-bit-modep)
                        (:rewrite xr-and-ia32e-la-to-pa-in-non-marking-view)
@@ -2456,8 +2457,8 @@
                        infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-1)
                       (:rewrite
                        infer-disjointness-with-all-xlation-governing-entries-paddrs-from-gather-all-paging-structure-qword-addresses-2)
-                      (:linear mv-nth-1-idiv-spec)
-                      (:linear mv-nth-1-div-spec)
+                      ; (:linear mv-nth-1-idiv-spec)
+                      ; (:linear mv-nth-1-div-spec)
                       (:definition len)
                       (:rewrite cdr-mv-nth-1-las-to-pas-no-error)
                       (:rewrite default-+-1)

--- a/books/projects/x86isa/proofs/utilities/sys-view/non-marking-view-top.lisp
+++ b/books/projects/x86isa/proofs/utilities/sys-view/non-marking-view-top.lisp
@@ -41,6 +41,9 @@
 ; Yahya Sohail        <yahya.sohail@intel.com>
 
 (in-package "X86ISA")
+
+(include-book "x86" :ttags :all :dir :machine)
+(include-book "../basics" :ttags :all)
 (include-book "common-system-level-utils")
 (include-book "paging/top")
 

--- a/books/projects/x86isa/proofs/utilities/sys-view/physical-memory-utils.lisp
+++ b/books/projects/x86isa/proofs/utilities/sys-view/physical-memory-utils.lisp
@@ -243,7 +243,8 @@
                             (n32p-lower-16-val-logior-loghead-ash
                              combining-logior-of-loghead-and-ash-loghead-logtail
                              combining-logior-of-loghead-and-ash-logtail
-                             putting-logior-loghead-ash-logtail-together))
+                             ;; putting-logior-loghead-ash-logtail-together
+                             ))
             :use ((:instance n32p-lower-16-val-logior-loghead-ash))))))
 
 
@@ -335,7 +336,7 @@
                              (force)
                              member-p-cons
                              acl2::commutativity-of-logior
-                             mv-nth-2-rcl-spec-16
+                             ;; mv-nth-2-rcl-spec-16
                              write-to-physical-memory-xw-mem-member-p
                              (:linear bitops::logior-<-0-linear-2)
                              (:type-prescription bitops::logior-natp-type)


### PR DESCRIPTION
Most of these books don't need to include all the instructions.  I did ensure that the top.lisp books still include everything that they did before.