### PR TITLE
[X86ISA] Speed up bitstruct proofs.

### DIFF
--- a/books/projects/x86isa/utils/basic-structs.lisp
+++ b/books/projects/x86isa/utils/basic-structs.lisp
@@ -40,6 +40,11 @@
 
 (include-book "centaur/fty/bitstruct" :dir :system)
 
+;; We do these once, here, to avoid each defbitstruct below doing them locally:
+(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
+(local (include-book "centaur/bitops/equal-by-logbitp" :dir :system))
+(local (include-book "arithmetic/top-with-meta" :dir :system))
+
 (local (xdoc::set-default-parents structures))
 
 ;; Bitstruct field widths:

--- a/books/projects/x86isa/utils/fp-structures.lisp
+++ b/books/projects/x86isa/utils/fp-structures.lisp
@@ -41,6 +41,11 @@
 (include-book "utilities")
 (include-book "basic-structs")
 
+;; We do these once, here, to avoid each defbitstruct below doing them locally:
+(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
+(local (include-book "centaur/bitops/equal-by-logbitp" :dir :system))
+(local (include-book "arithmetic/top-with-meta" :dir :system))
+
 ;; ----------------------------------------------------------------------
 
 (defsection fp-bitstructs

--- a/books/projects/x86isa/utils/paging-structures.lisp
+++ b/books/projects/x86isa/utils/paging-structures.lisp
@@ -40,6 +40,11 @@
 
 (include-book "basic-structs")
 
+;; We do these once, here, to avoid each defbitstruct below doing them locally:
+(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
+(local (include-book "centaur/bitops/equal-by-logbitp" :dir :system))
+(local (include-book "arithmetic/top-with-meta" :dir :system))
+
 ;; ----------------------------------------------------------------------
 
 (defsection paging-bitstructs

--- a/books/projects/x86isa/utils/segmentation-structures.lisp
+++ b/books/projects/x86isa/utils/segmentation-structures.lisp
@@ -40,6 +40,11 @@
 
 (include-book "basic-structs")
 
+;; We do these once, here, to avoid each defbitstruct below doing them locally:
+(local (include-book "centaur/bitops/ihsext-basics" :dir :system))
+(local (include-book "centaur/bitops/equal-by-logbitp" :dir :system))
+(local (include-book "arithmetic/top-with-meta" :dir :system))
+
 ;; ----------------------------------------------------------------------
 
 (defsection segmentation-bitstructs

--- a/books/projects/x86isa/utils/structures.lisp
+++ b/books/projects/x86isa/utils/structures.lisp
@@ -46,6 +46,10 @@
 
 (local (include-book "centaur/bitops/ihsext-basics" :dir :system))
 
+;; We do these once, here, to avoid each defbitstruct below doing them locally:
+(local (include-book "centaur/bitops/equal-by-logbitp" :dir :system))
+(local (include-book "arithmetic/top-with-meta" :dir :system))
+
 (std::make-define-config
  :no-function t
  :inline t)


### PR DESCRIPTION
Each call to defbitstruct locally includes some helper books.  To avoid doing those includes over and over, we do them (locally) at the start of each book that calls defbitstruct repeatedly.

This saves about 14 seconds of the 60 seconds needed for this directory, on a very fast machine.