### PR TITLE
Add `abc.history` to gitignore

### DIFF
--- a/books/centaur/glmc/.gitignore
+++ b/books/centaur/glmc/.gitignore
@@ -1,2 +1,3 @@
 gl-abc-input.aig
 gl-abc-script
+abc.history


### PR DESCRIPTION
I occasionally see this generated file in my local git repositories (under `books/centaur/glmc/`). I assume it should never be checked in to version control and therefore it is best to add to the local `.gitignore`.