### PR TITLE
[X86ISA] Disable some rules generated by defbitstruct.

### DIFF
--- a/books/kestrel/x86/floats.lisp
+++ b/books/kestrel/x86/floats.lisp
@@ -522,10 +522,12 @@
   (integerp (!MXCSRBITS->IE$INLINE bit mxcsr)))
 
 (defthm unsigned-byte-p-32-of-!MXCSRBITS->IE
-  (unsigned-byte-p 32 (!MXCSRBITS->IE$INLINE bit mxcsr)))
+  (unsigned-byte-p 32 (!MXCSRBITS->IE$INLINE bit mxcsr))
+  :hints (("Goal" :in-theory (enable x86isa::unsigned-byte-p-when-mxcsrbits-p))))
 
 (defthm unsigned-byte-p-32-of-!MXCSRBITS->DE
-  (unsigned-byte-p 32 (!MXCSRBITS->DE$INLINE bit mxcsr)))
+  (unsigned-byte-p 32 (!MXCSRBITS->DE$INLINE bit mxcsr))
+  :hints (("Goal" :in-theory (enable x86isa::unsigned-byte-p-when-mxcsrbits-p))))
 
 (defthm integerp-of-!MXCSRBITS->DE
   (integerp (!MXCSRBITS->DE$INLINE bit mxcsr)))

--- a/books/projects/x86isa/machine/instructions/fp/arith-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/arith-spec.lisp
@@ -209,7 +209,7 @@
   (defthm-unsigned-byte-p n32p-mxcsr-sse-max/min
     :bound 32
     :concl (mv-nth 2 (sse-max/min operation op1 op2 mxcsr exp-width frac-width))
-    :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))
+    :hints (("Goal" :in-theory (e/d* (unsigned-byte-p-when-mxcsrbits-p) (unsigned-byte-p))))
     :gen-type t
     :gen-linear t))
 

--- a/books/projects/x86isa/machine/instructions/fp/cmp-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/cmp-spec.lisp
@@ -237,7 +237,7 @@
   (defthm-unsigned-byte-p n32p-mxcsr-sse-cmp
     :bound 32
     :concl (mv-nth 2 (sse-cmp operation op1 op2 mxcsr exp-width frac-width))
-    :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))
+    :hints (("Goal" :in-theory (e/d* (unsigned-byte-p-when-mxcsrbits-p) (unsigned-byte-p))))
     :gen-type t
     :gen-linear t))
 

--- a/books/projects/x86isa/machine/instructions/fp/cvt-spec.lisp
+++ b/books/projects/x86isa/machine/instructions/fp/cvt-spec.lisp
@@ -168,7 +168,7 @@
     :bound 32
     :concl (mv-nth 2 (sse-cvt-fp-to-int
                       nbytes op mxcsr trunc exp-width frac-width))
-    :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))
+    :hints (("Goal" :in-theory (e/d* (unsigned-byte-p-when-mxcsrbits-p) (unsigned-byte-p))))
     :gen-type t
     :gen-linear t))
 
@@ -215,7 +215,7 @@
   (defthm-unsigned-byte-p n32p-mxcsr-sse-cvt-int-to-fp
     :bound 32
     :concl (mv-nth 2 (sse-cvt-int-to-fp op mxcsr exp-width frac-width))
-    :hints (("Goal" :in-theory (e/d* () (unsigned-byte-p))))
+    :hints (("Goal" :in-theory (e/d* (unsigned-byte-p-when-mxcsrbits-p) (unsigned-byte-p))))
     :gen-type t
     :gen-linear t))
 
@@ -400,7 +400,7 @@
   :concl (mv-nth
           2
           (sse-cvt-fp1-to-fp2 op mxcsr exp-width1 frac-width1 exp-width2 frac-width2))
-  :hints (("Goal" :in-theory (e/d* ()
+  :hints (("Goal" :in-theory (e/d* (unsigned-byte-p-when-mxcsrbits-p)
                                    (rtl::sse-post-comp
                                     bitops::loghead-of-loghead-1
                                     unsigned-byte-p

--- a/books/projects/x86isa/machine/register-readers-and-writers.lisp
+++ b/books/projects/x86isa/machine/register-readers-and-writers.lisp
@@ -742,7 +742,7 @@ pointer, or opcode registers\).</em></p>"
   (define mmx-instruction-updates (x86)
     :inline t
     :no-function t
-    :guard-hints (("Goal" :in-theory (e/d ()
+    :guard-hints (("Goal" :in-theory (e/d (unsigned-byte-p-when-fp-statusbits-p)
                                           ())))
     :short "We set the FPU tag and TOS field to 00B \(valid\) and 000B
     respectively.  This function accounts for the effects of all MMX

--- a/books/projects/x86isa/utils/fp-structures.lisp
+++ b/books/projects/x86isa/utils/fp-structures.lisp
@@ -82,6 +82,8 @@
         (unsigned-byte-p 16 x))
    :rule-classes nil))
 
+(in-theory (disable unsigned-byte-p-when-fp-statusbits-p))
+
 (defbitstruct mxcsrBits
   :short "The MXCSR Control and Status Register."
   :long "<p>Source: Intel Manual, Dec-23, Vol. 1, Section 10.2.3.</p>"
@@ -116,5 +118,7 @@
    (iff (mxcsrBits-p x)
         (unsigned-byte-p 32 x))
    :rule-classes nil))
+
+(in-theory (disable unsigned-byte-p-when-mxcsrbits-p))
 
 ;; ----------------------------------------------------------------------


### PR DESCRIPTION
These backchain from unsigned-byte-p to the specific bitstruct predicates.  So they can introduce reasoning about the bitstructs out of nowhere in unrelated contexts.  Thus, I think we don't want them enabled by default.  I re-enabled them only where needed.

Example of problematic rule:

(DEFTHM UNSIGNED-BYTE-P-WHEN-MXCSRBITS-P
  (IMPLIES (MXCSRBITS-P X)
           (UNSIGNED-BYTE-P 32 X)))

If people approve this change, I can make similar changes for other bitstructs.  Even better would be to have defbitstruct (optionally) disable these rules.

