### PR TITLE
[X86ISA] Improve guard proofs in linear-memory.lisp.

### DIFF
--- a/books/projects/x86isa/machine/guard-helpers.lisp
+++ b/books/projects/x86isa/machine/guard-helpers.lisp
@@ -53,189 +53,240 @@
 
 ;; Various lemmas for the guard proofs of rm* functions
 
-(defthm-using-gl rml16-guard-proof-helper
-  :hyp (and (n08p a)
-            (n08p b))
-  :concl (< (logior a (ash b 8)) *2^16*)
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8)))
-  :rule-classes :linear)
+;; (defthm-using-gl rml16-guard-proof-helper
+;;   :hyp (and (n08p a)
+;;             (n08p b))
+;;   :concl (< (logior a (ash b 8)) *2^16*)
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8)))
+;;   :rule-classes :linear)
 
-(defthm-using-gl rb-and-rvm32-helper
-  :hyp (and (n08p a)
-            (n08p b)
-            (n16p c))
-  :concl (equal (logior a (ash b 8) (ash c 16))
-                (logior a (ash (logior b (ash c 8)) 8)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8)) (:nat c 16))
-  :rule-classes :linear)
+;; (defthm-using-gl rb-and-rvm32-helper
+;;   :hyp (and (n08p a)
+;;             (n08p b)
+;;             (n16p c))
+;;   :concl (equal (logior a (ash b 8) (ash c 16))
+;;                 (logior a (ash (logior b (ash c 8)) 8)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8)) (:nat c 16))
+;;   :rule-classes :linear)
 
-(defthm-using-gl rml32-guard-proof-helper
-  :hyp (and (n08p a)
-            (n08p b)
-            (n08p c)
-            (n08p d))
-  :concl (<
-          (logior a
-                  (ash (logior b
-                               (ash (logior c (ash d 8)) 8))
-                       8))
-          *2^32*)
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)))
-  :rule-classes :linear)
+;; (defthm-using-gl rml32-guard-proof-helper
+;;   :hyp (and (n08p a)
+;;             (n08p b)
+;;             (n08p c)
+;;             (n08p d))
+;;   :concl (<
+;;           (logior a
+;;                   (ash (logior b
+;;                                (ash (logior c (ash d 8)) 8))
+;;                        8))
+;;           *2^32*)
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)))
+;;   :rule-classes :linear)
 
-(defthm-using-gl rml48-guard-proof-helper
-  :hyp (and (n08p a) (n08p b) (n32p c))
-  :concl (equal (logior a (ash b 8) (ash c 16))
-                (logior a (ash (logior b (ash c 8)) 8)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 32) (:nat b 32) (:nat c 32)))
-  :rule-classes :linear)
+;; (defthm-using-gl rml48-guard-proof-helper
+;;   :hyp (and (n08p a) (n08p b) (n32p c))
+;;   :concl (equal (logior a (ash b 8) (ash c 16))
+;;                 (logior a (ash (logior b (ash c 8)) 8)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 32) (:nat b 32) (:nat c 32)))
+;;   :rule-classes :linear)
 
-(defthm-using-gl rb-and-rml48-helper-1
-  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
-            (n08p e) (n08p f))
-  :concl (equal (logior
-                 a
-                 (ash (logior
-                       b
-                       (ash (logior
-                             c
-                             (ash (logior
-                                   d (ash (logior e (ash f 8)) 8)) 8)) 8)) 8))
-                (logior
-                 a
-                 (ash b 8)
-                 (ash (logior
-                       c
-                       (ash (logior d (ash (logior e (ash f 8)) 8))
-                            8)) 16)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
-         (:nat e 8) (:nat f 8))))
+;; (defthm-using-gl rb-and-rml48-helper-1
+;;   :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
+;;             (n08p e) (n08p f))
+;;   :concl (equal (logior
+;;                  a
+;;                  (ash (logior
+;;                        b
+;;                        (ash (logior
+;;                              c
+;;                              (ash (logior
+;;                                    d (ash (logior e (ash f 8)) 8)) 8)) 8)) 8))
+;;                 (logior
+;;                  a
+;;                  (ash b 8)
+;;                  (ash (logior
+;;                        c
+;;                        (ash (logior d (ash (logior e (ash f 8)) 8))
+;;                             8)) 16)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
+;;          (:nat e 8) (:nat f 8))))
 
-(defthm-using-gl rb-and-rml48-helper-2
-  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
-            (n08p e) (n08p f))
-  :concl (<
-          (logior
-           a
-           (ash b 8)
-           (ash (logior
-                 c
-                 (ash (logior d (ash (logior e (ash f 8)) 8))
-                      8)) 16))
-          #.*2^48*)
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
-         (:nat e 8) (:nat f 8))))
+;; (defthm-using-gl rb-and-rml48-helper-2
+;;   :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
+;;             (n08p e) (n08p f))
+;;   :concl (<
+;;           (logior
+;;            a
+;;            (ash b 8)
+;;            (ash (logior
+;;                  c
+;;                  (ash (logior d (ash (logior e (ash f 8)) 8))
+;;                       8)) 16))
+;;           #.*2^48*)
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
+;;          (:nat e 8) (:nat f 8))))
 
-(defthm-using-gl rb-and-rvm64-helper
-  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
-            (n08p e) (n08p f) (n08p g) (n08p h))
-  :concl (equal
-          (logior a (ash b 8)
-                  (ash (logior c (ash d 8)) 16)
-                  (ash (logior e (ash f 8) (ash (logior g (ash h 8)) 16)) 32))
-          (logior a
-                  (ash (logior
-                        b
-                        (ash (logior
-                              c
-                              (ash (logior
-                                    d
-                                    (ash (logior
-                                          e
-                                          (ash (logior f (ash (logior g (ash h 8)) 8)) 8)) 8)) 8))
-                             8))
-                       8)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
-         (:nat e 8) (:nat f 8) (:nat g 8) (:nat h 8))))
+;; (defthm-using-gl rb-and-rvm64-helper
+;;   :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
+;;             (n08p e) (n08p f) (n08p g) (n08p h))
+;;   :concl (equal
+;;           (logior a (ash b 8)
+;;                   (ash (logior c (ash d 8)) 16)
+;;                   (ash (logior e (ash f 8) (ash (logior g (ash h 8)) 16)) 32))
+;;           (logior a
+;;                   (ash (logior
+;;                         b
+;;                         (ash (logior
+;;                               c
+;;                               (ash (logior
+;;                                     d
+;;                                     (ash (logior
+;;                                           e
+;;                                           (ash (logior f (ash (logior g (ash h 8)) 8)) 8)) 8)) 8))
+;;                              8))
+;;                        8)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
+;;          (:nat e 8) (:nat f 8) (:nat g 8) (:nat h 8))))
 
-(defthm-using-gl rml64-guard-proof-helper
-  :hyp (and (n32p a) (n32p b))
-  :concl (< (logior a (ash b 32)) *2^64*)
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 32) (:nat b 32)))
-  :rule-classes :linear)
+;; (defthm-using-gl rml64-guard-proof-helper
+;;   :hyp (and (n32p a) (n32p b))
+;;   :concl (< (logior a (ash b 32)) *2^64*)
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 32) (:nat b 32)))
+;;   :rule-classes :linear)
 
-(defthm-using-gl rml80-guard-proof-helper
-  :hyp (and (n08p a) (n08p b) (n64p c))
-  :concl (equal (logior a (ash b 8) (ash c 16))
-                (logior a (ash (logior b (ash c 8)) 8)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 64) (:nat b 64) (:nat c 64)))
-  :rule-classes :linear)
+;; (defthm-using-gl rml80-guard-proof-helper
+;;   :hyp (and (n08p a) (n08p b) (n64p c))
+;;   :concl (equal (logior a (ash b 8) (ash c 16))
+;;                 (logior a (ash (logior b (ash c 8)) 8)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 64) (:nat b 64) (:nat c 64)))
+;;   :rule-classes :linear)
 
-(defthm-using-gl rml80-in-sys-view-guard-proof-helper
-  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d) (n08p e)
-            (n08p f) (n08p g) (n08p h) (n08p i) (n08p j))
-  :concl (<
-          (logior a
-                  (ash b 8)
-                  (ash (logior
-                        c
-                        (ash
-                         (logior
-                          d
-                          (ash
-                           (logior
-                            e
-                            (ash
-                             (logior
-                              f
-                              (ash
-                               (logior g
-                                       (ash (logior
-                                             h (ash
-                                                (logior i (ash j 8))
-                                                8)) 8)) 8)) 8)) 8)) 8)) 16))
-          *2^80*)
-  :g-bindings (gl::auto-bindings
-               (:mix (:nat a 8)
-                     (:nat b 8)
-                     (:nat c 8)
-                     (:nat d 8)
-                     (:nat e 8)
-                     (:nat f 8)
-                     (:nat g 8)
-                     (:nat h 8)
-                     (:nat i 8)
-                     (:nat j 8))))
+;; (defthm-using-gl rml80-in-sys-view-guard-proof-helper
+;;   :hyp (and (n08p a) (n08p b) (n08p c) (n08p d) (n08p e)
+;;             (n08p f) (n08p g) (n08p h) (n08p i) (n08p j))
+;;   :concl (<
+;;           (logior a
+;;                   (ash b 8)
+;;                   (ash (logior
+;;                         c
+;;                         (ash
+;;                          (logior
+;;                           d
+;;                           (ash
+;;                            (logior
+;;                             e
+;;                             (ash
+;;                              (logior
+;;                               f
+;;                               (ash
+;;                                (logior g
+;;                                        (ash (logior
+;;                                              h (ash
+;;                                                 (logior i (ash j 8))
+;;                                                 8)) 8)) 8)) 8)) 8)) 8)) 16))
+;;           *2^80*)
+;;   :g-bindings (gl::auto-bindings
+;;                (:mix (:nat a 8)
+;;                      (:nat b 8)
+;;                      (:nat c 8)
+;;                      (:nat d 8)
+;;                      (:nat e 8)
+;;                      (:nat f 8)
+;;                      (:nat g 8)
+;;                      (:nat h 8)
+;;                      (:nat i 8)
+;;                      (:nat j 8))))
 
-(in-theory (e/d ()
-                (rml16-guard-proof-helper
-                 rml48-guard-proof-helper
-                 rb-and-rml48-helper-1
-                 rb-and-rml48-helper-2
-                 rb-and-rvm32-helper
-                 rml32-guard-proof-helper
-                 rb-and-rvm64-helper
-                 rml64-guard-proof-helper
-                 rml80-in-sys-view-guard-proof-helper)))
+;; (in-theory (e/d ()
+;;                 (rml16-guard-proof-helper
+;;                  rml48-guard-proof-helper
+;;                  rb-and-rml48-helper-1
+;;                  rb-and-rml48-helper-2
+;;                  rb-and-rvm32-helper
+;;                  rml32-guard-proof-helper
+;;                  rb-and-rvm64-helper
+;;                  rml64-guard-proof-helper
+;;                  rml80-in-sys-view-guard-proof-helper
+;;                  )))
 
-(defthm-using-gl rml32-rb-sys-view-proof-helper
-  :hyp (and (n08p a)
-            (n08p b)
-            (n08p c)
-            (n08p d))
-  :concl (equal (logior a (ash b 8) (ash (logior c (ash d 8)) 16))
-                (logior a (ash (logior b (ash (logior c (ash d 8)) 8)) 8)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8))))
+;; (defthm-using-gl rml32-rb-sys-view-proof-helper
+;;   :hyp (and (n08p a)
+;;             (n08p b)
+;;             (n08p c)
+;;             (n08p d))
+;;   :concl (equal (logior a (ash b 8) (ash (logior c (ash d 8)) 16))
+;;                 (logior a (ash (logior b (ash (logior c (ash d 8)) 8)) 8)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8))))
+
+;; ;; (defthm-using-gl rml64-in-sys-view-guard-proof-helper
+;; ;;   :hyp (and (n08p a)
+;; ;;             (n08p b)
+;; ;;             (n08p c)
+;; ;;             (n08p d)
+;; ;;             (n08p e)
+;; ;;             (n08p f)
+;; ;;             (n08p g)
+;; ;;             (n08p h))
+;; ;;   :concl (< (logior a
+;; ;;                     (ash b 8)
+;; ;;                     (ash (logior c (ash d 8)) 16)
+;; ;;                     (ash (logior
+;; ;;                           e (ash f 8)
+;; ;;                           (ash (logior g (ash h 8)) 16)) 32))
+;; ;;             *2^64*)
+;; ;;   :g-bindings (gl::auto-bindings
+;; ;;                (:mix (:nat a 8)
+;; ;;                      (:nat b 8)
+;; ;;                      (:nat c 8)
+;; ;;                      (:nat d 8)
+;; ;;                      (:nat e 8)
+;; ;;                      (:nat f 8)
+;; ;;                      (:nat g 8)
+;; ;;                      (:nat h 8))))
+
+;; (defthm-using-gl rml64-to-rb-in-sys-view-helper
+;;   :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
+;;             (n08p e) (n08p f) (n08p g) (n08p h))
+;;   :concl (equal
+;;           (logior a
+;;                   (ash (logior b (ash (logior c (ash d 8)) 8)) 8)
+;;                   (ash (logior e (ash (logior f (ash (logior g (ash h 8)) 8)) 8)) 32))
+;;           (logior
+;;            a
+;;            (ash (logior
+;;                  b
+;;                  (ash (logior
+;;                        c
+;;                        (ash (logior d
+;;                                     (ash
+;;                                      (logior e
+;;                                              (ash
+;;                                               (logior f
+;;                                                       (ash (logior g (ash h 8)) 8)) 8)) 8)) 8)) 8)) 8)))
+;;   :g-bindings
+;;   (gl::auto-bindings
+;;    (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
+;;          (:nat e 8) (:nat f 8) (:nat g 8) (:nat h 8))))
 
 ;; (defthm-using-gl rml64-in-sys-view-guard-proof-helper
 ;;   :hyp (and (n08p a)
@@ -246,12 +297,18 @@
 ;;             (n08p f)
 ;;             (n08p g)
 ;;             (n08p h))
-;;   :concl (< (logior a
-;;                     (ash b 8)
-;;                     (ash (logior c (ash d 8)) 16)
-;;                     (ash (logior
-;;                           e (ash f 8)
-;;                           (ash (logior g (ash h 8)) 16)) 32))
+;;   :concl (< (logior
+;;              a
+;;              (ash (logior
+;;                    b
+;;                    (ash (logior
+;;                          c
+;;                          (ash (logior d
+;;                                       (ash
+;;                                        (logior e
+;;                                                (ash
+;;                                                 (logior f
+;;                                                         (ash (logior g (ash h 8)) 8)) 8)) 8)) 8)) 8)) 8))
 ;;             *2^64*)
 ;;   :g-bindings (gl::auto-bindings
 ;;                (:mix (:nat a 8)
@@ -262,62 +319,6 @@
 ;;                      (:nat f 8)
 ;;                      (:nat g 8)
 ;;                      (:nat h 8))))
-
-(defthm-using-gl rml64-to-rb-in-sys-view-helper
-  :hyp (and (n08p a) (n08p b) (n08p c) (n08p d)
-            (n08p e) (n08p f) (n08p g) (n08p h))
-  :concl (equal
-          (logior a
-                  (ash (logior b (ash (logior c (ash d 8)) 8)) 8)
-                  (ash (logior e (ash (logior f (ash (logior g (ash h 8)) 8)) 8)) 32))
-          (logior
-           a
-           (ash (logior
-                 b
-                 (ash (logior
-                       c
-                       (ash (logior d
-                                    (ash
-                                     (logior e
-                                             (ash
-                                              (logior f
-                                                      (ash (logior g (ash h 8)) 8)) 8)) 8)) 8)) 8)) 8)))
-  :g-bindings
-  (gl::auto-bindings
-   (:mix (:nat a 8) (:nat b 8) (:nat c 8) (:nat d 8)
-         (:nat e 8) (:nat f 8) (:nat g 8) (:nat h 8))))
-
-(defthm-using-gl rml64-in-sys-view-guard-proof-helper
-  :hyp (and (n08p a)
-            (n08p b)
-            (n08p c)
-            (n08p d)
-            (n08p e)
-            (n08p f)
-            (n08p g)
-            (n08p h))
-  :concl (< (logior
-             a
-             (ash (logior
-                   b
-                   (ash (logior
-                         c
-                         (ash (logior d
-                                      (ash
-                                       (logior e
-                                               (ash
-                                                (logior f
-                                                        (ash (logior g (ash h 8)) 8)) 8)) 8)) 8)) 8)) 8))
-            *2^64*)
-  :g-bindings (gl::auto-bindings
-               (:mix (:nat a 8)
-                     (:nat b 8)
-                     (:nat c 8)
-                     (:nat d 8)
-                     (:nat e 8)
-                     (:nat f 8)
-                     (:nat g 8)
-                     (:nat h 8))))
 
 ;; ======================================================================
 

--- a/books/projects/x86isa/machine/linear-memory.lisp
+++ b/books/projects/x86isa/machine/linear-memory.lisp
@@ -48,7 +48,7 @@
 
 ;; ======================================================================
 
-(local (include-book "guard-helpers"))
+;(local (include-book "guard-helpers"))
 ; (local (include-book "centaur/bitops/ihs-extensions" :dir :system)) ;; Redundant
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 (local (include-book "arithmetic/top-with-meta" :dir :system))
@@ -1332,6 +1332,21 @@
 
 (local (in-theory (e/d* () (member-equal))))
 
+(local
+  (defthmd las-to-pas-opener-when-canonical
+    (implies (and (posp n)
+                  (canonical-address-p lin-addr))
+             (equal (las-to-pas n lin-addr r-w-x x86)
+                    (b* (((mv flg p-addr x86)
+                          (ia32e-la-to-pa lin-addr r-w-x x86))
+                         ((when flg) (mv flg nil x86))
+                         ((mv flg p-addrs x86)
+                          (las-to-pas (1- n)
+                                      (1+ lin-addr)
+                                      r-w-x x86)))
+                      (mv flg (if flg nil (cons p-addr p-addrs))
+                          x86))))))
+
 (define rml08 ((lin-addr :type (signed-byte #.*max-linear-address-size*))
                (r-x      :type (member  :r :x))
                (x86))
@@ -2216,12 +2231,9 @@
   :parents (linear-memory)
   :guard (canonical-address-p lin-addr)
   :guard-hints (("Goal"
-                 :expand ((las-to-pas 6 lin-addr r-x x86)
-                          (las-to-pas 5 (+ 1 lin-addr) r-x (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86))))
                  :in-theory (e/d (rb-and-rvm48
-                                   rml08
-                                   rb-and-rml48-helper-1
-                                   rb-and-rml48-helper-2)
+                                  las-to-pas-opener-when-canonical
+                                  push-ash-inside-logior)
                                  (not
                                    (:rewrite acl2::ash-0)
                                    (:rewrite acl2::zip-open)
@@ -2258,9 +2270,9 @@
                             (rb 6 lin-addr r-x x86)))
             :hints (("Goal"
                      :in-theory (e/d (rb-and-rvm48-helper
-                                       rml48-guard-proof-helper)
+                                      push-ash-inside-logior)
                                      (signed-byte-p
-                                       force (force)))))))
+                                      force (force)))))))
 
   (if (mbt (canonical-address-p lin-addr))
 
@@ -2444,9 +2456,8 @@
   :guard (canonical-address-p lin-addr)
 
   :guard-hints (("Goal"
-                 :expand ((las-to-pas 6 lin-addr :w x86)
-                          (las-to-pas 5 (+ 1 lin-addr) :w (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86))))
-                 :in-theory (e/d (wb-and-wvm48)
+                 :in-theory (e/d (wb-and-wvm48
+                                  las-to-pas-opener-when-canonical)
                                  ((:rewrite acl2::ash-0)
                                   (:rewrite acl2::zip-open)
                                   (:linear bitops::logior-<-0-linear-2)
@@ -2573,17 +2584,9 @@
   :guard (canonical-address-p lin-addr)
   :guard-hints
   (("Goal"
-    :expand
-    ((las-to-pas 8 lin-addr r-x x86)
-     (las-to-pas 7 (+ 1 lin-addr) r-x (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86)))
-     (las-to-pas 6 (+ 2 lin-addr) r-x
-                 (mv-nth 2 (ia32e-la-to-pa (+ 1 lin-addr) r-x
-                                           (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86)))))
-     (las-to-pas 5 (+ 3 lin-addr) r-x
-                 (mv-nth 2 (las-to-pas 6 (+ 2 lin-addr) r-x
-                                       (mv-nth 2 (ia32e-la-to-pa (+ 1 lin-addr) r-x
-                                                                 (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86))))))))
-    :in-theory (e/d (rb-and-rvm64 rml08)
+    :in-theory (e/d (rb-and-rvm64
+                     las-to-pas-opener-when-canonical
+                     push-ash-inside-logior)
                     (not
                       (:rewrite acl2::ash-0)
                       (:rewrite acl2::zip-open)
@@ -2593,9 +2596,6 @@
 
   :prepwork
   (
-   ;; Maybe we don't need this lemma anymore?
-   (local (in-theory (e/d* () (rb-and-rvm64-helper))))
-
    (local
      (defthmd rb-and-rvm64-helper-1
               (implies (and (app-view x86)
@@ -2643,10 +2643,8 @@
                                       (n 8)))
                      :in-theory (e/d (rb-and-rvm64-helper-1
                                        rb-and-rvm64-helper-2)
-                                     (rb-and-rvm32-helper
-                                       rml64-guard-proof-helper
-                                       signed-byte-p
-                                       force (force)))))))
+                                     (signed-byte-p
+                                      force (force)))))))
 
   (if (mbt (canonical-address-p lin-addr))
 
@@ -2875,17 +2873,7 @@
 
   :guard-hints
   (("Goal"
-    :expand
-    ((las-to-pas 8 lin-addr :w x86)
-     (las-to-pas 7 (+ 1 lin-addr) :w (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86)))
-     (las-to-pas 6 (+ 2 lin-addr) :w
-                 (mv-nth 2 (ia32e-la-to-pa (+ 1 lin-addr) :w
-                                           (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86)))))
-     (las-to-pas 5 (+ 3 lin-addr) :w
-                 (mv-nth 2 (las-to-pas 6 (+ 2 lin-addr) :w
-                                       (mv-nth 2 (ia32e-la-to-pa (+ 1 lin-addr) :w
-                                                                 (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86))))))))
-    :in-theory (e/d (wb-and-wvm64)
+    :in-theory (e/d (wb-and-wvm64 las-to-pas-opener-when-canonical)
                     ((:rewrite acl2::ash-0)
                      (:rewrite acl2::zip-open)
                      (:linear bitops::logior-<-0-linear-2)
@@ -3033,20 +3021,9 @@
   :guard (canonical-address-p lin-addr)
   :guard-hints
   (("Goal"
-    :expand
-    ((las-to-pas 10 lin-addr r-x x86)
-     (las-to-pas 9 (+ 1 lin-addr) r-x (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86)))
-     (las-to-pas 8 (+ 2 lin-addr) r-x
-                 (mv-nth 2 (ia32e-la-to-pa (+ 1 lin-addr) r-x
-                                           (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86)))))
-     (las-to-pas 7 (+ 3 lin-addr) r-x
-                 (mv-nth 2 (ia32e-la-to-pa (+ 2 lin-addr) r-x
-                                           (mv-nth 2 (ia32e-la-to-pa
-                                                       (+ 1 lin-addr) r-x
-                                                       (mv-nth 2 (ia32e-la-to-pa lin-addr r-x x86))))))))
     :in-theory (e/d (rb-and-rvm80
-                      rml80-in-sys-view-guard-proof-helper
-                      rml08)
+                     las-to-pas-opener-when-canonical
+                     push-ash-inside-logior)
                     (not
                       (:rewrite acl2::ash-0)
                       (:rewrite acl2::zip-open)
@@ -3063,8 +3040,7 @@
                      (equal (rvm80 lin-addr x86)
                             (rb 10 lin-addr r-x x86)))
             :hints (("Goal"
-
-                     :in-theory (e/d (rvm80 rb-and-rvm16 rb-and-rvm64 rml80-guard-proof-helper)
+                     :in-theory (e/d (rvm80 rb-and-rvm16 rb-and-rvm64 push-ash-inside-logior)
                                      (force (force)))))))
 
   (if (mbt (canonical-address-p lin-addr))
@@ -3286,18 +3262,7 @@
   :guard (canonical-address-p lin-addr)
   :guard-hints
   (("Goal"
-    :expand
-    ((las-to-pas 10 lin-addr :w x86)
-     (las-to-pas 9 (+ 1 lin-addr) :w (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86)))
-     (las-to-pas 8 (+ 2 lin-addr) :w
-                 (mv-nth 2 (ia32e-la-to-pa (+ 1 lin-addr) :w
-                                           (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86)))))
-     (las-to-pas 7 (+ 3 lin-addr) :w
-                 (mv-nth 2 (ia32e-la-to-pa (+ 2 lin-addr) :w
-                                           (mv-nth 2 (ia32e-la-to-pa
-                                                       (+ 1 lin-addr) :w
-                                                       (mv-nth 2 (ia32e-la-to-pa lin-addr :w x86))))))))
-    :in-theory (e/d (wb-and-wvm80)
+    :in-theory (e/d (wb-and-wvm80 las-to-pas-opener-when-canonical)
                     ((:rewrite acl2::ash-0)
                      (:rewrite acl2::zip-open)
                      (:linear bitops::logior-<-0-linear-2)
@@ -3444,22 +3409,6 @@
 ; Thanks to Dmitry Nadezhin for proving the equivalence of rm/wml128
 ; to rb/wb.
 
-(local
-  (defthmd las-to-pas-opener
-    (implies (posp n)
-             (equal (las-to-pas n lin-addr r-w-x x86)
-                    (B* (((UNLESS (CANONICAL-ADDRESS-P LIN-ADDR))
-                          (MV T NIL X86))
-                         ((MV FLG P-ADDR X86)
-                          (IA32E-LA-TO-PA LIN-ADDR R-W-X X86))
-                         ((WHEN FLG) (MV FLG NIL X86))
-                         ((MV FLG P-ADDRS X86)
-                          (LAS-TO-PAS (1- N)
-                                      (1+ LIN-ADDR)
-                                      R-W-X X86)))
-                      (MV FLG (IF FLG NIL (CONS P-ADDR P-ADDRS))
-                          X86))))))
-
 (define rml128 ((lin-addr :type (signed-byte #.*max-linear-address-size*))
                 (r-x      :type (member :r :x))
                 (x86))
@@ -3467,13 +3416,10 @@
   :parents (linear-memory)
   :guard (canonical-address-p lin-addr)
   :guard-hints (("Goal"
-                 :in-theory (e/d (las-to-pas-opener
+                 :in-theory (e/d (las-to-pas-opener-when-canonical
                                   rb-and-rvm128
-                                   ;rml08 rml64
-                                   rb-and-rvm128-helper-1
-                                   rb-and-rvm128-helper-2
-                                   bitops::merge-16-u8s
-                                   LOGAPP-IS-LOGAPP-INLINE)
+                                  bitops::merge-16-u8s
+                                  logapp-is-logapp-inline)
                                  (not
                                    (:rewrite acl2::ash-0)
                                    (:rewrite acl2::zip-open)
@@ -3995,10 +3941,7 @@
   :parents (linear-memory)
   :guard (canonical-address-p lin-addr)
   :guard-hints (("Goal"
-                 :in-theory (e/d (rb-and-rvm256
-                                  rml08 rml128
-                                  rb-and-rvm256-helper-1
-                                  rb-and-rvm256-helper-2)
+                 :in-theory (e/d (rb-and-rvm256)
                                  (not
                                   (:rewrite acl2::ash-0)
                                   (:rewrite acl2::zip-open)
@@ -4444,8 +4387,7 @@
 
   :guard-hints
   (("Goal" :in-theory (e/d (wb-and-wvm256)
-                           (wvm256
-                            not
+                           (not
                             (:rewrite acl2::ash-0)
                             (:rewrite acl2::zip-open)
                             (:linear bitops::logior-<-0-linear-2)
@@ -4793,10 +4735,7 @@
   :parents (linear-memory)
   :guard (canonical-address-p lin-addr)
   :guard-hints (("Goal"
-                 :in-theory (e/d (rb-and-rvm512
-                                  rml08 rml256
-                                  rb-and-rvm512-helper-1
-                                  rb-and-rvm512-helper-2)
+                 :in-theory (e/d (rb-and-rvm512)
                                  (not
                                   (:rewrite acl2::ash-0)
                                   (:rewrite acl2::zip-open)
@@ -5496,11 +5435,9 @@
 
   :parents (linear-memory)
   :guard (canonical-address-p lin-addr)
-
   :guard-hints
   (("Goal" :in-theory (e/d (wb-and-wvm512)
-                           (wvm512
-                            not
+                           (not
                             (:rewrite acl2::ash-0)
                             (:rewrite acl2::zip-open)
                             (:linear bitops::logior-<-0-linear-2)


### PR DESCRIPTION
Simplify hints and remove dependence on guard-helpers book.  Comment out unneeded stuff in guard-helpers book.

Now linear-memory.lisp doesn't depend on GL (except gl/portcullis).