### PR TITLE
[oslib] Introduce `get-decoded-time$` and refactor `date`

### DIFF
--- a/books/doc/top-topic.lisp
+++ b/books/doc/top-topic.lisp
@@ -59,7 +59,8 @@ connecting ACL2 to other systems, productivity tools for better proof
 automation and debugging, and specialty libraries for areas like @(see
 hardware-verification).</p>
 
-<p>This manual was generated on <b>@(`(:raw (oslib::date))`)</b>.  It includes</p>
+<p>This manual was generated on <b>@(`(:raw (oslib::date state :zone t))`)</b>.
+It includes</p>
 
 <ul>
 

--- a/books/oslib/date-logic.lisp
+++ b/books/oslib/date-logic.lisp
@@ -46,7 +46,7 @@
                (hour natp :rule-classes :type-prescription)
                (date posp :rule-classes :type-prescription)
                (month posp :rule-classes :type-prescription)
-               (year natp :rule-classes :type-prescription)
+               (year integerp :rule-classes :type-prescription)
                (day natp :rule-classes :type-prescription)
                daylight-p
                (zone rationalp :rule-classes :type-prescription)
@@ -65,7 +65,7 @@ function.  In the logic, this is modeled as a read from the ACL2 oracle.</p>
     represents the day of the month.</li>
   <li>@('month') &mdash; A positive natural number less than @('13').  January
     is @('1'), February is @('2'), etc.</li>
-  <li>@('year') &mdash; A natural number representing the year A.D.</li>
+  <li>@('year') &mdash; An integer number representing the year A.D.</li>
   <li>@('day') &mdash; A natural number less than @('7').  This represents the
     day of the week.  Monday is @('0'), Tuesday is @('1'), etc.</li>
   <li>@('daylight-p') &mdash; A generalized boolean indicating whether daylight
@@ -91,7 +91,7 @@ the current time.</p>"
              (integer-range-p 0 24 (third val))
              (integer-range-p 1 32 (fourth val))
              (integer-range-p 1 13 (fifth val))
-             (natp (sixth val))
+             (integerp (sixth val))
              (integer-range-p 0 7 (seventh val))
              (rationalp (ninth val))
              (<= -24 (ninth val))
@@ -293,7 +293,7 @@ the current time.</p>"
     (let ((month (nth (- month 1) '("January" "February" "March" "April" "May"
                                     "June" "July" "August" "September" "October"
                                     "November" "December")))
-          (year   (str::natstr year))
+          (year   (str::natstr (if (<= 0 year) year 0)))
           (date   (str::natstr date))
           (hour   (if (< hour 10)
                       (str::cat "0" (str::natstr hour))

--- a/books/oslib/date-logic.lisp
+++ b/books/oslib/date-logic.lisp
@@ -38,6 +38,7 @@
 (local (xdoc::set-default-parents oslib))
 
 ;; These return theorems are justified by the specification for
+;; - get-decode-time: https://www.lispworks.com/documentation/HyperSpec/Body/f_get_un.htm#get-decoded-time
 ;; - decoded time: https://www.lispworks.com/documentation/HyperSpec/Body/25_ada.htm
 ;; - time zone: https://www.lispworks.com/documentation/HyperSpec/Body/26_glo_t.htm#time_zone
 (define get-decoded-time$ (state)

--- a/books/oslib/date-logic.lisp
+++ b/books/oslib/date-logic.lisp
@@ -27,21 +27,57 @@
 ;   DEALINGS IN THE SOFTWARE.
 ;
 ; Original author: Jared Davis <jared@centtech.com>
+; Contributing author: Grant Jurgensen <grant@kestrel.edu>
 
 (in-package "OSLIB")
 (include-book "read-acl2-oracle")
+(include-book "std/strings/cat" :dir :system)
+(include-book "std/strings/decimal" :dir :system)
 (include-book "std/util/define" :dir :system)
+(local (include-book "std/typed-lists/string-listp" :dir :system))
 (local (xdoc::set-default-parents oslib))
 
-(define date (&optional (state 'state))
-  :returns (mv (datestamp stringp :rule-classes :type-prescription)
+;; These return theorems are justified by the specification for
+;; - decoded time: https://www.lispworks.com/documentation/HyperSpec/Body/25_ada.htm
+;; - time zone: https://www.lispworks.com/documentation/HyperSpec/Body/26_glo_t.htm#time_zone
+(define get-decoded-time$ (state)
+  :returns (mv (second natp :rule-classes :type-prescription)
+               (minute natp :rule-classes :type-prescription)
+               (hour natp :rule-classes :type-prescription)
+               (date posp :rule-classes :type-prescription)
+               (month posp :rule-classes :type-prescription)
+               (year natp :rule-classes :type-prescription)
+               (day natp :rule-classes :type-prescription)
+               daylight-p
+               (zone rationalp :rule-classes :type-prescription)
                (state state-p1 :hyp (force (state-p1 state))))
-  :short "Get the current datestamp, like \"November 17, 2010 10:25:33\"."
+  :short "Get the current time represented as a decoded time."
 
-  :long "<p>In the logic this function reads from the ACL2 oracle.  In the
-execution we use Common Lisp's @('get-decoded-time') function to figure out
-what the current date and time is.  We think this <i>should</i> work on any
-Common Lisp system.</p>
+  :long "<p>This is a wrapper to the standard @('get-decoded-time') Common Lisp
+function.  In the logic, this is modeled as a read from the ACL2 oracle.</p>
+
+<p>There are nine return values in addition to @('state'):</p>
+<ul>
+  <li>@('second') &mdash; A natural number less than @('60').</li>
+  <li>@('minute') &mdash; A natural number less than @('60').</li>
+  <li>@('hour') &mdash; A natural number less than @('24').</li>
+  <li>@('date') &mdash; A positive natural number less than @('32').  This
+    represents the day of the month.</li>
+  <li>@('month') &mdash; A positive natural number less than @('13').  January
+    is @('1'), February is @('2'), etc.</li>
+  <li>@('year') &mdash; A natural number representing the year A.D.</li>
+  <li>@('day') &mdash; A natural number less than @('7').  This represents the
+    day of the week.  Monday is @('0'), Tuesday is @('1'), etc.</li>
+  <li>@('daylight-p') &mdash; A generalized boolean indicating whether daylight
+     savings time is active.</li>
+  <li>@('zone') &mdash; A rational number between @('-24') and @('24')
+    (inclusive).  This represents the number of hours <i>west</i> of GMT.  This
+    value will be a multiple of @('1/3600') (i.e. a granularity of one
+    second).  This value is <i>not</i> dependent on @('daylight-p').  E.g.,
+    the value @('6') always represents central time (either Central Standard
+    Time or Central Daylight Time depending on @('daylight-p')).  See
+    @(tsee time-zone-abbreviation) for an example of the use of this value.</li>
+</ul>
 
 <p>See also @(see universal-time), which returns an integer representation of
 the current time.</p>"
@@ -49,9 +85,66 @@ the current time.</p>"
   (b* ((- (raise "Raw Lisp definition not installed?"))
        ((mv err val state) (read-acl2-oracle state)))
     (if (and (not err)
-             (stringp val))
-        (mv val state)
-      (mv "Error reading date." state))))
+             (equal (len val) 9)
+             (integer-range-p 0 60 (first val))
+             (integer-range-p 0 60 (second val))
+             (integer-range-p 0 24 (third val))
+             (integer-range-p 1 32 (fourth val))
+             (integer-range-p 1 13 (fifth val))
+             (natp (sixth val))
+             (integer-range-p 0 7 (seventh val))
+             (rationalp (ninth val))
+             (<= -24 (ninth val))
+             (<= (ninth val) 24)
+             (equal (mod (ninth val) 1/3600) 0))
+        (mv (first val)
+            (second val)
+            (third val)
+            (fourth val)
+            (fifth val)
+            (sixth val)
+            (seventh val)
+            (eighth val)
+            (ninth val)
+            state)
+      (mv 0 0 0 1 1 0 0 nil 0 state)))
+  ///
+
+  (defret get-decoded-time$.second-linear
+    (< second 60)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.minute-linear
+    (< minute 60)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.hour-linear
+    (< hour 24)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.date-linear
+    (< date 32)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.month-linear
+    (< month 13)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.day-linear
+    (< day 7)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.zone-min-linear
+    (<= -24 zone)
+    :rule-classes :linear)
+
+  (defret get-decoded-time$.zone-max-linear
+    (<= zone 24)
+    :rule-classes :linear)
+
+  (defret mod-of-get-decoded-time$.zone-and-1/3600
+    (equal (mod zone 1/3600)
+           0)))
 
 (define universal-time (&optional (state 'state))
   :returns (mv (seconds natp :rule-classes :type-prescription)
@@ -79,3 +172,151 @@ external tools.</p>"
              (natp val))
         (mv val state)
       (mv 0 state))))
+
+(define time-zone-to-utc-string ((zone rationalp))
+  (declare (xargs :split-types t)
+           (type rational zone))
+  :parents (get-decoded-time$)
+  :short "Convert a time zone to a UTC offset string."
+
+  :long "<p>See @(tsee get-decoded-time$) for a description of time zone
+values.</p>"
+
+  (let* ((sign (if (<= zone 0) "+" "-"))
+         (total-minutes (abs (floor (* zone 60) 1)))
+         (hours (floor total-minutes 60))
+         (minutes (mod total-minutes 60)))
+    (str::cat "UTC"
+              sign
+              (str::natstr (floor hours 10))
+              (str::natstr (mod hours 10))
+              ":"
+              (str::natstr (floor minutes 10))
+              (str::natstr (mod minutes 10))))
+  :prepwork ((local (include-book "kestrel/arithmetic-light/floor" :dir :system))
+             (local (include-book "kestrel/arithmetic-light/mod" :dir :system))))
+
+(define time-zone-abbreviation ((zone rationalp) daylight-p)
+  (declare (xargs :split-types t)
+           (type rational zone))
+  :parents (get-decoded-time$)
+  :short "Convert a time zone to an abbreviation string."
+
+  :long "<p>This will map certain time zone values to abbreviations.  There are
+many time zone values which correspond to multiple time zones.  The choice of
+mapped time zone is therefore largely arbitrary.  Time zone values which are
+not mapped are instead rendered as a UTC offset. See
+@(tsee time-zone-to-utc-string).</p>
+
+<p>See @(tsee get-decoded-time$) for a description of time zone
+values.</p>"
+
+  (case zone
+    ;; Note: Common Lisp time zones proceed *west* from GMT. Therefore, a
+    ;; negative value like -14 represents a positive UTC offset, UTC+14.
+    (-14 "LINT")        ; Line Islands Time
+    (-12 (if daylight-p
+             "NZDT"     ; New Zealand Daylight Time
+           "NZST"))     ; New Zealand Standard Time
+    (-11 "SBT")         ; Solomon Islands Time
+    (-10 (if daylight-p
+             "AEDT"     ; Australian Eastern Daylight Time
+           "AEST"))     ; Australian Eastern Standard Time
+    (-19/2 (if daylight-p
+               "ACDT"   ; Australian Central Daylight Time
+             "ACST"))   ; Australian Central Standard Time
+    (-9 "JST")          ; Japan Standard Time
+    (-8 (if daylight-p
+            "CST China" ; China Standard Time
+          "AWST"))      ; Australian Western Standard Time
+    (-7 "WIB")          ; Western Indonesia Time
+    (-13/2 "MMT")       ; Myanmar Time
+    (-6 "BST")          ; Bangladesh Standard Time
+    (-23/4 "NPT")       ; Nepal Time
+    (-11/2 "IST")       ; India Standard Time
+    (-5 "PKT")          ; Pakistan Standard Time
+    (-9/2 "AFT")        ; Afghanistan Time
+    (-4 "GST")          ; Gulf Standard Time
+    (-7/2 "IRST")       ; Iran Standard Time
+    (-3 "MSK")          ; Moscow Time
+    (-2 (if daylight-p
+            "EEST"      ; Eastern European Summer Time
+          "EET"))       ; Eastern European Time
+    (-1 (if daylight-p
+            "CEST"      ; Central European Summer Time
+          "CET"))       ; Central European Time
+    (0 "GMT")           ; Greenwich Mean Time
+    (1 "AZOT")          ; Azores Time
+    (2 "GST")           ; South Georgia Time
+    (3 "BRT")           ; Brasília Time
+    (7/2 (if daylight-p
+             "NDT"      ; Newfoundland Daylight Time
+           "NST"))      ; Newfoundland Standard Time
+    (4 (if daylight-p
+           "ADT"        ; Atlantic Daylight Time
+         "AST"))        ; Atlantic Standard Time
+    (5 (if daylight-p
+           "EDT"        ; Eastern Daylight Time
+         "EST"))        ; Eastern Standard Time
+    (6 (if daylight-p
+           "CDT"        ; Central Daylight Time
+         "CST"))        ; Central Standard Time
+    (7 (if daylight-p
+           "MDT"        ; Mountain Daylight Time
+         "MST"))        ; Mountain Standard Time
+    (8 (if daylight-p
+           "PDT"        ; Pacific Daylight Time
+         "PST"))        ; Pacific Standard Time
+    (9 (if daylight-p
+           "AKDT"       ; Alaska Daylight Time
+         "AKST"))       ; Alaska Standard Time
+    (10 "HST")          ; Hawaii-Aleutian Standard Time
+    (11 "SST")          ; Samoa Standard Time
+    (12 "BIT")          ; Baker Island Time
+    (otherwise (time-zone-to-utc-string zone))))
+
+(define date (&optional (state 'state) &key (zone 'nil))
+  :returns (mv (datestamp stringp :rule-classes :type-prescription)
+               (state state-p1 :hyp (force (state-p1 state))))
+  :short "Get the current datestamp, like \"November 17, 2010 10:25:33\"."
+
+  :long "<p>The datestamp string is constructed from the values returned by
+@(tsee get-decoded-time$).  Optionally, specify @(':zone t') to include a time
+zone abbreviation in the datestamp.  (The default is no time zone.)</p>
+
+<p>See also @(see universal-time), which returns an integer representation of
+the current time.</p>"
+
+  (mv-let (second minute hour date month year day daylight-p zone-code state)
+          (get-decoded-time$ state)
+    (declare (ignore day))
+    (let ((month (nth (- month 1) '("January" "February" "March" "April" "May"
+                                    "June" "July" "August" "September" "October"
+                                    "November" "December")))
+          (year   (str::natstr year))
+          (date   (str::natstr date))
+          (hour   (if (< hour 10)
+                      (str::cat "0" (str::natstr hour))
+                    (str::natstr hour)))
+          (minute (if (< minute 10)
+                      (str::cat "0" (str::natstr minute))
+                    (str::natstr minute)))
+          (second (if (< second 10)
+                      (str::cat "0" (str::natstr second))
+                    (str::natstr second))))
+      (mv (str::cat month
+                    " "
+                    date
+                    ", "
+                    year
+                    " "
+                    hour
+                    ":"
+                    minute
+                    ":"
+                    second
+                    (if zone
+                        (str::cat " "
+                                  (time-zone-abbreviation zone-code daylight-p))
+                      ""))
+          state))))

--- a/books/oslib/date-logic.lisp
+++ b/books/oslib/date-logic.lisp
@@ -38,7 +38,7 @@
 (local (xdoc::set-default-parents oslib))
 
 ;; These return theorems are justified by the specification for
-;; - get-decode-time: https://www.lispworks.com/documentation/HyperSpec/Body/f_get_un.htm#get-decoded-time
+;; - get-decoded-time: https://www.lispworks.com/documentation/HyperSpec/Body/f_get_un.htm#get-decoded-time
 ;; - decoded time: https://www.lispworks.com/documentation/HyperSpec/Body/25_ada.htm
 ;; - time zone: https://www.lispworks.com/documentation/HyperSpec/Body/26_glo_t.htm#time_zone
 (define get-decoded-time$ (state)
@@ -62,9 +62,9 @@ function.  In the logic, this is modeled as a read from the ACL2 oracle.</p>
   <li>@('second') &mdash; A natural number less than @('60').</li>
   <li>@('minute') &mdash; A natural number less than @('60').</li>
   <li>@('hour') &mdash; A natural number less than @('24').</li>
-  <li>@('date') &mdash; A positive natural number less than @('32').  This
-    represents the day of the month.</li>
-  <li>@('month') &mdash; A positive natural number less than @('13').  January
+  <li>@('date') &mdash; A positive integer less than @('32').  This represents
+    the day of the month.</li>
+  <li>@('month') &mdash; A positive integer less than @('13').  January
     is @('1'), February is @('2'), etc.</li>
   <li>@('year') &mdash; An integer number representing the year A.D.</li>
   <li>@('day') &mdash; A natural number less than @('7').  This represents the
@@ -112,27 +112,27 @@ the current time.</p>"
   ///
 
   (defret get-decoded-time$.second-linear
-    (< second 60)
+    (<= second 59)
     :rule-classes :linear)
 
   (defret get-decoded-time$.minute-linear
-    (< minute 60)
+    (<= minute 59)
     :rule-classes :linear)
 
   (defret get-decoded-time$.hour-linear
-    (< hour 24)
+    (<= hour 23)
     :rule-classes :linear)
 
   (defret get-decoded-time$.date-linear
-    (< date 32)
+    (<= date 31)
     :rule-classes :linear)
 
   (defret get-decoded-time$.month-linear
-    (< month 13)
+    (<= month 12)
     :rule-classes :linear)
 
   (defret get-decoded-time$.day-linear
-    (< day 7)
+    (<= day 6)
     :rule-classes :linear)
 
   (defret get-decoded-time$.zone-min-linear

--- a/books/oslib/date-raw.lsp
+++ b/books/oslib/date-raw.lsp
@@ -37,10 +37,13 @@
      (er hard? 'get-decoded-time$ "Get-decoded-time$ can only be called on a live state.")
      (mv 0 0 0 1 1 0 0 nil 0 state))
 
-   (multiple-value-bind
-    (second minute hour date month year day daylight-p zone)
-    (get-decoded-time)
-    (mv second minute hour date month year day daylight-p zone state)))
+   (handler-case
+       (multiple-value-bind
+         (second minute hour date month year day daylight-p zone)
+         (get-decoded-time)
+         (mv second minute hour date month year day daylight-p zone state))
+     (error ()
+            (mv 0 0 0 1 1 0 0 nil 0 state))))
 
 
 (defun universal-time-fn (state)

--- a/books/oslib/date-raw.lsp
+++ b/books/oslib/date-raw.lsp
@@ -27,35 +27,20 @@
 ;   DEALINGS IN THE SOFTWARE.
 ;
 ; Original author: Jared Davis <jared@centtech.com>
+; Contributing author: Grant Jurgensen <grant@kestrel.edu>
 
 (in-package "OSLIB")
 
-(defun date-fn (state)
+(defun get-decoded-time$ (state)
 
    (unless (live-state-p state)
-     (er hard? 'date "Date can only be called on a live state.")
-     (mv "Error reading date." state))
+     (er hard? 'get-decoded-time$ "Get-decoded-time$ can only be called on a live state.")
+     (mv 0 0 0 1 1 0 0 nil 0 state))
 
    (multiple-value-bind
     (second minute hour date month year day daylight-p zone)
     (get-decoded-time)
-    (declare (ignore daylight-p zone day))
-    (let ((month (nth (- month 1) '("January" "February" "March" "April" "May"
-                                    "June" "July" "August" "September" "October"
-                                    "November" "December")))
-          (year    (str::natstr year))
-          (date    (str::natstr date))
-          (hour    (if (< hour 10)
-                       (str::cat "0" (str::natstr hour))
-                     (str::natstr hour)))
-          (minute  (if (< minute 10)
-                       (str::cat "0" (str::natstr minute))
-                     (str::natstr minute)))
-          (second  (if (< second 10)
-                       (str::cat "0" (str::natstr second))
-                     (str::natstr second))))
-      (mv (str::cat month " " date ", " year " " hour ":" minute ":" second)
-          state))))
+    (mv second minute hour date month year day daylight-p zone state)))
 
 
 (defun universal-time-fn (state)
@@ -68,4 +53,3 @@
      (unless (natp ans)
        (er hard? 'universal-time "Common Lisp's get-universal-time returned a non-natural: ~x0." ans))
      (mv ans state)))
-

--- a/books/oslib/date.lisp
+++ b/books/oslib/date.lisp
@@ -35,5 +35,8 @@
 (include-book "tools/include-raw" :dir :system)
 ; (depends-on "date-raw.lsp")
 
+; handler-case is not defined in non-ANSI GCL.
+; cert_param: (ansi-only)
+
 (defttag oslib)
 (include-raw "date-raw.lsp")

--- a/books/oslib/date.lisp
+++ b/books/oslib/date.lisp
@@ -30,8 +30,6 @@
 
 (in-package "OSLIB")
 (include-book "date-logic")
-(include-book "std/strings/cat" :dir :system)
-(include-book "std/strings/decimal" :dir :system)
 (include-book "tools/include-raw" :dir :system)
 ; (depends-on "date-raw.lsp")
 


### PR DESCRIPTION
The `oslib::date` function previously called the Common Lisp `get-decoded-time` function in its raw Lisp definition. This change adds an `oslib::get-decoded-time$` function as a wrapper around this Common Lisp function and modifies `oslib::date` to call the ACL2 `get-decoded-time$` function. This minimizes the amount of work done in raw Lisp and exposes more information about the decoded time to ACL2.

Note that the return theorems for `oslib::get-decoded-time$` are rather strong, but I believe they are justified by the spec. Relevant links:
- https://www.lispworks.com/documentation/HyperSpec/Body/f_get_un.htm#get-decoded-time
- https://www.lispworks.com/documentation/HyperSpec/Body/25_ada.htm
- https://www.lispworks.com/documentation/HyperSpec/Body/26_glo_t.htm#time_zone

The return theorems are based on the understanding that, as long as an error hasn't been signaled, the values returned form a valid decoded time, although perhaps not necessarily the correct time.

`oslib::date` was extended with a `:zone` keyword argument. By default, it is `nil` and the behavior is the same as before. If instead a non-`nil` value is provided, the returned date string will include time zone information (an abbreviation if one is known, or a UTC offset otherwise).

The combined manual `top` topic is also modified to use `:zone t` in its call to `date`.