### PR TITLE
Remove unnecessay inclusion of application-level-memory book

### DIFF
--- a/books/kestrel/x86/rflags-spec-sub.lisp
+++ b/books/kestrel/x86/rflags-spec-sub.lisp
@@ -1,7 +1,7 @@
 ; Some changes to the open-source x86 model
 ;
 ; Copyright (C) 2022 Kestrel Technology, LLC
-; Copyright (C) 2024 Kestrel Institute
+; Copyright (C) 2024-2025 Kestrel Institute
 ;
 ; License: A 3-clause BSD license. See the file books/3BSD-mod.txt.
 ;
@@ -16,6 +16,7 @@
 ;(include-book "std/basic/arith-equiv-defs" :dir :system) ; for bool->bit
 (include-book "projects/x86isa/machine/rflags-spec" :dir :system)
 (local (include-book "kestrel/arithmetic-light/expt" :dir :system))
+(local (include-book "kestrel/arithmetic-light/mod" :dir :system))
 
 ;; These are in the X86ISA package, because we are going to suggest adding them to the model.
 

--- a/books/kestrel/x86/rflags.lisp
+++ b/books/kestrel/x86/rflags.lisp
@@ -1,7 +1,7 @@
 ; Theorems about functions like cf-spec32
 ;
 ; Copyright (C) 2022 Kestrel Technology, LLC
-; Copyright (C) 2024 Kestrel Institute
+; Copyright (C) 2024-2025 Kestrel Institute
 ;
 ; License: A 3-clause BSD license. See the file books/3BSD-mod.txt.
 ;
@@ -18,37 +18,37 @@
 
 ;; There is no af-spec8, etc.
 
-(defthm unsigned-byte-p-of-cf-spec8 (implies (posp n) (unsigned-byte-p n (cf-spec8 result))) :hints (("Goal" :in-theory (enable cf-spec8))))
-(defthm unsigned-byte-p-of-cf-spec16 (implies (posp n) (unsigned-byte-p n (cf-spec16 result))) :hints (("Goal" :in-theory (enable cf-spec16))))
-(defthm unsigned-byte-p-of-cf-spec32 (implies (posp n) (unsigned-byte-p n (cf-spec32 result))) :hints (("Goal" :in-theory (enable cf-spec32))))
-(defthm unsigned-byte-p-of-cf-spec64 (implies (posp n) (unsigned-byte-p n (cf-spec64 result))) :hints (("Goal" :in-theory (enable cf-spec64))))
+(defthm unsigned-byte-p-of-cf-spec8 (implies (posp n) (unsigned-byte-p n (cf-spec8 result))))
+(defthm unsigned-byte-p-of-cf-spec16 (implies (posp n) (unsigned-byte-p n (cf-spec16 result))))
+(defthm unsigned-byte-p-of-cf-spec32 (implies (posp n) (unsigned-byte-p n (cf-spec32 result))))
+(defthm unsigned-byte-p-of-cf-spec64 (implies (posp n) (unsigned-byte-p n (cf-spec64 result))))
 (defthm bitp-of-cf-spec8 (bitp (cf-spec8 x)))
 (defthm bitp-of-cf-spec16 (bitp (cf-spec16 x)))
 (defthm bitp-of-cf-spec32 (bitp (cf-spec32 x)))
 (defthm bitp-of-cf-spec64 (bitp (cf-spec64 x)))
 
-(defthm unsigned-byte-p-of-of-spec8 (implies (posp n) (unsigned-byte-p n (of-spec8 result))) :hints (("Goal" :in-theory (enable of-spec8))))
-(defthm unsigned-byte-p-of-of-spec16 (implies (posp n) (unsigned-byte-p n (of-spec16 result))) :hints (("Goal" :in-theory (enable of-spec16))))
-(defthm unsigned-byte-p-of-of-spec32 (implies (posp n) (unsigned-byte-p n (of-spec32 result))) :hints (("Goal" :in-theory (enable of-spec32))))
-(defthm unsigned-byte-p-of-of-spec64 (implies (posp n) (unsigned-byte-p n (of-spec64 result))) :hints (("Goal" :in-theory (enable of-spec64))))
+(defthm unsigned-byte-p-of-of-spec8 (implies (posp n) (unsigned-byte-p n (of-spec8 result))))
+(defthm unsigned-byte-p-of-of-spec16 (implies (posp n) (unsigned-byte-p n (of-spec16 result))))
+(defthm unsigned-byte-p-of-of-spec32 (implies (posp n) (unsigned-byte-p n (of-spec32 result))))
+(defthm unsigned-byte-p-of-of-spec64 (implies (posp n) (unsigned-byte-p n (of-spec64 result))))
 (defthm bitp-of-of-spec8 (bitp (of-spec8 x)))
 (defthm bitp-of-of-spec16 (bitp (of-spec16 x)))
 (defthm bitp-of-of-spec32 (bitp (of-spec32 x)))
 (defthm bitp-of-of-spec64 (bitp (of-spec64 x)))
 
-(defthm unsigned-byte-p-of-pf-spec8 (implies (posp n) (unsigned-byte-p n (pf-spec8 result))) :hints (("Goal" :in-theory (enable pf-spec8))))
-(defthm unsigned-byte-p-of-pf-spec16 (implies (posp n) (unsigned-byte-p n (pf-spec16 result))) :hints (("Goal" :in-theory (enable pf-spec16))))
-(defthm unsigned-byte-p-of-pf-spec32 (implies (posp n) (unsigned-byte-p n (pf-spec32 result))) :hints (("Goal" :in-theory (enable pf-spec32))))
-(defthm unsigned-byte-p-of-sf-spec64 (implies (posp n) (unsigned-byte-p n (sf-spec64 result))) :hints (("Goal" :in-theory (enable sf-spec64))))
+(defthm unsigned-byte-p-of-pf-spec8 (implies (posp n) (unsigned-byte-p n (pf-spec8 result))))
+(defthm unsigned-byte-p-of-pf-spec16 (implies (posp n) (unsigned-byte-p n (pf-spec16 result))))
+(defthm unsigned-byte-p-of-pf-spec32 (implies (posp n) (unsigned-byte-p n (pf-spec32 result))))
+(defthm unsigned-byte-p-of-pf-spec64 (implies (posp n) (unsigned-byte-p n (pf-spec64 result))))
 (defthm bitp-of-pf-spec8 (bitp (pf-spec8 x)))
 (defthm bitp-of-pf-spec16 (bitp (pf-spec16 x)))
 (defthm bitp-of-pf-spec32 (bitp (pf-spec32 x)))
 (defthm bitp-of-pf-spec64 (bitp (pf-spec64 x)))
 
-(defthm unsigned-byte-p-of-sf-spec8 (implies (posp n) (unsigned-byte-p n (sf-spec8 result))) :hints (("Goal" :in-theory (enable sf-spec8))))
-(defthm unsigned-byte-p-of-sf-spec16 (implies (posp n) (unsigned-byte-p n (sf-spec16 result))) :hints (("Goal" :in-theory (enable sf-spec16))))
-(defthm unsigned-byte-p-of-sf-spec32 (implies (posp n) (unsigned-byte-p n (sf-spec32 result))) :hints (("Goal" :in-theory (enable sf-spec32))))
-(defthm unsigned-byte-p-of-pf-spec64 (implies (posp n) (unsigned-byte-p n (pf-spec64 result))) :hints (("Goal" :in-theory (enable pf-spec64))))
+(defthm unsigned-byte-p-of-sf-spec8 (implies (posp n) (unsigned-byte-p n (sf-spec8 result))))
+(defthm unsigned-byte-p-of-sf-spec16 (implies (posp n) (unsigned-byte-p n (sf-spec16 result))))
+(defthm unsigned-byte-p-of-sf-spec32 (implies (posp n) (unsigned-byte-p n (sf-spec32 result))))
+(defthm unsigned-byte-p-of-sf-spec64 (implies (posp n) (unsigned-byte-p n (sf-spec64 result))))
 (defthm bitp-of-sf-spec8 (bitp (sf-spec8 x)))
 (defthm bitp-of-sf-spec16 (bitp (sf-spec16 x)))
 (defthm bitp-of-sf-spec32 (bitp (sf-spec32 x)))

--- a/books/kestrel/x86/rflags2.lisp
+++ b/books/kestrel/x86/rflags2.lisp
@@ -15,6 +15,7 @@
 (include-book "kestrel/x86/rflags-spec-sub" :dir :system)
 (include-book "kestrel/bv/bvchop-def" :dir :system)
 (local (include-book "kestrel/bv/bvchop" :dir :system))
+(local (include-book "kestrel/bv/bitops" :dir :system))
 (local (include-book "kestrel/bv/logext" :dir :system))
 (local (include-book "kestrel/bv/slice" :dir :system))
 (local (include-book "kestrel/arithmetic-light/expt" :dir :system))
@@ -38,10 +39,12 @@
          0)
   :hints (("Goal" :in-theory (enable of-spec32))))
 
+;more like this?
 (defthm sf-spec64-of-bvchop-64
   (equal (sf-spec64 (bvchop 64 x))
          (sf-spec64 x))
-  :hints (("Goal" :in-theory (enable sf-spec64 acl2::logtail-of-bvchop))))
+  :hints (("Goal" :in-theory (e/d (sf-spec64)
+                                  (part-select-width-low$inline)))))
 
 (defthm of-spec64-of-logext-64
   (equal (of-spec64 (logext 64 x))

--- a/books/projects/x86isa/machine/instructions/add-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/add-spec.lisp
@@ -41,6 +41,7 @@
 ;; This book contains the specification of the following instructions:
 ;; add  adc
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 

--- a/books/projects/x86isa/machine/instructions/and-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/and-spec.lisp
@@ -41,6 +41,7 @@
 ;; This book contains the specification of the following instructions:
 ;; and
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 

--- a/books/projects/x86isa/machine/instructions/or-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/or-spec.lisp
@@ -41,6 +41,7 @@
 ;; This book contains the specification of the following instructions:
 ;; or
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 

--- a/books/projects/x86isa/machine/instructions/rotates-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/rotates-spec.lisp
@@ -41,6 +41,7 @@
 
 (in-package "X86ISA")
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 

--- a/books/projects/x86isa/machine/instructions/shifts-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/shifts-spec.lisp
@@ -46,6 +46,7 @@
 
 (in-package "X86ISA")
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 (include-book "centaur/bitops/fast-rotate" :dir :system)
@@ -1143,6 +1144,7 @@ most-significant bit of the original operand.</p>"
        (defthm-unsigned-byte-p ,(mk-name "N" size "-MV-NTH-0-" fn-name)
          :bound ,size
          :concl (mv-nth 0 (,fn-name dst src cnt input-rflags))
+         :hints (("Goal" :in-theory (enable bool->bit)))
          :gen-type t
          :gen-linear t)
 

--- a/books/projects/x86isa/machine/instructions/sub-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/sub-spec.lisp
@@ -41,6 +41,7 @@
 ;; This book contains the specification of the following instructions:
 ;; sub  sbb
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 

--- a/books/projects/x86isa/machine/instructions/xor-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/xor-spec.lisp
@@ -41,6 +41,7 @@
 ;; This book contains the specification of the following instructions:
 ;; xor
 
+(include-book "structures" :dir :utils)
 (include-book "../rflags-spec"
               :ttags (:undef-flg))
 

--- a/books/projects/x86isa/machine/paging.lisp
+++ b/books/projects/x86isa/machine/paging.lisp
@@ -42,6 +42,7 @@
 ; Yahya Sohail        <yahya.sohail@intel.com>
 
 (in-package "X86ISA")
+(include-book "application-level-memory")
 (include-book "paging-structures" :dir :utils)
 (include-book "physical-memory" :ttags (:undef-flg))
 (include-book "clause-processors/find-matching" :dir :system)

--- a/books/projects/x86isa/machine/register-readers-and-writers.lisp
+++ b/books/projects/x86isa/machine/register-readers-and-writers.lisp
@@ -40,6 +40,7 @@
 ; Alessandro Coglio (www.alessandrocoglio.info)
 
 (in-package "X86ISA")
+(include-book "state")
 (include-book "rflags-spec")
 (include-book "fp-structures" :dir :utils)
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))

--- a/books/projects/x86isa/machine/rflags-spec.lisp
+++ b/books/projects/x86isa/machine/rflags-spec.lisp
@@ -38,7 +38,8 @@
 
 (in-package "X86ISA")
 
-(include-book "application-level-memory")
+(include-book "std/util/def-bound-theorems" :dir :system)
+(include-book "../utils/utilities")
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
Compensate by adding some includes in less fundamental books and tweaking a few Kestrel books.