### PR TITLE
[vl/vl2014/misc] Fix error messages in SEQ books.

### DIFF
--- a/books/centaur/vl/loader/parser/seq.lisp
+++ b/books/centaur/vl/loader/parser/seq.lisp
@@ -279,7 +279,8 @@
                  ((not (mbt (,(case type (:s= '<) (:w= '<=))
                              (len (vl-tokstream->tokens))
                              (len !!!tokens))))
-                  (prog2$ (er hard? "SEQ count failed for (~x0 ~x1.)~%"
+                  (prog2$ (er hard? 'seq-process-bind
+                              "SEQ count failed for (~x0 ~x1.)~%"
                               ',type ',action)
                           (mv (make-vl-warning :type :vl-seq-fail
                                                :msg "SEQ count failure."
@@ -494,4 +495,3 @@
 
 (defmacro seq-backtrack (stream &rest blocks)
   (seq-backtrack-fn stream blocks))
-

--- a/books/centaur/vl2014/loader/parser/seq.lisp
+++ b/books/centaur/vl2014/loader/parser/seq.lisp
@@ -279,7 +279,8 @@
                  ((not (mbt (,(case type (:s= '<) (:w= '<=))
                              (len (vl-tokstream->tokens))
                              (len !!!tokens))))
-                  (prog2$ (er hard? "SEQ count failed for (~x0 ~x1.)~%"
+                  (prog2$ (er hard? 'seq-process-bind
+                              "SEQ count failed for (~x0 ~x1.)~%"
                               ',type ',action)
                           (mv (make-vl-warning :type :vl-seq-fail
                                                :msg "SEQ count failure."
@@ -494,4 +495,3 @@
 
 (defmacro seq-backtrack (stream &rest blocks)
   (seq-backtrack-fn stream blocks))
-

--- a/books/misc/seq.lisp
+++ b/books/misc/seq.lisp
@@ -425,7 +425,8 @@ creation of warnings while processing the stream.</p>")
                             ((not (mbt (,(case (car x) (:s= '<) (:w= '<=))
                                         (len ,stream)
                                         (len !!!stream))))
-                             (prog2$ (er hard? "SEQ count failed for (~x0 ~x1.)~%"
+                             (prog2$ (er hard? 'seq-process-bind
+                                         "SEQ count failed for (~x0 ~x1.)~%"
                                          ',(car x) ',action)
                                      (mv "SEQ count failure." nil ,stream)))
                             (t
@@ -457,7 +458,8 @@ creation of warnings while processing the stream.</p>")
                                    ((not (mbt (,(case type (:s= '<) (:w= '<=))
                                                (len ,stream)
                                                (len !!!stream))))
-                                    (prog2$ (er hard? "SEQ count failed for (~x0 ~x1 ~x2.)~%"
+                                    (prog2$ (er hard? 'seq-process-bind
+                                                "SEQ count failed for (~x0 ~x1 ~x2.)~%"
                                                 ',nametree ',type ',action)
                                             (mv "SEQ count failure." nil ,stream)))
                                    (t
@@ -483,7 +485,8 @@ creation of warnings while processing the stream.</p>")
                                  ((not (mbt (,(case type (:s= '<) (:w= '<=))
                                              (len ,stream)
                                              (len !!!stream))))
-                                  (prog2$ (er hard?  "SEQ count failed for (~x0 ~x1 ~x2.)~%"
+                                  (prog2$ (er hard? 'seq-process-bind
+                                              "SEQ count failed for (~x0 ~x1 ~x2.)~%"
                                               ',nametree ',type ',action)
                                           (mv "SEQ count failure." nil ,stream)))
                                  (t


### PR DESCRIPTION
The Linter revealed that the calls to ER were missing the context arguments (so ER treated the format string as the context and the first value as the format 'string').  The calls of ER are in generated code, and it might be best to use the surrounding function name as the ctx.  However, I didn't see a nice, general way to access that, so I just used 'seq-process-bind as the context argument.

BTW, there seem to be 3 copies of the seq.lisp book.  It would be nice to have only one.  Two of the copies (in vl and vl2014) are identical except for the package and copyright years.