### PR TITLE
Remove unnecessary (ttags :all) from run-tests-sub.lisp

### DIFF
--- a/books/kestrel/axe/x86/tests/ndsu/run-tests-sub.lisp
+++ b/books/kestrel/axe/x86/tests/ndsu/run-tests-sub.lisp
@@ -9,8 +9,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
-; cert_param: (ttags :all)
 ; cert_param: (uses-stp)
 (in-package "X") ; X is the package for doing x86 proofs with Axe
 


### PR DESCRIPTION
Removed ; cert_param: (ttags :all) from this test file. After further review, the book and its dependencies do not use any trust tags, so this parameter is not required.