### PR TITLE
[X86ISA] Move includes of docs.

### DIFF
--- a/books/projects/x86isa/doc.lisp
+++ b/books/projects/x86isa/doc.lisp
@@ -43,6 +43,8 @@
 ;; x86 ISA model specification
 (include-book "machine/x86" :ttags :all)
 (include-book "machine/inst-listing" :ttags :all)
+(include-book "machine/inst-doc" :ttags :all)
+(include-book "machine/catalogue-doc" :ttags :all)
 
 ;; Misc. tools
 (include-book "tools/execution/top" :ttags :all)

--- a/books/projects/x86isa/machine/x86.lisp
+++ b/books/projects/x86isa/machine/x86.lisp
@@ -59,8 +59,6 @@
 (include-book "get-prefixes")
 (include-book "interrupt-servicing")
 (include-book "std/strings/hexify" :dir :system)
-(include-book "catalogue-doc")
-(include-book "inst-doc")
 
 (local (include-book "dispatch-creator"))
 (local (include-book "centaur/bitops/ihs-extensions" :dir :system))


### PR DESCRIPTION
So I can get machine/x86 without having to include those docs.