### PR TITLE
[FTY] Add `deffold-map`

### DIFF
--- a/books/kestrel/fty/database.lisp
+++ b/books/kestrel/fty/database.lisp
@@ -99,6 +99,23 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define flextype->fix (flextype)
+  :returns (name symbolp)
+  :short "Name of the fix function for a sum, list, alist, transparent sum,
+          set, or omap type, given the information associated to the type."
+  (b* ((name (cond ((flexsum-p flextype) (flexsum->fix flextype))
+                   ((flexlist-p flextype) (flexlist->fix flextype))
+                   ((flexalist-p flextype) (flexalist->fix flextype))
+                   ((flextranssum-p flextype) (flextranssum->fix flextype))
+                   ((flexset-p flextype) (flexset->fix flextype))
+                   ((flexomap-p flextype) (flexomap->fix flextype))
+                   (t (raise "Internal error: malformed type ~x0." flextype))))
+       ((unless (symbolp name))
+        (raise "Internal error: malformed fix function name ~x0." name)))
+    name))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define flextype-with-name ((name symbolp) (fty-table alistp))
   :returns flextype?
   :short "Find, in the FTY table,

--- a/books/kestrel/fty/deffold-map-doc.lisp
+++ b/books/kestrel/fty/deffold-map-doc.lisp
@@ -294,6 +294,19 @@
        and added to the generated ruleset described below."))
 
     (xdoc::desc
+     "Accompanying option theorems."
+     (xdoc::p
+      "For each @(tsee defoption) type specified by the @(':types') input,
+       we generate the following theorems,
+       whose exact form can be inspected with @(tsee pe) or similar command:")
+     (xdoc::ul
+      (xdoc::li
+       "@('<type>-<suffix>-under-iff')"))
+     (xdoc::p
+      "These theorems are disabled,
+       and added to the generated ruleset described below."))
+
+    (xdoc::desc
      "Accompanying omap type theorems."
      (xdoc::p
       "For each @(tsee defomap) type specified by the @(':types') input,
@@ -301,7 +314,15 @@
        whose exact form can be inspected with @(tsee pe) or similar command:")
      (xdoc::ul
       (xdoc::li
-       "@('<type>-<suffix>-when-emptyp')"))
+       "@('<type>-<suffix>-type-prescription')")
+      (xdoc::li
+       "@('<type>-<suffix>-when-emptyp')")
+      (xdoc::li
+       "@('emptyp-of-<type>-<suffix>')")
+      (xdoc::li
+       "@('keys-of-<type>-<suffix>')")
+      (xdoc::li
+       "@('assoc-of-<type>-<suffix>')"))
      (xdoc::p
       "These theorems are disabled,
        and added to the generated ruleset described below."))

--- a/books/kestrel/fty/deffold-map-doc.lisp
+++ b/books/kestrel/fty/deffold-map-doc.lisp
@@ -71,7 +71,7 @@
     (xdoc::desc
      "@(':types') &mdash; no default"
      (xdoc::p
-      "Fixtype for which map functions must be generated.")
+      "Fixtypes for which map functions must be generated.")
      (xdoc::p
       "This must be a list of symbols, which is not evaluated by the macro,
        where each symbols must be one of the following:")

--- a/books/kestrel/fty/deffold-map-doc.lisp
+++ b/books/kestrel/fty/deffold-map-doc.lisp
@@ -4,7 +4,9 @@
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (www.alessandrocoglio.info)
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+; Based on deffold-reduce-doc.lisp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -15,7 +17,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defxdoc deffold-reduce
+(defxdoc deffold-map
 
   :parents (fold)
 
@@ -31,13 +33,11 @@
 
     (xdoc::p
      "This macro automates the creation of
-      the `reducing' class of folds on fixtypes
+      the `mapping' class of folds on fixtypes
       described in @(see fold).
-      The user specifies @('R'),
-      a default for the constant arguments,
-      the binary operation on @('R'),
-      and any number of overrides of the boilerplate code
-      for specific cases of the fixtypes.")
+      The user specifies any number of overrides of the boilerplate code
+      for specific cases of the fixtypes
+      in the same manner as @(see deffold-reduce).")
     (xdoc::p))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -45,16 +45,13 @@
    (xdoc::evmac-section-form
 
     (xdoc::codeblock
-     "(deffold-reduce suffix"
-     "                :types      ...  ; no default"
-     "                :extra-args ...  ; default nil"
-     "                :result     ...  ; no default"
-     "                :default    ...  ; no default"
-     "                :combine    ...  ; no default"
-     "                :override   ...  ; default nil"
-     "                :parents    ...  ; no default"
-     "                :short      ...  ; no default"
-     "                :long       ...  ; no default"
+     "(deffold-map suffix"
+     "             :types      ...  ; no default"
+     "             :extra-args ...  ; default nil"
+     "             :override   ...  ; default nil"
+     "             :parents    ...  ; no default"
+     "             :short      ...  ; no default"
+     "             :long       ...  ; no default"
      "  )"))
 
    ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -74,7 +71,7 @@
     (xdoc::desc
      "@(':types') &mdash; no default"
      (xdoc::p
-      "Fixtype for which fold functions must be generated.")
+      "Fixtype for which map functions must be generated.")
      (xdoc::p
       "This must be a list of symbols, which is not evaluated by the macro,
        where each symbols must be one of the following:")
@@ -121,32 +118,7 @@
      (xdoc::p
       "This must be a list of "
       (xdoc::seetopic "std::extended-formals" "extended formals")
-      " which @('deffold-reduce') puts into the generated @(tsee define)s."))
-
-    (xdoc::desc
-     "@(':result') &mdash; no default"
-     (xdoc::p
-      "Recognizer of the @('R') type of results.")
-     (xdoc::p
-      "It must be a symbol that names an existing unary predicate,
-       which is used for the results of the generated functions."))
-
-    (xdoc::desc
-     "@(':default') &mdash; no default"
-     (xdoc::p
-      "Default result of the generated functions,
-       used as described in the Section `Generated Events' below.")
-     (xdoc::p
-      "This must be a term."))
-
-    (xdoc::desc
-     "@(':combine') &mdash; no default"
-     (xdoc::p
-      "Binary operation to combine results.")
-     (xdoc::p
-      "It must be a symbol that names an existing binary function,
-       which is used to combine the results of the recursive calls
-       in the generated functions."))
+      " which @('deffold-map') puts into the generated @(tsee define)s."))
 
     (xdoc::desc
      "@(':override') &mdash; default @('nil')"
@@ -203,7 +175,7 @@
      "@('<type>-<suffix>')"
      (xdoc::p
       "For each type @('<type>') specified by the @(':types') input,
-       a fold function for that type, defined as follows:")
+       a map function for that type, defined as follows:")
      (xdoc::ul
       (xdoc::li
        "If @('<type>') is a @(tsee defprod):"
@@ -221,22 +193,12 @@
           "If @('<type>') has no components whose type
            is specified by the @(':types') input,
            the function is defined to return
-           the term specified by the @(':default') input.")
+           the fixed input.")
          (xdoc::li
-          "If @('<type>') has exactly one component whose type
-           is specified by the @(':types') input,
-           the function is defined to return
-           the result of applying the fold function for that type
-           to that component.")
-         (xdoc::li
-          "If @('<type>') has two or more components whose types
+          "If @('<type>') has one or more components whose types
            are specified by the @(':types') input,
            the function is defined to return
-           the result of combining,
-           via the function specified by the @(':combine') input,
-           the results of applying the corresponding fold functions
-           to the components, nested to the right
-           (i.e. @('(combine val1 ... (combine valN-1 valN))'))."))))
+           the map over the product fields."))))
       (xdoc::li
        "If @('<type>') is a @(tsee deftagsum):"
        (xdoc::ul
@@ -264,64 +226,43 @@
               the term specified by the @(':default') input.")
             (xdoc::li
              "If the summand corresponding to @('<kind>')
-              has one component whose type
-              is specified by the @(':types') input,
-              the case is defined to return
-              the result of applying the fold function for that type
-              to that component.")
-            (xdoc::li
-             "If the summand corresponding to @('<kind>')
-              has two or more components whose types
+              has one or more components whose types
               are specified by the @(':types') input,
               the case is defined to return
-              the result of combining,
-              via the function specified by the @(':combine') input,
-              the results of applying the corresponding fold functions
-              to the components, nested to the right
-              (i.e. @('(combine val1 ... (combine valN-1 valN))')).")))))))
+              the map over the product fields.")))))))
       (xdoc::li
        "If @('<type>') is a @(tsee deflist):"
        (xdoc::ul
         (xdoc::li
          "If the list is empty,
-          the function is defined to return
-          the term specified by the @(':default') input.")
+          the function is defined to return @('nil').")
         (xdoc::li
          "If the list is not empty,
           the function is defined to return
-          the result of combining,
-          via the function specified by the @(':combine') input,
-          the result of applying the element type's fold function
-          to the @(tsee car) of the list
-          with the result of applying to list type's fold function
-          to the @(tsee cdr) of the list.")))
+          the @(tsee cons) of the mapped @(tsee car)
+          to the recursively mapped @(tsee cdr).")))
       (xdoc::li
        "If @('<type>') is a @(tsee defoption):"
        (xdoc::ul
         (xdoc::li
          "If the option value is @('nil'),
-          the function is defined to return
-          the term specified by the @(':default') input.")
+          the function is defined to return @('nil').")
         (xdoc::li
          "If the option value is not @('nil'),
           the function is defined to return
-          the result of applying the fold for the base type on the value.")))
+          the map function of the base type applied to the value.")))
       (xdoc::li
        "If @('<type>') is a @(tsee defomap):"
        (xdoc::ul
         (xdoc::li
          "If the map is empty,
-          the function is defined to return
-          the term specified by the @(':default') input.")
+          the function is defined to return @('nil').")
         (xdoc::li
          "If the map is not empty,
           the function is defined to return
-          the result of combining,
-          via the function specified by the @(':combine') input,
-          the result of applying the map value type's fold function
-          to the head value of the map
-          with the result of applying to list type's fold function
-          to the tail of the map.")))))
+          the @(tsee omap::update) of the @(tsee head) key
+          and the mapped value
+          to the recursively mapped @(omap::tail).")))))
 
     (xdoc::desc
      "Accompanying list theorems."
@@ -331,9 +272,23 @@
        whose exact form can be inspected with @(tsee pe) or similar command:")
      (xdoc::ul
       (xdoc::li
+       "@('<type>-<suffix>-type-prescription')")
+      (xdoc::li
        "@('<type>-<suffix>-when-atom')")
       (xdoc::li
-       "@('<type>-<suffix>-of-cons')"))
+       "@('<type>-<suffix>-of-cons')")
+      (xdoc::li
+       "@('<type>-<suffix>-of-append')")
+      (xdoc::li
+       "@('consp-of-<type>-<suffix>')")
+      (xdoc::li
+       "@('len-of-<type>-<suffix>')")
+      (xdoc::li
+       "@('nth-of-<type>-<suffix>')")
+      (xdoc::li
+       "@('<type>-<suffix>-of-revappend')")
+      (xdoc::li
+       "@('<type>-<suffix>-of-reverse')"))
      (xdoc::p
       "These theorems are disabled,
        and added to the generated ruleset described below."))

--- a/books/kestrel/fty/deffold-map-doc.lisp
+++ b/books/kestrel/fty/deffold-map-doc.lisp
@@ -21,7 +21,7 @@
 
   :parents (fold)
 
-  :short "Reducing folds for fixtypes."
+  :short "Mapping folds for fixtypes."
 
   :long
 

--- a/books/kestrel/fty/deffold-map-doc.lisp
+++ b/books/kestrel/fty/deffold-map-doc.lisp
@@ -262,7 +262,7 @@
           the function is defined to return
           the @(tsee omap::update) of the @(tsee head) key
           and the mapped value
-          to the recursively mapped @(omap::tail).")))))
+          to the recursively mapped @('omap::tail').")))))
 
     (xdoc::desc
      "Accompanying list theorems."

--- a/books/kestrel/fty/deffold-map-tests.lisp
+++ b/books/kestrel/fty/deffold-map-tests.lisp
@@ -1,0 +1,209 @@
+; FTY Library
+;
+; Copyright (C) 2025 Kestrel Institute (http://www.kestrel.edu)
+;
+; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
+;
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(in-package "FTY")
+
+(include-book "std/testing/assert-equal" :dir :system)
+(include-book "std/testing/must-succeed-star" :dir :system)
+
+(local (include-book "deffold-map"))
+
+(local (include-book "centaur/fty/top" :dir :system))
+(local (include-book "std/basic/two-nats-measure" :dir :system))
+(local (include-book "std/typed-lists/string-listp" :dir :system))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(acl2::must-succeed*
+  ;; This example algebraic type clique is taken from deffold-reduce-tests.lisp
+  (deftypes exprs
+    (deftagsum aexpr
+      (:const ((value acl2::int)))
+      (:var ((name string)))
+      (:add ((left aexpr) (right aexpr)))
+      (:cond ((test bexpr) (left aexpr) (right aexpr)))
+      :pred aexprp)
+    (deftagsum bexpr
+      (:true ())
+      (:false ())
+      (:and ((left bexpr) (right bexpr)))
+      (:less ((left aexpr) (right aexpr)))
+      :pred bexprp))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  (deffold-map invert
+    :types (exprs)
+    :override
+    ((bexpr :true (bexpr-false))
+     (bexpr :false (bexpr-true))))
+
+  (acl2::assert-equal
+    (aexpr-invert (aexpr-cond (bexpr-false) (aexpr-const 0) (aexpr-const 1)))
+    (aexpr-cond (bexpr-true) (aexpr-const 0) (aexpr-const 1)))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  (deffold-map simpadd0
+    :types (exprs)
+    :override
+    ((aexpr
+      :add
+      (b* ((left (aexpr-simpadd0 aexpr.left))
+           (right (aexpr-simpadd0 aexpr.right)))
+        (cond ((equal left (aexpr-const 0))
+               right)
+              ((equal right (aexpr-const 0))
+               left)
+              (t (aexpr-add left right)))))))
+
+  (acl2::assert-equal
+    (aexpr-simpadd0 (aexpr-add (aexpr-const 42)
+                               (aexpr-add (aexpr-const 0) (aexpr-const 0))))
+    (aexpr-const 42))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  (deffold-map subst-vars
+    :types (exprs)
+    :extra-args ((alist alistp))
+    :override
+    ((aexpr
+      :var
+      (let ((lookup (assoc-equal aexpr.name alist)))
+        (if (and lookup
+                 (stringp (cdr lookup)))
+            (aexpr-var (cdr lookup))
+          (aexpr-fix aexpr))))))
+
+  (acl2::assert-equal
+    (bexpr-subst-vars (bexpr-less (aexpr-var "x") (aexpr-var "y"))
+                      (acons "x" "foo" nil))
+    (bexpr-less (aexpr-var "foo") (aexpr-var "y")))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(acl2::must-succeed*
+  (deftypes foo+
+    (deftagsum foo
+      (:list ((list foo-list)))
+      (:omap ((omap foo-omap)))
+      (:bar ())
+      :pred foop)
+    (deflist foo-list
+      :elt-type foo
+      :true-listp t
+      :pred foo-listp)
+    (defomap foo-omap
+      :key-type acl2::int
+      :val-type foo
+      :pred foo-omapp))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  (deffold-map becomes-bar
+    :types (foo+)
+    :override
+    ((foo :list (foo-bar))
+     (foo :omap (foo-bar))))
+
+  (acl2::assert-equal
+    (foo-omap-becomes-bar
+      (omap::update 0
+                    (foo-list nil)
+                    (omap::update 1
+                                  (foo-omap nil)
+                                  nil)))
+    (omap::update 0
+                  (foo-bar)
+                  (omap::update 1
+                                (foo-bar)
+                                nil)))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(acl2::must-succeed*
+  (deftypes foo+
+    (deftagsum foo
+      (:list ((list foo-list)))
+      (:omap ((omap foo-omap)))
+      (:int ((int acl2::int)))
+      :pred foop)
+    ;; This time without :true-listp t
+    (deflist foo-list
+      :elt-type foo
+      :pred foo-listp)
+    (defomap foo-omap
+      :key-type acl2::int
+      :val-type foo
+      :pred foo-omapp))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  (deffold-map replace-int
+    :types (foo+)
+    :extra-args ((i integerp))
+    :override
+    ((foo :int (foo-int i))))
+
+  (acl2::assert-equal
+    (foo-omap-replace-int
+      (omap::update 0
+                    (foo-list nil)
+                    (omap::update 1
+                                  (foo-int 2)
+                                  nil))
+      42)
+    (omap::update 0
+                  (foo-list nil)
+                  (omap::update 1
+                                (foo-int 42)
+                                nil)))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  :with-output-off nil)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(acl2::must-succeed*
+  (deftypes foo+
+    (deftagsum foo
+      (:bar ((foo? foo-optionp)))
+      (:baz ())
+      :measure (acl2::nat-list-measure (list (acl2-count x) 0))
+      :pred foop)
+    (defoption foo-option
+      foo
+      :measure (acl2::nat-list-measure (list (acl2-count x) 1))
+      :pred foo-optionp))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  (deffold-map becomes-baz
+    :types (foo+)
+    :override
+    ((foo :bar (foo-baz))))
+
+  (acl2::assert-equal
+    (foo-option-becomes-baz (foo-bar nil))
+    (foo-baz))
+
+  ;;;;;;;;;;;;;;;;;;;;
+
+  :with-output-off nil)

--- a/books/kestrel/fty/deffold-map.lisp
+++ b/books/kestrel/fty/deffold-map.lisp
@@ -4,12 +4,15 @@
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (www.alessandrocoglio.info)
+; Author: Grant Jurgensen (grant@kestrel.edu)
+
+; Based on deffold-reduce.lisp
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (in-package "FTY")
 
+(include-book "kestrel/event-macros/xdoc-constructors" :dir :system)
 (include-book "kestrel/fty/database" :dir :system)
 (include-book "kestrel/utilities/er-soft-plus" :dir :system)
 (include-book "std/omaps/portcullis" :dir :system)
@@ -19,6 +22,11 @@
 (include-book "std/util/error-value-tuples" :dir :system)
 (include-book "system/pseudo-event-form-listp" :dir :system)
 
+(local (include-book "kestrel/built-ins/disable" :dir :system))
+(local (acl2::disable-most-builtin-logic-defuns))
+(local (acl2::disable-builtin-rewrite-rules-for-defaults))
+(set-induction-depth-limit 0)
+
 (local (include-book "std/alists/top" :dir :system))
 (local (include-book "std/lists/true-listp" :dir :system))
 (local (include-book "std/system/partition-rest-and-keyword-args" :dir :system))
@@ -27,11 +35,6 @@
 (local (include-book "std/typed-lists/atom-listp" :dir :system))
 (local (include-book "std/typed-alists/symbol-alistp" :dir :system))
 (local (include-book "std/typed-lists/symbol-listp" :dir :system))
-
-(local (include-book "kestrel/built-ins/disable" :dir :system))
-(local (acl2::disable-most-builtin-logic-defuns))
-(local (acl2::disable-builtin-rewrite-rules-for-defaults))
-(set-induction-depth-limit 0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -47,7 +50,7 @@
 
 (xdoc::evmac-topic-implementation
 
- deffold-reduce
+ deffold-map
 
  :items
 
@@ -59,10 +62,6 @@
 
   (xdoc::evmac-topic-implementation-item-input "result")
 
-  (xdoc::evmac-topic-implementation-item-input "default")
-
-  (xdoc::evmac-topic-implementation-item-input "combine")
-
   (xdoc::evmac-topic-implementation-item-input "override")
 
   (xdoc::evmac-topic-implementation-item-input "parents")
@@ -72,7 +71,7 @@
   (xdoc::evmac-topic-implementation-item-input "long")
 
   "@('overrides') is an alist representation of the @(':override') input.
-   With reference to the documentation page of @(tsee deffold-reduce):
+   With reference to the documentation page of @(tsee deffold-map):
    for each element @('<type> <term>') in @(':override'),
    this alist has an element @('(cons <type> <term>)');
    for each element @('<type> <kind> <term>') in @(':override'),
@@ -87,17 +86,19 @@
    being in singleton cliques."
 
   "@('targets') is a list (in no particular order)
-   of all the type names for which fold functions are generated."
+   of all the type names for which map functions are generated."
 
   "@('target') is an element of @('targets') explained above."))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(xdoc::evmac-topic-input-processing deffold-reduce)
+(xdoc::evmac-topic-input-processing deffold-map)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-process-types (types (fty-table alistp))
+(define deffold-map-process-types
+  (types
+   (fty-table alistp))
   :returns (mv erp
                (types symbol-listp)
                (targets symbol-listp))
@@ -107,7 +108,7 @@
    (xdoc::p
     "If processing is successful,
      we return the list of all the fixtype names (symbols)
-     for which fold functions must be generated.")
+     for which map functions must be generated.")
    (xdoc::p
     "We just check that this input is a list of symbols;
      we do not yet check that each symbol identifies a fixtype clique
@@ -120,14 +121,16 @@
   (b* (((reterr) nil nil)
        ((unless (symbol-listp types))
         (reterr (msg "The :TYPES input must be a alist of symbols, ~
-                            but it is ~x0 instead."
+                      but it is ~x0 instead."
                      types))))
     (retok types
            (flextype-names-in-flextypes-with-names types fty-table))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-process-override (override (fty-table alistp))
+(define deffold-map-process-override
+  (override
+   (fty-table alistp))
   :returns (mv erp (overrides alistp))
   :short "Process the @(':override') input."
   :long
@@ -147,10 +150,10 @@
         (reterr (msg "The :OVERRIDE input must be a list, ~
                       but it is ~x0 instead."
                      override))))
-    (deffoldred-process-override-loop override fty-table))
+    (deffold-map-process-override-loop override fty-table))
   :prepwork
-  ((define deffoldred-process-override-loop ((override true-listp)
-                                             (fty-table alistp))
+  ((define deffold-map-process-override-loop ((override true-listp)
+                                          (fty-table alistp))
      :returns (mv erp (overrides alistp))
      :parents nil
      (b* (((reterr) nil)
@@ -214,20 +217,17 @@
                                 kind type))))
                (retok (cons type kind) term))))
           ((erp alist)
-           (deffoldred-process-override-loop (cdr override) fty-table)))
+           (deffold-map-process-override-loop (cdr override) fty-table)))
        (retok (acons key val alist)))
      :prepwork ((local (in-theory (enable acons))))
      :verify-guards :after-returns)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defval *deffoldred-allowed-options*
-  :short "Keyword options accepted by @(tsee deffold-reduce)."
+(defval *deffold-map-allowed-options*
+  :short "Keyword options accepted by @(tsee deffold-map)."
   '(:types
     :extra-args
-    :result
-    :default
-    :combine
     :override
     :parents
     :short
@@ -235,15 +235,14 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-process-inputs ((args true-listp) (fty-table alistp))
+(define deffold-map-process-inputs
+  ((args true-listp)
+   (fty-table alistp))
   :returns (mv erp
                (suffix symbolp)
                (types symbol-listp)
                (targets symbol-listp)
                (extra-args true-listp)
-               (result symbolp)
-               (default t)
-               (combine symbolp)
                (overrides alistp)
                (parents-presentp booleanp)
                parents
@@ -252,15 +251,15 @@
                (long-presentp booleanp)
                long)
   :short "Process all the inputs."
-  (b* (((reterr) nil nil nil nil nil nil nil nil nil nil nil nil nil nil)
+  (b* (((reterr) nil nil nil nil nil nil nil nil nil nil nil)
        ((mv erp suffix options)
-        (partition-rest-and-keyword-args args *deffoldred-allowed-options*))
+        (partition-rest-and-keyword-args args *deffold-map-allowed-options*))
        ((when (or erp
                   (not (consp suffix))
                   (not (endp (cdr suffix)))))
         (reterr (msg "The inputs must be the suffix name ~
                       followed by the options ~&0."
-                     *deffoldred-allowed-options*)))
+                     *deffold-map-allowed-options*)))
        (suffix (car suffix))
        ((unless (symbolp suffix))
         (reterr (msg "The SUFFIX input must be a symbol, ~
@@ -270,7 +269,7 @@
        ((unless types-option)
         (reterr (msg "The :TYPES input must be supplied.")))
        (types (cdr types-option))
-       ((erp types targets) (deffoldred-process-types types fty-table))
+       ((erp types targets) (deffold-map-process-types types fty-table))
        (extra-args-option (assoc-eq :extra-args options))
        (extra-args (if extra-args-option
                        (cdr extra-args-option)
@@ -279,31 +278,11 @@
         (reterr (msg "The :EXTRA-ARGS input must be a list, ~
                       but it is ~x0 instead."
                      extra-args)))
-       (result-option (assoc-eq :result options))
-       ((unless result-option)
-        (reterr (msg "The :RESULT input must be supplied.")))
-       (result (cdr result-option))
-       ((unless (symbolp result))
-        (reterr (msg "The :RESULT input must be a symbol, ~
-                      but it is ~x0 instead."
-                     result)))
-       (default-option (assoc-eq :default options))
-       ((unless default-option)
-        (reterr (msg "The :DEFAULT input must be supplied.")))
-       (default (cdr default-option))
-       (combine-option (assoc-eq :combine options))
-       ((unless combine-option)
-        (reterr (msg "The :COMBINE input must be supplied.")))
-       (combine (cdr combine-option))
-       ((unless (symbolp combine))
-        (reterr (msg "The :COMBINE input must be a symbol, ~
-                      but it is ~x0 instead."
-                     combine)))
        (override-option (assoc-eq :override options))
        (override (if override-option
                      (cdr override-option)
                    nil))
-       ((erp overrides) (deffoldred-process-override override fty-table))
+       ((erp overrides) (deffold-map-process-override override fty-table))
        (parents-option (assoc-eq :parents options))
        (parents-presentp (consp parents-option))
        (parents (cdr parents-option))
@@ -317,9 +296,6 @@
            types
            targets
            extra-args
-           result
-           default
-           combine
            overrides
            parents-presentp
            parents
@@ -331,115 +307,129 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(xdoc::evmac-topic-event-generation deffold-reduce)
+(xdoc::evmac-topic-event-generation deffold-map)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-topic-name ((suffix symbolp))
+(define deffold-map-gen-topic-name ((suffix symbolp))
   :returns (name symbolp)
   :short "Generate the name of the XDOC topic."
   (acl2::packn-pos (list 'abstract-syntax- suffix) suffix))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-fold-name ((type symbolp) (suffix symbolp))
+(define deffold-map-gen-map-name
+  ((type symbolp)
+   (suffix symbolp))
   :returns (name symbolp)
-  :short "Generate the name of the fold function for a type."
+  :short "Generate the name of the map function for a type."
   (acl2::packn-pos (list type '- suffix) suffix))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-ruleset-name ((suffix symbolp))
+(define deffold-map-gen-ruleset-name ((suffix symbolp))
   :returns (name symbolp)
   :short "Generate the name of the ruleset."
   (acl2::packn-pos (list 'abstract-syntax- suffix '-rules) suffix))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-extra-args-to-names ((extra-args true-listp))
+(define deffold-map-extra-args-to-names ((extra-args true-listp))
   :returns (names true-listp)
   :short "Map the @(':extra-args') input to
           a list of the names of the arguments."
   (b* (((when (endp extra-args)) nil)
        (extra-arg (car extra-args))
        (name (if (atom extra-arg) extra-arg (car extra-arg)))
-       (names (deffoldred-extra-args-to-names (cdr extra-args))))
+       (names (deffold-map-extra-args-to-names (cdr extra-args))))
     (cons name names)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-prod-combination ((type symbolp)
-                                         (fields flexprod-field-listp)
-                                         (suffix symbolp)
-                                         (targets symbol-listp)
-                                         (extra-args true-listp)
-                                         (default t)
-                                         (combine symbolp)
-                                         (fty-table alistp))
+(define deffold-map-gen-sum-case
+  ((type symbolp)
+   (fix symbolp)
+   (prod flexprod-p)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (fty-table alistp))
   :returns term
-  :short "Generate the combination for the fields of a product type."
+  :short "Generate the map for the fields of a product type."
   :long
   (xdoc::topstring
    (xdoc::p
     "This is the term returned, in the absence of overriding,
-     by the fold function of a @(tsee defprod),
-     or by a case of the fold function of a @(tsee deftagsum).
-     See @(tsee deffold-reduce).")
+     by the map function of a @(tsee defprod),
+     or by a case of the map function of a @(tsee deftagsum).
+     See @(tsee deffold-map).")
    (xdoc::p
-    "We go through the fields,
-     and we return a right-associated nest of the @(':combine') operator
-     of the result of the fold functions applied to
-     the fields for which fold functions are generated,
-     starting with the @(':default') term,
-     but in case of a single @('(combine X default)'), we just return @('X').
-     For each field, we obtain the recognizer name,
-     and from that we obtain the type information.
-     If there is no type information,
-     which means that the field has a built-in type (e.g. @('nat')),
-     then we skip the field.
-     If there is type information,
-     we skip the field unless its type is in @('targets').
-     If a field is not skipped,
-     we apply the fold function for its type to
-     the accessor of the field
-     applied to a variable with the same name as
-     the product (not field) type;
-     this relies on the fact that the functions we generate
-     use the type names as their formals."))
-  (b* (((when (endp fields)) default)
-       (field (car fields))
-       (recog (flexprod-field->type field))
-       ((unless (symbolp recog))
-        (raise "Internal error: malformed field recognizer ~x0." recog))
-       (info (flextype-with-recognizer recog fty-table))
-       (field-type (and info
-                        (flextype->name info)))
-       ((unless (and field-type
-                     (member-eq field-type targets)))
-        (deffoldred-gen-prod-combination
-          type (cdr fields) suffix
-          targets extra-args default combine fty-table))
-       (accessor (flexprod-field->acc-name field))
-       (field-type-suffix (deffoldred-gen-fold-name field-type suffix))
-       (extra-args-names (deffoldred-extra-args-to-names extra-args))
-       (fold `(,field-type-suffix (,accessor ,type) ,@extra-args-names))
-       (folds (deffoldred-gen-prod-combination
-                type (cdr fields) suffix
-                targets extra-args default combine fty-table))
-       ((when (equal folds default)) fold))
-    `(,combine ,fold ,folds)))
+    "For each field, we apply the relevant map if it is in the target list.
+     If there exists at least one targeted field,
+     we return the application of the product constructor
+     to each potentially mapped field.
+     If no field is targeted,
+     we instead return the fixed argument without deconstructing it."))
+  (b* ((fields (flexprod->fields prod))
+       ((unless (flexprod-field-listp fields))
+        (raise "Internal error: malformed fields ~x0." fields))
+       ((mv maps targeted)
+        (deffold-map-gen-sum-case-loop
+          type fields suffix
+          targets extra-args fty-table)))
+    (if targeted
+        (cons (flexprod->ctor-name prod) maps)
+      (list fix type)))
+
+  :prepwork
+  ((define deffold-map-gen-sum-case-loop
+     ((type symbolp)
+      (fields flexprod-field-listp)
+      (suffix symbolp)
+      (targets symbol-listp)
+      (extra-args true-listp)
+      (fty-table alistp))
+     :returns (mv (maps true-listp)
+                  (targeted booleanp))
+     (b* (((when (endp fields)) (mv nil nil))
+          (field (car fields))
+          (recog (flexprod-field->type field))
+          ((unless (symbolp recog))
+           (raise "Internal error: malformed field recognizer ~x0." recog)
+           (mv nil nil))
+          (info (flextype-with-recognizer recog fty-table))
+          (field-type (and info
+                           (flextype->name info)))
+          (accessor (flexprod-field->acc-name field))
+          (field-type-suffix (deffold-map-gen-map-name field-type suffix))
+          ((unless (and field-type
+                        (member-eq field-type targets)))
+           (b* (((mv maps targeted)
+                 (deffold-map-gen-sum-case-loop
+                   type (cdr fields) suffix
+                   targets extra-args fty-table)))
+             (mv (cons `(,accessor ,type) maps)
+                 targeted)))
+          (extra-args-names (deffold-map-extra-args-to-names extra-args))
+          (map `(,field-type-suffix (,accessor ,type) ,@extra-args-names))
+          ((mv maps -)
+           (deffold-map-gen-sum-case-loop
+             type (cdr fields) suffix
+             targets extra-args fty-table)))
+       (mv (cons map maps)
+           t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-sum-cases ((type symbolp)
-                                  (prods flexprod-listp)
-                                  (suffix symbolp)
-                                  (targets symbol-listp)
-                                  (extra-args true-listp)
-                                  (default t)
-                                  (combine symbolp)
-                                  (overrides alistp)
-                                  (fty-table alistp))
+(define deffold-map-gen-sum-cases
+  ((type symbolp)
+   (fix symbolp)
+   (prods flexprod-listp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :returns (keyword+term-list true-listp)
   :short "Generate the code for the cases of a sum type."
   :long
@@ -454,7 +444,7 @@
    (xdoc::p
     "For each case, first we check whether there is an overriding term,
      in which case we use that as the term for the case.
-     Otherwise, we obtain the combination for the fields."))
+     Otherwise, we map over the fields."))
   (b* (((when (endp prods)) nil)
        (prod (car prods))
        (kind (flexprod->kind prod))
@@ -462,34 +452,29 @@
         (raise "Internal error: kind ~x0 is not a keyword." kind))
        (term
         (b* ((term-assoc (assoc-equal (cons type kind) overrides))
-             ((when term-assoc) (cdr term-assoc))
-             (fields (flexprod->fields prod))
-             ((unless (flexprod-field-listp fields))
-              (raise "Internal error: malformed fields ~x0." fields)))
-          (deffoldred-gen-prod-combination
-            type fields suffix targets
-            extra-args default combine fty-table))))
+             ((when term-assoc) (cdr term-assoc)))
+          (deffold-map-gen-sum-case
+            type fix prod suffix
+            targets extra-args fty-table))))
     (list* kind
            term
-           (deffoldred-gen-sum-cases
-             type (cdr prods) suffix
-             targets extra-args default combine overrides fty-table))))
+           (deffold-map-gen-sum-cases
+             type fix (cdr prods) suffix
+             targets extra-args overrides fty-table))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-prod-fold ((sum flexsum-p)
-                                  (mutrecp booleanp)
-                                  (suffix symbolp)
-                                  (targets symbol-listp)
-                                  (extra-args true-listp)
-                                  (result symbolp)
-                                  (default t)
-                                  (combine symbolp)
-                                  (overrides alistp)
-                                  (fty-table alistp))
+(define deffold-map-gen-prod-map
+  ((sum flexsum-p)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :guard (eq (flexsum->typemacro sum) 'defprod)
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate the fold function for a product type."
+  :short "Generate the map function for a product type."
   :long
   (xdoc::topstring
    (xdoc::p
@@ -501,13 +486,12 @@
      we use that as the body of the function.")
    (xdoc::p
     "If there is no overriding term,
-     the body is the combination
-     returned by @(tsee deffoldred-gen-prod-combination),
+     the body is the map
+     returned by @(tsee deffold-map-gen-sum-case),
      which is never expected to be empty.")
    (xdoc::p
     "We also generate an `ignorable' declaration for the main formal,
-     in case the overriding term does not mention the formal,
-     or in case the combination is just the default.")
+     in case the overriding term does not mention the formal.")
    (xdoc::p
     "The @('mutrecp') flag says whether
      this product type is part of a mutually recursive clique."))
@@ -515,9 +499,13 @@
        ((unless (symbolp type))
         (raise "Internal error: malformed type name ~x0." type)
         '(_))
-       (type-suffix (deffoldred-gen-fold-name type suffix))
+       (type-suffix (deffold-map-gen-map-name type suffix))
        (type-count (flexsum->count sum))
        (recog (flexsum->pred sum))
+       (fix (flexsum->fix sum))
+       ((unless (symbolp fix))
+        (raise "Internal error: malformed flexsum fix function ~x0." fix)
+        '(_))
        (recp (flexsum->recp sum))
        (body
         (b* ((term-assoc (assoc-equal type overrides))
@@ -528,16 +516,13 @@
              ((unless (and (consp prods)
                            (endp (cdr prods))))
               (raise "Internal error: non-singleton product ~x0." prods))
-             (prod (car prods))
-             (fields (flexprod->fields prod))
-             ((unless (flexprod-field-listp fields))
-              (raise "Internal error: malformed fields ~x0." fields)))
-          (deffoldred-gen-prod-combination
-            type fields suffix targets extra-args default combine fty-table))))
+             (prod (car prods)))
+          (deffold-map-gen-sum-case
+            type fix prod suffix targets extra-args fty-table))))
     `(define ,type-suffix ((,type ,recog) ,@extra-args)
        (declare (ignorable ,type))
-       :returns (result ,result)
-       :parents (,(deffoldred-gen-topic-name suffix))
+       :returns (result ,recog)
+       :parents (,(deffold-map-gen-topic-name suffix))
        ,body
        ,@(and (or mutrecp recp) `(:measure (,type-count ,type)))
        ,@(and (not mutrecp) '(:verify-guards :after-returns))
@@ -545,19 +530,18 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-sum-fold ((sum flexsum-p)
-                                 (mutrecp booleanp)
-                                 (suffix symbolp)
-                                 (targets symbol-listp)
-                                 (extra-args true-listp)
-                                 (result symbolp)
-                                 (default t)
-                                 (combine symbolp)
-                                 (overrides alistp)
-                                 (fty-table alistp))
+;; TODO: prove this preserves the kind function
+(define deffold-map-gen-sum-map
+  ((sum flexsum-p)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :guard (eq (flexsum->typemacro sum) 'deftagsum)
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate the fold function for a sum type."
+  :short "Generate the map function for a sum type."
   :long
   (xdoc::topstring
    (xdoc::p
@@ -569,11 +553,10 @@
      we use that as the body of the function.")
    (xdoc::p
     "Otherwise, the function is defined by cases,
-     which are generated by @(tsee deffoldred-gen-sum-cases).")
+     which are generated by @(tsee deffold-map-gen-sum-cases).")
    (xdoc::p
     "We also generate an `ignorable' declaration,
-     in case the overriding term does not mention the formal,
-     or in case all the cases are just the default.")
+     in case the overriding term does not mention the formal.")
    (xdoc::p
     "The @('mutrecp') flag says whether
      this sum type is part of a mutually recursive clique."))
@@ -581,9 +564,13 @@
        ((unless (symbolp type))
         (raise "Internal error: malformed type name ~x0." type)
         '(_))
-       (type-suffix (deffoldred-gen-fold-name type suffix))
+       (type-suffix (deffold-map-gen-map-name type suffix))
        (type-count (flexsum->count sum))
        (recog (flexsum->pred sum))
+       (fix (flexsum->fix sum))
+       ((unless (symbolp fix))
+        (raise "Internal error: malformed flexsum fix function ~x0." fix)
+        '(_))
        (recp (flexsum->recp sum))
        (body
         (b* ((term-assoc (assoc-equal type overrides))
@@ -592,14 +579,14 @@
              (prods (flexsum->prods sum))
              ((unless (flexprod-listp prods))
               (raise "Internal error: products ~x0 have the wrong type." prods))
-             (cases (deffoldred-gen-sum-cases
-                      type prods suffix
-                      targets extra-args default combine overrides fty-table)))
+             (cases (deffold-map-gen-sum-cases
+                      type fix prods suffix
+                      targets extra-args overrides fty-table)))
           `(,type-case ,type ,@cases))))
     `(define ,type-suffix ((,type ,recog) ,@extra-args)
        (declare (ignorable ,type))
-       :returns (result ,result)
-       :parents (,(deffoldred-gen-topic-name suffix))
+       :returns (result ,recog)
+       :parents (,(deffold-map-gen-topic-name suffix))
        ,body
        ,@(and (or mutrecp recp) `(:measure (,type-count ,type)))
        ,@(and (not mutrecp) '(:verify-guards :after-returns))
@@ -607,23 +594,23 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-option-fold ((sum flexsum-p)
-                                    (mutrecp booleanp)
-                                    (suffix symbolp)
-                                    (extra-args true-listp)
-                                    (result symbolp)
-                                    (default t)
-                                    (fty-table alistp))
+;; TODO: prove this respects iff
+(define deffold-map-gen-option-map
+  ((sum flexsum-p)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (extra-args true-listp)
+   (fty-table alistp))
   :guard (eq (flexsum->typemacro sum) 'defoption)
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate the fold function for an option type."
+  :short "Generate the map function for an option type."
   :long
   (xdoc::topstring
    (xdoc::p
     "In the FTY table, option types are stored as sum types,
      but with an indication of @(tsee defoption) as the type macro.")
    (xdoc::p
-    "This function is as described in @(tsee deffold-reduce).")
+    "This function is as described in @(tsee deffold-map).")
    (xdoc::p
     "The @('mutrecp') flag says whether
      this option type is part of a mutually recursive clique."))
@@ -631,22 +618,22 @@
        ((unless (symbolp type))
         (raise "Internal error: malformed type name ~x0." type)
         '(_))
-       (type-suffix (deffoldred-gen-fold-name type suffix))
+       (type-suffix (deffold-map-gen-map-name type suffix))
        (type-count (flexsum->count sum))
        (recog (flexsum->pred sum))
        (recp (flexsum->recp sum))
        (type-case (flexsum->case sum))
        ((mv base-type accessor)
         (components-of-flexoption-with-name type fty-table))
-       (base-type-suffix (deffoldred-gen-fold-name base-type suffix))
-       (extra-args-names (deffoldred-extra-args-to-names extra-args))
+       (base-type-suffix (deffold-map-gen-map-name base-type suffix))
+       (extra-args-names (deffold-map-extra-args-to-names extra-args))
        (body `(,type-case ,type
                           :some (,base-type-suffix (,accessor ,type)
                                                    ,@extra-args-names)
-                          :none ,default)))
+                          :none nil)))
     `(define ,type-suffix ((,type ,recog) ,@extra-args)
-       :returns (result ,result)
-       :parents (,(deffoldred-gen-topic-name suffix))
+       :returns (result ,recog)
+       :parents (,(deffold-map-gen-topic-name suffix))
        ,body
        ,@(and (or mutrecp recp) `(:measure (,type-count ,type)))
        ,@(and (not mutrecp) '(:verify-guards :after-returns))
@@ -654,18 +641,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-prod/sum/option-fold ((sum flexsum-p)
-                                             (mutrecp booleanp)
-                                             (suffix symbolp)
-                                             (targets symbol-listp)
-                                             (extra-args true-listp)
-                                             (result symbolp)
-                                             (default t)
-                                             (combine symbolp)
-                                             (overrides alistp)
-                                             (fty-table alistp))
+(define deffold-map-gen-prod/sum/option-map
+  ((sum flexsum-p)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate the fold function for a product, sum, or option type."
+  :short "Generate the map function for a product, sum, or option type."
   :long
   (xdoc::topstring
    (xdoc::p
@@ -674,37 +659,32 @@
   (b* ((typemacro (flexsum->typemacro sum)))
     (cond
      ((eq typemacro 'defprod)
-      (deffoldred-gen-prod-fold
-        sum mutrecp suffix
-        targets extra-args result default combine overrides fty-table))
+      (deffold-map-gen-prod-map
+        sum mutrecp suffix targets extra-args overrides fty-table))
      ((eq typemacro 'deftagsum)
-      (deffoldred-gen-sum-fold
-        sum mutrecp suffix
-        targets extra-args result default combine overrides fty-table))
+      (deffold-map-gen-sum-map
+        sum mutrecp suffix targets extra-args overrides fty-table))
      ((eq typemacro 'defoption)
-      (deffoldred-gen-option-fold
-        sum mutrecp suffix extra-args result default fty-table))
+      (deffold-map-gen-option-map sum mutrecp suffix extra-args fty-table))
      (t (prog2$
          (raise "Internal error: unsupported sum type ~x0." sum)
          '(_))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-list-fold ((list flexlist-p)
-                                  (mutrecp booleanp)
-                                  (suffix symbolp)
-                                  (extra-args true-listp)
-                                  (result symbolp)
-                                  (default t)
-                                  (combine symbolp)
-                                  (fty-table alistp))
+(define deffold-map-gen-list-map
+  ((list flexlist-p)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (extra-args true-listp)
+   (fty-table alistp))
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate the fold function for a list type,
+  :short "Generate the map function for a list type,
           with accompanying theorems."
   :long
   (xdoc::topstring
    (xdoc::p
-    "This is as described in @(tsee deffold-reduce).")
+    "This is as described in @(tsee deffold-map).")
    (xdoc::p
     "The @('mutrecp') flag says whether
      this list type is part of a mutually recursive clique."))
@@ -712,7 +692,7 @@
        ((unless (symbolp type))
         (raise "Internal error: malformed type name ~x0." type)
         '(_))
-       (type-suffix (deffoldred-gen-fold-name type suffix))
+       (type-suffix (deffold-map-gen-map-name type suffix))
        (type-count (flexlist->count list))
        (recog (flexlist->pred list))
        (elt-recog (flexlist->elt-type list))
@@ -725,34 +705,103 @@
        ((unless (symbolp elt-type))
         (raise "Internal error: malformed type name ~x0." elt-type)
         '(_))
-       (elt-type-suffix (deffoldred-gen-fold-name elt-type suffix))
-       (extra-args-names (deffoldred-extra-args-to-names extra-args))
+       (elt-type-suffix (deffold-map-gen-map-name elt-type suffix))
+       (extra-args-names (deffold-map-extra-args-to-names extra-args))
        (body
-        `(cond ((endp ,type)
-                ,default)
-               (t (,combine (,elt-type-suffix (car ,type) ,@extra-args-names)
-                            (,type-suffix (cdr ,type) ,@extra-args-names)))))
+        `(if (,(if (flexlist->true-listp list) 'endp 'atom) ,type)
+             nil
+           (cons (,elt-type-suffix (car ,type) ,@extra-args-names)
+                 (,type-suffix (cdr ,type) ,@extra-args-names))))
+       (type-suffix-type-prescription
+         (acl2::packn-pos (list type-suffix '-type-prescription) suffix))
        (type-suffix-when-atom
         (acl2::packn-pos (list type-suffix '-when-atom) suffix))
        (type-suffix-of-cons
         (acl2::packn-pos (list type-suffix '-of-cons) suffix))
+       (type-suffix-of-append
+         (acl2::packn-pos (list type-suffix '-of-append) suffix))
+       (consp-of-type-suffix
+         (acl2::packn-pos (list 'consp-of- type-suffix) suffix))
+       (len-of-type-suffix
+         (acl2::packn-pos (list 'len-of- type-suffix) suffix))
+       (nth-of-type-suffix
+         (acl2::packn-pos (list 'nth-of- type-suffix) suffix))
+       (type-suffix-of-revappend
+         (acl2::packn-pos (list type-suffix '-of-revappend) suffix))
+       (type-suffix-of-reverse
+         (acl2::packn-pos (list type-suffix '-of-reverse) suffix))
        (thm-events
-        `((defruled ,type-suffix-when-atom
+        `((defruled ,type-suffix-type-prescription
+            (true-listp (,type-suffix ,type ,@extra-args-names))
+            :rule-classes :type-prescription
+            :hints (("Goal" :in-theory '(true-listp)
+                            :expand ((,type-suffix ,type ,@extra-args-names))
+                            :induct (true-listp ,type))))
+          (defruled ,type-suffix-when-atom
             (implies (atom ,type)
                      (equal (,type-suffix ,type ,@extra-args-names)
-                            ,default)))
+                            nil))
+            :hints (("Goal" :in-theory '(,type-suffix))))
           (defruled ,type-suffix-of-cons
             (equal (,type-suffix (cons ,elt-type ,type) ,@extra-args-names)
-                   (,combine (,elt-type-suffix ,elt-type ,@extra-args-names)
-                             (,type-suffix ,type ,@extra-args-names)))
-            :expand (,type-suffix (cons ,elt-type ,type) ,@extra-args-names))))
+                   (cons (,elt-type-suffix ,elt-type ,@extra-args-names)
+                         (,type-suffix ,type ,@extra-args-names)))
+            :hints (("Goal" :in-theory '(,type-suffix car-cons cdr-cons))))
+          (defruled ,type-suffix-of-append
+            (equal (,type-suffix (append x y) ,@extra-args-names)
+                   (append (,type-suffix x ,@extra-args-names)
+                           (,type-suffix y ,@extra-args-names)))
+            :hints (("Goal" :in-theory '(append ,type-suffix car-cons cdr-cons)
+                            :induct (append x y))))
+          (defruled ,consp-of-type-suffix
+            (equal (consp (,type-suffix ,type ,@extra-args-names))
+                   (consp ,type))
+            :hints (("Goal" :in-theory nil
+                            :expand ((,type-suffix ,type ,@extra-args-names)))))
+          (defruled ,len-of-type-suffix
+            (equal (len (,type-suffix ,type ,@extra-args-names))
+                   (len ,type))
+            :hints (("Goal" :in-theory '(len cdr-cons)
+                            :expand ((,type-suffix ,type ,@extra-args-names))
+                            :induct (len ,type))))
+          (defruled ,nth-of-type-suffix
+            (equal (nth n (,type-suffix ,type ,@extra-args-names))
+                   (if (< (nfix n) (len ,type))
+                       (,elt-type-suffix (nth n ,type) ,@extra-args-names)
+                     nil))
+            :hints (("Goal" :in-theory '(nth ,type-suffix
+                                         len (:t len)
+                                         nfix zp car-cons cdr-cons)
+                            :expand ((,type-suffix ,type ,@extra-args-names)
+                                     (len ,type))
+                            :induct (nth n ,type))))
+          (defruled ,type-suffix-of-revappend
+            (equal (,type-suffix (revappend x y) ,@extra-args-names)
+                   (revappend (,type-suffix x ,@extra-args-names)
+                              (,type-suffix y ,@extra-args-names)))
+            :hints (("Goal" :in-theory '(revappend ,type-suffix car-cons cdr-cons)
+                            :induct (revappend x y))))
+          (defruled ,type-suffix-of-reverse
+            (equal (,type-suffix (reverse ,type) ,@extra-args-names)
+                   (reverse (,type-suffix ,type ,@extra-args-names)))
+            :hints (("Goal" :in-theory '(reverse revappend
+                                         ,type-suffix-type-prescription
+                                         ,type-suffix-when-atom
+                                         ,type-suffix-of-revappend))))))
        (ruleset-event
-        `(add-to-ruleset ,(deffoldred-gen-ruleset-name suffix)
-                         '(,type-suffix-when-atom
-                           ,type-suffix-of-cons))))
+        `(add-to-ruleset ,(deffold-map-gen-ruleset-name suffix)
+                         '(,type-suffix-type-prescription
+                           ,type-suffix-when-atom
+                           ,type-suffix-of-cons
+                           ,type-suffix-of-append
+                           ,consp-of-type-suffix
+                           ,len-of-type-suffix
+                           ,nth-of-type-suffix
+                           ,type-suffix-of-revappend
+                           ,type-suffix-of-reverse))))
     `(define ,type-suffix ((,type ,recog) ,@extra-args)
-       :returns (result ,result)
-       :parents (,(deffoldred-gen-topic-name suffix))
+       :returns (result ,recog)
+       :parents (,(deffold-map-gen-topic-name suffix))
        ,body
        ,@(and (or mutrecp recp) `(:measure (,type-count ,type)))
        ,@(and (not mutrecp) '(:verify-guards :after-returns))
@@ -763,21 +812,20 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-omap-fold ((omap flexomap-p)
-                                  (mutrecp booleanp)
-                                  (suffix symbolp)
-                                  (extra-args true-listp)
-                                  (result symbolp)
-                                  (default t)
-                                  (combine symbolp)
-                                  (fty-table alistp))
+;; TODO: more theorems
+(define deffold-map-gen-omap-map
+  ((omap flexomap-p)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (extra-args true-listp)
+   (fty-table alistp))
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate a fold function for an omap type,
+  :short "Generate a map function for an omap type,
           with accompanying theorems."
   :long
   (xdoc::topstring
    (xdoc::p
-    "This is as described in @(tsee deffold-reduce).")
+    "This is as described in @(tsee deffold-map).")
    (xdoc::p
     "The @('mutrecp') flag says whether
      this omap type is part of a mutually recursive clique."))
@@ -785,7 +833,7 @@
        ((unless (symbolp type))
         (raise "Internal error: malformed type name ~x0." type)
         '(_))
-       (type-suffix (deffoldred-gen-fold-name type suffix))
+       (type-suffix (deffold-map-gen-map-name type suffix))
        (type-count (flexomap->count omap))
        (recog (flexomap->pred omap))
        (recp (flexomap->recp omap))
@@ -795,28 +843,32 @@
         '(_))
        (val-info (flextype-with-recognizer val-recog fty-table))
        (val-type (flextype->name val-info))
-       (val-type-suffix (deffoldred-gen-fold-name val-type suffix))
-       (extra-args-names (deffoldred-extra-args-to-names extra-args))
+       (val-type-suffix (deffold-map-gen-map-name val-type suffix))
+       (extra-args-names (deffold-map-extra-args-to-names extra-args))
        (body
-        `(cond ((not (mbt (,recog ,type))) ,default)
-               ((omap::emptyp ,type) ,default)
-               (t (,combine (,val-type-suffix (omap::head-val ,type)
-                                              ,@extra-args-names)
-                            (,type-suffix (omap::tail ,type)
-                                          ,@extra-args-names)))))
+        `(if (or (not (mbt (,recog ,type)))
+                 (omap::emptyp ,type))
+             nil
+           ;; TODO: omap should have a fast update when the key is known to <<
+           ;; subsequent keys (if any), in which case omap::update is just cons.
+           (omap::update (omap::head-key ,type)
+                         (,val-type-suffix (omap::head-val ,type)
+                                           ,@extra-args-names)
+                         (,type-suffix (omap::tail ,type)
+                                       ,@extra-args-names))))
        (type-suffix-when-emptyp
         (acl2::packn-pos (list type-suffix '-when-emptyp) suffix))
        (thm-events
         `((defruled ,type-suffix-when-emptyp
             (implies (omap::emptyp ,type)
                      (equal (,type-suffix ,type ,@extra-args-names)
-                            ,default)))))
+                            nil)))))
        (ruleset-event
-        `(add-to-ruleset ,(deffoldred-gen-ruleset-name suffix)
+        `(add-to-ruleset ,(deffold-map-gen-ruleset-name suffix)
                          '(,type-suffix-when-emptyp))))
     `(define ,type-suffix ((,type ,recog) ,@extra-args)
-       :returns (result ,result)
-       :parents (,(deffoldred-gen-topic-name suffix))
+       :returns (result ,recog)
+       :parents (,(deffold-map-gen-topic-name suffix))
        ,body
        ,@(and (or mutrecp recp) `(:measure (,type-count ,type)))
        ,@(and (not mutrecp) '(:verify-guards :after-returns))
@@ -827,71 +879,60 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-type-fold (flex
-                                  (mutrecp booleanp)
-                                  (suffix symbolp)
-                                  (targets symbol-listp)
-                                  (extra-args true-listp)
-                                  (result symbolp)
-                                  (default t)
-                                  (combine symbolp)
-                                  (overrides alistp)
-                                  (fty-table alistp))
+(define deffold-map-gen-type-map
+  (flex
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate a fold function for a type, with accompanying theorems."
+  :short "Generate a map function for a type, with accompanying theorems."
   (cond ((flexsum-p flex)
-         (deffoldred-gen-prod/sum/option-fold
-           flex mutrecp suffix
-           targets extra-args result default combine overrides fty-table))
+         (deffold-map-gen-prod/sum/option-map
+           flex mutrecp suffix targets extra-args overrides fty-table))
         ((flexlist-p flex)
-         (deffoldred-gen-list-fold flex mutrecp suffix
-           extra-args result default combine fty-table))
+         (deffold-map-gen-list-map flex mutrecp suffix extra-args fty-table))
         ((flexomap-p flex)
-         (deffoldred-gen-omap-fold flex mutrecp suffix
-           extra-args result default combine fty-table))
+         (deffold-map-gen-omap-map flex mutrecp suffix extra-args fty-table))
         (t (prog2$ (raise "Internal error: unsupported type ~x0." flex)
                    '(_)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-types-folds ((flexs true-listp)
-                                    (mutrecp booleanp)
-                                    (suffix symbolp)
-                                    (targets symbol-listp)
-                                    (extra-args true-listp)
-                                    (result symbolp)
-                                    (default t)
-                                    (combine symbolp)
-                                    (overrides alistp)
-                                    (fty-table alistp))
+(define deffold-map-gen-types-maps
+  ((flexs true-listp)
+   (mutrecp booleanp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :returns (events acl2::pseudo-event-form-listp)
-  :short "Generate fold functions for a list of types,
+  :short "Generate map functions for a list of types,
           with accompanying theorems."
   (b* (((when (endp flexs)) nil)
        (event
-        (deffoldred-gen-type-fold
-          (car flexs) mutrecp suffix
-          targets extra-args result default combine overrides fty-table))
+        (deffold-map-gen-type-map
+          (car flexs) mutrecp suffix targets extra-args overrides fty-table))
        (more-events
-        (deffoldred-gen-types-folds
-          (cdr flexs) mutrecp suffix
-          targets extra-args result default combine overrides fty-table)))
+        (deffold-map-gen-types-maps
+          (cdr flexs) mutrecp suffix targets extra-args overrides fty-table)))
     (cons event more-events)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-clique-fold/folds ((clique flextypes-p)
-                                          (suffix symbolp)
-                                          (targets symbol-listp)
-                                          (extra-args true-listp)
-                                          (result symbolp)
-                                          (default t)
-                                          (combine symbolp)
-                                          (overrides alistp)
-                                          (fty-table alistp))
+(define deffold-map-gen-clique-map/maps
+  ((clique flextypes-p)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :returns (event acl2::pseudo-event-formp)
-  :short "Generate a fold function,
-          or a clique of mutually recursive fold functions,
+  :short "Generate a map function,
+          or a clique of mutually recursive map functions,
           for a clique of types."
   :long
   (xdoc::topstring
@@ -923,20 +964,18 @@
         (raise "Internal error: empty type clique ~x0." clique)
         '(_))
        ((when (endp (cdr members)))
-        (deffoldred-gen-type-fold
-          (car members) nil suffix
-          targets extra-args result default combine overrides fty-table))
+        (deffold-map-gen-type-map
+          (car members) nil suffix targets extra-args overrides fty-table))
        (clique-name (flextypes->name clique))
        ((unless (symbolp clique-name))
         (raise "Internal error: malformed clique name ~x0." clique-name)
         '(_))
-       (clique-name-suffix (deffoldred-gen-fold-name clique-name suffix))
+       (clique-name-suffix (deffold-map-gen-map-name clique-name suffix))
        (events
-        (deffoldred-gen-types-folds
-          members t suffix
-          targets extra-args result default combine overrides fty-table)))
+        (deffold-map-gen-types-maps
+          members t suffix targets extra-args overrides fty-table)))
     `(defines ,clique-name-suffix
-       :parents (,(deffoldred-gen-topic-name suffix))
+       :parents (,(deffold-map-gen-topic-name suffix))
        ,@events
        :hints (("Goal" :in-theory (enable o< o-finp)))
        :verify-guards :after-returns
@@ -947,17 +986,15 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-cliques-folds ((clique-names symbol-listp)
-                                      (suffix symbolp)
-                                      (targets symbol-listp)
-                                      (extra-args true-listp)
-                                      (result symbolp)
-                                      (default t)
-                                      (combine symbolp)
-                                      (overrides alistp)
-                                      (fty-table alistp))
+(define deffold-map-gen-cliques-maps
+  ((clique-names symbol-listp)
+   (suffix symbolp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (fty-table alistp))
   :returns (events acl2::pseudo-event-form-listp)
-  :short "Generate fold functions, or fold function cliques,
+  :short "Generate map functions, or map function cliques,
           for a list of type cliques with given names."
   (b* (((when (endp clique-names)) nil)
        (clique-name (car clique-names))
@@ -966,40 +1003,34 @@
         (raise "Internal error: no type clique with name ~x0." clique-name))
        ((unless (flextypes-p clique))
         (raise "Internal error: malformed type clique ~x0." clique))
-       (event (deffoldred-gen-clique-fold/folds
-                clique suffix
-                targets extra-args result default combine
-                overrides fty-table))
-       (events (deffoldred-gen-cliques-folds
-                 (cdr clique-names) suffix
-                 targets extra-args result default combine
-                 overrides fty-table)))
+       (event (deffold-map-gen-clique-map/maps
+                clique suffix targets extra-args overrides fty-table))
+       (events (deffold-map-gen-cliques-maps
+                 (cdr clique-names) suffix targets
+                 extra-args overrides fty-table)))
     (cons event events)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-gen-everything ((suffix symbolp)
-                                   (types symbol-listp)
-                                   (targets symbol-listp)
-                                   (extra-args true-listp)
-                                   (result symbolp)
-                                   (default t)
-                                   (combine symbolp)
-                                   (overrides alistp)
-                                   (parents-presentp booleanp)
-                                   parents
-                                   (short-presentp booleanp)
-                                   short
-                                   (long-presentp booleanp)
-                                   long
-                                   (fty-table alistp))
+(define deffold-map-gen-everything
+  ((suffix symbolp)
+   (types symbol-listp)
+   (targets symbol-listp)
+   (extra-args true-listp)
+   (overrides alistp)
+   (parents-presentp booleanp)
+   parents
+   (short-presentp booleanp)
+   short
+   (long-presentp booleanp)
+   long
+   (fty-table alistp))
   :returns (event acl2::pseudo-event-formp)
   :short "Generate all the events."
-  (b* ((fold-events
-        (deffoldred-gen-cliques-folds
-          types suffix targets extra-args result default combine
-          overrides fty-table))
-       (xdoc-name (deffoldred-gen-topic-name suffix))
+  (b* ((map-events
+        (deffold-map-gen-cliques-maps
+          types suffix targets extra-args overrides fty-table))
+       (xdoc-name (deffold-map-gen-topic-name suffix))
        (xdoc-event
         `(acl2::defxdoc+ ,xdoc-name
            ,@(and parents-presentp `(:parents ,parents))
@@ -1007,19 +1038,21 @@
            ,@(and long-presentp `(:long ,long))
            :order-subtopics t))
        (ruleset-event
-        `(def-ruleset! ,(deffoldred-gen-ruleset-name suffix) nil)))
+        `(def-ruleset! ,(deffold-map-gen-ruleset-name suffix) nil)))
     `(encapsulate
        ()
        ,xdoc-event
        ,ruleset-event
-       ,@fold-events)))
+       ,@map-events)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-process-inputs-and-gen-everything ((args true-listp)
-                                                      (wrld plist-worldp))
-  :returns (mv erp (event acl2::pseudo-event-formp))
-  :parents (deffold-reduce-implementation)
+(define deffold-map-process-inputs-and-gen-everything
+  ((args true-listp)
+   (wrld plist-worldp))
+  :returns (mv erp
+               (event acl2::pseudo-event-formp))
+  :parents (deffold-map-implementation)
   :short "Process the inputs and generate the events."
   (b* (((reterr) '(_))
        (fty-table (acl2::table-alist+ 'flextypes-table wrld))
@@ -1027,9 +1060,6 @@
              types
              targets
              extra-args
-             result
-             default
-             combine
              overrides
              parents-presentp
              parents
@@ -1037,15 +1067,12 @@
              short
              long-presentp
              long)
-        (deffoldred-process-inputs args fty-table)))
-    (retok (deffoldred-gen-everything
+        (deffold-map-process-inputs args fty-table)))
+    (retok (deffold-map-gen-everything
              suffix
              types
              targets
              extra-args
-             result
-             default
-             combine
              overrides
              parents-presentp
              parents
@@ -1057,19 +1084,25 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define deffoldred-fn ((args true-listp) (ctx ctxp) state)
-  :returns (mv erp (event acl2::pseudo-event-formp) state)
-  :parents (deffold-reduce-implementation)
-  :short "Event expansion of @(tsee deffold-reduce)."
+(define deffold-map-fn
+  ((args true-listp)
+   (ctx ctxp)
+   state)
+  :returns (mv erp
+               (event acl2::pseudo-event-formp)
+               state)
+  :parents (deffold-map-implementation)
+  :short "Event expansion of @(tsee deffold-map)."
   (b* (((mv erp event)
-        (deffoldred-process-inputs-and-gen-everything args (w state)))
-       ((when erp) (acl2::er-soft+ ctx t '(_) "~@0" erp)))
+        (deffold-map-process-inputs-and-gen-everything args (w state)))
+       ((when erp)
+        (acl2::er-soft+ ctx t '(_) "~@0" erp)))
     (value event)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defsection deffoldred-macro-definition
-  :parents (deffold-reduce-implementation)
-  :short "Definition of @(tsee deffold-reduce)."
-  (defmacro deffold-reduce (&rest args)
-    `(make-event (deffoldred-fn ',args 'deffold-reduce state))))
+(defsection deffold-map-macro-definition
+  :parents (deffold-map-implementation)
+  :short "Definition of @(tsee deffold-map)."
+  (defmacro deffold-map (&rest args)
+    `(make-event (deffold-map-fn ',args 'deffold-map state))))

--- a/books/kestrel/fty/deffold-reduce-doc.lisp
+++ b/books/kestrel/fty/deffold-reduce-doc.lisp
@@ -74,7 +74,7 @@
     (xdoc::desc
      "@(':types') &mdash; no default"
      (xdoc::p
-      "Fixtype for which fold functions must be generated.")
+      "Fixtypes for which fold functions must be generated.")
      (xdoc::p
       "This must be a list of symbols, which is not evaluated by the macro,
        where each symbols must be one of the following:")

--- a/books/kestrel/fty/fold.lisp
+++ b/books/kestrel/fty/fold.lisp
@@ -165,8 +165,8 @@
       with possibly some variations,
       e.g. turning a list of integers into a list of doubled integers."))
    (xdoc::p
-    "The @(tsee deffold-reduce) event macro generates reducing folds.
-     We plan to add an event macro to generate mapping folds as well.")))
+    "The @(tsee deffold-reduce) event macro generates reducing folds and
+     the @(tsee deffold-map) event macro generates mapping folds.")))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/fty/top.lisp
+++ b/books/kestrel/fty/top.lisp
@@ -34,6 +34,8 @@
 (include-book "deffixtype-alias")
 (include-book "defflatsum")
 (include-book "defflatsum-doc")
+(include-book "deffold-map")
+(include-book "deffold-map-doc")
 (include-book "deffold-reduce")
 (include-book "deffold-reduce-doc")
 (include-book "deflist-of-len")

--- a/books/std/omaps/core.lisp
+++ b/books/std/omaps/core.lisp
@@ -378,6 +378,13 @@
                             (update key val (tail map))))))))
   ///
 
+  (in-theory (disable (:type-prescription update)))
+
+  (defrule update-type-prescription
+    (and (consp (update x y z))
+         (true-listp (update x y z)))
+    :rule-classes :type-prescription)
+
   (defrule update-of-head-and-tail
     (implies (not (emptyp map))
              (equal (update (mv-nth 0 (head map))


### PR DESCRIPTION
This is a fold for FTY types based on `deffold-reduce`. Unlike `deffold-reduce`, it does not take a `:combine` or `:default` flag, since it is a mapping fold. Instead, each case of the map is the relevant constructor applied to the recursively mapped fields.

This PR also includes some minor changes to `deffold-reduce` (a couple typos and a missing include) and to `omap`s (strengthening the `:type-prescription` rule).