### PR TITLE
Update BibTeX workshop references to cover 2018-2023 workshops

### DIFF
--- a/books/workshops/references/README.org
+++ b/books/workshops/references/README.org
@@ -21,7 +21,8 @@ This directory contains the following files:
 
 This data was first compiled by Jared Davis, covering the workshops
 from 2000 to 2004, and later extended by Keshav Kini to cover the
-workshops from 1999 to 2017.
+workshops from 1999 to 2017 and extended by Andrew T. Walter to cover
+2018-2023.
 
 Please keep this BibTeX resource up to date as new ACL2 workshops
 occur, and feel free to correct any errors or mistakes in the data if

--- a/books/workshops/references/workshops.bib
+++ b/books/workshops/references/workshops.bib
@@ -1946,3 +1946,503 @@
   year=2017,
   month="May"
 }
+
+% ACL2 Workshop 2018 ===========================================================
+@inproceedings{18-coglio-java,
+  author="Alessandro Coglio",
+  title="A Simple Java Code Generator for {ACL2} Based on a Deep Embedding of {ACL2} in Java",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.1}
+}
+
+@inproceedings{18-mehta-filesystems,
+  author="Mihir Parang Mehta",
+  title="Formalising Filesystems in the {ACL2} Theorem Prover: an Application to {FAT32}",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.2}
+}
+
+@inproceedings{18-greve-generalization,
+  author="David A. Greve and Andrew Gacek",
+  title="Trapezoidal Generalization over Linear Constraints",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.3}
+}
+
+@inproceedings{18-swords-sat,
+  author="Sol Swords",
+  title="Incremental {SAT} Library Integration Using Abstract Stobjs",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.4}
+}
+
+@inproceedings{18-hardin-data-structures,
+  author="David S. Hardin and Konrad Slind",
+  title="Using {ACL2} in the Design of Efficient, Verifiable Data Structures for High-Assurance Systems",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.5}
+}
+
+@inproceedings{18-coglio-x86,
+  author="Alessandro Coglio and Shilpi Goel",
+  title="Adding 32-bit Mode to the {ACL2} Model of the x86 {ISA}",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.6}
+}
+
+@inproceedings{18-sumners-toolbox,
+  author="Rob Sumners",
+  title="A Toolbox For Property Checking From Simulation Using
+Incremental {SAT} (Extended Abstract)",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.7}
+}
+
+@inproceedings{18-gamboa-algebra,
+  author="Ruben Gamboa and John R. Cowles",
+  title="The Fundamental Theorem of Algebra in {ACL2}",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.8}
+}
+
+@inproceedings{18-kwan-cauchy-schwarz,
+  author="Carl Kwan and Mark R. Greenstreet",
+  title="Real Vector Spaces and the {Cauchy-Schwarz} Inequality in {ACL2}(r)",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.9}
+}
+
+@inproceedings{18-kwan-convex,
+  author="Carl Kwan and Mark R. Greenstreet",
+  title="Convex Functions in {ACL2}(r)",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.10}
+}
+
+@inproceedings{18-peng-algebra,
+  author="Yan Peng and Mark R. Greenstreet",
+  title="{Smtlink} 2.0",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.11}
+}
+
+@inproceedings{18-kaufmann-defunt,
+  author="Matt Kaufmann",
+  title="{DefunT}: A Tool for Automating Termination Proofs by Using the Community Books (Extended Abstract)",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.12}
+}
+
+@inproceedings{18-swords-orchestration,
+  author="Sol Swords",
+  title="Hint Orchestration Using {ACL2}'s Simplifier",
+  booktitle="Proceedings of the Fifteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '18)",
+  year=2018,
+  month="November",
+  doi={10.4204/EPTCS.280.13}
+}
+
+% ACL2 Workshop 2020 ===========================================================
+@inproceedings{20-russinoff-rtl,
+  author="David M. Russinoff",
+  title="Formal Verification of Arithmetic {RTL:} Translating Verilog to {C++} to {ACL2}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.1}
+}
+
+@inproceedings{20-kaufmann-iteration,
+  author="Matt Kaufmann and J Strother Moore",
+  title="Iteration in {ACL2}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.2}
+}
+
+@inproceedings{20-swords-fgl,
+  author="Sol Swords",
+  title="New Rewriter Features in {FGL}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.3}
+}
+
+@inproceedings{20-sumners-orderings,
+  author="Rob Sumners",
+  title="Computing and Proving Well-founded Orderings through Finite Abstractions",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.4}
+}
+
+@inproceedings{20-temel-rp-rewriter,
+  author="Mertcan Temel",
+  title="RP-Rewriter: An Optimized Rewriter for Large Terms in {ACL2}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.5}
+}
+
+@inproceedings{20-gamboa-quadratic,
+  author="Ruben Gamboa and John R. Cowles and Woodrow Gamboa",
+  title="Quadratic Extensions in {ACL2}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.6}
+}
+
+@inproceedings{20-peng-inference,
+  author="Yan Peng and Mark R. Greenstreet",
+  title="Type Inference Using Meta-extract for {Smtlink} and Beyond",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.7}
+}
+
+@inproceedings{20-kwan-cauchy-schwarz,
+  author="Carl Kwan and Yan Peng and Mark R. Greenstreet",
+  title="{Cauchy-Schwarz} in {ACL2}(r) Abstract Vector Spaces",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.8}
+}
+
+@inproceedings{20-greve-representations,
+  author="David Greve",
+  title="Minimal Fractional Representations of Integers mod M",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.9}
+}
+
+@inproceedings{20-swords-inductive,
+  author="Sol Swords",
+  title="Generating Mutually Inductive Theorems from Concise Descriptions",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.10}
+}
+
+@inproceedings{20-coglio-ethereum,
+  author="Alessandro Coglio",
+  title="Ethereum's Recursive Length Prefix in {ACL2}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.11}
+}
+
+@inproceedings{20-coglio-isomorphic,
+  author="Alessandro Coglio and Stephen J. Westfold",
+  title="Isomorphic Data Type Transformations",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.12}
+}
+
+@inproceedings{20-hardin-rac,
+  author="David Hardin",
+  title="Put Me on the {RAC}",
+  booktitle="Proceedings of the Sixteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '20)",
+  year=2020,
+  month="May",
+  doi={10.4204/EPTCS.327.13}
+}
+
+% ACL2 Workshop 2022 ===========================================================
+@inproceedings{22-kaufmann-tables,
+  author="Matt Kaufmann and Rob Sumners and Sol Swords",
+  title="Extended Abstract: Stobj-tables",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.1}
+}
+
+@inproceedings{22-kaufmann-iteration,
+  author="Matt Kaufmann and J Strother Moore",
+  title="Extended Abstract: Iteration in {ACL2}, {WITH} .. {DO}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.2}
+}
+
+@inproceedings{22-gamboa-prime,
+  author="Ruben Gamboa and Woodrow Gamboa",
+  title="All Prime Numbers Have Primitive Roots",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.3}
+}
+
+@inproceedings{22-gamboa-teach,
+  author="Ruben Gamboa and Alicia Thoney",
+  title="Using {ACL2} To Teach Students About Software Testing",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.4}
+}
+
+@inproceedings{22-greve-dpss,
+  author="David A. Greve and Jennifer A. Davis and Laura R. Humphrey",
+  title="A Mechanized Proof of Bounded Convergence Time for the Distributed Perimeter Surveillance System {(DPSS)} Algorithm {A}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.5}
+}
+
+@inproceedings{22-russinoff-calendar,
+  author="David M. Russinoff",
+  title="Properties of the Hebrew Calendar",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.6}
+}
+
+@inproceedings{22-hunt-vwsim,
+  author="Warren A. Hunt Jr. and Vivek Ramanathan and J Strother Moore",
+  title="{VWSIM:} {A} Circuit Simulator",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.7}
+}
+
+@inproceedings{22-bapanapally-rotations,
+  author="Jagadish Bapanapally and Ruben Gamboa",
+  title="A Free Group of Rotations of Rank 2",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.8}
+}
+
+@inproceedings{22-young-complexity,
+  author="William D. Young",
+  title="Modeling Asymptotic Complexity Using {ACL2}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.9}
+}
+
+@inproceedings{22-russinoff-groups,
+  author="David M. Russinoff",
+  title="A Formalization of Finite Group Theory",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.10}
+}
+
+@inproceedings{22-temel-multipliers,
+  author="Mertcan Temel",
+  title="Verified Implementation of an Efficient Term-Rewriting Algorithm for Multiplier Verification on {ACL2}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.11}
+}
+
+@inproceedings{22-walter-systems,
+  author="Andrew T. Walter and Panagiotis Manolios",
+  title="{ACL2s} Systems Programming",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.12}
+}
+
+@inproceedings{22-coglio-syntheto,
+  author="Alessandro Coglio and Eric McCarthy and Stephen J. Westfold and Daniel Balasubramanian and Abhishek Dubey and Gabor Karsai",
+  title="Syntheto: {A} Surface Language for {APT} and {ACL2}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.13}
+}
+
+@inproceedings{22-coglio-java,
+  author="Alessandro Coglio",
+  title="A Complex Java Code Generator for {ACL2} Based on a Shallow Embedding of {ACL2} in Java",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.14}
+}
+
+@inproceedings{22-coglio-c,
+  author="Alessandro Coglio",
+  title="A Proof-Generating {C} Code Generator for {ACL2} Based on a Shallow Embedding of {C} in {ACL2}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.15}
+}
+
+@inproceedings{22-hardin-rust,
+  author="David S. Hardin",
+  title="Hardware/Software Co-Assurance using the Rust Programming Language and {ACL2}",
+  booktitle="Proceedings of the Seventeenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '22)",
+  year=2022,
+  month="May",
+  doi={10.4204/EPTCS.359.16}
+}
+
+% ACL2 Workshop 2023 ===========================================================
+@inproceedings{23-kwan-lu,
+  author="Carl Kwan",
+  title="Extended Abstract: Classical LU Decomposition in {ACL2}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.1}
+}
+
+@inproceedings{23-kwan-cheri,
+  author="Carl Kwan and Yutong Xin and William D. Young",
+  title="Extended Abstract: {CHERI} Concentrate in {ACL2}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.2}
+}
+
+@inproceedings{23-swords-bounds,
+  author="Sol Swords",
+  title="Extended Abstract: A Bound-Finding Tool for Arithmetic Terms",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.3}
+}
+
+@inproceedings{23-russinoff-groups-two,
+  author="David M. Russinoff",
+  title="A Formalization of Finite Group Theory: Part {II}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.4}
+}
+
+@inproceedings{23-russinoff-groups-three,
+  author="David M. Russinoff",
+  title="A Formalization of Finite Group Theory: Part {III}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.5}
+}
+
+@inproceedings{23-von-hippel-protocol,
+  author="Max von Hippel and Panagiotis Manolios and Kenneth L. McMillan and Cristina Nita{-}Rotaru and Lenore D. Zuck",
+  title="A Case Study in Analytic Protocol Analysis in {ACL2}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.6}
+}
+
+@inproceedings{23-kaufmann-debugging,
+  author="Matt Kaufmann and J Strother Moore",
+  title="Advances in {ACL2} Proof Debugging Tools",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.7}
+}
+
+@inproceedings{23-gamboa-missing,
+  author="Ruben Gamboa and Panagiotis Manolios and Eric Whitman Smith and Kyle Thompson",
+  title="Using Counterexample Generation and Theory Exploration to Suggest Missing Hypotheses",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.8}
+}
+
+@inproceedings{23-coglio-zkc,
+  author="Alessandro Coglio and Eric McCarthy and Eric Whitman Smith",
+  title="Formal Verification of Zero-Knowledge Circuits",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.9}
+}
+
+@inproceedings{23-kumar-gossipsub,
+  author="Ankit Kumar and Max von Hippel and Panagiotis Manolios and Cristina Nita{-}Rotaru",
+  title="Verification of GossipSub in {ACL2s}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.10}
+}
+
+@inproceedings{23-walter-calculational,
+  author="Andrew T. Walter and Ankit Kumar and Panagiotis Manolios",
+  title="Proving Calculational Proofs Correct",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.11}
+}
+
+@inproceedings{23-passmore-imandra,
+  author="Grant O. Passmore",
+  title="{ACL2} Proofs of Nonlinear Inequalities with Imandra",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.12}
+}
+
+@inproceedings{23-hardin-dancing,
+  author="David S. Hardin",
+  title="Verification of a Rust Implementation of Knuth's Dancing Links using {ACL2}",
+  booktitle="Proceedings of the Eighteenth International Workshop on the {ACL2} Theorem Prover and its Applications ({ACL2} '23)",
+  year=2023,
+  month="November",
+  doi={10.4204/EPTCS.393.13}
+}

--- a/books/workshops/references/workshops.tex
+++ b/books/workshops/references/workshops.tex
@@ -3,7 +3,7 @@
 \usepackage[T1]{fontenc}
 
 \title{BibTeX Entries for the ACL2 Workshops}
-\author{Jared Davis and Keshav Kini}
+\author{Jared Davis and Keshav Kini and Andrew T. Walter}
 
 \begin{document}
 
@@ -732,6 +732,186 @@ Term-Level Reasoning in Support of Bit-blasting \\
 
 \noindent {\sf 17-chau-de}\cite{17-chau-de} \\
 Formal Specification and Verification of the {FM9001} Microprocessor Using the {DE} System \\
+
+
+\section{ACL2 Workshop 2018}
+
+\noindent {\sf 18-coglio-java}\cite{18-coglio-java} \\
+A Simple Java Code Generator for {ACL2} Based on a Deep Embedding of {ACL2} in Java \\
+
+\noindent {\sf 18-mehta-filesystems}\cite{18-mehta-filesystems} \\
+Formalising Filesystems in the {ACL2} Theorem Prover: an Application to {FAT32} \\
+
+\noindent {\sf 18-greve-generalization}\cite{18-greve-generalization} \\
+Trapezoidal Generalization over Linear Constraints \\
+
+\noindent {\sf 18-swords-sat}\cite{18-swords-sat} \\
+Incremental {SAT} Library Integration Using Abstract Stobjs \\
+
+\noindent {\sf 18-hardin-data-structures}\cite{18-hardin-data-structures} \\
+Trapezoidal Generalization over Linear Constraints \\
+
+\noindent {\sf 18-hardin-data-structures}\cite{18-hardin-data-structures} \\
+Using {ACL2} in the Design of Efficient, Verifiable Data Structures for High-Assurance Systems \\
+
+\noindent {\sf 18-coglio-x86}\cite{18-coglio-x86} \\
+Adding 32-bit Mode to the {ACL2} Model of the x86 {ISA} \\
+
+\noindent {\sf 18-sumners-toolbox}\cite{18-sumners-toolbox} \\
+A Toolbox For Property Checking From Simulation Using
+Incremental {SAT} \\
+
+\noindent {\sf 18-gamboa-algebra}\cite{18-gamboa-algebra} \\
+The Fundamental Theorem of Algebra in {ACL2} \\
+
+\noindent {\sf 18-kwan-cauchy-schwarz}\cite{18-kwan-cauchy-schwarz} \\
+Real Vector Spaces and the Cauchy-Schwarz Inequality in {ACL2}(r) \\
+
+\noindent {\sf 18-kwan-convex}\cite{18-kwan-convex} \\
+Convex Functions in {ACL2}(r) \\
+
+\noindent {\sf 18-peng-algebra}\cite{18-peng-algebra} \\
+{Smtlink} 2.0 \\
+
+\noindent {\sf 18-kaufmann-defunt}\cite{18-kaufmann-defunt} \\
+{DefunT}: A Tool for Automating Termination Proofs by Using the Community Books \\
+
+\noindent {\sf 18-swords-orchestration}\cite{18-swords-orchestration} \\
+Hint Orchestration Using {ACL2}'s Simplifier \\
+
+\section{ACL2 Workshop 2020}
+
+\noindent {\sf 20-russinoff-rtl}\cite{20-russinoff-rtl} \\
+Formal Verification of Arithmetic {RTL:} Translating Verilog to {C++} to {ACL2} \\
+
+\noindent {\sf 20-kaufmann-iteration}\cite{20-kaufmann-iteration} \\
+Iteration in {ACL2} \\
+
+\noindent {\sf 20-swords-fgl}\cite{20-swords-fgl} \\
+New Rewriter Features in {FGL} \\
+
+\noindent {\sf 20-sumners-orderings}\cite{20-sumners-orderings} \\
+Computing and Proving Well-founded Orderings through Finite Abstractions \\
+
+\noindent {\sf 20-temel-rp-rewriter}\cite{20-temel-rp-rewriter} \\
+RP-Rewriter: An Optimized Rewriter for Large Terms in {ACL2} \\
+
+\noindent {\sf 20-gamboa-quadratic}\cite{20-gamboa-quadratic} \\
+Quadratic Extensions in {ACL2} \\
+
+\noindent {\sf 20-peng-inference}\cite{20-peng-inference} \\
+Type Inference Using Meta-extract for {Smtlink} and Beyond \\
+
+\noindent {\sf 20-kwan-cauchy-schwarz}\cite{20-kwan-cauchy-schwarz} \\
+{Cauchy-Schwarz} in {ACL2}(r) Abstract Vector Spaces \\
+
+\noindent {\sf 20-greve-representations}\cite{20-greve-representations} \\
+Minimal Fractional Representations of Integers mod M \\
+
+\noindent {\sf 20-swords-inductive}\cite{20-swords-inductive} \\
+Generating Mutually Inductive Theorems from Concise Descriptions \\
+
+\noindent {\sf 20-coglio-ethereum}\cite{20-coglio-ethereum} \\
+Ethereum's Recursive Length Prefix in {ACL2} \\
+
+\noindent {\sf 20-coglio-isomorphic}\cite{20-coglio-isomorphic} \\
+Isomorphic Data Type Transformations \\
+
+\noindent {\sf 20-hardin-rac}\cite{20-hardin-rac} \\
+Put Me on the {RAC} \\
+
+
+\section{ACL2 Workshop 2022}
+
+\noindent {\sf 22-kaufmann-tables}\cite{22-kaufmann-tables} \\
+Extended Abstract: Stobj-tables \\
+
+\noindent {\sf 22-kaufmann-iteration}\cite{22-kaufmann-iteration} \\
+Extended Abstract: Iteration in {ACL2}, {WITH} .. {DO} \\
+
+\noindent {\sf 22-gamboa-prime}\cite{22-gamboa-prime} \\
+All Prime Numbers Have Primitive Roots \\
+
+\noindent {\sf 22-gamboa-teach}\cite{22-gamboa-teach} \\
+Using {ACL2} To Teach Students About Software Testing \\
+
+\noindent {\sf 22-greve-dpss}\cite{22-greve-dpss} \\
+A Mechanized Proof of Bounded Convergence Time for the Distributed Perimeter Surveillance System {(DPSS)} Algorithm {A} \\
+
+\noindent {\sf 22-russinoff-calendar}\cite{22-russinoff-calendar} \\
+Properties of the Hebrew Calendar \\
+
+\noindent {\sf 22-hunt-vwsim}\cite{22-hunt-vwsim} \\
+{VWSIM:} {A} Circuit Simulator \\
+
+\noindent {\sf 22-bapanapally-rotations}\cite{22-bapanapally-rotations} \\
+A Free Group of Rotations of Rank 2 \\
+
+\noindent {\sf 22-young-complexity}\cite{22-young-complexity} \\
+Modeling Asymptotic Complexity Using {ACL2} \\
+
+\noindent {\sf 22-russinoff-groups}\cite{22-russinoff-groups} \\
+A Formalization of Finite Group Theory \\
+
+\noindent {\sf 22-temel-multipliers}\cite{22-temel-multipliers} \\
+Verified Implementation of an Efficient Term-Rewriting Algorithm for Multiplier Verification on {ACL2} \\
+
+\noindent {\sf 22-walter-systems}\cite{22-walter-systems} \\
+{ACL2s} Systems Programming \\
+
+\noindent {\sf 22-coglio-syntheto}\cite{22-coglio-syntheto} \\
+Syntheto: {A} Surface Language for {APT} and {ACL2} \\
+
+\noindent {\sf 22-coglio-java}\cite{22-coglio-java} \\
+A Complex Java Code Generator for {ACL2} Based on a Shallow Embedding of {ACL2} in Java \\
+
+\noindent {\sf 22-coglio-c}\cite{22-coglio-c} \\
+A Proof-Generating {C} Code Generator for {ACL2} Based on a Shallow Embedding of {C} in {ACL2} \\
+
+\noindent {\sf 22-hardin-rust}\cite{22-hardin-rust} \\
+Hardware/Software Co-Assurance using the Rust Programming Language and {ACL2} \\
+
+
+\section{ACL2 Workshop 2023}
+
+\noindent {\sf 23-kwan-lu}\cite{23-kwan-lu} \\
+Extended Abstract: Classical LU Decomposition in {ACL2} \\
+
+\noindent {\sf 23-kwan-cheri}\cite{23-kwan-cheri} \\
+Extended Abstract: {CHERI} Concentrate in {ACL2} \\
+
+\noindent {\sf 23-swords-bounds}\cite{23-swords-bounds} \\
+Extended Abstract: A Bound-Finding Tool for Arithmetic Terms \\
+
+\noindent {\sf 23-russinoff-groups-two}\cite{23-russinoff-groups-two} \\
+A Formalization of Finite Group Theory: Part {II} \\
+
+\noindent {\sf 23-russinoff-groups-three}\cite{23-russinoff-groups-three} \\
+A Formalization of Finite Group Theory: Part {III} \\
+
+\noindent {\sf 23-von-hippel-protocol}\cite{23-von-hippel-protocol} \\
+A Case Study in Analytic Protocol Analysis in {ACL2} \\
+
+\noindent {\sf 23-kaufmann-debugging}\cite{23-kaufmann-debugging} \\
+Advances in {ACL2} Proof Debugging Tools \\
+
+\noindent {\sf 23-gamboa-missing}\cite{23-gamboa-missing} \\
+Using Counterexample Generation and Theory Exploration to Suggest Missing Hypotheses \\
+
+\noindent {\sf 23-coglio-zkc}\cite{23-coglio-zkc} \\
+Formal Verification of Zero-Knowledge Circuits \\
+
+\noindent {\sf 23-kumar-gossipsub}\cite{23-kumar-gossipsub} \\
+Verification of GossipSub in {ACL2s} \\
+
+\noindent {\sf 23-walter-calculational}\cite{23-walter-calculational} \\
+Proving Calculational Proofs Correct \\
+
+\noindent {\sf 23-passmore-imandra}\cite{23-passmore-imandra} \\
+{ACL2} Proofs of Nonlinear Inequalities with Imandra \\
+
+\noindent {\sf 23-hardin-dancing}\cite{23-hardin-dancing} \\
+Verification of a Rust Implementation of Knuth's Dancing Links using {ACL2} \\
 
 
 \bibliographystyle{plain}


### PR DESCRIPTION
Update the workshop BibTeX references to cover the 2018, 2020, 2022 and 2023 workshops.