### PR TITLE
Add message utilities

### DIFF
--- a/books/kestrel/utilities/messages.lisp
+++ b/books/kestrel/utilities/messages.lisp
@@ -1,6 +1,6 @@
 ; Messages
 ;
-; Copyright (C) 2025 Kestrel Institute (http://www.kestrel.edu)
+; Copyright (C) 2018-2025 Kestrel Institute (http://www.kestrel.edu)
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;

--- a/books/kestrel/utilities/msgp.lisp
+++ b/books/kestrel/utilities/msgp.lisp
@@ -1,6 +1,6 @@
 ; A book about the built-in function msgp
 ;
-; Copyright (C) 2025 Kestrel Institute
+; Copyright (C) 2021-2025 Kestrel Institute
 ;
 ; License: A 3-clause BSD license. See the file books/3BSD-mod.txt.
 ;


### PR DESCRIPTION
This adds a number of new functions to `kestrel/utilities/messages`. `msg-fix` is an ordinary fixer. `msg$` is an alternative to `msg` which will expand to something which rewrites to `msg$-logic`, which is easier than `msg` to reason about, as `msg` macro-expands into a cons nest and can't be "disabled." `retmsg$` is just a convenient macro abbreviation for `(reterr (msg$ ...)`, which is a very common pattern when working with error value tuples.

This also generally refactors `kestrel/utilities/messages` after adding the built-in disables, tau-system disable, and induction depth limit.

@ericwhitmansmith, this includes just one addition to `kestrel/utilities/msgp`, which is a `compound-recognizer` rule (the strongest possible, I believe).