### PR TITLE
x86isa: Introduce `testgen` a test generator for asmtest

### DIFF
--- a/books/projects/x86isa/tools/execution/asmtest/.gitignore
+++ b/books/projects/x86isa/tools/execution/asmtest/.gitignore
@@ -1,0 +1,12 @@
+check-test
+check-test.*
+!check-test.lsp
+inputs
+results
+outputs
+snippets/testgen.nasm
+snippets-generated.txt
+snippets-combined.txt
+asmtest
+snippets.lsp
+snippets.h

--- a/books/projects/x86isa/tools/execution/asmtest/Makefile
+++ b/books/projects/x86isa/tools/execution/asmtest/Makefile
@@ -7,10 +7,10 @@ snippets.lsp : asmtest
 
 asmtest:
 
-SNIPPET_OBJS := $(patsubst %.nasm,%.o,$(wildcard snippets/*.nasm))
+SNIPPET_OBJS := $(patsubst %.nasm,%.o,$(wildcard snippets/*.nasm)) snippets/testgen.o
 
 
-snippets/%.o : snippets/%.nasm snippets/utils.mac
+snippets/%.o : snippets/%.nasm snippets/utils.mac snippets/testgen.nasm
 	cd snippets; nasm -f elf64 $*.nasm
 
 %.o : %.c
@@ -21,9 +21,32 @@ asmtest.o : asmtest.h snippets.h
 asmtest: asmtest.o $(SNIPPET_OBJS)
 	gcc -g $^ -o asmtest
 
-snippets.h : snippets.txt
+snippets.h : snippets-combined.txt
 	./snippet_table.py h
+
+testgen/testgen:
+	cd testgen && make testgen
+
+snippets-generated.txt snippets/testgen.nasm: testgen/testgen
+	./testgen/testgen -a snippets/testgen.nasm -t snippets-generated.txt
+
+snippets-combined.txt: snippets-generated.txt
+	echo "# Generated file -- do not edit" | cat - snippets.txt snippets-generated.txt > snippets-combined.txt
+
+check-test: snippets.lsp
+ifndef ACL2
+	$(error Variable ACL2 is undefined.)
+endif
+	< check-test.lsp $(ACL2)
+
+.PHONY: test
+test: check-test snippets.txt asmtest snippets.lsp
+	rm -rf inputs outputs results
+	mkdir -p inputs outputs
+	< snippets-combined.txt sed '/^#/d;/^$$/d' | ./run-tests.sh
+	< snippets-combined.txt sed '/^#/d;/^$$/d' | ./get-results.sh
 
 .PHONY: clean
 clean:
-	rm -f snippets.lsp asmtest snippets.h asmtest.o $(SNIPPET_OBJS)
+	pushd testgen && make clean && popd
+	rm -rf check-test check-test.lx86cl64 inputs outputs results snippets-generated.txt snippets-combined.txt snippets.lsp asmtest snippets.h asmtest.o $(SNIPPET_OBJS)

--- a/books/projects/x86isa/tools/execution/asmtest/asmtest.lisp
+++ b/books/projects/x86isa/tools/execution/asmtest/asmtest.lisp
@@ -48,6 +48,14 @@ and can then use the @('test-snippet') or @('test-snippetconf') utilities to
 repeatedly run the snippet on the model on the various inputs, comparing them
 to the outputs from the executable.</p>
 
+<p>We provide scripts to automate this process for randomly generated inputs.
+You can run @('make test') in the @('asmtest') directory to run all the
+snippets on random input. This will create a @('results') directory with a file
+for each test that contains the ACL2 output for that test. Generally,
+successful tests have little output while unsuccessful tests have large output,
+so sorting the contents of the directory by size makes it easy to find failing
+tests.</p>
+
 <p>Snippets are listed (along with their input and output block sizes) in
 snippets.txt (under the asmtest directory,
 books/projects/x86isa/tools/execution/asmtest).  This file is parsed by a
@@ -86,6 +94,11 @@ in @('tests/example.lsp'), e.g. @('(test-snippetconf-event \"my_testname.conf\")
 </ul>
 
 <h2>Generating Tests</h2>
+<p>Some snippets are generated with @('testgen'), which uses Intel's XED to
+iterate over instructions and generate tests for them. This is automatically
+done when you build @('asmtest') with the provided @('Makefile'). @('testgen')
+generated tests are named @('testgen_<idx>') where @('<idx>') is the index of
+the instruction in the XED database.</p>
 
 <p>A Python script \"text_to_binary.py\" is provided to help generate test
 input files. Mainly it helps write a bunch of numbers into a binary file. See

--- a/books/projects/x86isa/tools/execution/asmtest/check-test.lsp
+++ b/books/projects/x86isa/tools/execution/asmtest/check-test.lsp
@@ -1,0 +1,85 @@
+; http://opensource.org/licenses/BSD-3-Clause
+
+; Copyright (C) 2025, Yahya Sohail
+
+; All rights reserved.
+
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are
+; met:
+
+; o Redistributions of source code must retain the above copyright
+;   notice, this list of conditions and the following disclaimer.
+
+; o Redistributions in binary form must reproduce the above copyright
+;   notice, this list of conditions and the following disclaimer in the
+;   documentation and/or other materials provided with the distribution.
+
+; o Neither the name of the copyright holders nor the names of its
+;   contributors may be used to endorse or promote products derived
+;   from this software without specific prior written permission.
+
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+; "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+; LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+; A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+; HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+; SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+; LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+; THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+; Original Author(s):
+; Yahya Sohail        <yahya@yahyasohail.com>
+
+(in-package "X86ISA")
+
+(include-book "oslib/argv" :dir :system)
+
+(include-book "asmtest")
+(include-book "../top" :ttags (:undef-flg :other-non-det :instrument))
+
+(def-snippet-data real-snippet-data)
+
+(init-x86-state-64
+ nil
+ 0
+ nil         ;; GPRs
+ nil         ;; CRs
+ nil         ;; MSRs
+ nil         ;; SRs (visible)
+ nil nil nil ;; (hidden)
+ 0           ;; rflags
+ nil         ;;memory
+ x86)
+
+(!ctri *cr0* (change-cr0bits (ctri *cr0* x86)
+                             :em 0
+                             :mp 1) x86)
+
+(!ctri *cr4* (change-cr4bits (ctri *cr4* x86)
+                             :osfxsr 1
+                             :osxmmexcpt 1) x86)
+
+(binary-file-load "asmtest" :elf t)
+
+(define run-test (x86 state)
+  (b* (((mv argv state) (oslib::argv state))
+       ((when (or (not (consp argv))
+                  (not (stringp (car argv)))))
+        (prog2$ (raise "error argv nil")
+                (mv nil x86 state)))
+       (name (car argv))
+       (- (cw "~x0~%" name))
+       ((mv res x86 state)
+        (test-snippet name
+                      :input-file (str::cat "inputs/" name ".in")
+                      :output-file (str::cat "outputs/" name ".out")))
+       (- (cw "~x0~%" res))
+       (- (good-bye)))
+      (mv res x86 state)))
+
+:q
+(save-exec "check-test" "MODIFIED" :init-forms '((x86isa::run-test x86isa::x86 state)))

--- a/books/projects/x86isa/tools/execution/asmtest/get-results.sh
+++ b/books/projects/x86isa/tools/execution/asmtest/get-results.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# http://opensource.org/licenses/BSD-3-Clause
+
+# Copyright (C) 2025, Yahya Sohail
+
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# o Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+
+# o Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+
+# o Neither the name of the copyright holders nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Original Author(s):
+# Yahya Sohail        <yahya@yahyasohail.com>
+
+mkdir -p results
+
+process_file() {
+    name="$1"
+    if [ -s "outputs/${name}.out" ]; then
+        ./check-test -- "$name" > "results/${name}" </dev/null
+    fi
+}
+export -f process_file
+
+while read -r name szin szout; do
+    echo "$name"
+done | xargs -P $(nproc) -I {} bash -c 'process_file "{}"'

--- a/books/projects/x86isa/tools/execution/asmtest/run-tests.sh
+++ b/books/projects/x86isa/tools/execution/asmtest/run-tests.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# http://opensource.org/licenses/BSD-3-Clause
+
+# Copyright (C) 2025, Yahya Sohail
+
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# o Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+
+# o Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+
+# o Neither the name of the copyright holders nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Original Author(s):
+# Yahya Sohail        <yahya@yahyasohail.com>
+
+while read -r name szin szout; do
+  dd if=/dev/urandom of=inputs/$name.in bs=$szin count=1000 2>/dev/null
+  ./asmtest --input inputs/$name.in --output outputs/$name.out $name >/dev/null
+  if [ $? -ne 0 ]; then
+    echo $name failed
+  fi
+done

--- a/books/projects/x86isa/tools/execution/asmtest/snippet_table.py
+++ b/books/projects/x86isa/tools/execution/asmtest/snippet_table.py
@@ -30,9 +30,9 @@ write_lsp = sys.argv[1] == "lsp"
     
 
     
-# Parse the snippets.txt file into snips, a list of triples [name, inbytes, outbytes]
+# Parse the snippets-combined.txt file into snips, a list of triples [name, inbytes, outbytes]
 snips = []
-with open("snippets.txt", "r", encoding="utf-8") as infile:
+with open("snippets-combined.txt", "r", encoding="utf-8") as infile:
     for line in infile:
         line = line.strip()
         if (len(line) == 0):

--- a/books/projects/x86isa/tools/execution/asmtest/testgen/.gitignore
+++ b/books/projects/x86isa/tools/execution/asmtest/testgen/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.d
+deps
+testgen
+compile_commands.json
+.cache

--- a/books/projects/x86isa/tools/execution/asmtest/testgen/Makefile
+++ b/books/projects/x86isa/tools/execution/asmtest/testgen/Makefile
@@ -1,0 +1,30 @@
+CC = gcc
+LD = gcc
+CFLAGS = -ggdb -Wall -Wpedantic -Ideps/xed/obj/wkit/include -MMD -fsanitize=address
+LDFLAGS = -Ldeps/xed/obj/wkit/lib -lxed -fsanitize=address
+LDLIBS = -lxed
+RM = /bin/rm -f
+OBJS = $(subst .c,.o,*.c)
+
+testgen: $(OBJS) deps/xed/obj/wkit/lib/libxed.a
+	$(LD) $(LDFLAGS) $(OBJS) $(LDLIBS) -o testgen
+
+deps/xed:
+	git clone git@github.com:intelxed/xed.git deps/xed
+
+deps/mbuild:
+	git clone git@github.com:intelxed/mbuild.git deps/mbuild
+
+deps/xed/obj/wkit/lib/libxed.a: deps/xed deps/mbuild
+	@cd deps/xed && ./mfile.py
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $<
+
+clean:
+	$(RM) *.o *.d testgen
+
+depclean:
+	$(RM) -r deps
+
+-include *.d

--- a/books/projects/x86isa/tools/execution/asmtest/testgen/testgen.c
+++ b/books/projects/x86isa/tools/execution/asmtest/testgen/testgen.c
@@ -1,0 +1,638 @@
+// http://opensource.org/licenses/BSD-3-Clause
+
+// Copyright (C) 2025, Yahya Sohail
+
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+// o Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+
+// o Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+
+// o Neither the name of the copyright holders nor the names of its
+//   contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Original Author(s):
+// Yahya Sohail        <yahya@yahyasohail.com>
+
+#include <argp.h>
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <xed/xed-interface.h>
+
+const char *argp_program_version = "testgen 0.0.1";
+const char *argp_program_bug_address = "<yahya@yahyasohail.com>";
+
+/* Program documentation */
+static char doc[] = "Test generator for asmtest";
+
+/* A description of the arguments we accept */
+static char args_doc[] = "";
+
+/* The options we understand */
+static struct argp_option options[] = {
+    {"asm-output", 'a', "FILE", 0, "Output assembly file (required)"},
+    {"text-output", 't', "FILE", 0, "Output text file (required)"},
+    {0}};
+
+/* Used by main to communicate with parse_opt */
+struct arguments {
+  char *asm_file;
+  char *text_file;
+};
+
+/* Parse a single option */
+static error_t parse_opt(int key, char *arg, struct argp_state *state) {
+  struct arguments *arguments = state->input;
+
+  switch (key) {
+  case 'a':
+    arguments->asm_file = arg;
+    break;
+  case 't':
+    arguments->text_file = arg;
+    break;
+  case ARGP_KEY_END:
+    if (!arguments->asm_file || !arguments->text_file) {
+      argp_error(state, "Both --asm-output and --text-output are required");
+    }
+    break;
+  default:
+    return ARGP_ERR_UNKNOWN;
+  }
+  return 0;
+}
+
+/* Our argp parser */
+static struct argp argp = {options, parse_opt, args_doc, doc};
+
+struct frame_record_reg_entry {
+  xed_reg_enum_t reg;
+};
+
+struct frame_record_imm_entry {
+  uint8_t width;
+};
+
+struct frame_record {
+  bool has_flags;
+  uint64_t flags_mask;
+
+  size_t reg_size;
+  size_t reg_capacity;
+  struct frame_record_reg_entry *reg_entries;
+
+  size_t imm_size;
+  size_t imm_capacity;
+  struct frame_record_imm_entry *imm_entries;
+};
+
+void frame_record_init(struct frame_record *rec) {
+  rec->has_flags = false;
+
+  rec->reg_size = 0;
+  rec->reg_capacity = 1;
+  rec->reg_entries = malloc(sizeof(struct frame_record_reg_entry));
+
+  rec->imm_size = 0;
+  rec->imm_capacity = 1;
+  rec->imm_entries = malloc(sizeof(struct frame_record_reg_entry));
+}
+
+void frame_record_cleanup(struct frame_record *rec) {
+  free(rec->reg_entries);
+  free(rec->imm_entries);
+}
+
+void frame_record_insert_reg(struct frame_record *rec, xed_reg_enum_t reg) {
+  if (rec->reg_size == rec->reg_capacity) {
+    rec->reg_entries =
+        realloc(rec->reg_entries,
+                sizeof(struct frame_record_reg_entry) * rec->reg_capacity * 2);
+    rec->reg_capacity *= 2;
+  }
+
+  rec->reg_entries[rec->reg_size].reg = reg;
+  rec->reg_size++;
+}
+
+void frame_record_insert_imm(struct frame_record *rec, uint8_t width) {
+  if (rec->imm_size == rec->imm_capacity) {
+    rec->imm_entries =
+        realloc(rec->imm_entries,
+                sizeof(struct frame_record_imm_entry) * rec->imm_capacity * 2);
+    rec->imm_capacity *= 2;
+  }
+
+  rec->imm_entries[rec->imm_size].width = width;
+  rec->imm_size++;
+}
+
+void frame_record_add_flags(struct frame_record *rec, uint64_t mask) {
+  rec->has_flags = true;
+  rec->flags_mask = mask;
+}
+
+void frame_record_clear(struct frame_record *rec) {
+  rec->has_flags = false;
+  rec->reg_size = 0;
+  rec->imm_size = 0;
+}
+
+// given a register number 0 - 15, returns the gpr register of
+// corresponding width. For 8-bits, where we have 2 options, we return the lower
+// register
+xed_reg_enum_t get_width_reg(uint8_t regno, uint8_t width) {
+  assert(regno < 16);
+
+  switch (width) {
+  case 8:
+    return XED_REG_AL + regno;
+
+  case 16:
+    return XED_REG_AX + regno;
+
+  case 32:
+    return XED_REG_EAX + regno;
+
+  case 64:
+    return XED_REG_RAX + regno;
+  }
+
+  assert(false);
+}
+
+bool inst_frame_records(const xed_inst_t *inst, struct frame_record *in_rec,
+                        xed_reg_enum_t operand_allocations[16],
+                        struct frame_record *out_rec) {
+  xed_iclass_enum_t iclass = xed_inst_iclass(inst);
+  xed_isa_set_enum_t isa_set = xed_inst_isa_set(inst);
+  xed_category_enum_t category = xed_inst_category(inst);
+
+#define UNSUPPORTED_ATTRIBUTE(attr)                                            \
+  if (xed_inst_get_attribute(inst, attr))                                      \
+    return true;
+#define UNSUPPORTED_ISA_SET(iset)                                              \
+  if (isa_set == iset)                                                         \
+    return true;
+#define UNSUPPORTED_ISA_SET_RANGE(start, end)                                  \
+  if (start <= isa_set && isa_set <= end)                                      \
+    return true;
+#define UNSUPPORTED_ICLASS(class)                                              \
+  if (iclass == class)                                                         \
+    return true;
+#define UNSUPPORTED_CATEGORY(cat)                                              \
+  if (category == cat)                                                         \
+    return true;
+
+#include "unsupported.h"
+
+#undef UNSUPPORTED_ATTRIBUTE
+#undef UNSUPPORTED_ISA_SET
+#undef UNSUPPORTED_ISA_SET_RANGE
+#undef UNSUPPORTED_ICLASS
+#undef UNSUPPORTED_CATEGORY
+
+  unsigned int noperands = xed_inst_noperands(inst);
+
+  if (noperands == 0)
+    return true;
+
+  bool allocated_gpr[16] = {false};
+  bool allocated_xmm[32] = {false};
+
+  // Allocate rdi and rsi (which hold in and out memory regions) and sysv abi
+  // caller saved registers
+  allocated_gpr[XED_REG_RSI - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_RDI - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_RBX - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_RSP - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_RBP - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_R12 - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_R13 - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_R14 - XED_REG_RAX] = true;
+  allocated_gpr[XED_REG_R15 - XED_REG_RAX] = true;
+
+  size_t allocation_idx = 0;
+  size_t n_output = 0;
+
+  for (unsigned int j = 0; j < noperands; j++) {
+    const xed_operand_t *op = xed_inst_operand(inst, j);
+    const xed_operand_enum_t opname = xed_operand_name(op);
+    const bool read = xed_operand_read(op);
+    const bool written = xed_operand_written(op);
+    const xed_reg_enum_t reg = xed_operand_reg(op);
+    const xed_reg_class_enum_t class = xed_reg_class(reg);
+
+    // Don't support if memory operand
+    if (opname == XED_OPERAND_MEM0 || opname == XED_OPERAND_MEM1)
+      return true;
+
+    if (written)
+      n_output++;
+
+    if (reg == XED_REG_FLAGS) {
+      // We handle flags separately after encoding because XED only lets us get
+      // at flag information for decoded instructions
+      continue;
+    }
+
+    if (xed_operand_imm(op)) {
+      // Immediates aren't written
+      frame_record_insert_imm(in_rec, xed_operand_width_bits(op, 3) / 8);
+      continue;
+    }
+
+    if (class == XED_REG_CLASS_GPR) {
+      allocated_gpr[xed_get_largest_enclosing_register(reg) - XED_REG_RAX] =
+          true;
+      if (read)
+        frame_record_insert_reg(in_rec, reg);
+      if (written)
+        frame_record_insert_reg(out_rec, reg);
+      continue;
+    } else if (class == XED_REG_CLASS_XMM) {
+      allocated_xmm[reg - XED_REG_XMM0] = true;
+      if (read)
+        frame_record_insert_reg(in_rec, reg);
+      if (written)
+        frame_record_insert_reg(out_rec, reg);
+      continue;
+    }
+
+    if (reg != XED_REG_INVALID) {
+      // Don't support other registers atm
+      return true;
+    }
+
+    xed_nonterminal_enum_t nonterminal = xed_operand_nonterminal_name(op);
+
+    if (XED_NONTERMINAL_GPR16_B <= nonterminal &&
+        nonterminal <= XED_NONTERMINAL_GPRZ_R) {
+      // Find unallocated register
+      uint8_t regno = 8;
+      while (allocated_gpr[regno]) {
+        regno++;
+        assert(regno < 16);
+      }
+      allocated_gpr[regno] = true;
+
+      const xed_reg_enum_t reg =
+          get_width_reg(regno, xed_operand_width_bits(op, 3));
+      operand_allocations[allocation_idx++] = reg;
+      if (read)
+        frame_record_insert_reg(in_rec, reg);
+      if (written)
+        frame_record_insert_reg(out_rec, reg);
+      continue;
+    } else if (XED_NONTERMINAL_XMM_B <= nonterminal &&
+               nonterminal <= XED_NONTERMINAL_XMM_SE64) {
+      // Find unallocated register
+      uint8_t regno = 8;
+      while (allocated_xmm[regno]) {
+        regno++;
+        assert(regno < 32);
+      }
+      allocated_xmm[regno] = true;
+
+      const xed_reg_enum_t reg = XED_REG_XMM0 + regno;
+      operand_allocations[allocation_idx++] = reg;
+      if (read)
+        frame_record_insert_reg(in_rec, reg);
+      if (written)
+        frame_record_insert_reg(out_rec, reg);
+      continue;
+    }
+
+    if (nonterminal == XED_NONTERMINAL_RFLAGS) {
+      // handle rflags later
+      continue;
+    }
+
+    // Unsupported operand
+    return true;
+  }
+
+  return n_output == 0;
+}
+
+bool encode_inst(const xed_inst_t *inst,
+                 const xed_reg_enum_t operand_allocations[16], uint8_t buf[15],
+                 unsigned int *enc_len, xed_state_t *state) {
+  unsigned int noperands = xed_inst_noperands(inst);
+
+  // Encode the instruction
+  xed_encoder_request_t enc_req;
+  xed_encoder_request_zero_set_mode(&enc_req, state);
+  xed_encoder_request_set_effective_operand_width(&enc_req, 64);
+  xed_encoder_request_set_iclass(&enc_req, xed_inst_iclass(inst));
+
+  // Set operands
+  size_t allocation_idx = 0;
+  for (unsigned int i = 0; i < noperands; i++) {
+    const xed_operand_t *op = xed_inst_operand(inst, i);
+
+    if (xed_operand_operand_visibility(op) == XED_OPVIS_SUPPRESSED)
+      continue;
+
+    if (xed_operand_operand_visibility(op) == XED_OPVIS_IMPLICIT)
+      xed_encoder_request_set_reg(&enc_req, xed_operand_name(op),
+                                  xed_operand_reg(op));
+    else
+      // XED_OPVIS_EXPLICIT
+      if (xed_operand_name(op) == XED_OPERAND_IMM0) {
+        xed_encoder_request_set_uimm0(&enc_req, 0,
+                                      xed_operand_width_bits(op, 3) / 8);
+      } else if (xed_operand_name(op) == XED_OPERAND_IMM1) {
+        xed_encoder_request_set_uimm1(&enc_req, 0);
+      } else {
+        xed_encoder_request_set_reg(&enc_req, xed_operand_name(op),
+                                    operand_allocations[allocation_idx++]);
+      }
+
+    xed_encoder_request_set_operand_order(&enc_req, i, xed_operand_name(op));
+  }
+
+  // Encode
+  xed_error_enum_t enc_error = xed_encode(&enc_req, buf, 15, enc_len);
+
+  if (enc_error != XED_ERROR_NONE) {
+    fprintf(stderr, "Error %s encoding instruction %s\n",
+            xed_error_enum_t2str(enc_error),
+            xed_iclass_enum_t2str(xed_inst_iclass(inst)));
+    fputs("skipping\n", stderr);
+
+    return true;
+  }
+
+  return false;
+}
+
+void frame_record_flags(uint8_t inst_buf[15], struct frame_record *in_rec,
+                        struct frame_record *out_rec, xed_state_t *state) {
+  // We must decode our encoded instruction to get at the flag info
+  xed_decoded_inst_t xedd;
+  xed_decoded_inst_zero(&xedd);
+  xed_decoded_inst_set_mode(&xedd, state->mmode, state->stack_addr_width);
+
+  xed_error_enum_t xed_error = xed_decode(&xedd, inst_buf, 15);
+  if (xed_error != XED_ERROR_NONE) {
+    assert(false);
+  }
+
+  const xed_simple_flag_t *flags = xed_decoded_inst_get_rflags_info(&xedd);
+  if (!flags)
+    return;
+
+  uint64_t read_mask =
+      xed_flag_set_mask(xed_simple_flag_get_read_flag_set(flags));
+  if (read_mask)
+    frame_record_add_flags(in_rec, read_mask);
+
+  uint64_t written_mask =
+      xed_flag_set_mask(xed_simple_flag_get_written_flag_set(flags)) &
+      ~xed_flag_set_mask(xed_simple_flag_get_undefined_flag_set(flags));
+
+  if (written_mask)
+    frame_record_add_flags(out_rec, written_mask);
+}
+
+void write_test_asm(uint8_t inst_buf[15], unsigned int inst_len,
+                    const struct frame_record *in_rec,
+                    const struct frame_record *out_rec, size_t i,
+                    FILE *stream) {
+  fprintf(stream, "global testgen_%lu\ntestgen_%lu:\n", i, i);
+
+  // Write the preamble
+  size_t offset = 0;
+  for (size_t j = 0; j < in_rec->imm_size; j++) {
+    uint8_t width = in_rec->imm_entries[j].width;
+
+    fputs("push rax\n", stream);
+
+    // loading the 8 or 16-bit registers doesn't clear the rest, so load the
+    // corresponding 32-bit register with zero extension
+    if (width == 1) {
+      fprintf(stream, "movzx eax, BYTE [rdi + 0x%lx]\n", offset);
+      fprintf(stream, "mov [testgen_inst_end_%ld - %ld], al\n", i,
+              offset + width);
+    } else if (width == 2) {
+      fprintf(stream, "movzx eax, WORD [rdi + 0x%lx]\n", offset);
+      fprintf(stream, "mov [testgen_inst_end_%ld - %ld], ax\n", i,
+              offset + width);
+    } else if (width == 4) {
+      fprintf(stream, "mov eax, [rdi + 0x%lx]\n", offset);
+      fprintf(stream, "mov [testgen_inst_end_%ld - %ld], eax\n", i,
+              offset + width);
+    } else if (width == 8) {
+      fprintf(stream, "mov rax, [rdi + 0x%lx]\n", offset);
+      fprintf(stream, "mov [testgen_inst_end_%ld - %ld], rax\n", i,
+              offset + width);
+    } else {
+      assert(false);
+    }
+
+    fputs("pop rax\n", stream);
+
+    offset += width;
+  }
+
+  if (in_rec->has_flags) {
+    fputs("push rax\n", stream);
+
+    fprintf(stream, "mov rax, [rdi + 0x%lx]\n", offset);
+    fprintf(stream, "and rax, 0x%lx\n", in_rec->flags_mask);
+    fputs("push rax\n", stream);
+    fputs("popfq\n", stream);
+
+    fputs("pop rax\n", stream);
+    offset += 8;
+  }
+
+  for (size_t j = 0; j < in_rec->reg_size; j++) {
+    const struct frame_record_reg_entry *entry = in_rec->reg_entries + j;
+
+    size_t width = xed_get_register_width_bits64(entry->reg) / 8;
+
+    // loading the 8 or 16-bit registers doesn't clear the rest, so load the
+    // corresponding 32-bit register with zero extension
+    if (width == 1) {
+      fprintf(stream, "movzx %s, BYTE [rdi + 0x%lx]\n",
+              xed_reg_enum_t2str((entry->reg - XED_REG_AL) + XED_REG_EAX),
+              offset);
+    } else if (width == 2) {
+      fprintf(stream, "movzx %s, WORD [rdi + 0x%lx]\n",
+              xed_reg_enum_t2str((entry->reg - XED_REG_AX) + XED_REG_EAX),
+              offset);
+    } else if (xed_reg_class(entry->reg) == XED_REG_CLASS_XMM) {
+      fprintf(stream, "movdqu %s, [rdi + 0x%lx]\n",
+              xed_reg_enum_t2str(entry->reg), offset);
+    } else {
+      fprintf(stream, "mov %s, [rdi + 0x%lx]\n", xed_reg_enum_t2str(entry->reg),
+              offset);
+    }
+
+    offset += width;
+  }
+
+  // Write instruction
+  fputs("db ", stream);
+  for (size_t j = 0; j < inst_len; j++) {
+    fprintf(stream, "0x%02x, ", inst_buf[j]);
+  }
+  fprintf(stream, "\ntestgen_inst_end_%lu:\n", i);
+
+  // Write epilogue
+  offset = 0;
+  if (out_rec->has_flags) {
+    fputs("push rax\n", stream);
+
+    fputs("pushfq\n", stream);
+    fputs("pop rax\n", stream);
+    fprintf(stream, "and rax, 0x%lx\n", out_rec->flags_mask);
+    fprintf(stream, "mov [rsi + 0x%lx], rax\n", offset);
+
+    fputs("pop rax\n", stream);
+    offset += 8;
+  }
+
+  for (size_t j = 0; j < out_rec->reg_size; j++) {
+    const struct frame_record_reg_entry *entry = out_rec->reg_entries + j;
+    if (xed_reg_class(entry->reg) == XED_REG_CLASS_XMM) {
+      fprintf(stream, "movdqu [rsi + 0x%lx], %s\n", offset,
+              xed_reg_enum_t2str(entry->reg));
+    } else {
+      assert(entry->reg != XED_REG_INVALID);
+      fprintf(stream, "mov [rsi + 0x%lx], %s\n", offset,
+              xed_reg_enum_t2str(entry->reg));
+
+      offset += xed_get_register_width_bits64(entry->reg) / 8;
+    }
+  }
+
+  fputs("ret\n", stream);
+}
+
+size_t get_frame_record_size(const struct frame_record *rec) {
+  size_t size = 0;
+
+  if (rec->has_flags)
+    size += 8;
+
+  for (size_t i = 0; i < rec->reg_size; i++) {
+    size += xed_get_register_width_bits64(rec->reg_entries[i].reg) / 8;
+  }
+
+  for (size_t i = 0; i < rec->imm_size; i++) {
+    size += rec->imm_entries[i].width;
+  }
+
+  return size;
+}
+
+void write_snippets(const struct frame_record *in_rec,
+                    const struct frame_record *out_rec, size_t i,
+                    FILE *stream) {
+  fprintf(stream, "testgen_%lu\t%lu\t%lu\n", i, get_frame_record_size(in_rec),
+          get_frame_record_size(out_rec));
+}
+
+int main(int argc, char **argv) {
+  struct arguments arguments;
+
+  /* Initialize to NULL to detect missing arguments */
+  arguments.asm_file = NULL;
+  arguments.text_file = NULL;
+
+  /* Parse arguments */
+  argp_parse(&argp, argc, argv, 0, 0, &arguments);
+
+  xed_tables_init();
+
+  xed_state_t state;
+  xed_state_zero(&state);
+
+  /* Initialize for 64-bit mode */
+  xed_state_init2(&state, XED_MACHINE_MODE_LONG_64, XED_ADDRESS_WIDTH_64b);
+
+  struct frame_record in_rec;
+  struct frame_record out_rec;
+  frame_record_init(&in_rec);
+  frame_record_init(&out_rec);
+
+  FILE *asm_file = fopen(arguments.asm_file, "w");
+  if (!asm_file) {
+    fprintf(stderr, "Error: Could not open %s for writing\n",
+            arguments.asm_file);
+    return 1;
+  }
+
+  FILE *snippets_file = fopen(arguments.text_file, "w");
+  if (!snippets_file) {
+    fprintf(stderr, "Error: Could not open %s for writing\n",
+            arguments.text_file);
+    fclose(asm_file);
+    return 1;
+  }
+
+  fputs("; Generated file -- do not edit\ndefault rel\nsection .testgen exec "
+        "write\n",
+        asm_file);
+  fputs("# Generated file -- do not edit", snippets_file);
+
+  const xed_inst_t *table = xed_inst_table_base();
+  for (size_t i = 0; i < XED_MAX_INST_TABLE_NODES; i++) {
+    const xed_inst_t *inst = &table[i];
+    xed_reg_enum_t operand_allocations[16];
+    uint8_t inst_buf[15];
+    unsigned int inst_len;
+
+    bool fail =
+        inst_frame_records(inst, &in_rec, operand_allocations, &out_rec);
+    if (fail)
+      goto cont;
+
+    fail = encode_inst(inst, operand_allocations, inst_buf, &inst_len, &state);
+    if (fail)
+      goto cont;
+
+    frame_record_flags(inst_buf, &in_rec, &out_rec, &state);
+
+    write_test_asm(inst_buf, inst_len, &in_rec, &out_rec, i, asm_file);
+    write_snippets(&in_rec, &out_rec, i, snippets_file);
+
+  cont:
+    frame_record_clear(&in_rec);
+    frame_record_clear(&out_rec);
+  }
+
+  fclose(asm_file);
+  fclose(snippets_file);
+
+  frame_record_cleanup(&in_rec);
+  frame_record_cleanup(&out_rec);
+  return 0;
+}

--- a/books/projects/x86isa/tools/execution/asmtest/testgen/unsupported.h
+++ b/books/projects/x86isa/tools/execution/asmtest/testgen/unsupported.h
@@ -1,0 +1,61 @@
+// http://opensource.org/licenses/BSD-3-Clause
+
+// Copyright (C) 2025, Yahya Sohail
+
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+// o Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+
+// o Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+
+// o Neither the name of the copyright holders nor the names of its
+//   contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Original Author(s):
+// Yahya Sohail        <yahya@yahyasohail.com>
+
+// This file defines what instructions are unsupported
+
+UNSUPPORTED_ATTRIBUTE(XED_ATTRIBUTE_RING0);
+UNSUPPORTED_ATTRIBUTE(XED_ATTRIBUTE_PROTECTED_MODE);
+UNSUPPORTED_ATTRIBUTE(XED_ATTRIBUTE_AMDONLY);
+
+UNSUPPORTED_ISA_SET(XED_ISA_SET_VTX);
+UNSUPPORTED_ISA_SET(XED_ISA_SET_RTM);
+UNSUPPORTED_ISA_SET(XED_ISA_SET_TDX);
+UNSUPPORTED_ISA_SET(XED_ISA_SET_UINTR);
+UNSUPPORTED_ISA_SET(XED_ISA_SET_MSRLIST);
+UNSUPPORTED_ISA_SET(XED_ISA_SET_SGX_ENCLV);
+
+UNSUPPORTED_ISA_SET_RANGE(XED_ISA_SET_APX_F, XED_ISA_SET_APX_F_VMX);
+
+UNSUPPORTED_ICLASS(XED_ICLASS_CLI);
+UNSUPPORTED_ICLASS(XED_ICLASS_STI);
+UNSUPPORTED_ICLASS(XED_ICLASS_MCOMMIT);
+UNSUPPORTED_ICLASS(XED_ICLASS_RDRAND);
+UNSUPPORTED_ICLASS(XED_ICLASS_RDSEED);
+UNSUPPORTED_ICLASS(XED_ICLASS_CPUID);
+UNSUPPORTED_ICLASS(XED_ICLASS_PCONFIG);
+
+UNSUPPORTED_CATEGORY(XED_CATEGORY_PTWRITE);
+UNSUPPORTED_CATEGORY(XED_CATEGORY_PBNDKB);


### PR DESCRIPTION
`testgen` uses XED to iterate over x86 instructions and generate tests
for them. It has some restrictions on instructions it supports. The big
ones are it only works with instructions that operate on flags, gprs,
xmm registers, and immediates. Beyond introducing `testgen`, this also
introduces some scripts to make it easy to run all snippets with random
inputs.

At the moment there are a few issues:
  - XED errors when trying to encode some instructions. I don't know why
    exactly that is.
  - `asmtest` crashes with various errors when running some tests.
  - Some instructions fail tests because some flags are undefined. We
    handle undefined flags correctly but flags which are undefined
    only sometimes can't easily be dealt with in an automated fashion.

That being said, these issues are handled gracefully and I'm comfortable
having this merged into the community books.
