### PR TITLE
[FTY] Make a generated proof more robust.

### DIFF
--- a/books/centaur/fty/fty-list.lisp
+++ b/books/centaur/fty/fty-list.lisp
@@ -395,7 +395,7 @@
                  :hints (("goal"
                           :induct (nth n x)
                           :expand ((,x.fix x))
-                          :in-theory (enable nth len))))
+                          :in-theory (enable nth len nfix))))
                (defthm ,foo-equiv-implies-foo-equiv-append-1
                  (implies (,x.equiv x x-equiv)
                           (,x.equiv (append x y)


### PR DESCRIPTION
At least a proof generated by `fty::deflist` implicitly assumes that `nfix` is enabled in order to work: `fty::deflist` fails at that theorem if `nfix` is not enabled. This commit enables `nfix` in that theorem.