### PR TITLE
[XDOC] Don't suppress error messages in `defsection`

### DIFF
--- a/books/xdoc/tests/defsection-tests.lisp
+++ b/books/xdoc/tests/defsection-tests.lisp
@@ -251,6 +251,10 @@
 (defsection oops :short 17)
 (defsection oops :long 17)
 
+(defsection oops :parents foo)
+(defsection oops :short foo)
+(defsection oops :long foo)
+
 ;; [Ugly] big pile of "encapsulate" messages after the error.
 (defsection oops :parents 17 (defun blah))
 (defsection oops :short 17 (defun blah))

--- a/books/xdoc/top.lisp
+++ b/books/xdoc/top.lisp
@@ -459,7 +459,7 @@
            (let ((marker `(table acl2::intro-table :mark ',name)))
              `(with-output
                 :stack :push
-                :off :all
+                :off (:other-than error)
                 (progn
                   ;; We originally just put down a single marker here, but that
                   ;; led to problems when there were multiple extensions of the


### PR DESCRIPTION
This avoids the issue of `defsection` and forms which generates `defsection`s (like `define`) from failing silently on bad `:short` and `:long` forms.

For instance errors in the application of xdoc constructors in a `define` currently cause a silent failure. After this change, the failure is printed like normal to the comment window.