### PR TITLE
Avoid spurious dependency.

### DIFF
--- a/books/acl2s/match.lisp
+++ b/books/acl2s/match.lisp
@@ -621,7 +621,8 @@ Examples and proof mentioned in documentation.
 
 Testing.
 
-(include-book "xdoc/debug" :dir :system)
+(include-book ;; Newline to fool ACL2/cert.pl dependency scanner
+ "xdoc/debug" :dir :system)
 :doc match
 
 |#


### PR DESCRIPTION
This include-book is in a comment but causes lots of acl2s stuff to be rebuilt when xdoc machinery is changed.