### PR TITLE
[X86ISA] Reduce includes of defthm-using-gl.

### DIFF
--- a/books/projects/x86isa/machine/guard-helpers.lisp
+++ b/books/projects/x86isa/machine/guard-helpers.lisp
@@ -45,6 +45,7 @@
 (include-book "../utils/segmentation-structures")
 (include-book "tools/rulesets" :dir :system)
 (include-book "centaur/bitops/ihs-extensions" :dir :system)
+(include-book "centaur/gl/defthm-using-gl" :dir :system)
 
 (local (include-book "centaur/gl/gl" :dir :system))
 

--- a/books/projects/x86isa/proofs/codewalker-examples/factorial.lisp
+++ b/books/projects/x86isa/proofs/codewalker-examples/factorial.lisp
@@ -39,6 +39,7 @@
 (in-package "X86ISA")
 
 (include-book "base")
+(include-book "centaur/gl/defthm-using-gl" :dir :system)
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 (local (include-book "arithmetic/top-with-meta" :dir :system))

--- a/books/projects/x86isa/proofs/dataCopy/init.lisp
+++ b/books/projects/x86isa/proofs/dataCopy/init.lisp
@@ -41,6 +41,7 @@
 ;; Tweaked by Eric Smith to include official top-level book for app-view proofs:
 (include-book "app-view/top" :dir :proof-utils :ttags :all)
 (include-book "centaur/bitops/ihs-extensions" :dir :system)
+(include-book "centaur/gl/defthm-using-gl" :dir :system)
 
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 (local (include-book "arithmetic/top-with-meta" :dir :system))

--- a/books/projects/x86isa/proofs/utilities/sys-view/gl-lemmas.lisp
+++ b/books/projects/x86isa/proofs/utilities/sys-view/gl-lemmas.lisp
@@ -40,6 +40,7 @@
 
 (include-book "paging" :dir :machine)
 (include-book "../../../portcullis/utils")
+(include-book "centaur/gl/defthm-using-gl" :dir :system)
 (local (include-book "centaur/gl/gl" :dir :system))
 
 ;; ======================================================================

--- a/books/projects/x86isa/utils/utilities.lisp
+++ b/books/projects/x86isa/utils/utilities.lisp
@@ -45,11 +45,11 @@
 
 (include-book "xdoc/top" :dir :system)
 (include-book "std/util/define" :dir :system)
+(include-book "std/util/defrule" :dir :system)
 (include-book "std/util/def-bound-theorems" :dir :system)
 (include-book "std/strings/case-conversion" :dir :system)
 (include-book "centaur/bitops/part-install" :dir :system)
 (include-book "centaur/bitops/fast-logext" :dir :system)
-(include-book "centaur/gl/defthm-using-gl" :dir :system)
 
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "centaur/bitops/logbitp-bounds" :dir :system))


### PR DESCRIPTION
Include it only where needed, so that including the model doesn't bring it in.