### PR TITLE
[RAC] Change array inialization

### DIFF
--- a/books/projects/rac/examples/imul/imul.cpp
+++ b/books/projects/rac/examples/imul/imul.cpp
@@ -66,7 +66,7 @@ array<ui3, 17> Booth(ui35 x) {
   ui35 x35 = x << 1;
 
   // Compute the booth encodings:
-  array<ui3, 17> a = {};
+  array<ui3, 17> a = {{}};
   for (int k = 0; k < 17; k++) {
     a[k] = Encode(x35.slc<3>(2 * k));
   }
@@ -76,7 +76,7 @@ array<ui3, 17> Booth(ui35 x) {
 // Step 2: Form the partial products.
 
 array<ui33, 17> PartialProducts(array<ui3, 17> m21, ui33 y) {
-  array<ui33, 17> pp = {};
+  array<ui33, 17> pp = {{}};
 
   for (int k = 0; k < 17; k++) {
     ui33 row = 0;
@@ -101,15 +101,15 @@ array<ui33, 17> PartialProducts(array<ui3, 17> m21, ui33 y) {
 array<ui64, 17> Align(array<ui3, 17> bds, array<ui33, 17> pps) {
 
   // Extract the sign bits from the booth encodings:
-  array<bool, 17> sb = {};
-  array<bool, 18> psb = {};
+  array<bool, 17> sb = {{}};
+  array<bool, 18> psb = {{}};
   for (int k = 0; k < 17; k++) {
     sb[k] = bds[k][2];
     psb[k + 1] = bds[k][2];
   }
 
   // Build the table:
-  array<ui64, 17> tble = {};
+  array<ui64, 17> tble = {{}};
   for (int k = 0; k < 17; k++) {
     ui67 tmp = 0;
     tmp.set_slc(2 * k, pps[k]);
@@ -152,25 +152,25 @@ tuple<ui64, ui64> Compress42(ui64 in0, ui64 in1, ui64 in2, ui64 in3) {
 ui64 Sum(array<ui64, 17> in) {
 
   // level 1 consists of 4 4:2 compressors
-  array<ui64, 8> A1 = {};
+  array<ui64, 8> A1 = {{}};
   for (uint i = 0; i < 4; i++) {
     tie(A1[2 * i + 0], A1[2 * i + 1]) =
         Compress42(in[4 * i], in[4 * i + 1], in[4 * i + 2], in[4 * i + 3]);
   }
 
   // level 2 consists of 2 4:2 compressors
-  array<ui64, 4> A2 = {};
+  array<ui64, 4> A2 = {{}};
   for (uint i = 0; i < 2; i++) {
     tie(A2[2 * i + 0], A2[2 * i + 1]) =
         Compress42(A1[4 * i], A1[4 * i + 1], A1[4 * i + 2], A1[4 * i + 3]);
   }
 
   // level 3 consists of 1 4:2 compressor
-  array<ui64, 2> A3 = {};
+  array<ui64, 2> A3 = {{}};
   tie(A3[0], A3[1]) = Compress42(A2[0], A2[1], A2[2], A2[3]);
 
   // level 4 consists of 1 3:2 compressor
-  array<ui64, 2> A4 = {};
+  array<ui64, 2> A4 = {{}};
   tie(A4[0], A4[1]) = Compress32(A3[0], A3[1], in[16]);
 
   // The final sum:

--- a/books/projects/rac/src/program/parser/ast/expressions.cpp
+++ b/books/projects/rac/src/program/parser/ast/expressions.cpp
@@ -320,7 +320,13 @@ void Initializer::display(std::ostream &os) const {
     if (!first) {
       os << ", ";
     }
-    v->ACL2Expr()->display(os);
+
+    if (auto init = dynamic_cast<const Initializer *>(v)) {
+      init->display(os);
+    } else {
+      v->ACL2Expr()->display(os);
+    }
+
     first = false;
   }
   os << '}';

--- a/books/projects/rac/src/program/parser/ast/types.cpp
+++ b/books/projects/rac/src/program/parser/ast/types.cpp
@@ -463,6 +463,12 @@ bool ArrayType::isEqual(const Type *other) const {
 Sexpression *ArrayType::cast(Expression *rval) const {
 
   if (auto init = dynamic_cast<Initializer *>(rval)) {
+    // Array initializer must be a double initializer list (see comment in
+    // typing.cpp). "vals" is guarranted to have a single element: an
+    // Initializer list (checked during typing).
+    if (isSTDArray()) {
+      init = always_cast<Initializer *>(*init->vals.begin());
+    }
     return init->ACL2ArrayExpr(this);
   } else {
     return rval->ACL2Expr();

--- a/books/projects/rac/src/program/process/typing.h
+++ b/books/projects/rac/src/program/process/typing.h
@@ -81,6 +81,8 @@ public:
   // Check if all "fast arrray" are const.
   bool VisitArrayType(const ArrayType *t);
 
+  bool VisitStructType(const StructType *t);
+
 private:
   using base_t = RecursiveASTVisitor<TypingAction>;
 

--- a/books/projects/rac/tests/testsuite.py
+++ b/books/projects/rac/tests/testsuite.py
@@ -13,7 +13,7 @@ test_dir_path = 'yaml_test/'
 
 def preprocess(working_dir, input):
     cpp = sp.run(['g++', '-D__RAC__', '-C', '-E', '-std=c++14', '-I../../../include',
-    input, '-o', input + '.i'], capture_output=True, text=True, cwd=working_dir)
+        input, '-o', input + '.i'], capture_output=True, text=True, cwd=working_dir)
     assert cpp.returncode == 0, 'Preprocessor failed:\n' + cpp.stderr
 
 def run_parser(bin_path, working_dir, input, timeout, env):

--- a/books/projects/rac/tests/yaml_test/arithmetics/arithmetics.yml
+++ b/books/projects/rac/tests/yaml_test/arithmetics/arithmetics.yml
@@ -1,6 +1,7 @@
 - name: int-arith
 
 - name: int-arith-invalid
+  preprocess: 'int-arith-invalid.cpp'
   args: ['int-arith-invalid.cpp']
   env: {RAC_BYPASS_ERROR: 'true'}
   disabled-checks:

--- a/books/projects/rac/tests/yaml_test/arithmetics/int-arith-invalid.cpp
+++ b/books/projects/rac/tests/yaml_test/arithmetics/int-arith-invalid.cpp
@@ -8,13 +8,13 @@ using namespace std;
 int binary_invalid(int a, array<int, 3> b) { return a && b; }
 
 int prefix_invalid() {
-  array<int, 3> a = { 0, 1, 2 };
+  array<int, 3> a = {{ 0, 1, 2 }};
   return -a;
 }
 
 int no_implicit_cast() {
   ac_int<3, false> x = 0;
-  array<int, 3> a = { 0, 1, 2 };
+  array<int, 3> a = {{ 0, 1, 2 }};
   x = x + a;
 
   return 0;
@@ -22,7 +22,7 @@ int no_implicit_cast() {
 
 int ternary_invalid() {
   ac_int<3, false> x = 0;
-  array<int, 3> a = { 0, 1, 2 };
+  array<int, 3> a = {{ 0, 1, 2 }};
   x = true ? x : a;
 
   return 0;
@@ -30,7 +30,7 @@ int ternary_invalid() {
 
 typedef array<int, 3> array3;
 int prefix_invalid_with_typedef() {
-  array3 a = { 0, 1, 2 };
+  array3 a = {{ 0, 1, 2 }};
   return -a;
 }
 

--- a/books/projects/rac/tests/yaml_test/data_types/annonymous-struct-in-array.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/annonymous-struct-in-array.cpp
@@ -4,7 +4,7 @@ int foo() {
   array < struct {
     int a;
     int b;
-  }, 4 > arr = {};
+  }, 4 > arr = {{}};
   return 0;
 }
 

--- a/books/projects/rac/tests/yaml_test/data_types/array-in-struct-with-default-value.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/array-in-struct-with-default-value.cpp
@@ -4,7 +4,7 @@ using namespace std;
 // RAC begin
 
 struct S1 {
-  array<int, 4> a = {1, 2, 3, 4};
+  array<int, 4> a = {{1, 2, 3, 4}};
 };
 
 int foo() {

--- a/books/projects/rac/tests/yaml_test/data_types/basic.yml
+++ b/books/projects/rac/tests/yaml_test/data_types/basic.yml
@@ -139,6 +139,8 @@
   should_report_error: true
 
 - name: struct-default-values
+- name: struct-default-values-incompatible
+  should_report_error: true
 - name: struct-default-values-partially-init
 
 - name: struct-default-values-no-init-list

--- a/books/projects/rac/tests/yaml_test/data_types/const-arrays-2.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/const-arrays-2.cpp
@@ -7,8 +7,8 @@ int foo(const array<int, 3> a) {
   return a[2];
 }
 
-const array<int, 3> global_a = { 1, 2, 3 };
+const array<int, 3> global_a = {{ 1, 2, 3 }};
 int bar() {
-  const array<int, 3> local_a = { 1, 2, 3 };
+  const array<int, 3> local_a = {{ 1, 2, 3 }};
   return foo(global_a) + foo(local_a);
 }

--- a/books/projects/rac/tests/yaml_test/data_types/fast-arrays-mixed.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/fast-arrays-mixed.cpp
@@ -13,6 +13,6 @@ int bar(const array<int, 3> a) {
 }
 
 int foo() {
-  const fast_array<int, 3> a_fast_local = { 1, 2, 3 };
+  const fast_array<int, 3> a_fast_local = {{ 1, 2, 3 }};
   return bar(a_fast_local);
 }

--- a/books/projects/rac/tests/yaml_test/data_types/fast-arrays-non-const.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/fast-arrays-non-const.cpp
@@ -8,6 +8,6 @@ using fast_array =array<T, N>;
 // RAC begin
 
 int foo() {
-  fast_array<int, 3> a_fast_local = { 1, 2, 3 };
+  fast_array<int, 3> a_fast_local = {{ 1, 2, 3 }};
   return a_fast_local[1];
 }

--- a/books/projects/rac/tests/yaml_test/data_types/fast-arrays-non-const.ref.stderr
+++ b/books/projects/rac/tests/yaml_test/data_types/fast-arrays-non-const.ref.stderr
@@ -1,3 +1,3 @@
 fast-arrays-non-const.cpp:11 (2-20): Fast array must be const
- 11 |   fast_array<int, 3> a_fast_local = { 1, 2, 3 };
+ 11 |   fast_array<int, 3> a_fast_local = {{ 1, 2, 3 }};
     |   ^^^^^^^^^^^^^^^^^^

--- a/books/projects/rac/tests/yaml_test/data_types/fast-arrays.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/fast-arrays.cpp
@@ -7,15 +7,15 @@ using fast_array =array<T, N>;
 
 // RAC begin
 
-const array<int, 3> a_global = { 1, 2, 3 };
-const fast_array<int, 3> a_fast_global = { 1, 2, 3 };
+const array<int, 3> a_global = {{ 1, 2, 3 }};
+const fast_array<int, 3> a_fast_global = {{ 1, 2, 3 }};
 
 int global_use() {
   return a_global[1] + a_fast_global[1];
 }
 
 int local_use() {
-  const array<int, 3> a_local = { 1, 2, 3 };
-  const fast_array<int, 3> a_fast_local = { 1, 2, 3 };
+  const array<int, 3> a_local = {{ 1, 2, 3 }};
+  const fast_array<int, 3> a_fast_local = {{ 1, 2, 3 }};
   return a_local[1] + a_fast_local[1];
 }

--- a/books/projects/rac/tests/yaml_test/data_types/global-constant.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/global-constant.cpp
@@ -15,7 +15,7 @@ const int a = 2;
 const int b = 2;
 
 const int arr[4] = { 1, 2, 3, 4 };
-const array<int, 2> std_arr = { 1, 2 };
+const array<int, 2> std_arr = {{ 1, 2 }};
 
 int foo() { return a + s.a + n; }
 

--- a/books/projects/rac/tests/yaml_test/data_types/initializer-list-ac-types.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/initializer-list-ac-types.cpp
@@ -14,7 +14,7 @@ tuple<ui2, ui2> foo() {
 }
 
 array<ui2, 2> bar() {
-  array<ui2, 2> t = { 1, 4 };
+  array<ui2, 2> t = {{ 1, 4 }};
   return t;
 }
 

--- a/books/projects/rac/tests/yaml_test/data_types/initializer-list-mismatch-types.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/initializer-list-mismatch-types.cpp
@@ -8,7 +8,7 @@ struct S {
 };
 
 int foo() {
-  array<int, 3> a = {};
+  array<int, 3> a = {{}};
   S s = { a };
   return 0;
 }

--- a/books/projects/rac/tests/yaml_test/data_types/initializer-list.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/initializer-list.cpp
@@ -4,7 +4,7 @@ using namespace std;
 // RAC begin
 
 array<int, 2> bar() {
-  array<int, 2> t = { 1, 2 };
+  array<int, 2> t = {{ 1, 2 }};
   return t;
 }
 

--- a/books/projects/rac/tests/yaml_test/data_types/std-array-initializer-diff-size.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/std-array-initializer-diff-size.cpp
@@ -4,7 +4,7 @@ using namespace std;
 // RAC begin
 
 int foo() {
-  array<int, 3> a = { 2, 4 };
+  array<int, 3> a = {{ 2, 4 }};
   return a[2];
 }
 

--- a/books/projects/rac/tests/yaml_test/data_types/std-array-initializer-incomplete.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/std-array-initializer-incomplete.cpp
@@ -4,7 +4,7 @@ using namespace std;
 // RAC begin
 
 int foo() {
-  array<int, 3> incomplete = {};
+  array<int, 3> incomplete = {{}};
   return 0;
 }
 

--- a/books/projects/rac/tests/yaml_test/data_types/std-array.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/std-array.cpp
@@ -8,7 +8,7 @@ using namespace std;
 int foo(array<int, 5> a) { return a[4]; }
 
 array<int, 2> bar(int a, int b) {
-  array<int, 2> arr = {};
+  array<int, 2> arr = {{}};
   arr[0] = a;
   arr[1] = b;
 

--- a/books/projects/rac/tests/yaml_test/data_types/struct-default-values-incompatible.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/struct-default-values-incompatible.cpp
@@ -1,0 +1,3 @@
+// RAC begin
+
+struct S { int a[] = 3; }

--- a/books/projects/rac/tests/yaml_test/data_types/struct-default-values-incompatible.ref.stderr
+++ b/books/projects/rac/tests/yaml_test/data_types/struct-default-values-incompatible.ref.stderr
@@ -1,0 +1,3 @@
+struct-default-values-incompatible.cpp:3 (17-18): syntax error, unexpected ']'
+ 3 | struct S { int a[] = 3; }
+   |                  ^

--- a/books/projects/rac/tests/yaml_test/data_types/typedef-array.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/typedef-array.cpp
@@ -6,7 +6,7 @@ using namespace std;
 typedef array<int, 5> u5;
 
 u5 foo() {
-  u5 a = {};
+  u5 a = {{}};
   a[2] = 2;
   return a;
 }

--- a/books/projects/rac/tests/yaml_test/program_structure/imul-pc.cpp.ref.pc
+++ b/books/projects/rac/tests/yaml_test/program_structure/imul-pc.cpp.ref.pc
@@ -36,7 +36,7 @@ ui3 Encode(ui3 slice) {
 
 ui3[17] Booth(ui35 x) {
   ui35 x35 = x << 1;
-  ui3 a[17] = {};
+  ui3 a[17] = {{}};
   for (int k = 0; k < 17; k++) {
     a[k] = Encode(x35[2 * k + 3 - 1:2 * k]);
   }
@@ -44,7 +44,7 @@ ui3[17] Booth(ui35 x) {
 }
 
 ui33[17] PartialProducts(ui3 m21[17], ui33 y) {
-  ui33 pp[17] = {};
+  ui33 pp[17] = {{}};
   for (int k = 0; k < 17; k++) {
     ui33 row = 0;
     switch (m21[k][1:0]) {
@@ -63,13 +63,13 @@ ui33[17] PartialProducts(ui3 m21[17], ui33 y) {
 }
 
 ui64[17] Align(ui3 bds[17], ui33 pps[17]) {
-  bool sb[17] = {};
-  bool psb[18] = {};
+  bool sb[17] = {{}};
+  bool psb[18] = {{}};
   for (int k = 0; k < 17; k++) {
     sb[k] = bds[k][2];
     psb[k + 1] = bds[k][2];
   }
-  ui64 tble[17] = {};
+  ui64 tble[17] = {{}};
   for (int k = 0; k < 17; k++) {
     ui67 tmp = 0;
     tmp[2 * k + 33 - 1:2 * k] = pps[k];
@@ -104,17 +104,17 @@ ui64[17] Align(ui3 bds[17], ui33 pps[17]) {
 }
 
 ui64 Sum(ui64 in[17]) {
-  ui64 A1[8] = {};
+  ui64 A1[8] = {{}};
   for (uint i = 0; i < 4; i++) {
     <A1[2 * i + 0], A1[2 * i + 1]> = Compress42(in[4 * i], in[4 * i + 1], in[4 * i + 2], in[4 * i + 3]);
   }
-  ui64 A2[4] = {};
+  ui64 A2[4] = {{}};
   for (uint i = 0; i < 2; i++) {
     <A2[2 * i + 0], A2[2 * i + 1]> = Compress42(A1[4 * i], A1[4 * i + 1], A1[4 * i + 2], A1[4 * i + 3]);
   }
-  ui64 A3[2] = {};
+  ui64 A3[2] = {{}};
   <A3[0], A3[1]> = Compress42(A2[0], A2[1], A2[2], A2[3]);
-  ui64 A4[2] = {};
+  ui64 A4[2] = {{}};
   <A4[0], A4[1]> = Compress32(A3[0], A3[1], in[16]);
   return A4[0] + A4[1];
 }

--- a/books/projects/rac/tests/yaml_test/program_structure/variable-decl.cpp
+++ b/books/projects/rac/tests/yaml_test/program_structure/variable-decl.cpp
@@ -9,7 +9,7 @@ int foo() {
   ac_int<2, false> a1 = 1;
   ac_int<2, true> a2 = -4;
   int c = 9;
-  array<int, 4> d = {};
+  array<int, 4> d = {{}};
   int64 e = 4;
   uint64 f = 4;
 


### PR DESCRIPTION
std::arrays should be able to be initialized using {{}} and {} (braces elision). Before, std::arrays were only initialized using {} but for some other (older) compilers, the full syntax must be supported. Brace elision is not implemented, "{}" now reports an error