### PR TITLE
[DEFINE] Show output for verify-guards done after the :returns.

### DIFF
--- a/books/std/util/define.lisp
+++ b/books/std/util/define.lisp
@@ -1479,7 +1479,7 @@ examples.</p>")
          ;; :after-returns is used, irrespective of whether returns are
          ;; specified or not.
          ,@(and guts.guards-after-returns
-                `((verify-guards ,guts.name-fn)))
+                `((with-output :stack :pop (verify-guards ,guts.name-fn))))
 
          ;; BOZO using name-fn here is kind of weird, but otherwise we see ugly
          ;; output when there are macro arguments involved because ACL2 shows us


### PR DESCRIPTION
This lets failures be debugged and is consistent with how output is treated for other parts of the define that do proofs (e.g., when the guard proof is not delayed until after the :returns).