### PR TITLE
Xdoc entities

### DIFF
--- a/books/xdoc/fancy/xslt.js
+++ b/books/xdoc/fancy/xslt.js
@@ -35,9 +35,8 @@
 // Compatibility wrapper for lack of XSLT standards in browsers.
 //
 
-// Warning: Keep this in sync with *entity-strings* and
-// *entitytok-as-plaintext-fal* in ../parse-xml.lisp,
-// *xml-entity-stuff* in ../prepare-topic.lisp, and
+// Warning: Keep this in sync with *entity-info*
+// in ../parse-xml.lisp, and
 // (defxdoc entities ...) in topics.lisp, and
 // wrap_xdoc_fragment in xdata2html.pl
 /**

--- a/books/xdoc/parse-xml.lisp
+++ b/books/xdoc/parse-xml.lisp
@@ -28,6 +28,7 @@
 ;
 ; Original author: Jared Davis <jared@centtech.com>
 ; Updated 7/2022 for more entities: Matt Kaufmann <matthew.j.kaufmann@gmail.com>
+; Updated 7/2025 to simplify entity handling: Eric Smith (eric.smith@kestrel.edu)
 
 (in-package "XDOC")
 (include-book "autolink")

--- a/books/xdoc/parse-xml.lisp
+++ b/books/xdoc/parse-xml.lisp
@@ -288,9 +288,9 @@
     (intern name "KEYWORD")))
 
 ;; Example alist entry: ("Omega" :ENTITY :|Omega|)
-(defun entity-strings-to-keywords-fal (strings fal)
+(defun entity-strings-to-tokens-fal (strings fal)
   (cond ((endp strings) fal)
-        (t (entity-strings-to-keywords-fal
+        (t (entity-strings-to-tokens-fal
             (cdr strings)
             (hons-acons (car strings)
                         (list :ENTITY
@@ -409,8 +409,8 @@
     ))
 
 ;; Example alist entry: ("Omega" :ENTITY :|Omega|)
-(defconst *entity-strings-to-keywords-fal*
-  (entity-strings-to-keywords-fal *entity-strings* nil))
+(defconst *entity-strings-to-tokens-fal*
+  (entity-strings-to-tokens-fal *entity-strings* nil))
 
 ;; Example alist entry: (:|Omega| . "&Omega;")
 (defconst *entity-keywords-to-strings-fal*
@@ -436,7 +436,7 @@
             n nil))
        (n (+ 1 n)) ;; eat the ;
        (str (str::rchars-to-string rchars))
-       (doublet (cdr (hons-get str *entity-strings-to-keywords-fal*)))
+       (doublet (cdr (hons-get str *entity-strings-to-tokens-fal*)))
        ((when doublet) (mv nil n doublet)))
     (mv (str::cat "Unsupported entity: &" str ";" *nls*
                   "Nearby text: {" (error-context x saved-n xl) "}" *nls*)

--- a/books/xdoc/parse-xml.lisp
+++ b/books/xdoc/parse-xml.lisp
@@ -287,6 +287,7 @@
                 (acl2::string-upcase s))))
     (intern name "KEYWORD")))
 
+;; Example alist entry: ("Omega" :ENTITY :|Omega|)
 (defun entity-strings-to-keywords-fal (strings fal)
   (cond ((endp strings) fal)
         (t (entity-strings-to-keywords-fal
@@ -296,6 +297,7 @@
                               (keyword-from-entity-string (car strings)))
                         fal)))))
 
+;; Example alist entry: (:|Omega| . "&Omega;")
 (defun entity-keywords-to-strings-fal (strings fal)
   (cond ((endp strings) fal)
         (t (entity-keywords-to-strings-fal
@@ -406,9 +408,11 @@
     "sum"
     ))
 
+;; Example alist entry: ("Omega" :ENTITY :|Omega|)
 (defconst *entity-strings-to-keywords-fal*
   (entity-strings-to-keywords-fal *entity-strings* nil))
 
+;; Example alist entry: (:|Omega| . "&Omega;")
 (defconst *entity-keywords-to-strings-fal*
   (let* ((fal (entity-keywords-to-strings-fal *entity-strings* nil))
          (dup (acl2::duplicate-keysp-eq fal)))

--- a/books/xdoc/parse-xml.lisp
+++ b/books/xdoc/parse-xml.lisp
@@ -288,133 +288,153 @@
     (intern name "KEYWORD")))
 
 ;; Example alist entry: ("Omega" :ENTITY :|Omega|)
-(defun entity-strings-to-tokens-fal (strings fal)
-  (cond ((endp strings) fal)
+(defun entity-strings-to-tokens-fal (entity-info fal)
+  (cond ((endp entity-info) fal)
         (t (entity-strings-to-tokens-fal
-            (cdr strings)
-            (hons-acons (car strings)
-                        (list :ENTITY
-                              (keyword-from-entity-string (car strings)))
-                        fal)))))
+            (cdr entity-info)
+            (let* ((entry (car entity-info))
+                   (string (car entry)))
+              (hons-acons string
+                          (list :ENTITY
+                                (keyword-from-entity-string string))
+                          fal))))))
 
 ;; Example alist entry: (:|Omega| . "&Omega;")
-(defun entity-keywords-to-strings-fal (strings fal)
-  (cond ((endp strings) fal)
+(defun entity-keywords-to-strings-fal (entity-info fal)
+  (cond ((endp entity-info) fal)
         (t (entity-keywords-to-strings-fal
-            (cdr strings)
-            (hons-acons (keyword-from-entity-string (car strings))
-                        (concatenate 'string
-                                     "&"
-                                     (car strings)
-                                     ";")
-                        fal)))))
+            (cdr entity-info)
+            (let* ((entry (car entity-info))
+                   (string (car entry)))
+              (hons-acons (keyword-from-entity-string string)
+                          (concatenate 'string
+                                       "&"
+                                       string
+                                       ";")
+                          fal))))))
 
-(defconst *entity-strings*
+(defconst *entity-info*
 
-; Warning: Keep this in sync with *entitytok-as-plaintext-fal* below,
-; *xml-entity-stuff* in prepare-topic.lisp, wrapXdocFragment in
-; fancy/xslt.js, (defxdoc entities ...) in topics.lisp, and
-; wrap_xdoc_fragment in fancy/xdata2html.pl
+; Warning: Keep this in sync with:
+; - wrapXdocFragment in fancy/xslt.js,
+; - wrap_xdoc_fragment in fancy/xdata2html.pl
+; - (defxdoc entities ...) in topics.lisp
 
-  '("amp"
-    "lt"
-    "gt"
-    "quot"
-    "apos"
-    "nbsp"
-    "ndash"
-    "mdash"
-    "larr"
-    "rarr"
-    "harr"
-    "lang"
-    "rang"
-    "hellip"
-    "lsquo"
-    "rsquo"
-    "ldquo"
-    "rdquo"
-    "and"
-    "or"
-    "not"
-    "ne"
-    "le"
-    "ge"
-    "mid"
-    "times"
+; Each entry is of the form:
+;  (<entity> <plaintext> <decimal-number>)
+; or (for the 5 special values)
+;  (<entity> <plaintext> :built-in)
+
+; See https://www.w3schools.com/charsets/ref_html_entities_4.asp
+
+; The decimal values below for Greek letters were obtained from
+; https://www.htmlhelp.com/reference/html40/entities/symbols.html.
+
+; The additional symbols below are from
+; https://www.w3schools.com/html/html_symbols.asp.
+
+  '(;; These 5 are treated specially by make-xml-entity-stuff-items-aux as they
+    ;; not be declared (see https://www.w3.org/TR/xml/):
+    ("amp"  "&" :built-in)
+    ("lt"   "<" :built-in)
+    ("gt"   ">" :built-in)
+    ("quot" "\"" :built-in)
+    ("apos" "'" :built-in)
+
+    ("nbsp"   " " 160) ; wart: disappears when preceded only by spaces except in <code>..</code>
+    ("ndash"  "--" 8211)
+    ("mdash"  "---" 8212)
+    ("larr"   "<--" 8592)
+    ("rarr"   "-->" 8594)
+    ("harr"   "<->" 8596)
+    ("lang"   "<" 9001)
+    ("rang"   ">" 9002)
+    ("hellip" "..." 8230)
+    ("lsquo"  "`" 8216)
+    ("rsquo"  "'" 8217)
+    ("ldquo"  "``" 8220)
+    ("rdquo"  "''" 8221)
+    ("and"    "&" 8743)
+    ("or"     "\\/" 8744)
+    ("not"    "~" 172)
+    ("ne"     "!=" 8800)
+    ("le"     "<=" 8804)
+    ("ge"     ">=" 8805)
+    ("mid"    "|" 8739)
+    ("times"  "\\times" 215)
 
 ; capitalized Greek letters
 
-    "Alpha"
-    "Beta"
-    "Gamma"
-    "Delta"
-    "Epsilon"
-    "Zeta"
-    "Eta"
-    "Theta"
-    "Iota"
-    "Kappa"
-    "Lambda"
-    "Mu"
-    "Nu"
-    "Xi"
-    "Omicron"
-    "Pi"
-    "Rho"
-    "Sigma"
-    "Tau"
-    "Upsilon"
-    "Phi"
-    "Chi"
-    "Psi"
-    "Omega"
+    ("Alpha"   "\\Alpha" 913)
+    ("Beta"    "\\Beta" 914)
+    ("Gamma"   "\\Gamma" 915)
+    ("Delta"   "\\Delta" 916)
+    ("Epsilon" "\\Epsilon" 917)
+    ("Zeta"    "\\Zeta" 918)
+    ("Eta"     "\\Eta" 919)
+    ("Theta"   "\\Theta" 920)
+    ("Iota"    "\\Iota" 921)
+    ("Kappa"   "\\Kappa" 922)
+    ("Lambda"  "\\Lambda" 923)
+    ("Mu"      "\\Mu" 924)
+    ("Nu"      "\\Nu" 925)
+    ("Xi"      "\\Xi" 926)
+    ("Omicron" "\\Omicron" 927)
+    ("Pi"      "\\Pi" 928)
+    ("Rho"     "\\Rho" 929) ;; number 930 is not used
+    ("Sigma"   "\\Sigma" 931)
+    ("Tau"     "\\Tau" 932)
+    ("Upsilon" "\\Upsilon" 933)
+    ("Phi"     "\\Phi" 934)
+    ("Chi"     "\\Chi" 935)
+    ("Psi"     "\\Psi" 936)
+    ("Omega"   "\\Omega" 937)
 
 ; lower case Greek letters
 
-    "alpha"
-    "beta"
-    "gamma"
-    "delta"
-    "epsilon"
-    "zeta"
-    "eta"
-    "theta"
-    "iota"
-    "kappa"
-    "lambda"
-    "mu"
-    "nu"
-    "xi"
-    "omicron"
-    "pi"
-    "rho"
-    "sigma"
-    "tau"
-    "upsilon"
-    "phi"
-    "chi"
-    "psi"
-    "omega"
+    ("alpha"   "\\alpha" 945)
+    ("beta"    "\\beta" 946)
+    ("gamma"   "\\gamma" 947)
+    ("delta"   "\\delta" 948)
+    ("epsilon" "\\epsilon" 949)
+    ("zeta"    "\\zeta" 950)
+    ("eta"     "\\eta" 951)
+    ("theta"   "\\theta" 952)
+    ("iota"    "\\iota" 953)
+    ("kappa"   "\\kappa" 954)
+    ("lambda"  "\\lambda" 955)
+    ("mu"      "\\mu" 956)
+    ("nu"      "\\nu" 957)
+    ("xi"      "\\xi" 958)
+    ("omicron" "\\omicron" 959)
+    ("pi"      "\\pi" 960)
+    ("rho"     "\\rho" 961) ; could add sigmaf here (962)
+    ("sigma"   "\\sigma" 963)
+    ("tau"     "\\tau" 964)
+    ("upsilon" "\\upsilon" 965)
+    ("phi"     "\\phi" 966)
+    ("chi"     "\\chi" 967)
+    ("psi"     "\\psi" 968)
+    ("omega"   "\\omega" 969)
 
 ; math symbols (ok to add more)
 
-    "forall"
-    "exist"
-    "empty"
-    "isin"
-    "notin"
-    "prod"
-    "sum"
+    ("forall" "\\forall" 8704)
+    ("exist"  "\\exist" 8707)
+    ("empty"  "\\empty" 8709)
+    ("isin"   "\\isin" 8712)
+    ("notin"  "\\notin" 8713)
+    ("prod"   "\\prod" 8719)
+    ("sum"    "\\sum" 8721)
     ))
 
 ;; Example alist entry: ("Omega" :ENTITY :|Omega|)
 (defconst *entity-strings-to-tokens-fal*
-  (entity-strings-to-tokens-fal *entity-strings* nil))
+  (entity-strings-to-tokens-fal *entity-info* nil))
 
 ;; Example alist entry: (:|Omega| . "&Omega;")
 (defconst *entity-keywords-to-strings-fal*
-  (let* ((fal (entity-keywords-to-strings-fal *entity-strings* nil))
+  (let* ((fal (entity-keywords-to-strings-fal *entity-info* nil))
          (dup (acl2::duplicate-keysp-eq fal)))
     (if dup
         (er hard 'top
@@ -477,98 +497,19 @@
   (cdr (hons-get (entitytok-type x)
                  *entity-keywords-to-strings-fal*)))
 
+(defun entitytok-as-plaintext-fal (entity-info fal)
+  (cond ((endp entity-info) fal) ; the reverse may not be needed
+        (t (entitytok-as-plaintext-fal
+            (cdr entity-info)
+            (let* ((entry (car entity-info))
+                   (string (car entry))
+                   (plaintext (second entry)))
+              (hons-acons (keyword-from-entity-string string)
+                          plaintext
+                          fal))))))
+
 (defconst *entitytok-as-plaintext-fal*
-
-; Warning: Keep this in sync with *entity-strings* above, *xml-entity-stuff* in
-; prepare-topic.lisp, and wrapXdocFragment in fancy/xslt.js, and (defxdoc
-; entities ...) in topics.lisp.
-
-  (make-fast-alist
-   '((:AMP   . "&")
-     (:LT    . "<")
-     (:GT    . ">")
-     (:QUOT  . "\"")
-     (:APOS  . "'")
-     (:NBSP  . " ") ; wart: disappears when preceded only by spaces except in <code>..</code>
-     (:NDASH . "--")
-     (:MDASH . "---")
-     (:LARR  . "<--")
-     (:RARR  . "-->")
-     (:HARR  . "<->")
-     (:LANG  . "<")
-     (:RANG  . ">")
-     (:HELLIP . "...")
-     (:LSQUO . "`")
-     (:RSQUO . "'")
-     (:LDQUO . "``")
-     (:RDQUO . "''")
-     (:AND   . "&")
-     (:OR    . "\\/")
-     (:NOT   . "~")
-     (:NE    . "!=")
-     (:LE    . "<=")
-     (:GE    . ">=")
-     (:MID   . "|")
-     (:TIMES . "\\times")
-
-     (:|Alpha|   . "\\Alpha")
-     (:|Beta|    . "\\Beta")
-     (:|Gamma|   . "\\Gamma")
-     (:|Delta|   . "\\Delta")
-     (:|Epsilon| . "\\Epsilon")
-     (:|Zeta|    . "\\Zeta")
-     (:|Eta|     . "\\Eta")
-     (:|Theta|   . "\\Theta")
-     (:|Iota|    . "\\Iota")
-     (:|Kappa|   . "\\Kappa")
-     (:|Lambda|  . "\\Lambda")
-     (:|Mu|      . "\\Mu")
-     (:|Nu|      . "\\Nu")
-     (:|Xi|      . "\\Xi")
-     (:|Omicron| . "\\Omicron")
-     (:|Pi|      . "\\Pi")
-     (:|Rho|     . "\\Rho")
-     (:|Sigma|   . "\\Sigma")
-     (:|Tau|     . "\\Tau")
-     (:|Upsilon| . "\\Upsilon")
-     (:|Phi|     . "\\Phi")
-     (:|Chi|     . "\\Chi")
-     (:|Psi|     . "\\Psi")
-     (:|Omega|   . "\\Omega")
-
-     (:ALPHA   . "\\alpha")
-     (:BETA    . "\\beta")
-     (:GAMMA   . "\\gamma")
-     (:DELTA   . "\\delta")
-     (:EPSILON . "\\epsilon")
-     (:ZETA    . "\\zeta")
-     (:ETA     . "\\eta")
-     (:THETA   . "\\theta")
-     (:IOTA    . "\\iota")
-     (:KAPPA   . "\\kappa")
-     (:LAMBDA  . "\\lambda")
-     (:MU      . "\\mu")
-     (:NU      . "\\nu")
-     (:XI      . "\\xi")
-     (:OMICRON . "\\omicron")
-     (:PI      . "\\pi")
-     (:RHO     . "\\rho")
-     (:SIGMA   . "\\sigma")
-     (:TAU     . "\\tau")
-     (:UPSILON . "\\upsilon")
-     (:PHI     . "\\phi")
-     (:CHI     . "\\chi")
-     (:PSI     . "\\psi")
-     (:OMEGA   . "\\omega")
-
-     (:FORALL  . "\\forall")
-     (:EXIST   . "\\exist")
-     (:EMPTY   . "\\empty")
-     (:ISIN    . "\\isin")
-     (:NOTIN   . "\\notin")
-     (:PROD    . "\\prod")
-     (:SUM     . "\\sum")
-     )))
+  (entitytok-as-plaintext-fal *entity-info* nil))
 
 (defun entitytok-as-plaintext (x)
   (cdr (hons-get (entitytok-type x)

--- a/books/xdoc/prepare-topic.lisp
+++ b/books/xdoc/prepare-topic.lisp
@@ -90,6 +90,8 @@
 ; *entitytok-as-plaintext-fal* in parse-xml.lisp, wrapXdocFragment in
 ; fancy/xslt.js, (defxdoc entities ...) in topics.lisp, and
 ; wrap_xdoc_fragment in fancy/xdata2html.pl
+; but note that 5 entities (amp, lt, gt, apos, quot) need not be
+; declared here (see https://www.w3.org/TR/xml/).
 
 ; The decimal values below for Greek letters were obtained from
 ; https://www.htmlhelp.com/reference/html40/entities/symbols.html.

--- a/books/xdoc/prepare-topic.lisp
+++ b/books/xdoc/prepare-topic.lisp
@@ -27,6 +27,7 @@
 ;   DEALINGS IN THE SOFTWARE.
 ;
 ; Original author: Jared Davis <jared@centtech.com>
+; Updated 7/2025 to simplify entity handling: Eric Smith (eric.smith@kestrel.edu)
 
 (in-package "XDOC")
 (include-book "base")

--- a/books/xdoc/prepare-topic.lisp
+++ b/books/xdoc/prepare-topic.lisp
@@ -84,102 +84,36 @@
            (remove-duplicates-eq children-names))
           (t (mergesort children-names)))))
 
-(defconst *xml-entity-stuff*
-
-; Warning: Keep this in sync with *entity-strings* and
-; *entitytok-as-plaintext-fal* in parse-xml.lisp, wrapXdocFragment in
-; fancy/xslt.js, (defxdoc entities ...) in topics.lisp, and
-; wrap_xdoc_fragment in fancy/xdata2html.pl
-; but note that 5 entities (amp, lt, gt, apos, quot) need not be
-; declared here (see https://www.w3.org/TR/xml/).
-
-; The decimal values below for Greek letters were obtained from
-; https://www.htmlhelp.com/reference/html40/entities/symbols.html.
-
-; The additional symbols below are from
-; https://www.w3schools.com/html/html_symbols.asp.
-
-  "<!DOCTYPE xdoc [
-  <!ENTITY nbsp \"&#160;\">
-  <!ENTITY ndash \"&#8211;\">
-  <!ENTITY mdash \"&#8212;\">
-  <!ENTITY larr \"&#8592;\">
-  <!ENTITY rarr \"&#8594;\">
-  <!ENTITY harr \"&#8596;\">
-  <!ENTITY lang \"&#9001;\">
-  <!ENTITY rang \"&#9002;\">
-  <!ENTITY hellip \"&#8230;\">
-  <!ENTITY lsquo \"&#8216;\">
-  <!ENTITY rsquo \"&#8217;\">
-  <!ENTITY ldquo \"&#8220;\">
-  <!ENTITY rdquo \"&#8221;\">
-  <!ENTITY and   \"&#8743;\">
-  <!ENTITY or    \"&#8744;\">
-  <!ENTITY not   \"&#172;\">
-  <!ENTITY ne    \"&#8800;\">
-  <!ENTITY le    \"&#8804;\">
-  <!ENTITY ge    \"&#8805;\">
-  <!ENTITY mid   \"&#8739;\">
-  <!ENTITY times \"&#215;\">
-
-  <!ENTITY Alpha   \"&#913;\">
-  <!ENTITY Beta    \"&#914;\">
-  <!ENTITY Gamma   \"&#915;\">
-  <!ENTITY Delta   \"&#916;\">
-  <!ENTITY Epsilon \"&#917;\">
-  <!ENTITY Zeta    \"&#918;\">
-  <!ENTITY Eta     \"&#919;\">
-  <!ENTITY Theta   \"&#920;\">
-  <!ENTITY Iota    \"&#921;\">
-  <!ENTITY Kappa   \"&#922;\">
-  <!ENTITY Lambda  \"&#923;\">
-  <!ENTITY Mu      \"&#924;\">
-  <!ENTITY Nu      \"&#925;\">
-  <!ENTITY Xi      \"&#926;\">
-  <!ENTITY Omicron \"&#927;\">
-  <!ENTITY Pi      \"&#928;\">
-  <!ENTITY Rho     \"&#929;\">
-  <!ENTITY Sigma   \"&#931;\">
-  <!ENTITY Tau     \"&#932;\">
-  <!ENTITY Upsilon \"&#933;\">
-  <!ENTITY Phi     \"&#934;\">
-  <!ENTITY Chi     \"&#935;\">
-  <!ENTITY Psi     \"&#936;\">
-  <!ENTITY Omega   \"&#937;\">
-  <!ENTITY alpha   \"&#945;\">
-  <!ENTITY beta    \"&#946;\">
-  <!ENTITY gamma   \"&#947;\">
-  <!ENTITY delta   \"&#948;\">
-  <!ENTITY epsilon \"&#949;\">
-  <!ENTITY zeta    \"&#950;\">
-  <!ENTITY eta     \"&#951;\">
-  <!ENTITY theta   \"&#952;\">
-  <!ENTITY iota    \"&#953;\">
-  <!ENTITY kappa   \"&#954;\">
-  <!ENTITY lambda  \"&#955;\">
-  <!ENTITY mu      \"&#956;\">
-  <!ENTITY nu      \"&#957;\">
-  <!ENTITY xi      \"&#958;\">
-  <!ENTITY omicron \"&#959;\">
-  <!ENTITY pi      \"&#960;\">
-  <!ENTITY rho     \"&#961;\">
-  <!ENTITY sigma   \"&#963;\">
-  <!ENTITY tau     \"&#964;\">
-  <!ENTITY upsilon \"&#965;\">
-  <!ENTITY phi     \"&#966;\">
-  <!ENTITY chi     \"&#967;\">
-  <!ENTITY psi     \"&#968;\">
-  <!ENTITY omega   \"&#969;\">
-  <!ENTITY forall  \"&#8704;\">
-  <!ENTITY exist   \"&#8707;\">
-  <!ENTITY empty   \"&#8709;\">
-  <!ENTITY isin    \"&#8712;\">
-  <!ENTITY notin   \"&#8713;\">
-  <!ENTITY prod    \"&#8719;\">
-  <!ENTITY sum     \"&#8721;\">
-]>
+(defconst *newline* "
 ")
 
+(defun make-xml-entity-stuff-items-aux (entity-info acc)
+  (if (endp entity-info)
+      (reverse acc)
+    (let* ((entry (car entity-info))
+           (string (car entry))
+           (decimal-code (caddr entry)))
+      (make-xml-entity-stuff-items-aux
+       (rest entity-info)
+       (if (eq decimal-code :built-in)
+           acc
+         (cons (str::cat "  <!ENTITY "
+                         string
+                         (implode (acl2::repeat (max 1 (- 8 (length string)))
+                                                #\Space)) ; must have at least 1 space
+                         "\"&#"
+                         (str::nat-to-dec-string decimal-code)
+                         ";\">"
+                         *newline*)
+               acc))))))
+
+(defun make-xml-entity-stuff-items (entity-info)
+  (string-append-lst (list "<!DOCTYPE xdoc [" *newline*
+                           (string-append-lst (make-xml-entity-stuff-items-aux entity-info nil))
+                           "]>" *newline*)))
+
+(defconst *xml-entity-stuff*
+  (make-xml-entity-stuff-items *entity-info*))
 
 ; ------------------ Making Flat Indexes ------------------------
 

--- a/books/xdoc/topics.lisp
+++ b/books/xdoc/topics.lisp
@@ -1834,9 +1834,9 @@ manual.</p>")
 
 (defxdoc entities
 
-; Warning: Keep this in sync with *entity-strings* and
-; *entitytok-as-plaintext-fal* in parse-xml.lisp, wrapXdocFragment in
-; fancy/xslt.js, *xml-entity-stuff*in prepare-topic.lisp, and
+; Warning: Keep this in sync with *entity-info*
+; in parse-xml.lisp, wrapXdocFragment in
+; fancy/xslt.js, and
 ; wrap_xdoc_fragment in fancy/xdata2html.pl
 
   :parents (xdoc xdoc-tests)


### PR DESCRIPTION
This simplifies and clarifies the XML entity machinery used by xdoc, to support more easily adding additional entities, such as accented letters in names of paper authors (in future commits).

Now there are fewer things that must be kept in sync (4 things instead of 6).

I confirmed that the generated alist constants are the same (except one is reversed, like the others, because it is now generated, like the others -- and it has no duplicate keys).

I confirmed that the big string constant, *xml-entity-stuff*, is the same except for whitespace, which is now more regular since that string is now generated.

I checked the web manual topic "entities" to ensure that things still rendered correctly.  I also checked the output of :doc entities at the ACL2 prompt.