### PR TITLE
Change the `cert_param` `uses-cpp` to `uses-gcc-c17`

### DIFF
--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -414,7 +414,7 @@ OK_CERTS := $(filter-out $(CERT_PL_USES_STP), $(OK_CERTS))
 endif
 
 ifeq ($(OS_HAS_GCC_C17), )
-$(info Excluding books that invoke GCC with \"-std=c17\": [$(CERT_PL_USES_GCC_C17)])
+$(info Excluding books that require a GCC with \"-std=c17\": [$(CERT_PL_USES_GCC_C17)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_GCC_C17), $(OK_CERTS))
 endif
 

--- a/books/GNUmakefile
+++ b/books/GNUmakefile
@@ -233,7 +233,7 @@ $(info OS_HAS_GLUCOSE      := $(OS_HAS_GLUCOSE))
 $(info OS_HAS_IPASIR       := $(OS_HAS_IPASIR))
 $(info OS_HAS_SMTLINK      := $(OS_HAS_SMTLINK))
 $(info OS_HAS_STP          := $(OS_HAS_STP))
-$(info OS_HAS_CPP          := $(OS_HAS_CPP))
+$(info OS_HAS_GCC_C17      := $(OS_HAS_GCC_C17))
 $(info USE_QUICKLISP       := $(USE_QUICKLISP))
 $(info ACL2_USELESS_RUNES  := $(ACL2_USELESS_RUNES))
 $(info Done with features.)
@@ -413,9 +413,9 @@ $(info Excluding books that need STP: [$(CERT_PL_USES_STP)])
 OK_CERTS := $(filter-out $(CERT_PL_USES_STP), $(OK_CERTS))
 endif
 
-ifeq ($(OS_HAS_CPP), )
-$(info Excluding books that invoke cpp: [$(CERT_PL_USES_CPP)])
-OK_CERTS := $(filter-out $(CERT_PL_USES_CPP), $(OK_CERTS))
+ifeq ($(OS_HAS_GCC_C17), )
+$(info Excluding books that invoke GCC with \"-std=c17\": [$(CERT_PL_USES_GCC_C17)])
+OK_CERTS := $(filter-out $(CERT_PL_USES_GCC_C17), $(OK_CERTS))
 endif
 
 ifeq ($(ACL2_HAS_REALS), )

--- a/books/build/doc.lisp
+++ b/books/build/doc.lisp
@@ -1436,8 +1436,8 @@ certification using @('make')."
 
  <li>@('uses-quicklisp'): only certify when quicklisp is available</li>
 
- <li>@('uses-cpp'): only certify when cpp is available. See @(see
- c$::preprocessing).</li>
+ <li>@('uses-gcc-c17'): only certify when GCC is available with @('-std=c17').
+ See @(see c$::preprocessing).</li>
 
  </ul>
 
@@ -1468,7 +1468,7 @@ certification using @('make')."
 (acl2::defpointer uses-stp cert_param)
 (acl2::defpointer uses-quicklisp cert_param)
 
-(acl2::defpointer uses-cpp cert_param)
+(acl2::defpointer uses-gcc-c17 cert_param)
 
 ;; Added by Eric Smith
 (acl2::defpointer cert-flags custom-certify-book-commands)

--- a/books/build/features.sh
+++ b/books/build/features.sh
@@ -170,12 +170,12 @@ EXPORTED_VARS += OS_HAS_STP
 EOF
 fi
 
-echo "Determining whether cpp is installed" 1>&2
-if cpp --version 2>/dev/null;
+echo "Determining whether GCC is installed and supports the c17 standard" 1>&2
+if gcc -std=c17 -x c -c /dev/null -o /dev/null 2>/dev/null;
 then
     cat >> Makefile-features <<EOF
-export OS_HAS_CPP ?= 1
-EXPORTED_VARS += OS_HAS_CPP
+export OS_HAS_GCC_C17 ?= 1
+EXPORTED_VARS += OS_HAS_GCC_C17
 EOF
 fi
 

--- a/books/kestrel/c/syntax/input-files-doc.lisp
+++ b/books/kestrel/c/syntax/input-files-doc.lisp
@@ -111,8 +111,7 @@
         which must be in the current system path for executables.")
       (xdoc::li
        "@(':auto'),
-        which implicitly names the preprocessor @('\"cpp\"')
-        (a common default),
+        which implicitly names the preprocessor @('\"gcc\"'),
         which must be in the current system path for executables."))
      (xdoc::p
       "The preprocessing (if this input is not @('nil')),

--- a/books/kestrel/c/syntax/input-files.lisp
+++ b/books/kestrel/c/syntax/input-files.lisp
@@ -175,7 +175,7 @@
                       but it is ~x0 instead."
                      preprocess)))
        (preprocessor (if (eq preprocess :auto)
-                         "cpp"
+                         "gcc"
                        preprocess)))
     (retok preprocessor)))
 

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -45,19 +45,20 @@
      "A collection of tools to invoke an external C preprocessor.")
    (xdoc::p
      "These tools appeal to a configurable C preprocessor, and the prerequisite
-      dependencies may not be present on all systems. For books which use the
-      default preprocessor \"cpp\", certification may be controlled with
-      the @(see build::uses-cpp) @(see build::cert_param) flag.")
+      dependencies may not be present on all systems. For books which use GCC
+      (the default), certification may be controlled with the
+      @(see build::uses-gcc-c17) @(see build::cert_param) flag.")
    (xdoc::p
-     "The community books Makefile will autodetect whether \"cpp\" is
-      available, and exclude books appropriately. Certification of such books
-      may be suppressed by manually undefining the Makefile variable
-      \"OS_HAS_CPP\". E.g., to run a regression excluding books calling cpp:")
+     "The community books Makefile will autodetect whether GCC is available,
+      and exclude books appropriately. Certification of such books may be
+      suppressed by manually undefining the Makefile variable
+      \"OS_HAS_GCC_C17\". E.g., to run a regression excluding books calling
+     cpp:")
    (xdoc::code
-     "OS_HAS_CPP= make regression")
+     "OS_HAS_GCC_C17= make regression")
    (xdoc::p
      "Further @(see build::cert_param) flags may need to be defined if using a
-      C preprocessor other than \"cpp\"."))
+      C preprocessor other than GCC."))
   :order-subtopics t)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/c/syntax/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/preprocess-file.lisp
@@ -53,7 +53,7 @@
       and exclude books appropriately. Certification of such books may be
       suppressed by manually undefining the Makefile variable
       \"OS_HAS_GCC_C17\". E.g., to run a regression excluding books calling
-     cpp:")
+     GCC:")
    (xdoc::code
      "OS_HAS_GCC_C17= make regression")
    (xdoc::p
@@ -100,9 +100,9 @@
     't)
    ((preprocessor stringp
                   "The preprocessor executable to use. The default is
-                   \"cpp\". Other reasonable values might be \"gcc\",
+                   \"gcc\". Other reasonable values might be \"gcc\",
                    \"clang\", \"cc\", etc.")
-    '"cpp")
+    '"gcc")
    ((extra-args string-listp
                 "Arguments to pass to the C preprocessor, in addition to
                  \"-E\". The default value is @('(list \"-P\" \"-std=c17\")').
@@ -224,9 +224,9 @@
     ':auto)
    ((preprocessor stringp
                   "The preprocessor executable to use. The default is
-                   \"cpp\". Other reasonable values might be \"gcc\",
+                   \"gcc\". Other reasonable values might be \"cpp\",
                    \"clang\", \"cc\", etc.")
-    '"cpp")
+    '"gcc")
    ((extra-args string-listp
                 "Arguments to pass to the C preprocessor, in addition to
                  \"-E\". The default value is @('(list \"-P\" \"-std=c17\")').

--- a/books/kestrel/c/syntax/tests/input-files.lisp
+++ b/books/kestrel/c/syntax/tests/input-files.lisp
@@ -10,7 +10,7 @@
 
 (in-package "C$")
 
-; cert_param: (uses-cpp)
+; cert_param: (uses-gcc-c17)
 
 (include-book "../input-files")
 

--- a/books/kestrel/c/syntax/tests/preprocess-file.lisp
+++ b/books/kestrel/c/syntax/tests/preprocess-file.lisp
@@ -10,7 +10,7 @@
 
 (in-package "C$")
 
-; cert_param: (uses-cpp)
+; cert_param: (uses-gcc-c17)
 
 (include-book "std/testing/must-eval-to-t" :dir :system)
 (include-book "std/testing/must-succeed" :dir :system)


### PR DESCRIPTION
Similarly, changes the Makefile flag `OS_HAS_CPP` to `OS_HAS_GCC_C17`.

Updates the feature detection to search for `gcc` instead of `cpp`, and requires that `"-std=c17"` is supported.