### PR TITLE
Improve defthm-unsigned-byte-p.

### DIFF
--- a/books/std/util/def-bound-theorems-tests.lisp
+++ b/books/std/util/def-bound-theorems-tests.lisp
@@ -1,0 +1,55 @@
+; Tests of def-bound-theorems
+;
+; Copyright (C) 2025 Kestrel Institute
+;
+; License: A 3-clause BSD license. See the file books/3BSD-mod.txt.
+;
+; Author: Eric Smith (eric.smith@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "STD")
+
+;; TODO: Add tests of defthm-natp and defthm-signed-byte-p
+
+(include-book "def-bound-theorems")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Basic test:
+
+(defund foo (x) (if (unsigned-byte-p 8 x) x 0))
+
+(defthm-unsigned-byte-p unsigned-byte-p-foo
+  :bound 8
+  :concl (foo x)
+  :gen-type t
+  :gen-linear t
+  :hints (("Goal" :in-theory (enable foo))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test the bound=1 case in which the :type-prescription rule uses bitp:
+
+(defund bar (x) (if (unsigned-byte-p 1 x) x 0))
+
+(defthm-unsigned-byte-p unsigned-byte-p-bar
+  :bound 1
+  :concl (bar x)
+  :gen-type t
+  :gen-linear t
+  :hints (("Goal" :in-theory (enable bar))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Test :hyp :
+
+(defund decrement (x) (+ -1 x))
+
+(defthm-unsigned-byte-p unsigned-byte-p-decrement
+  :bound 8
+  :hyp (and (unsigned-byte-p 8 x) (< 0 x))
+  :concl (decrement x)
+  :gen-type t
+  :gen-linear t
+  :hints (("Goal" :in-theory (enable decrement))))

--- a/books/std/util/def-bound-theorems.lisp
+++ b/books/std/util/def-bound-theorems.lisp
@@ -261,40 +261,40 @@
                                        otf-flg)
   (if (and concl bound)
       (let* ((hyp-t (or hyp-t hyp))
-            (hyp-l (or hyp-l hyp))
-            ;; Could check for '1 here, but we follow the
-            ;; precedent below of not handling a quoted bound when
-            ;; setting 2^bound:
-            (bitp (equal 1 bound))
-            (hints-t (or hints-t
-                         ;; If :HINTS-T is not supplied, the following hints,
-                         ;; given the definitions of UNSIGNED-BYTE-P,
-                         ;; INTEGER-RANGE-P, and NATP, should suffice to prove
-                         ;; the corollary from the main theorem, assuming that
-                         ;; :HYP-T is a superset of :HYP, or perhaps has some
-                         ;; extra calls to FORCE.
-                         `(("Goal" :in-theory '(unsigned-byte-p
-                                                integer-range-p
-                                                natp
-                                                ,@(and bitp '(bitp
-                                                              (:e expt))))))))
-            (hints-l (or hints-l
-                         ;; If :HINTS-L is not supplied, the following hints,
-                         ;; given the definitions of UNSIGNED-BYTE-P and
-                         ;; INTEGER-RANGE-P, should suffice to prove the
-                         ;; corollary from the main theorem, assuming that
-                         ;; :HYP-L is a superset of :HYP, or perhaps has some
-                         ;; extra calls to FORCE. The (:E EXPT) is motivated by
-                         ;; the fact that, if :BOUND is a number, the generated
-                         ;; linear rule involves not a call of EXPT but
-                         ;; directly the value of such a call (see 2^BOUND
-                         ;; below).
-                         '(("Goal" :in-theory '(unsigned-byte-p
-                                                integer-range-p
-                                                (:e expt))))))
-            (2^bound (if (natp bound)
-                         (expt 2 bound)
-                       `(expt 2 ,bound))))
+             (hyp-l (or hyp-l hyp))
+             ;; Could check for '1 here, but we follow the
+             ;; precedent below of not handling a quoted bound when
+             ;; setting 2^bound:
+             (bitp (equal 1 bound))
+             (hints-t (or hints-t
+                          ;; If :HINTS-T is not supplied, the following hints,
+                          ;; given the definitions of UNSIGNED-BYTE-P,
+                          ;; INTEGER-RANGE-P, and NATP, should suffice to prove
+                          ;; the corollary from the main theorem, assuming that
+                          ;; :HYP-T is a superset of :HYP, or perhaps has some
+                          ;; extra calls to FORCE.
+                          `(("Goal" :in-theory '(unsigned-byte-p
+                                                 integer-range-p
+                                                 natp
+                                                 ,@(and bitp '(bitp
+                                                               (:e expt))))))))
+             (hints-l (or hints-l
+                          ;; If :HINTS-L is not supplied, the following hints,
+                          ;; given the definitions of UNSIGNED-BYTE-P and
+                          ;; INTEGER-RANGE-P, should suffice to prove the
+                          ;; corollary from the main theorem, assuming that
+                          ;; :HYP-L is a superset of :HYP, or perhaps has some
+                          ;; extra calls to FORCE. The (:E EXPT) is motivated by
+                          ;; the fact that, if :BOUND is a number, the generated
+                          ;; linear rule involves not a call of EXPT but
+                          ;; directly the value of such a call (see 2^BOUND
+                          ;; below).
+                          '(("Goal" :in-theory '(unsigned-byte-p
+                                                 integer-range-p
+                                                 (:e expt))))))
+             (2^bound (if (natp bound)
+                          (expt 2 bound)
+                        `(expt 2 ,bound))))
         `(defthm ,name
            ,(if (eq hyp t)
                 `(unsigned-byte-p ,bound ,concl)


### PR DESCRIPTION
When :bound is 1, have it generate a stronger :type-prescription rule (that the value is a bit, not just a natural).

This is used quite a bit in the x86isa model.

To see the main change, just look at the first commit.