### PR TITLE
[RAC] Fix pseudo code bug

### DIFF
--- a/books/projects/rac/src/program/parser/ast/statements.cpp
+++ b/books/projects/rac/src/program/parser/ast/statements.cpp
@@ -181,7 +181,7 @@ Sexpression *MulVarDec::ACL2Expr() {
 // TODO refactore
 void MulVarDec::displaySimple(std::ostream &os) {
   auto dlist = decs.begin();
-  (*dlist)->get_type()->displayVarType(os);
+  (*dlist)->get_original_type()->displayVarType(os);
   while (dlist != decs.end()) {
     os << " ";
     (*dlist)->get_type()->displayVarName((*dlist)->getname(), os);
@@ -337,10 +337,13 @@ MultipleAssignment::MultipleAssignment(Location loc, FunCall *r,
 void MultipleAssignment::displaySimple(std::ostream &os) {
   assert(lval_.size() > 0);
   os << "<";
-  lval_[0]->display(os);
+  bool first = true;
   for (Expression *e : lval_) {
-    os << ", ";
+    if (!first) {
+      os << ", ";
+    }
     e->display(os);
+    first = false;
   }
   os << "> = ";
   rval_->display(os);

--- a/books/projects/rac/tests/yaml_test/program_structure/basics.yml
+++ b/books/projects/rac/tests/yaml_test/program_structure/basics.yml
@@ -134,6 +134,12 @@
   out_generated: ../../../examples/imul/imul.cpp.pc
   ref_generated: imul-pc.cpp.ref.pc
 
+- name: mulvar-pc
+  args: ['mulvar-pc.cpp', '-rac']
+  preprocess: 'mulvar-pc.cpp'
+  out_generated: mulvar-pc.cpp.pc
+  ref_generated: mulvar-pc.cpp.ref.pc
+
 - name: variable-mix-upper-lower-case
   should_report_error: true
 

--- a/books/projects/rac/tests/yaml_test/program_structure/imul-pc.cpp.ref.pc
+++ b/books/projects/rac/tests/yaml_test/program_structure/imul-pc.cpp.ref.pc
@@ -106,16 +106,16 @@ ui64[17] Align(ui3 bds[17], ui33 pps[17]) {
 ui64 Sum(ui64 in[17]) {
   ui64 A1[8] = {};
   for (uint i = 0; i < 4; i++) {
-    <A1[2 * i + 0], A1[2 * i + 0], A1[2 * i + 1]> = Compress42(in[4 * i], in[4 * i + 1], in[4 * i + 2], in[4 * i + 3]);
+    <A1[2 * i + 0], A1[2 * i + 1]> = Compress42(in[4 * i], in[4 * i + 1], in[4 * i + 2], in[4 * i + 3]);
   }
   ui64 A2[4] = {};
   for (uint i = 0; i < 2; i++) {
-    <A2[2 * i + 0], A2[2 * i + 0], A2[2 * i + 1]> = Compress42(A1[4 * i], A1[4 * i + 1], A1[4 * i + 2], A1[4 * i + 3]);
+    <A2[2 * i + 0], A2[2 * i + 1]> = Compress42(A1[4 * i], A1[4 * i + 1], A1[4 * i + 2], A1[4 * i + 3]);
   }
   ui64 A3[2] = {};
-  <A3[0], A3[0], A3[1]> = Compress42(A2[0], A2[1], A2[2], A2[3]);
+  <A3[0], A3[1]> = Compress42(A2[0], A2[1], A2[2], A2[3]);
   ui64 A4[2] = {};
-  <A4[0], A4[0], A4[1]> = Compress32(A3[0], A3[1], in[16]);
+  <A4[0], A4[1]> = Compress32(A3[0], A3[1], in[16]);
   return A4[0] + A4[1];
 }
 

--- a/books/projects/rac/tests/yaml_test/program_structure/mulvar-pc.cpp
+++ b/books/projects/rac/tests/yaml_test/program_structure/mulvar-pc.cpp
@@ -1,0 +1,20 @@
+#include <ac_int.h>
+#include <tuple>
+
+using namespace std;
+
+// RAC begin
+
+typedef ac_int<64, false> ui64;
+
+
+tuple<ui64, ui64> foo() {
+  return tuple<ui64, ui64>(0, 0);
+}
+
+int main() {
+
+  ui64 a, b;
+  tie(a, b) = foo();
+  return 0;
+}

--- a/books/projects/rac/tests/yaml_test/program_structure/mulvar-pc.cpp.ref.pc
+++ b/books/projects/rac/tests/yaml_test/program_structure/mulvar-pc.cpp.ref.pc
@@ -1,0 +1,14 @@
+
+typedef ac_int<64, false> ui64;
+
+
+<ui64, ui64> foo() {
+  return <0, 0>;
+}
+
+int main() {
+  ui64 a, b;
+  <a, b> = foo();
+  return 0;
+}
+


### PR DESCRIPTION
* In a tie expression, the first variable used to be printed twice
* In a MulVarDec, instead of printing the typedef name, it was showing the original type.

Thanks David for the report.