### PR TITLE
[acl2s] Add simple-tcp-service library

### DIFF
--- a/books/acl2s/aspf/simple-tcp-service/.gitignore
+++ b/books/acl2s/aspf/simple-tcp-service/.gitignore
@@ -1,0 +1,72 @@
+# Common Lisp
+*.FASL
+*.fasl
+*.lisp-temp
+*.dfsl
+*.pfsl
+*.d64fsl
+*.p64fsl
+*.lx64fsl
+*.lx32fsl
+*.dx64fsl
+*.dx32fsl
+*.fx64fsl
+*.fx32fsl
+*.sx64fsl
+*.sx32fsl
+*.wx64fsl
+*.wx32fsl
+
+# Quicklisp for examples
+system-index.txt
+
+# Emacs
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+

--- a/books/acl2s/aspf/simple-tcp-service/LICENSE
+++ b/books/acl2s/aspf/simple-tcp-service/LICENSE
@@ -1,0 +1,24 @@
+Unless otherwise specified, the contents of this repository are
+released under the MIT License.
+
+Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "
+Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice (including the
+next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/books/acl2s/aspf/simple-tcp-service/README.md
+++ b/books/acl2s/aspf/simple-tcp-service/README.md
@@ -1,0 +1,42 @@
+# simple-tcp-service
+
+## What is this?
+
+This directory contains code that is intended to make it easier to
+produce services that expose TCP sockets and use ACL2s.
+
+This directory contains several parts:
+- An ASDF system providing a TCP server that allows one to create a
+  customized "ACL2s service" that exposes some capabilities over a TCP
+  socket using a custom protocol
+- An ASDF system providing a library for encoding and decoding Defdata
+  values as JSON
+- A small Python module for connecting to and interacting with an
+  ACL2s service
+- A simple example ACL2s service
+
+## Prerequisites
+To run the examples, Quicklisp should be installed. If not installed
+at `~/quicklisp`, the `QUICKLISP_SETUP` environment variable should be
+set to the path to the `quicklisp/setup.lisp` file. If your ACL2 image
+starts with Quicklisp loaded, this is not required. (you can check
+this by exiting into raw lisp and checking whether `*features*`
+contains `:QUICKLISP`)
+
+## How do I use this?
+
+To create a service, one needs to create a request handler for
+it. This is a function that takes in the body of a message (decoded as
+a UTF-8 string) and produces a string (that will be encoded using
+UTF-8 and sent back to the requester).  In most cases, one can simply
+use the rest of the files from the `basic-server` example with the
+custom request handler (updating `load`s as appropriate).
+
+The Python module supports both starting up a ACL2s service image in a
+subprocess and connecting to an existing service (given its TCP
+port). This means that the services can be running on different
+computers and interacted with over a network if desired, as long as
+the appropriate network configuration is performed to e.g. forward
+ports if needed. One could also create several services in
+subprocesses to create a worker pool and use something like Flask to
+integrate the service with a REST API.

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-json/README.md
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-json/README.md
@@ -1,0 +1,5 @@
+# Example of JSON library
+
+This directory contains a simple example that loads the JSON encoding
+component of the `simple-tcp-service` library and shows how one might
+use it.

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-json/example.lsp
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-json/example.lsp
@@ -1,0 +1,78 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+(make-event `(add-include-book-dir :acl2s-modes (:system . "acl2s/")))
+(ld "acl2s-mode.lsp" :dir :acl2s-modes)
+(acl2s-defaults :set verbosity-level 1)
+(set-inhibit-warnings! "Invariant-risk" "theory")
+(reset-prehistory t)
+
+(in-package "ACL2S")
+;; Some data definitions, for use in examples below.
+(defdata student
+    (record (name . string)
+            (age . nat)
+            (grade . nat)))
+
+(defdata lo-student
+    (listof student))
+
+(defdata classroom
+    (enum '(1 2 3 4 5 6)))
+
+(defdata classroom-assignment
+    (alistof classroom lo-student))
+
+:q
+
+(load "try-load-quicklisp.lsp")
+
+(in-package "ACL2S")
+
+(pushnew (truename "../../") ql:*local-project-directories*)
+(ql:register-local-projects)
+(ql:quickload :simple-tcp-service/json)
+
+;; Integers are turned into strings, to allow larger integers than
+;; JSON libraries typically accept in an interoperable fashion.
+(acl2s-json::encode-value 4)
+
+;; Rationals are expressed as a numerator and denominator
+(acl2s-json::encode-value (/ 3 4))
+
+;; Symbols are translated into a data structure that also contains
+;; package information.
+(acl2s-json::encode-value 'a)
+
+;; Strings are translated directly, no wrapping object.
+(acl2s-json::encode-value "Hello, World!")
+
+;; Nil is treated as a symbol
+(acl2s-json::encode-value nil)
+
+;; Lists are turned into arrays, with each element recursively being
+;; encoded
+(acl2s-json::encode-value '(1 2 3))
+
+;; Certain kinds of alists are treated specially. In particular, if it
+;; is a nonempty list where the first element is a cons and the cdr of
+;; that cons is not itself a list, it will be encoded as an alist.
+(acl2s-json::encode-value '((1 . "a") (2 . "b") (4 . "d")))
+
+;; Note that conses are encoded as lists in a way that makes them
+;; indistinguishable from true lists, e.g. the following two produce
+;; the same encoding.
+(acl2s-json::encode-value '(1 . "a"))
+(acl2s-json::encode-value '(1 "a"))
+
+;; The above alist behavior can be disabled via the
+;; *encode-alists-as-plain-lists* setting.
+(setf acl2s-json::*encode-alists-as-plain-lists* t)
+;; In that case, alists will just be translated into arrays of arrays.
+(acl2s-json::encode-value '((1 . "a") (2 . "b") (4 . "d")))
+
+;; Resetting to the default value
+(setf acl2s-json::*encode-alists-as-plain-lists* nil)
+
+;; Defdata records are treated specially, and are translated into
+;; objects.
+(acl2s-json::encode-value (nth-classroom-assignment/acc 2 9))

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-json/try-load-quicklisp.lsp
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-json/try-load-quicklisp.lsp
@@ -1,0 +1,21 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+(defun error-no-ql ()
+  (error "Quicklisp not found. Either it is not installed, or you have not set it to load automatically. Either set the QUICKLISP_SETUP environment variable to the path to your system's quicklisp/setup.lisp file, or modify build-server.lsp so that it is loaded."))
+
+(defun error-load-failed ()
+  (error "Tried to load Quicklisp from either the user-provided QUICKLISP_SETUP file or from the default Quicklisp setup location but this failed."))
+
+(let ((ql-load-attempted
+      (cond
+       ((member :quicklisp *features*) t)
+       ((acl2::getenv$-raw "QUICKLISP_SETUP")
+        (load (acl2::getenv$-raw "QUICKLISP_SETUP"))
+        t)
+       ((probe-file "~/quicklisp/setup.lisp")
+        (load "~/quicklisp/setup.lisp")
+        t)
+       (t nil))))
+  (cond ((member :quicklisp *features*) t)
+        (ql-load-attempted (error-load-failed))
+        (t (error-no-ql))))

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/.gitignore
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/.gitignore
@@ -1,0 +1,2 @@
+*.core
+server

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/Makefile
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/Makefile
@@ -1,0 +1,12 @@
+all: build
+
+.PHONY: all clean build
+
+ACL2_EXE ?= ${ACL2_SYSTEM_BOOKS}/../saved_acl2
+
+clean:
+	rm -f server server.core
+
+build:
+	${ACL2_EXE} < build.lsp
+

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/README.md
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/README.md
@@ -1,0 +1,29 @@
+# Example server
+
+This directory contains an example service handler plus some Python
+code that interfaces with it.
+
+To provide more functionality, one can modify the `handle-request`
+function in `handler.lsp` and add additional cases. This file will be
+interpreted in Common Lisp rather than ACL2's `ld`.
+
+## Building
+
+Before running the demo, one should build the image for the ACL2 side
+of the demo. This can be done by running `make` in this directory,
+assuming that one has defined the `ACL2_SYSTEM_BOOKS` environment
+variable to point to the `books` directory of the ACL2 repo, and one
+has built an ACL2 image.
+
+## Running
+
+To run the demo, run `python demo.py` in this directory. It should
+print something of the form:
+
+```
+('OK', 'Echo!')
+('OK', 'HVnlX')
+```
+
+where the second line may have a different value for the second tuple
+element.

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/build.lsp
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/build.lsp
@@ -1,0 +1,55 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+(make-event `(add-include-book-dir :acl2s-modes (:system . "acl2s/")))
+(ld "acl2s-mode.lsp" :dir :acl2s-modes)
+(acl2s-defaults :set verbosity-level 1)
+(set-inhibit-warnings! "Invariant-risk" "theory")
+(reset-prehistory t)
+:q
+
+(load "try-load-quicklisp.lsp")
+
+(in-package "ACL2")
+;; A few hacks to disable some printing
+(defun print-ttag-note (val active-book-name include-bookp deferred-p state)
+  (declare (xargs :stobjs state)
+           (ignore val active-book-name include-bookp deferred-p))
+  state)
+(defun print-deferred-ttag-notes-summary (state)
+  state)
+(defun notify-on-defttag (val active-book-name include-bookp state)
+  state)
+
+(in-package "ACL2S")
+
+;; We have to do this dance with readtables because usocket uses read
+;;   macros that ACL2 doesn't support. We could alternatively get around
+;;   this using include-raw with `:host-readtable t`.
+(ql:quickload :named-readtables)
+(named-readtables:defreadtable ACL2s (:merge :current))
+(named-readtables:in-readtable :common-lisp)
+
+;; Load simple-tcp-service (after setting up local-project-directories)
+(pushnew (truename "../../") ql:*local-project-directories*)
+(ql:register-local-projects)
+(ql:quickload :simple-tcp-service)
+
+;; Revert to the ACL2s readtable
+(named-readtables:in-readtable ACL2s)
+
+(load "handler.lsp")
+
+(in-package "ACL2")
+(defun main (args)
+  (cond ((< (len args) 3)
+         (progn (print "Usage: server output_fd seed")
+                (sb-ext:quit)))
+        ((= (len args) 3)
+         (let ((out-fd (sb-sys:make-fd-stream (parse-integer (second args)) :output t :buffering :none))
+               ;; Note that we don't use this argument here.
+               (new-seed (parse-integer (third args))))
+	   (server:run-tcp-server "0.0.0.0" #'server::handle-request :print-stream out-fd)))))
+
+(save-exec "server" nil
+           :init-forms '((value :q))
+           :toplevel-args "--eval '(acl2::main sb-ext:*posix-argv*)' --disable-debugger")

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/demo.py
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/demo.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+# SPDX-License-Identifier: MIT
+import os
+import sys
+
+# Set up the Python include path appropriately so it can find the
+# Python interface library.
+THIS_FILE_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(THIS_FILE_DIR+'/../../python-interface')
+from acl2s import Acl2sService
+
+PROVER_IMG = THIS_FILE_DIR + "/server"
+service = Acl2sService()
+service.start(PROVER_IMG)
+# Test echoing, should print ("OK", "Echo!")
+print(service.run_command("E", "Echo!"))
+# Test another endpoint. This one generates a random string using
+# ACL2s' string enumerator.
+print(service.run_command("R", ""))
+service.stop()

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/handler.lsp
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/handler.lsp
@@ -1,0 +1,28 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+(in-package :server)
+
+;; This function takes in a string corresponding to the message sent
+;; to the server, and should return a string that will be encoded and
+;; sent back to the requester.
+;; If this function signals an error, the server will respond with the
+;; stringified version of the error, plus a flag indicating that the
+;; request resulted in an error in the handler.
+;; If this function signals a condition of class
+;; handler-shutdown-request, the server will shutdown.
+(defun handle-request (str)
+  (let ((command (char str 0))
+        (contents (subseq str 1 (length str)))) ;; TODO: possibly inefficient to do this because creates a copy
+    ;; This will throw an error if command doesn't match any of the
+    ;; provided cases.
+    (ecase command
+           ;; The E and Q commands are required by the provided Python
+           ;; interface, but feel free to add, remove, or modify any
+           ;; other cases.
+           (#\E ;; Echo the contents of the recieved request.
+            contents)
+           (#\Q ;; Tell the server to shutdown.
+            (signal 'handler-shutdown-request))
+           (#\R ;; Do a thing!  In this case, call one of ACL2s'
+            ;; enumerators with a random seed value.
+            (acl2s::nth-string (random (expt 2 63)))))))

--- a/books/acl2s/aspf/simple-tcp-service/examples/basic-server/try-load-quicklisp.lsp
+++ b/books/acl2s/aspf/simple-tcp-service/examples/basic-server/try-load-quicklisp.lsp
@@ -1,0 +1,21 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+(defun error-no-ql ()
+  (error "Quicklisp not found. Either it is not installed, or you have not set it to load automatically. Either set the QUICKLISP_SETUP environment variable to the path to your system's quicklisp/setup.lisp file, or modify build-server.lsp so that it is loaded."))
+
+(defun error-load-failed ()
+  (error "Tried to load Quicklisp from either the user-provided QUICKLISP_SETUP file or from the default Quicklisp setup location but this failed."))
+
+(let ((ql-load-attempted
+      (cond
+       ((member :quicklisp *features*) t)
+       ((acl2::getenv$-raw "QUICKLISP_SETUP")
+        (load (acl2::getenv$-raw "QUICKLISP_SETUP"))
+        t)
+       ((probe-file "~/quicklisp/setup.lisp")
+        (load "~/quicklisp/setup.lisp")
+        t)
+       (t nil))))
+  (cond ((member :quicklisp *features*) t)
+        (ql-load-attempted (error-load-failed))
+        (t (error-no-ql))))

--- a/books/acl2s/aspf/simple-tcp-service/python-interface/.gitignore
+++ b/books/acl2s/aspf/simple-tcp-service/python-interface/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/books/acl2s/aspf/simple-tcp-service/python-interface/README.md
+++ b/books/acl2s/aspf/simple-tcp-service/python-interface/README.md
@@ -1,0 +1,32 @@
+# ACL2s TCP Service Python Interface
+
+This library provides a Python interface for use when interacting with
+a service implemented using the ACL2s simple-tcp-service library.
+
+This interface expects that the service in question implements the
+following two commands:
+- `E`, which is expected to respond with "OK" followed by the payload
+  of the original command
+- `Q`, which responds with "OK" and then stops the service
+
+Message payloads are expected to be UTF-8 encoded. The first two bytes
+of a message response payload are expected to denote the status of the
+response, either `OK` for success or `ER` for failure.
+
+The message format is described in `src/tcp-worker/tcp-server.lisp`.
+
+## Usage
+
+This library is capable of starting a service executable locally and
+connecting to it, or connecting to an already-running service that is
+accessible via TCP.
+
+The first can be performed by calling the `start` method on an
+`Acl2sService` object. This method takes in a path to the service
+executable, which is expected to take in a file descriptor to which it
+will write the port number (5 bytes, each to be interpreted as an
+ASCII digit) for the TCP port that it is listening on.
+
+One can connect to an existing service by calling the `connect`
+method, which takes in the port number to connect to and optionally
+the host IP to connect to (by default, `0.0.0.0`).

--- a/books/acl2s/aspf/simple-tcp-service/python-interface/acl2s.py
+++ b/books/acl2s/aspf/simple-tcp-service/python-interface/acl2s.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+# SPDX-License-Identifier: MIT
+import time
+import subprocess
+import os
+import socket
+import struct
+
+ACL2S_COMMAND_RUN_TIMEOUT_S = 20 # seconds in which the ACL2S process should start and run our command
+
+class Acl2sServiceException(Exception):
+    pass
+
+class InvalidHeaderException(Acl2sServiceException):
+    def __init__(self, actual_header):
+        self.message = f"Expected QK but got ${actual_header}."
+
+class MessageSizeMismatchException(Acl2sServiceException):
+    def __init__(self, expected, actual):
+        self.message = f"Expected message length to be ${expected} bytes, but actually only recieved ${actual} bytes."
+
+class ConnectionTestFailedException(Acl2sServiceException):
+    def __init__(self):
+        self.message = "Connection test failed - ensure that the service executes correctly and supports the E echo command"
+
+class Acl2sService:
+    """A class representing a an ACL2s service. Can either connect to an
+    existing ACL2s service with connect(), or start an ACL2s service
+    image in a subprocess and manage it.
+    """
+    def __init__(self, run_timeout=ACL2S_COMMAND_RUN_TIMEOUT_S):
+        self.output_read_fd = None
+        self.output_write_fd = None
+        self.process = None
+        self.sock = None
+        self.run_timeout = run_timeout
+
+    # 1382728371 is the default random seed for ACL2s
+    # See books/acl2s/defdata/random-state-basis1.lisp.
+    def start(self, executable, seed=1382728371, debug=False):
+        """Start the ACL2s service and connect to it.
+        Returns the port that the ACL2s service is listening on.
+        
+        Note that the optional seed parameter must be a 63-bit unsigned
+        integer (per defdata).
+        
+        The ACL2s service image must output the port number that it is
+        listening on to the file descriptor that it is passed in.
+        """
+        # Create pipes for receiving data from acl2s.
+        self.output_read_fd, self.output_write_fd = os.pipe()
+        # TODO: preexec_fn does not work on windows. But this is probably
+        # true of most of the code in this file.
+        # Pipe stdout and stderr to /dev/null unless debug is True.
+        stdout = subprocess.DEVNULL
+        stderr = subprocess.DEVNULL
+        if debug:
+            stdout = None
+            stderr = None
+        self.process = subprocess.Popen(
+            [executable, str(self.output_write_fd), str(seed)],
+            stdin=subprocess.DEVNULL,
+            stdout=stdout,
+            stderr=stderr,
+            pass_fds=[self.output_write_fd],
+            # Ignore CTRL-C
+            preexec_fn=os.setpgrp)
+        d = os.read(self.output_read_fd, 5)
+        decoded = d.decode()
+        port = int(decoded)
+        self.connect(port, host="0.0.0.0")
+        return port
+
+    def connect(self, port, host="0.0.0.0"):
+        """Connect to a running ACL2s service on the given port.
+        The `host` argument is optional, and by default is 0.0.0.0.
+        
+        After connecting, this service will test whether the server
+        responds as expected to an E (echo) command. If this fails, a
+        `ConnectionTestFailedException `is raised but the socket remains
+        connected.
+        """
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.connect((host, port))
+        self.sock.settimeout(self.run_timeout)
+        if not self.run_command("E", "test") == ("OK", "test"):
+            raise ConnectionTestFailedException()
+
+    def disconnect(self):
+        """Disconnect from a running ACL2s service.
+        
+        This will not stop the service, it will only close the TCP
+        connection.
+        """
+        self.sock.close()
+
+    def stop(self):
+        """Stop the running ACL2s service and disconnect from it.
+        
+        If the ACL2s service was started in this Python instance using
+        the `start` method of Acl2sService, the process will also be
+        killed, and the file descriptors used to communicate with it at
+        initialization time will be closed.
+        
+        The process kill and file descriptor cleanup will occur even if
+        the stop command fails to execute for some reason.
+        """
+        try:
+            self.run_command("Q")
+            self.sock.close()
+        finally:
+            if self.process:
+                self.process.kill()
+            if self.output_write_fd:
+                os.close(self.output_write_fd)
+            if self.output_read_fd:
+                os.close(self.output_read_fd)
+
+    def write(self, body):
+        """Send data to the ACL2s service."""
+        body_en = body.encode(encoding="utf-8")
+        nbytes = len(body_en)
+        return self.sock.send(b''.join([b'QK', struct.pack('>I', nbytes), body_en]))
+
+    def read(self):
+        """Recieve data from the ACL2s service.
+
+        This method will raise a `socket.timeout` exception if no
+        message is received within the configured `run_timeout`
+        duration.
+        """
+        header = self.sock.recv(6)
+        if not header[0:2] == b'QK':
+            raise InvalidHeaderException()
+        nbytes = struct.unpack('>I', header[2:])[0]
+        totbytes = 0
+        body = []
+        # Note that the message may come in as several TCP packets,
+        # so we need to make sure we wait for them all here
+        # TODO: add timeout or something
+        while totbytes < nbytes:
+            data = self.sock.recv(nbytes-totbytes)
+            body.append(data)
+            totbytes = totbytes + len(data)
+        if not totbytes == nbytes:
+            raise MessageSizeMismatchException(nbytes, totbytes)
+        return b''.join(body).decode(encoding="utf-8")
+
+    def run(self, data):
+        """Send a data to the ACL2s service and wait for it to respond.
+
+        This method will raise a `socket.timeout` exception if the Lisp
+        command(s) take longer than the configured `run_timeout`
+        duration to evaluate.
+        """
+        self.write(data)
+        return self.read()
+
+    def write_command(self, command, data=""):
+        if len(command) != 1:
+            raise ValueError("Command should be a single-character string.")
+        return self.write(command + str(data))
+
+    def read_command(self):
+        output = self.read()
+        return (output[0:2], output[2:])
+
+    def run_command(self, command, data=""):
+        """Send a command to the ACL2s service with (optionally) some
+        data and wait for it to respond.
+
+        This method will raise a `socket.timeout` exception if the Lisp
+        command(s) take longer than the configured `run_timeout`
+        duration to evaluate.
+        """
+        self.write_command(command, data)
+        return self.read_command()
+
+if __name__ == "__main__":
+    # TODO: add better example
+    #p = Acl2sService()
+    #try:
+    #    p.start()
+    #    print(p.run_command("E", "foobar"))
+    #finally:
+    #    p.stop()
+    pass

--- a/books/acl2s/aspf/simple-tcp-service/simple-tcp-service.asd
+++ b/books/acl2s/aspf/simple-tcp-service/simple-tcp-service.asd
@@ -1,0 +1,19 @@
+(defsystem "simple-tcp-service/tcp-worker"
+    :depends-on ("alexandria" "usocket" "usocket-server" "flexi-streams")
+    :serial t
+    :pathname "src/tcp-worker"
+    :components
+    ((:file "package")
+     (:file "string-trim")
+     (:file "tcp-server")))
+
+(defsystem "simple-tcp-service/json"
+  :depends-on ("cl-json" "trivia")
+  :pathname "src/json"
+  :serial t
+  :components
+  ((:file "package")
+   (:file "json")))
+
+(defsystem "simple-tcp-service"
+    :depends-on ("simple-tcp-service/tcp-worker"))

--- a/books/acl2s/aspf/simple-tcp-service/src/json/json.lisp
+++ b/books/acl2s/aspf/simple-tcp-service/src/json/json.lisp
@@ -1,0 +1,179 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+(in-package :acl2s-json)
+
+(setq json::*json-identifier-name-to-lisp* 'json::simplified-camel-case-to-lisp)
+
+(defun recordp (val)
+  (and (acl2::alistp val)
+       (assoc :0TAG val)))
+
+(defparameter *encode-alists-as-plain-lists* nil
+  "This controls whether things that look like alists (e.g. that are
+nonempty lists where the first element is a cons of something onto an
+atom) get encoded as regular lists or as special alist values.")
+
+#|
+string -> string
+symbol -> { type: "sym", val: "<symbol in readable form here>" }
+rational -> { type: "rat", n: number, d: number }
+list -> [ <item1>, ... , <itemn> ]
+defdata object -> { type: "defdata", 0tag: string, fields... }
+|#
+
+(defun encode-alist-pair (val &optional (stream *standard-output*))
+  (format stream "\"~a\": " (car val))
+  (encode-value (cdr val) stream))
+
+(defun encode-alist (val &optional (stream *standard-output*))
+  (write-string "{" stream)
+  (if (consp val)
+      (progn
+        (loop for pair in (butlast val) do
+              (encode-alist-pair pair stream)
+              (write-string "," stream))
+        (encode-alist-pair (car (last val)) stream))
+    nil)
+  (write-string "}" stream))
+
+(defun encode-value (val &optional (stream *standard-output*))
+  (cond
+   ((characterp val) (format stream "\"~a\"" val))
+   ((stringp val) (format stream "~s" val))
+   ((integerp val) (encode-alist `((type . "int")
+                                   (val . ,(write-to-string val)))
+                                 stream))
+   ((acl2::rationalp val) (encode-alist
+                           `((type . "rat")
+                             (n . ,(write-to-string (acl2::numerator val)))
+                             (d . ,(write-to-string (acl2::denominator val))))
+                           stream))
+   ((acl2::complex-rationalp val) (encode-alist
+                                   `((type . "complex")
+                                     (real . (acl2::realpart val))
+                                     (imag . (acl2::imagpart val)))))
+   ;;((numberp val) (write-string (write-to-string val) stream))
+   ((symbolp val) (encode-alist
+                   `((type . "sym")
+                     (package . ,(package-name (symbol-package val)))
+                     (name . ,(symbol-name val)))
+                   stream))
+   ((recordp val) (encode-record val stream))
+   ((and (not *encode-alists-as-plain-lists*)
+         (consp val)
+         (consp (car val))
+         (not (consp (cdar val))))
+    ;; can't use encode-alist here, so we've gotta do it ourself.
+    (write-string "{" stream)
+    (encode-alist-pair '(type . "alist") stream)
+    (format stream ",\"~a\": " 'elements)
+    (encode-list val stream)
+    (write-string "}" stream))
+   ((consp val) (encode-list val stream))
+   (t (error "Don't know how to encode ~S" val))))
+
+(defun encode-list (val &optional (stream *standard-output*))
+  (write-string "[" stream)
+  (loop for elt in (butlast val) do
+	(encode-value elt stream)
+	(write-string ", " stream))
+  (encode-value (car (last val)) stream)
+  ;; this is needed so we don't just drop the last element of an
+  ;; improper list.
+  (when (and (consp (last val)) (not (null (cdr (last val)))))
+    (write-string ", " stream)
+    (encode-value (cdr (last val)) stream))
+  (write-string "]" stream))
+
+(defun encode-record (val &optional (stream *standard-output*))
+  (write-line "{" stream)
+  (encode-alist-pair '(type . "defdata") stream)
+  (write-string "," stream)
+  (loop for pair in (butlast val) do
+	(encode-alist-pair pair stream)
+	(write-line "," stream))
+  (encode-alist-pair (car (last val)) stream)
+  (write-line "" stream)
+  (write-string "}" stream))
+
+;;(encode-value 2)
+;;(encode-value (list 1 2 3 4))
+;;(encode-value (acl2s::nth-foo 324))
+;;(encode-value (acl2s::nth-foo 3292834))
+;;(encode-value (mapcar #'acl2s::nth-foo (list 1 2 3 4 5)))
+
+(defun encode-to-string (val)
+  (let ((s (make-string-output-stream)))
+    (handler-case
+        (progn
+          (encode-value val s)
+          (get-output-stream-string s))
+      (error (condition) (progn (close s)
+                                (signal condition)))
+      (:no-error (val) (progn (close s) val)))))
+
+(defun decode-from-string (str)
+  (let ((val (json:decode-json-from-string str)))
+    (decode-value val)))
+
+(defun decode-from-stream (stream)
+  (let ((val (json:decode-json stream)))
+    (decode-value val)))
+
+
+(defun decode-value (val)
+  (cond
+   ((stringp val) val)
+   ((acl2::alistp val) (decode-alist val))
+   ((listp val) (mapcar #'decode-value val))
+   (t (error "Don't know how to decode ~s" val))))
+
+(defun alist-get (key val)
+  (cdr (assoc key val)))
+
+(defun alist-remove (key val)
+  (remove-if (lambda (pair) (equal (car pair) key)) val))
+
+(defun decode-alist (val)
+  (if (assoc :type val)
+      (let ((ty (cdr (assoc :type val))))
+        (match ty
+          ("int" (values (parse-integer (alist-get :val val))))
+          ("rat" (/ (parse-integer (alist-get :n val))
+                    (parse-integer (alist-get :d val))))
+          ("sym" (values (intern (alist-get :name val) (alist-get :package val))))
+          ("defdata" (decode-record (alist-remove :type val)))
+          (otherwise (error "Don't know how to decode type ~s" ty))))
+    (error "Decoding general alists is not currently supported")))
+
+(defun decode-record (val)
+  (mapcar #'(lambda (pair) (cons (car pair) (decode-value (cdr pair)))) val))
+
+;;(decode-from-string (encode-to-string 1))
+;;(decode-from-string (encode-to-string "hi"))
+;;(decode-from-string (encode-to-string 'hi))
+;;(decode-from-string (encode-to-string :hi))
+;;(decode-from-string (encode-to-string (acl2s::nth-foo 1)))
+
+;; TODO: only do this if val is a quoted defdata record
+(defun unquote-if-needed (val)
+  (if (acl2::quotep val)
+      (acl2::unquote val)
+    val))
+
+(defun encode-counterexample (ctrex &optional (stream *standard-output*))
+  (write-string "{" stream)
+  (loop for var-ctrex in (butlast ctrex) do
+        (encode-alist-pair (cons (car var-ctrex) (unquote-if-needed (second var-ctrex))) stream)
+        (write-string "," stream))
+  (let ((var-ctrex (car (last ctrex))))
+    (encode-alist-pair (cons (car var-ctrex) (unquote-if-needed (second var-ctrex))) stream))
+  (write-string "}" stream))
+
+(defun encode-counterexamples (ctrexes &optional (stream *standard-output*))
+  (write-string "[" stream)
+  (loop for ctrex in (butlast ctrexes) do
+        (encode-counterexample ctrex stream)
+        (write-string "," stream))
+  (encode-counterexample (car (last ctrexes)) stream)
+  (write-string "]" stream))

--- a/books/acl2s/aspf/simple-tcp-service/src/json/package.lisp
+++ b/books/acl2s/aspf/simple-tcp-service/src/json/package.lisp
@@ -1,0 +1,11 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+
+#-ACL2 (error "This file must be loaded inside of an ACL2s image.")
+
+(defpackage :acl2s-json
+  (:use :cl :trivia)
+  (:import-from :acl2 :rationalp)
+  (:export #:encode-value #:encode-to-string
+           #:decode-from-string #:decode-from-stream
+           #:encode-counterexample #:encode-counterexamples))

--- a/books/acl2s/aspf/simple-tcp-service/src/tcp-worker/package.lisp
+++ b/books/acl2s/aspf/simple-tcp-service/src/tcp-worker/package.lisp
@@ -1,0 +1,7 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: MIT
+
+(defpackage :server
+  (:use :cl :usocket :flexi-streams)
+  (:import-from :alexandria #:define-constant)
+  (:export #:run-tcp-server #:handler-shutdown-request))

--- a/books/acl2s/aspf/simple-tcp-service/src/tcp-worker/string-trim.lisp
+++ b/books/acl2s/aspf/simple-tcp-service/src/tcp-worker/string-trim.lisp
@@ -1,0 +1,34 @@
+;; SPDX-FileCopyrightText: Copyright 2018-2020 vindarel
+;; SPDX-License-Identifier: MIT
+(in-package :server)
+
+;; This is from the cl-str library, which is released under the MIT
+;; license. 
+
+;; Copyright 2018-2020 vindarel
+;;
+;; Permission is hereby granted, free of charge, to any person
+;; obtaining a copy of this software and associated documentation
+;; files (the "Software"), to deal in the Software without
+;; restriction, including without limitation the rights to use, copy,
+;; modify, merge, publish, distribute, sublicense, and/or sell copies
+;; of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be
+;; included in all copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+(defvar *whitespaces* '(#\Space #\Newline #\Tab
+                        #\Page #\Return #\Rubout))
+(defun trim (s)
+  "Remove whitespaces at the beginning and end of s."
+  (string-trim *whitespaces* s))

--- a/books/acl2s/aspf/simple-tcp-service/src/tcp-worker/tcp-server.lisp
+++ b/books/acl2s/aspf/simple-tcp-service/src/tcp-worker/tcp-server.lisp
@@ -1,0 +1,171 @@
+;; SPDX-FileCopyrightText: Copyright (c) 2021 Andrew T. Walter <me@atwalter.com>
+;; SPDX-License-Identifier: BSD-3-Clause
+(in-package :server)
+
+;; The handler should signal this to indicate that the server should
+;; shutdown.
+(define-condition handler-shutdown-request () ())
+
+;; Uncomment this line to enable debug messages
+;;(push :lisp-server-debug cl:*features*)
+
+;; Parts of this file adapted from/inspired by
+;; https://gist.github.com/traut/648dc0d7b22fdfeae6771a5a4a19f877
+;; That code is licensed under the BSD 3-Clause License, as shown
+;; below.
+
+; BSD 3-Clause License
+; 
+; Copyright (c) 2018, Sergey Polzunov
+; All rights reserved.
+; 
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+; 
+; * Redistributions of source code must retain the above copyright notice, this
+;   list of conditions and the following disclaimer.
+; 
+; * Redistributions in binary form must reproduce the above copyright notice,
+;   this list of conditions and the following disclaimer in the documentation
+;   and/or other materials provided with the distribution.
+; 
+; * Neither the name of the copyright holder nor the names of its
+;   contributors may be used to endorse or promote products derived from
+;   this software without specific prior written permission.
+; 
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(defvar +max-buffer-size+ 32768)
+
+(defun logger (text &rest args)
+  "Wrapper around format to simplify logging"
+  #+lisp-server-debug
+  (apply 'format (append (list t (concatenate 'string text "~%")) args)))
+
+;; Message Protocol
+#|
+This server sends and recieves messages in the following binary format:
+[ 'Q' 'K' |  size   | contents...  ]
+[ 2 bytes | 4 bytes | <size> bytes ]
+
+Note that the contents are utf8 encoded.
+|#
+
+;; Why QK? This subsequence does not appear in any English word in the
+;; dictionary file I looked in.
+(define-constant +HEADER-B0+ (char-code #\Q))
+(define-constant +HEADER-B1+ (char-code #\K))
+(define-constant +OK-STATUS+ (flexi-streams:string-to-octets "OK" :external-format :utf-8) :test #'equalp)
+(define-constant +ERROR-STATUS+ (flexi-streams:string-to-octets "ER" :external-format :utf-8) :test #'equalp)
+
+(defun read-u32-big-endian (stream)
+  (let ((val 0))
+    (setf (ldb (byte 8 24) val) (read-byte stream))
+    (setf (ldb (byte 8 16) val) (read-byte stream))
+    (setf (ldb (byte 8 8) val) (read-byte stream))
+    (setf (ldb (byte 8 0) val) (read-byte stream))
+    val))
+
+(defun write-u32-big-endian (val stream)
+  (write-sequence (list (ldb (byte 8 24) val)
+			(ldb (byte 8 16) val)
+			(ldb (byte 8 8) val)
+			(ldb (byte 8 0) val))
+		  stream))
+
+(defun read-header (stream)
+  (assert (= (read-byte stream) +HEADER-B0+))
+  (assert (= (read-byte stream) +HEADER-B1+))
+  (read-u32-big-endian stream))
+
+(defun read-body (nbytes stream)
+  ;; TODO: check that nbytes are actually read
+  (let ((buffer (make-array nbytes
+                            :element-type '(unsigned-byte 8))))
+    (read-sequence buffer stream)
+    buffer))
+
+(defun write-header (nbytes stream)
+  (write-byte +HEADER-B0+ stream)
+  (write-byte +HEADER-B1+ stream)
+  (write-u32-big-endian nbytes stream))
+
+(defun write-body (body-string stream)
+  (write-sequence (flexi-streams:string-to-octets body-string :external-format :utf-8) stream))
+
+(defun write-message (status body stream)
+  "Write a message to the given stream."
+  (let ((body-nbytes (flexi-streams:octet-length body :external-format :utf-8)))
+    (write-header (+ body-nbytes (length status)) stream)
+    (write-sequence status stream)
+    (write-body body stream)
+    (force-output stream)))
+
+;; Top-level connection handling functions
+(defun tcp-handler (stream socket con handler)
+  ;; Keep reading data until we get an end-of-file error (i.e. the
+  ;; other side closed the connection)
+  (handler-case
+      (loop
+       (usocket:wait-for-input con)
+       (logger "Recieved data over socket.")
+       (let* ((nbytes (read-header stream))
+              (body (read-body nbytes stream))
+              (body-string (trim (flexi-streams:octets-to-string body :external-format :utf-8 :end nbytes)))
+              (output-with-status
+               (handler-case
+                   (funcall handler body-string)
+                 (handler-shutdown-request (c) (logger "Shutting down service.")
+                                           (write-message +OK-STATUS+ "" stream)
+                                           (signal c))
+                 (error (c) (logger "Error in request handler: ~S" c)
+                        (cons +ERROR-STATUS+ (princ-to-string c)))
+                 (:no-error (val) (cons +OK-STATUS+ val))))
+              (status (car output-with-status))
+              (output (cdr output-with-status)))
+         (write-message status output stream)))
+    (end-of-file () nil)))
+
+(defun run-tcp-server (host handler &key (print-stream *STANDARD-OUTPUT*) (on-socket-listen nil on-socket-listen-p))
+  "Run TCP server in a loop, listening to incoming connections.
+  This is a single-threaded version."
+  ;; TODO: Better approach would be to run tcp-handler in a separate
+  ;;       thread every time there is activity on the client socket
+  ;; We request a TCP socket on an arbitrary free port.
+  (let* ((socket (usocket:socket-listen host 0 :element-type '(unsigned-byte 8)))
+         (port (usocket:get-local-port socket)))
+    (handler-case
+        (unwind-protect
+            (progn
+              (logger "Listening on port ~a." port)
+              ;; We either call the provided on-socket-listen function with the
+              ;; port number, if the argument was provided, or print the port
+              ;; number out to print-stream. This is important because otherwise
+              ;; whatever called us wouldn't know what port to connect to.
+              (if on-socket-listen-p
+                  (funcall on-socket-listen port)
+                (progn
+                  ;; Ensure that the printed port number is exactly 5 characters
+                  (format print-stream "~5,'0D" port)
+                  (force-output print-stream)))
+              ;; Keep looping, accepting connections in serial.
+              (loop do
+                    (let* ((con (usocket:socket-accept socket))
+	                   (stream (usocket:socket-stream con)))
+                      (logger "Accepted connection.")
+                      (tcp-handler stream socket con handler)
+                      (close stream)
+                      (usocket:socket-close con))))
+          (usocket:socket-close socket))
+      (handler-shutdown-request (c) (uiop/image:quit 0 t)))))
+
+;;(run-tcp-server "0.0.0.0")


### PR DESCRIPTION
Add the simple-tcp-service library to the ACL2s books. This library allows one to set up a service in raw Lisp with endpoints that can be interacted with using a basic Python library.