### PR TITLE
x86isa Remove include-book from docs on changing memory model

### DIFF
--- a/books/projects/x86isa/linux/doc.lisp
+++ b/books/projects/x86isa/linux/doc.lisp
@@ -92,7 +92,6 @@
 
            @({
               (include-book \"centaur/bigmems/bigmem-asymmetric/bigmem-asymmetric\" :dir :system)
-              (include-book \"centaur/bigmems/bigmem/portcullis\" :dir :system)
               (attach-stobj bigmem::mem bigmem-asymmetric::mem)
            })
 

--- a/books/projects/x86isa/machine/state.lisp
+++ b/books/projects/x86isa/machine/state.lisp
@@ -119,7 +119,6 @@ before including the x86 books:</p>
 
 <code>
 (include-book \"centaur/bigmems/bigmem-asymmetric/bigmem-asymmetric\" :dir :system)
-(include-book \"centaur/bigmems/bigmem/portcullis\" :dir :system)
 (attach-stobj bigmem::mem bigmem-asymmetric::mem)
 </code>")
 


### PR DESCRIPTION
Just realized that I never sent a PR to merge this old change