### PR TITLE
x86isa: Update opcode maps to include X87 instructions

### DIFF
--- a/books/projects/x86isa/machine/catalogue-data.lisp
+++ b/books/projects/x86isa/machine/catalogue-data.lisp
@@ -175,38 +175,47 @@ perhaps similar to those of MOV to a segment register</li>
 ;; (def-sdm-instruction-section "5.1.16.1 Detection of VEX-Encoded GPR Instructions, LZCNT, TZCNT, and PREFETCHW")
 
 (def-sdm-instruction-section "5.2 X87 FPU Instructions")
-;;   :mnemonics '(FLD FST FSTP FILD FIST FISTP1 FBLD FBSTP FXCH FCMOVE FCMOVNE
-;;                    FCMOVB FCMOVBE FCMOVNB FCMOVNBE FCMOVU FCMOVNU)
-;;   )
-(def-sdm-instruction-section "5.2.1 X87 FPU Data Transfer Instructions"
-  :doc "<p>Decoding isn't implemented for X87 instructions (D8-DF escapes from
-one byte opcode map)</p>")
-(def-sdm-instruction-section "5.2.2 X87 FPU Basic Arithmetic Instructions"
-  :doc "<p>Decoding isn't implemented for X87 instructions (D8-DF escapes from
-one byte opcode map)</p>")
-(def-sdm-instruction-section "5.2.3 X87 FPU Comparison Instructions"
-  :doc "<p>Decoding isn't implemented for X87 instructions (D8-DF escapes from
-one byte opcode map)</p>")
-(def-sdm-instruction-section "5.2.4 X87 FPU Transcendental Instructions"
-  :doc "<p>Decoding isn't implemented for X87 instructions (D8-DF escapes from
-one byte opcode map)</p>")
-(def-sdm-instruction-section "5.2.5 X87 FPU Load Constants Instructions"
-  :doc "<p>Decoding isn't implemented for X87 instructions (D8-DF escapes from
-one byte opcode map)</p>")
-(def-sdm-instruction-section "5.2.6 X87 FPU Control Instructions"
-  :doc "<p>Decoding isn't implemented for X87 instructions (D8-DF escapes from
-one byte opcode map).</p>
 
-<p>Note also a few of X86 control instructions are listed in the SDM as being
+(def-sdm-instruction-section "5.2.1 X87 FPU Data Transfer Instructions"
+  :mnemonics '(FLD FST FSTP FILD FIST FISTP FBLD FBSTP FXCH FCMOVE FCMOVNE
+                   FCMOVB FCMOVBE FCMOVNB FCMOVNBE FCMOVU FCMOVNU))
+(def-sdm-instruction-section "5.2.2 X87 FPU Basic Arithmetic Instructions"
+  :mnemonics
+  '(FADD FADDP FIADD FSUB FSUBP FISUB FSUBR FSUBRP FISUBR FMUL FMULP FIMUL FDIV
+ FDIVP FIDIV FDIVR FDIVRP FIDIVR FPREM FPREM1 FABS FCHS FRNDINT FSCALE FSQRT
+ FXTRACT))
+
+(def-sdm-instruction-section "5.2.3 X87 FPU Comparison Instructions"
+  :mnemonics
+  '(FCOM FCOMP FCOMPP FUCOM FUCOMP FUCOMPP FICOM FICOMP FCOMI FUCOMI FCOMIP
+ FUCOMIP FTST FXAM))
+
+(def-sdm-instruction-section "5.2.4 X87 FPU Transcendental Instructions"
+  :mnemonics
+  '(FSIN FCOS FSINCOS FPTAN FPATAN F2XM1 FYL2X FYL2XP1))
+
+(def-sdm-instruction-section "5.2.5 X87 FPU Load Constants Instructions"
+  :mnemonics
+  '(FLD1 FLDZ FLDPI FLDL2E FLDLN2 FLDL2T FLDLG2))
+
+(def-sdm-instruction-section "5.2.6 X87 FPU Control Instructions"
+  :mnemonics
+  '(FINCSTP FDECSTP FFREE ;; FINIT
+            FNINIT        ;; FCLEX
+            FNCLEX        ;; FSTCW
+            FNSTCW FLDCW  ;; FSTENV
+            FNSTENV FLDENV ;; FSAVE
+            FNSAVE FRSTOR  ;; FSTSW
+            FNSTSW FWAIT/WAIT FNOP)
+  :doc "
+<p>Note a few of X86 control instructions are listed in the SDM as being
 encoded using 0x9B as a prefix. This is a bit weird since 9B is also an opcode
 on its own, FWAIT/WAIT. It seems as though the behavior of these 9B-prefixed
 instructions is basically to wait for exceptions and then (if no exception) do
 what the instruction. Not sure why they are listed that way.</p>")
 
 (def-sdm-instruction-section "5.3 X87 FPU and SIMD State Management Instructions"
-  :mnemonics '(FXSAVE FXRSTOR
-                      ;; added -- not present in SDM listing
-                      FWAIT/WAIT))
+  :mnemonics '(FXSAVE FXRSTOR))
 
 (def-sdm-instruction-section "5.4 MMX Instructions")
 (def-sdm-instruction-section "5.4.1 MMX Data Transfer Instructions"
@@ -381,7 +390,7 @@ float-integer are implemented as are scalar and packed float-float.</p>")
 
 (def-sdm-instruction-section "5.7 Intel(R) SSE3 Instructions")
 (def-sdm-instruction-section "5.7.1 Intel(R) SSE3 x87-FP Integer Conversion Instruction"
-  :doc "<p>Like other x87 instructions, FISTTP is not listed in opcode maps</p>")
+  :mnemonics '(FISTTP))
 
 (def-sdm-instruction-section "5.7.2 Intel(R) SSE3 Specialized 128-Bit Unaligned Data Load Instruction"
   :mnemonics '(LDDQU)

--- a/books/projects/x86isa/machine/inst-listing.lisp
+++ b/books/projects/x86isa/machine/inst-listing.lisp
@@ -1736,46 +1736,991 @@
     (INST "XLAT/XLATB" (OP :OP #xD7)
           NIL 'NIL
           '((:UD (UD-LOCK-USED))))
-    (INST :ESC (OP :OP #xD8)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+
+    
+    ;; X87 instruction entries (#xD8 through #xDF) generated from xed datafiles using:
+    ;; xedscan.py ~/work/xed/datafiles/xed-isa.txt xed-x87.txt
+
+    ;; See comments in xedscan.py for notes on how to extend to more instructions
+    
+    (INST "FADD"
+          (OP :OP #xd8 :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xD9)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FMUL"
+          (OP :OP #xd8 :REG 1 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xDA)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FCOMP"
+          (OP :OP #xd8 :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xDB)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FSUB"
+          (OP :OP #xd8 :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xDC)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FSUBR"
+          (OP :OP #xd8 :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xDD)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FDIV"
+          (OP :OP #xd8 :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xDE)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FDIVR"
+          (OP :OP #xd8 :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
-    (INST :ESC (OP :OP #xDF)
-          'NIL
-          'NIL
-          '((:NM (NM-CR0-TS-IS-1)
+    (INST "FADD"
+          (OP :OP #xd8 :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
                  (NM-CR0-EM-IS-1))))
+    (INST "FMUL"
+          (OP :OP #xd8 :REG 1 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOM"
+          (OP :OP #xdc :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOM"
+          (OP :OP #xd8 :REG 2 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FCOM"
+;;           (OP :OP #xdc :REG 2 :MOD 3 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+    (INST "FCOMP"
+          (OP :OP #xd8 :REG 3 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FCOMP"
+;;           (OP :OP #xde :REG 2 :MOD 3 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+    (INST "FSUB"
+          (OP :OP #xd8 :REG 4 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUBR"
+          (OP :OP #xd8 :REG 5 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIV"
+          (OP :OP #xd8 :REG 6 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIVR"
+          (OP :OP #xd8 :REG 7 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLD"
+          (OP :OP #xd9 :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FST"
+          (OP :OP #xd9 :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSTP"
+          (OP :OP #xdd :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSTP"
+          (OP :OP #xdd :REG 3 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FSTP"
+;;           (OP :OP #xdf :REG 3 :MOD 3 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FSTPNCE"
+;;           (OP :OP #xd9 :REG 3 :MOD 3 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+    (INST "FLDENV"
+          (OP :OP #xd9 :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDCW"
+          (OP :OP #xd9 :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FNSTENV"
+          (OP :OP #xd9 :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FNSTCW"
+          (OP :OP #xd9 :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLD"
+          (OP :OP #xd9 :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FXCH"
+          (OP :OP #xd9 :REG 1 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FXCH"
+;;           (OP :OP #xdd :REG 1 :MOD 3 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+    (INST "FNOP"
+          (OP :OP #xd9 :REG 2 :MOD 3 :R/M 0 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCHS"
+          (OP :OP #xd9 :REG 4 :MOD 3 :R/M 0 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FABS"
+          (OP :OP #xd9 :REG 4 :MOD 3 :R/M 1 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FTST"
+          (OP :OP #xd9 :REG 4 :MOD 3 :R/M 4 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FXAM"
+          (OP :OP #xd9 :REG 4 :MOD 3 :R/M 5 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLD1"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 0 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDL2T"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 1 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDL2E"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 2 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDPI"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDLG2"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 4 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDLN2"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 5 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLDZ"
+          (OP :OP #xd9 :REG 5 :MOD 3 :R/M 6 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "F2XM1"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 0 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FYL2X"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 1 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FPTAN"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 2 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FPATAN"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FXTRACT"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 4 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FPREM1"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 5 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDECSTP"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 6 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FINCSTP"
+          (OP :OP #xd9 :REG 6 :MOD 3 :R/M 7 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FPREM"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 0 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FYL2XP1"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 1 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSQRT"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 2 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSINCOS"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FRNDINT"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 4 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSCALE"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 5 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSIN"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 6 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOS"
+          (OP :OP #xd9 :REG 7 :MOD 3 :R/M 7 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIADD"
+          (OP :OP #xda :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIMUL"
+          (OP :OP #xda :REG 1 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FICOM"
+          (OP :OP #xda :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FICOMP"
+          (OP :OP #xda :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISUB"
+          (OP :OP #xda :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISUBR"
+          (OP :OP #xda :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIDIV"
+          (OP :OP #xda :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIDIVR"
+          (OP :OP #xda :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVB"
+          (OP :OP #xda :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVE"
+          (OP :OP #xda :REG 1 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVBE"
+          (OP :OP #xda :REG 2 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVU"
+          (OP :OP #xda :REG 3 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FUCOMPP"
+          (OP :OP #xda :REG 5 :MOD 3 :R/M 1 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FILD"
+          (OP :OP #xdb :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISTTP"
+          (OP :OP #xdb :REG 1 :MOD :MEM)
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIST"
+          (OP :OP #xdb :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISTP"
+          (OP :OP #xdb :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLD"
+          (OP :OP #xdb :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVNB"
+          (OP :OP #xdb :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVNE"
+          (OP :OP #xdb :REG 1 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVNBE"
+          (OP :OP #xdb :REG 2 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCMOVNU"
+          (OP :OP #xdb :REG 3 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FNCLEX"
+          (OP :OP #xdb :REG 4 :MOD 3 :R/M 2 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FNINIT"
+          (OP :OP #xdb :REG 4 :MOD 3 :R/M 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FSETPM287_NOP"
+;;           (OP :OP #xdb :REG 4 :MOD 3 :R/M 4 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FENI8087_NOP"
+;;           (OP :OP #xdb :REG 4 :MOD 3 :R/M 0 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FDISI8087_NOP"
+;;           (OP :OP #xdb :REG 4 :MOD 3 :R/M 1 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+    (INST "FUCOMI"
+          (OP :OP #xdb :REG 5 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOMI"
+          (OP :OP #xdb :REG 6 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FADD"
+          (OP :OP #xdc :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FMUL"
+          (OP :OP #xdc :REG 1 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOMP"
+          (OP :OP #xdc :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUB"
+          (OP :OP #xdc :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUBR"
+          (OP :OP #xdc :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIV"
+          (OP :OP #xdc :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIVR"
+          (OP :OP #xdc :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FADD"
+          (OP :OP #xdc :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FMUL"
+          (OP :OP #xdc :REG 1 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUBR"
+          (OP :OP #xdc :REG 4 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUB"
+          (OP :OP #xdc :REG 5 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIVR"
+          (OP :OP #xdc :REG 6 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIV"
+          (OP :OP #xdc :REG 7 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FLD"
+          (OP :OP #xdd :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISTTP"
+          (OP :OP #xdd :REG 1 :MOD :MEM)
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FST"
+          (OP :OP #xdd :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FRSTOR"
+          (OP :OP #xdd :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FNSAVE"
+          (OP :OP #xdd :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FNSTSW"
+          (OP :OP #xdd :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FFREE"
+          (OP :OP #xdd :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FST"
+          (OP :OP #xdd :REG 2 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FUCOM"
+          (OP :OP #xdd :REG 4 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FUCOMP"
+          (OP :OP #xdd :REG 5 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIADD"
+          (OP :OP #xde :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIMUL"
+          (OP :OP #xde :REG 1 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FICOM"
+          (OP :OP #xde :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FICOMP"
+          (OP :OP #xde :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISUB"
+          (OP :OP #xde :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISUBR"
+          (OP :OP #xde :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIDIV"
+          (OP :OP #xde :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIDIVR"
+          (OP :OP #xde :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FADDP"
+          (OP :OP #xde :REG 0 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FMULP"
+          (OP :OP #xde :REG 1 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOMPP"
+          (OP :OP #xde :REG 3 :MOD 3 :R/M 1 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUBRP"
+          (OP :OP #xde :REG 4 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FSUBP"
+          (OP :OP #xde :REG 5 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIVRP"
+          (OP :OP #xde :REG 6 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FDIVP"
+          (OP :OP #xde :REG 7 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FILD"
+          (OP :OP #xdf :REG 0 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISTTP"
+          (OP :OP #xdf :REG 1 :MOD :MEM)
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FIST"
+          (OP :OP #xdf :REG 2 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISTP"
+          (OP :OP #xdf :REG 3 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FBLD"
+          (OP :OP #xdf :REG 4 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FILD"
+          (OP :OP #xdf :REG 5 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FBSTP"
+          (OP :OP #xdf :REG 6 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FISTP"
+          (OP :OP #xdf :REG 7 :MOD :MEM :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+;; Undocumented (from xed-isa.txt):
+;;     (INST "FFREEP"
+;;           (OP :OP #xdf :REG 0 :MOD 3 :FEAT '(:FPU))
+;;           (ARG) ;; bozo x87 conventions
+;;           nil
+;;           '((:UD (UD-LOCK-USED))
+;;             (:NM (NM-CR0-TS-IS-1)
+;;                  (NM-CR0-EM-IS-1))))
+    (INST "FNSTSW"
+          (OP :OP #xdf :REG 4 :MOD 3 :R/M 0 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FUCOMIP"
+          (OP :OP #xdf :REG 5 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+    (INST "FCOMIP"
+          (OP :OP #xdf :REG 6 :MOD 3 :FEAT '(:FPU))
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))
+
+;; end x87 instructions generated by xedscan.py
+    
     (INST "LOOPNE/LOOPNZ"
           (OP :OP #xE0 :SUPERSCRIPTS '(:F64))
           (ARG :OP1 '(J B))

--- a/books/projects/x86isa/machine/xedscan.py
+++ b/books/projects/x86isa/machine/xedscan.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# X86ISA Library
+# Copyright (C) 2024 Kestrel Technology, LLC
+#
+# License: A 3-clause BSD license. See the file books/3BSD-mod.txt.
+#
+# Author: Sol Swords (sswords@gmail.com)
+
+import sys
+import re
+
+usage = """Usage: xedscan.py datafile.txt output.lsp
+
+NOTE: (Sol Swords, 1/4/2025)
+
+At the moment this is a small proof of concept for generating
+inst-listing.lisp opcode map entries by parsing XED data files.
+See the comments in this python script for more details.
+"""
+
+
+# This was designed to pick up the X87 instruction set which was
+# missing from our opcode maps. These use the "escape" opcodes D8
+# through DF so we look for these opcodes and ignore all others. While
+# the SDM treats these instructions specially (has tables for them
+# separate from the standard opcode maps), their decoding isn't much
+# different -- they just pack a lot of instructions into 8 opcodes by
+# using MOD and sometimes RM bits as opcode extensions.  These are
+# denoted in xed-isa.txt (from the xed source distribution) as in the
+# following examples:
+
+# PATTERN   : 0xDC MOD[mm] MOD!=3 REG[0b110] RM[nnn] MODRM()
+
+# This breaks down as:
+# 0xDC -- the opcode (multibyte opcodes are formatted as e.g. 0x0F 0x01)
+# MOD[mm] -- I think this notation just means that this field isn't fixed, maybe binds some variable mm to the decoded value?
+# MOD!=3 -- signifies the MOD fiel of MODRM d can't be 3
+# REG[0b110] -- REG field of MODRM must be 6
+# RM[nnn] -- again signifies RM field isn't fixed, maybe bound to nnn
+# MODRM() -- maybe signifies that a MODRM byte is required? not sure, not always present.
+
+# PATTERN   : 0xD9 MOD[0b11] MOD=3 REG[0b100] RM[0b001]
+
+# This breaks down as:
+# 0xD9: opcode
+# MOD[0b11] -- MOD field must be 3
+# MOD=3     -- MOD field must be 3, not sure what difference is to the above -- they always coincide
+# REG[0b100] -- REG field must be 4
+# RM[0b001] -- RM field must be 1.
+
+# Despite not understanding a fair amount about these, this is
+# sufficient to make basic opcode map entries for these x87 instructions.
+
+# One thing we haven't explored is generating ARG entries for better instruction decoding.
+
+# Exception conditions don't seem to be covered by the XED data files
+# unless I'm missing something. We've hardcoded exceptions common to
+# x87 instructions.
+
+# Further use of the XED data files to extend / check accuracy of our
+# opcode maps would be a good idea.  This script maybe provides a
+# starting point, though there are lots of cases it won't handle.
+
+
+
+if (len(sys.argv) != 3):
+    print(usage, file=sys.stderr)
+
+inname = sys.argv[1]
+outname = sys.argv[2]
+
+# Integer constants in xed datafiles seem to be either decimal or
+# prefixed 0x or 0b.  But many places can have either an integer or
+# some other string value, e.g. the RM field may be an integer or
+# 'nnn'. So in those cases we catch the execption and return the input string.
+def maybe_parse_integer(tok):
+    code = tok[0:2]
+    val = tok
+    try:
+        if (code == "0x"):
+            val = int(tok[2:], 16)
+        elif (code == "0b"):
+            val = int(tok[2:], 2)
+        else:
+            val = int(tok)
+    except ValueError:
+        None
+    return val
+
+
+# At the moment I'm recognizing patterns that contain the following sorts of elements:
+# 0xAB -- opcode bytes (only at the beginning)
+# KEY[val] where val is perhaps a number
+# KEY=val where val is perhaps a number (not sure if there's any difference)
+#  (note we don't include KEY!=val here -- we just say key can't end in !)
+# Other strings, which are just stored as keys associated to True.
+def parse_pattern(pat):
+    obj = {}
+    tokens = pat.split(" ")
+    opcode = 0
+    it = iter(tokens)
+    for tok in it:
+        if (tok[0:2] == "0x"):
+            opcode = (opcode<<8) + int(tok[2:], 16)
+        else:
+            break
+    obj['opcode'] = opcode
+    for tok in it:
+        if (m := re.search("^(?P<key>.*)\\[(?P<val>.*)\\]$", tok)):
+            obj[m.group('key')] = maybe_parse_integer(m.group('val'))
+        elif (m := re.search("^(?P<key>.*[^!])=(?P<val>.*)$", tok)):
+            obj[m.group('key')] = maybe_parse_integer(m.group('val'))
+        else:
+            obj[tok] = True
+    return obj
+        
+            
+    
+# This just reads lines of the form KEY : VAL until we reach a closing
+# } (on its own line).  For the PATTERN key, we parse the value using
+# parse_pattern above, otherwise we just store the value as a string.
+def parse_inst(infile):
+    obj = {}
+    for line in infile:
+        while ((len(line) >= 2) and (line[-2] == '\\')):
+            # join subsequent lines while they end in \
+            line = line[:-2] + next(infile)
+        line = line.strip()
+        if (line == "}"):
+            return obj
+        if (line == "" or line[0] == "#"):
+            continue
+        sides = line.split(":", 1)
+        if (len(sides) != 2):
+            print("bad line: " + line, file=sys.stderr)
+            continue
+        key = sides[0].strip()
+        val = sides[1].strip()
+        if (key == "PATTERN"):
+            val = parse_pattern(val)
+        obj[key] = val
+
+# Read and parse the xed data file into a bunch of inst objects, which
+# are just dictionaries; at the moment only the PATTERN entry is
+# parsed further, the rest are just stored as strings.
+insts = []
+with open(inname, "r", encoding="utf-8") as infile:
+    for line in infile:
+        while ((len(line) >= 2) and (line[-2] == '\\')):
+            # join subsequent lines while they end in \
+            line = line[:-2] + next(infile)
+        line = line.strip()
+        if (line == "{"):
+            insts.append(parse_inst(infile))
+
+def parse_features(extension):
+    if (extension == "X87"):
+        return " :FEAT '(:FPU)"
+    else:
+        return ""
+    # if (extension == "BASE"):
+    #     return ""
+    # elif
+    # else:
+    #     return " :FEAT '(:%s)" % extension
+
+def lisp_comment(string):
+    res = ""
+    for line in string.splitlines(True): # keep line breaks
+        res = res + ";; " + line
+    return res
+
+# Write out a list of INST forms (opcode map entries) based on what was read from the file
+with open(outname, "w", encoding="utf-8") as outfile:
+    outfile.write('''\
+;; Generated using:
+;; xedscan.py %s %s\n\n''' % (inname, outname))
+    for inst in insts:
+        opcode = inst["PATTERN"]['opcode']
+        # print("opcode: %x opcode>>8: %x opcode&0xf8: %x" % (opcode, opcode>>8, opcode & 0xf8));
+        if ((opcode & 0xf8 == 0xd8) and (opcode >> 8 == 0)):
+            pattern = inst["PATTERN"]
+            rm = pattern["RM"]
+            inst_entry = '''\
+    (INST "%s"
+          (OP :OP #x%x :REG %s :MOD %s%s%s)
+          (ARG) ;; bozo x87 conventions
+          nil
+          '((:UD (UD-LOCK-USED))
+            (:NM (NM-CR0-TS-IS-1)
+                 (NM-CR0-EM-IS-1))))\n''' % (inst["ICLASS"],
+                                           opcode,
+                                           str(pattern["REG"]),
+                                           ":MEM" if ('MOD!=3' in pattern) else str(pattern["MOD"]),
+                                           "" if (rm == 'nnn') else " :R/M " + str(rm),
+                                           parse_features(inst["EXTENSION"]) if "EXTENSION" in inst else "")
+            # Comment out the inst entry if it is marked UNDOCUMENTED.
+            if ("ATTRIBUTES" in inst and inst["ATTRIBUTES"].find("UNDOCUMENTED") >= 0):
+                inst_entry = ";; Undocumented (from xed-isa.txt):\n" + lisp_comment(inst_entry)
+            
+            outfile.write(inst_entry)


### PR DESCRIPTION
I generated basic opcode map entries for the x87 instructions from the XED datafile xed-isa.txt, just scanning it with a python script. This should be sufficient for matching the instructions to their opcode/mod/reg/rm combinations. I didn't try to generate argument entries -- I think we need some new types of entries for that. I also didn't read the exceptions from xed, just generated them with exceptions common to x87 instructions.

Note the SDM is pretty confusing in how it talks about X87 operations. They're not listed in the regular opcode maps, instead they have their own sub-tables (volume 2, appendix A-5). But for all that they are really just opcodes qualified by some extra fields of the mod/rm, which our opcode maps are already able to handle.