### PR TITLE
[x86isa] Improve guard of rml08.

### DIFF
--- a/books/projects/x86isa/machine/linear-memory.lisp
+++ b/books/projects/x86isa/machine/linear-memory.lisp
@@ -1337,7 +1337,9 @@
                (x86))
 
   :parents (linear-memory)
-  :guard (canonical-address-p lin-addr)
+  :guard (and (canonical-address-p lin-addr)
+              (member-eq r-x '(:r :x)))
+  :split-types t
   :guard-hints (("goal"
                  :in-theory (e/d* (ifix rvm08) ())))
 


### PR DESCRIPTION
Previously its guard included both (canonical-address-p lin-addr) and (signed-byte 48 lin-addr), which mean the same thing.  I added :split-types so that the signed-byte-p claim is used only as a :type, not in the guard.  I then had to add (member-eq r-x '(:r :x)) to the guard so that it implies the :type.

If people approve this PR, I can make similar changes to other functions.  A goal is to be able to keep canonical-address-p disabled more (e.g., to speed up some slow proofs involving linear-memory).