### PR TITLE
[X86ISA] Reduce includes of vex/evex dispatch books.

### DIFF
--- a/books/projects/x86isa/machine/evex-opcodes-dispatch.lisp
+++ b/books/projects/x86isa/machine/evex-opcodes-dispatch.lisp
@@ -38,15 +38,23 @@
 
 (in-package "X86ISA")
 
-(include-book "instructions/top"
-              :ttags (:syscall-exec :other-non-det :undef-flg))
+;; (include-book "instructions/top"
+;;               :ttags (:syscall-exec :other-non-det :undef-flg))
+;; Other instruction books may be needed here eventually:
+(include-book "instructions/bit")
+(include-book "instructions/padd")
+(include-book "instructions/psub")
+(include-book "instructions/rotate-and-shift")
+(include-book "instructions/fp/logical")
+(include-book "instructions/fp/mov")
+(include-book "instructions/fp/non-arith")
 (include-book "prefix-modrm-sib-decoding")
-(include-book "dispatch-macros")
-(include-book "cpuid")
-(include-book "std/strings/hexify" :dir :system)
+;; (include-book "dispatch-macros")
+;; (include-book "cpuid")
+;; (include-book "std/strings/hexify" :dir :system)
 
 (local (include-book "dispatch-creator"))
-(local (include-book "centaur/bitops/ihs-extensions" :dir :system))
+;; (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 
 (local (in-theory (e/d ()

--- a/books/projects/x86isa/machine/vex-opcodes-dispatch.lisp
+++ b/books/projects/x86isa/machine/vex-opcodes-dispatch.lisp
@@ -38,15 +38,23 @@
 
 (in-package "X86ISA")
 
-(include-book "instructions/top"
-              :ttags (:syscall-exec :other-non-det :undef-flg))
+;; (include-book "instructions/top"
+;;               :ttags (:syscall-exec :other-non-det :undef-flg))
+;; Other instruction books may be needed here eventually:
+(include-book "instructions/bit")
+(include-book "instructions/padd")
+(include-book "instructions/psub")
+(include-book "instructions/rotate-and-shift")
+(include-book "instructions/fp/logical")
+(include-book "instructions/fp/mov")
+(include-book "instructions/fp/non-arith")
 (include-book "prefix-modrm-sib-decoding")
-(include-book "dispatch-macros")
-(include-book "cpuid")
-(include-book "std/strings/hexify" :dir :system)
+;; (include-book "dispatch-macros")
+;; (include-book "cpuid")
+;; (include-book "std/strings/hexify" :dir :system)
 
 (local (include-book "dispatch-creator"))
-(local (include-book "centaur/bitops/ihs-extensions" :dir :system))
+;; (local (include-book "centaur/bitops/ihs-extensions" :dir :system))
 (local (include-book "centaur/bitops/signed-byte-p" :dir :system))
 
 (local (in-theory (e/d ()


### PR DESCRIPTION
By only including the needed instructions, these books can be certified earlier (evex-opcodes-dispatch is very slow on some Lisps).

A few other include-books also were unnecessary and so have been commented out.