### PR TITLE
[X86ISA] Replace many specialized rules with general rules.

### DIFF
--- a/books/projects/x86isa/machine/linear-memory.lisp
+++ b/books/projects/x86isa/machine/linear-memory.lisp
@@ -547,15 +547,6 @@
                        (xr fld index x86)))
               :hints (("Goal" :in-theory (e/d* () (force (force))))))
 
-    (make-event
-      (generate-xr-over-write-thms
-        (remove-elements-from-list
-          '(:mem :fault :tlb)
-          *x86-field-names-as-keywords*)
-        'las-to-pas
-        (acl2::formals 'las-to-pas (w state))
-        :output-index 2))
-
     ;; The double-rewrites below are crucial to the applicability of the rules
     ;; below (in sys-view mode).
     (defthm xr-rflags-las-to-pas
@@ -570,29 +561,24 @@
                             (xr :fault nil (double-rewrite x86))))
             :hints (("Goal" :in-theory (e/d* () (force (force))))))
 
-    (local (in-theory (e/d () (xr-las-to-pas))))
-
-    ;; The following two make-events generate a bunch of rules that
-    ;; together say the same thing as las-to-pas-xw-values, but these
-    ;; rules are more efficient than las-to-pas-xw-values as they
-    ;; match less frequently.
-    (make-event
-      (generate-read-fn-over-xw-thms
-        (remove-elements-from-list
-          '(:mem :rflags :fault :ctr :msr :app-view :marking-view :seg-visible :tlb :implicit-supervisor-access)
-          *x86-field-names-as-keywords*)
-        'las-to-pas
-        (acl2::formals 'las-to-pas (w state))
-        :output-index 0))
-
-    (make-event
-      (generate-read-fn-over-xw-thms
-        (remove-elements-from-list
-          '(:mem :rflags :fault :ctr :msr :app-view :marking-view :seg-visible :tlb :implicit-supervisor-access)
-          *x86-field-names-as-keywords*)
-        'las-to-pas
-        (acl2::formals 'las-to-pas (w state))
-        :output-index 1))
+    (defthm las-to-pas-xw-values
+      (implies (and (not (equal fld :mem))
+                    (not (equal fld :rflags))
+                    (not (equal fld :fault))
+                    (not (equal fld :ctr))
+                    (not (equal fld :msr))
+                    (not (equal fld :app-view))
+                    (not (equal fld :marking-view))
+                    (not (equal fld :seg-visible))
+                    (not (equal fld :tlb))
+                    (not (equal fld :implicit-supervisor-access))
+                    ;; or we could say this:
+                    ;; (not (member-equal fld '(:mem :rflags :fault :ctr :msr :app-view :marking-view :seg-visible :tlb :implicit-supervisor-access)))
+                    )
+               (and (equal (mv-nth 0 (las-to-pas n lin-addr r-w-x (xw fld index val x86)))
+                           (mv-nth 0 (las-to-pas n lin-addr r-w-x x86)))
+                    (equal (mv-nth 1 (las-to-pas n lin-addr r-w-x (xw fld index val x86)))
+                           (mv-nth 1 (las-to-pas n lin-addr r-w-x x86))))))
 
     (defrule 64-bit-modep-of-las-to-pas
              (equal (64-bit-modep (mv-nth 2 (las-to-pas n lin-addr r-w-x x86)))
@@ -605,18 +591,22 @@
              :hints (("Goal" :in-theory (e/d* (x86-operation-mode)
                                               (las-to-pas)))))
 
-    ;; The following make-event generate a bunch of rules that
-    ;; together say the same thing as las-to-pas-xw-state, but these
-    ;; rules are more efficient than las-to-pas-xw-state as they match
-    ;; less frequently.
-    (make-event
-      (generate-write-fn-over-xw-thms
-        (remove-elements-from-list
-          '(:mem :rflags :fault :ctr :msr :app-view :marking-view :seg-visible :tlb :implicit-supervisor-access)
-          *x86-field-names-as-keywords*)
-        'las-to-pas
-        (acl2::formals 'las-to-pas (w state))
-        :output-index 2))
+    (defthm las-to-pas-xw-state
+      (implies (and (not (equal fld :mem))
+                    (not (equal fld :rflags))
+                    (not (equal fld :fault))
+                    (not (equal fld :ctr))
+                    (not (equal fld :msr))
+                    (not (equal fld :app-view))
+                    (not (equal fld :marking-view))
+                    (not (equal fld :seg-visible))
+                    (not (equal fld :tlb))
+                    (not (equal fld :implicit-supervisor-access))
+                    ;; or we could say this:
+                    ;; (not (member-equal fld '(:mem :rflags :fault :ctr :msr :app-view :marking-view :seg-visible :tlb :implicit-supervisor-access)))
+                    )
+               (equal (mv-nth 2 (las-to-pas n lin-addr r-w-x (xw fld index val x86)))
+                      (xw fld index val(mv-nth 2 (las-to-pas n lin-addr r-w-x x86))))))
 
     (local
       (defun-nx las-to-pas-xw-rflags-not-ac-hint (lin-addr n r-w-x value x86)

--- a/books/projects/x86isa/proofs/utilities/sys-view/marking-view-top.lisp
+++ b/books/projects/x86isa/proofs/utilities/sys-view/marking-view-top.lisp
@@ -2258,10 +2258,10 @@
 
                all-xlation-governing-entries-paddrs-and-xw-mem-not-member
 
-               xr-app-view-mv-nth-2-las-to-pas
+               ;; xr-app-view-mv-nth-2-las-to-pas
                all-xlation-governing-entries-paddrs-and-xw-not-mem
-               xr-seg-visible-mv-nth-2-las-to-pas
-               xr-marking-view-mv-nth-2-las-to-pas
+               ;; xr-seg-visible-mv-nth-2-las-to-pas
+               ;; xr-marking-view-mv-nth-2-las-to-pas
                disjoint-p
                member-p
                rewrite-get-prefixes-to-get-prefixes-alt

--- a/books/projects/x86isa/proofs/zeroCopy/marking-view/zeroCopy.lisp
+++ b/books/projects/x86isa/proofs/zeroCopy/marking-view/zeroCopy.lisp
@@ -3302,7 +3302,7 @@
                              acl2::loghead-identity
                              mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
                              member-p-canonical-address-listp
-                             xr-marking-view-mv-nth-2-las-to-pas
+                             ;; xr-marking-view-mv-nth-2-las-to-pas
                              right-shift-to-logtail
                              (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
                              (:rewrite greater-logbitp-of-unsigned-byte-p . 2)
@@ -3357,7 +3357,7 @@
                   acl2::loghead-identity
                   mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
                   member-p-canonical-address-listp
-                  xr-marking-view-mv-nth-2-las-to-pas
+                  ;; xr-marking-view-mv-nth-2-las-to-pas
                   right-shift-to-logtail
                   (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
                   (:rewrite greater-logbitp-of-unsigned-byte-p . 2)
@@ -3535,7 +3535,7 @@
                              acl2::loghead-identity
                              mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
                              member-p-canonical-address-listp
-                             xr-marking-view-mv-nth-2-las-to-pas
+                             ;; xr-marking-view-mv-nth-2-las-to-pas
                              right-shift-to-logtail
                              (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
                              (:rewrite greater-logbitp-of-unsigned-byte-p . 2)
@@ -3626,7 +3626,7 @@
                         acl2::loghead-identity
                         mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
                         member-p-canonical-address-listp
-                        xr-marking-view-mv-nth-2-las-to-pas
+                        ;; xr-marking-view-mv-nth-2-las-to-pas
                         right-shift-to-logtail
                         (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
                         (:rewrite greater-logbitp-of-unsigned-byte-p . 2)
@@ -3645,7 +3645,7 @@
                         pdpt-base-addr-after-mv-nth-2-las-to-pas
                         rb-and-rm-low-64-for-direct-map
                         all-xlation-governing-entries-paddrs-1g-pages-and-wb-to-page-dir-ptr-table-entry-addr
-                        xr-ctr-mv-nth-2-las-to-pas
+                        ;; xr-ctr-mv-nth-2-las-to-pas
                         direct-map-p-and-wb-disjoint-from-xlation-governing-addrs
                         (:rewrite rb-no-reads-when-zp-n)
                         (:rewrite rb-values-1g-pages-and-wb-to-page-dir-ptr-table-entry-addr)
@@ -4064,7 +4064,7 @@
        acl2::loghead-identity
        mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
        member-p-canonical-address-listp
-       xr-marking-view-mv-nth-2-las-to-pas
+       ;; xr-marking-view-mv-nth-2-las-to-pas
        right-shift-to-logtail
        (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
        (:rewrite greater-logbitp-of-unsigned-byte-p . 2)
@@ -4174,7 +4174,7 @@
        (:meta acl2::mv-nth-cons-meta)
        mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
        member-p-canonical-address-listp
-       xr-marking-view-mv-nth-2-las-to-pas
+       ;; xr-marking-view-mv-nth-2-las-to-pas
        (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
        (:rewrite x86-run-opener-not-ms-not-zp-n)
        (:rewrite x86-run-opener-not-ms-not-fault-zp-n)
@@ -4254,7 +4254,7 @@
        (:meta acl2::mv-nth-cons-meta)
        mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
        member-p-canonical-address-listp
-       xr-marking-view-mv-nth-2-las-to-pas
+       ;; xr-marking-view-mv-nth-2-las-to-pas
        (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
        (:rewrite x86-run-opener-not-ms-not-zp-n)
        (:rewrite x86-run-opener-not-ms-not-fault-zp-n)
@@ -4335,7 +4335,7 @@
       (:meta acl2::mv-nth-cons-meta)
       mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
       member-p-canonical-address-listp
-      xr-marking-view-mv-nth-2-las-to-pas
+      ;; xr-marking-view-mv-nth-2-las-to-pas
       (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
       (:rewrite x86-run-opener-not-ms-not-zp-n)
       (:rewrite x86-run-opener-not-ms-not-fault-zp-n)
@@ -4525,7 +4525,7 @@
        (:meta acl2::mv-nth-cons-meta)
        mv-nth-1-rb-and-xlate-equiv-memory-disjoint-from-paging-structures
        member-p-canonical-address-listp
-       xr-marking-view-mv-nth-2-las-to-pas
+       ;; xr-marking-view-mv-nth-2-las-to-pas
        (:rewrite mv-nth-1-las-to-pas-subset-p-disjoint-from-other-p-addrs)
        (:rewrite x86-run-opener-not-ms-not-zp-n)
        (:rewrite x86-run-opener-not-ms-not-fault-zp-n)


### PR DESCRIPTION
Remove some make-events that generate dozens of special cases of general rules (each specialized rule talking about a single field of the x86 state).  Instead, just use a general rule in each case.  There are some comments indicating that the specialized rules are faster, but I believe that is incorrect.  The dozens of specialized rules are hung on common functions like mv-nth and xr and will cause a lot of wasted time trying and failing to match.  The general rules have hyps that should either succeed or fail quickly.  Indeed, this change seems to reliably speed up the big zeroCopy-part-2 proof by about 85 seconds (from ~820 seconds to ~735 seconds).