### PR TITLE
Implement server-side seaching for the web manual

### DIFF
--- a/books/xdoc/fancy/common.scss
+++ b/books/xdoc/fancy/common.scss
@@ -186,6 +186,12 @@ $jumptosize: 10em;
 .tt-highlight { background-color: #ffffd0; }
 
 
+
+/* ----------------------- SEARCH ---------------------------------- */
+
+.search-score { color: darkgray; }
+
+
 /* ----------------------- CONTENT --------------------------------- */
 
 img {

--- a/books/xdoc/fancy/desktop.css
+++ b/books/xdoc/fancy/desktop.css
@@ -1,216 +1,591 @@
-#top { background-color: #034569; }
+#top {
+  background-color: #034569;
+}
 
-#bottom { background-color: #228A4C; }
+#bottom {
+  background-color: #228A4C;
+}
 
-#left { background-color: #ffcba3; }
+#left {
+  background-color: #ffcba3;
+}
 
-#right { background-color: white; }
+#right {
+  background-color: white;
+}
 
-.xtable th { background-color: #ffdcb4; }
+.xtable th {
+  background-color: #ffdcb4;
+}
 
-.xtable tr:nth-child(odd) { background-color: #fff4e8; }
+.xtable tr:nth-child(odd) {
+  background-color: #fff4e8;
+}
 
 /*.xtable tr:nth-child(odd) td:nth-child(odd) { background-color:#fffff6; } */
-.xtable tr:nth-child(even) { background-color: #ffffff; }
+.xtable tr:nth-child(even) {
+  background-color: #ffffff;
+}
 
 /* .xtable tr:nth-child(even) td:nth-child(odd) { background-color:#fff6ff; } */
-#top, #bottom, #right, #left, #parents { border-color: #3C9DD0; }
+#top, #bottom, #right, #left, #parents {
+  border-color: #3C9DD0;
+}
 
-body { background-color: white; }
+body {
+  background-color: white;
+}
 
-h1, h2, h1 .tt, h2 .tt, h1 .v, h2 .v { color: #A64300; }
+h1, h2, h1 .tt, h2 .tt, h1 .v, h2 .v {
+  color: #A64300;
+}
 
-h3, h4, h5, h3 .tt, h4 .tt, h5 .tt, h3 .v, h4 .v, h5 .v { color: #FF6700; }
+h3, h4, h5, h3 .tt, h4 .tt, h5 .tt, h3 .v, h4 .v, h5 .v {
+  color: #FF6700;
+}
 
-.box { border-color: black; }
+.box {
+  border-color: black;
+}
 
-.code, .v, .tt { color: #306030; }
+.code, .v, .tt {
+  color: #306030;
+}
 
-.code a, .v a { color: #309030; }
+.code a, .v a {
+  color: #309030;
+}
 
-.code, .mathblockrendered { border-color: #3C9DD0; }
+.code, .mathblockrendered {
+  border-color: #3C9DD0;
+}
 
-#nav a:hover, #flat a:hover { background-color: #FFAB73; }
+#nav a:hover, #flat a:hover {
+  background-color: #FFAB73;
+}
 
-#data a:hover { background-color: #ffffa0; }
+#data a:hover {
+  background-color: #ffffa0;
+}
 
-#parents { background-color: #63DB93; }
+#parents {
+  background-color: #63DB93;
+}
 
-#parents li a:hover { background-color: #00B74A; text-decoration: none; }
+#parents li a:hover {
+  background-color: #00B74A;
+  text-decoration: none;
+}
 
-.tt-cursor { background-color: #ffffa0; }
+.tt-cursor {
+  background-color: #ffffa0;
+}
 
-#letters { padding-left: .4em; }
+#letters {
+  padding-left: 0.4em;
+}
 
-#letters a { color: #3C9DD0; }
+#letters a {
+  color: #3C9DD0;
+}
 
-#letters a:hover { text-decoration: none; color: white; background-color: #086CA2; }
+#letters a:hover {
+  text-decoration: none;
+  color: white;
+  background-color: #086CA2;
+}
 
-.dat_long { border-color: #FF6700; }
+.dat_long {
+  border-color: #FF6700;
+}
 
-.from { color: #3C9DD0; }
+.from {
+  color: #3C9DD0;
+}
 
 /* ----------------------- FONTS --------------------------------- */
 /* NOTE: don't just change these, there are also some additional fonts below. */
-body { font-family: "Noto Serif", serif; }
+body {
+  font-family: "Noto Serif", serif;
+}
 
-#parents, #toolbar, .basepkg, h1, h2, h3, h4, h5, .sf { font-family: "Lato", sans-serif; }
+#parents, #toolbar, .basepkg, h1, h2, h3, h4, h5, .sf {
+  font-family: "Lato", sans-serif;
+}
 
-dt, .hindex, #flat, #still_loading, .xtable th { font-family: "Lato", sans-serif; }
+dt, .hindex, #flat, #still_loading, .xtable th {
+  font-family: "Lato", sans-serif;
+}
 
-.code, .srclink, .tt, #letters, .from, .v { font-family: "Source Code Pro", monospace; }
+.code, .srclink, .tt, #letters, .from, .v {
+  font-family: "Source Code Pro", monospace;
+}
 
 /* ----------------------- PARENTS DISPLAY ----------------------- */
-#parents { padding: 10px; border-bottom-width: 1px; border-bottom-style: solid; }
-#parents ul { margin: 0; padding: 0; list-style-type: none; }
-#parents li { display: inline; }
-#parents li a { padding: .2em 1em; }
+#parents {
+  padding: 10px;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+#parents ul {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+#parents li {
+  display: inline;
+}
+#parents li a {
+  padding: 0.2em 1em;
+}
 
 /* ---------------------- JUMP TO BOX ---------------------------- */
-#jump { width: 10em; }
+#jump {
+  width: 10em;
+}
 
-#searchbox { width: 8em; }
+#searchbox {
+  width: 8em;
+}
 
-#jumpmsg, #searchmsg { color: white; margin-right: .1em; }
+#jumpmsg, #searchmsg {
+  color: white;
+  margin-right: 0.1em;
+}
 
-.typeahead { width: 10em; }
+.typeahead {
+  width: 10em;
+}
 
-#jump, #searchbox { box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.3); border-radius: 3px; border: 2px solid #dadada; background-clip: padding-box; background-color: #ffffa0; }
+#jump, #searchbox {
+  box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  border: 2px solid #dadada;
+  background-clip: padding-box;
+  background-color: #ffffa0;
+}
 
-#jump:focus, #searchbox:focus { outline: none; border-color: #9ecaed; box-shadow: 0 0 10px #9ecaed; }
+#jump:focus, #searchbox:focus {
+  outline: none;
+  border-color: #9ecaed;
+  box-shadow: 0 0 10px #9ecaed;
+}
 
 /* These are fancy things for the typeahead menu: */
-.tt-dropdown-menu { background-color: white; color: black; max-height: 500px; font-size: 90%; overflow-y: auto; overflow-x: hidden; border: 1px black solid; border-radius: 5px; }
+.tt-dropdown-menu {
+  background-color: white;
+  color: black;
+  max-height: 500px;
+  font-size: 90%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  border: 1px black solid;
+  border-radius: 5px;
+}
 
-.tt-suggestion { border: 1px black solid; padding: .25em; }
-.tt-suggestion tt { font-size: 90%; }
+.tt-suggestion {
+  border: 1px black solid;
+  padding: 0.25em;
+}
+.tt-suggestion tt {
+  font-size: 90%;
+}
 
-.tt-highlight { background-color: #ffffd0; }
+.tt-highlight {
+  background-color: #ffffd0;
+}
+
+/* ----------------------- SEARCH ---------------------------------- */
+.search-score {
+  color: darkgray;
+}
 
 /* ----------------------- CONTENT --------------------------------- */
-img { border: 0px; }
+img {
+  border: 0px;
+}
 
-h1 { font-size: 2.2em; text-align: center; margin-bottom: 0; }
+h1 {
+  font-size: 2.2em;
+  text-align: center;
+  margin-bottom: 0;
+}
 
-h2 { font-size: 1.8em; }
+h2 {
+  font-size: 1.8em;
+}
 
-h3 { font-size: 1.5em; }
+h3 {
+  font-size: 1.5em;
+}
 
-h4 { font-size: 1.2em; }
+h4 {
+  font-size: 1.2em;
+}
 
-h5 { font-size: 1.1em; }
+h5 {
+  font-size: 1.1em;
+}
 
-h4, h5 { margin-bottom: 0; }
+h4, h5 {
+  margin-bottom: 0;
+}
 
-li { margin-bottom: 0.5em; }
+li {
+  margin-bottom: 0.5em;
+}
 
-li li { margin-left: -1.0em; margin-bottom: 0em; }
+li li {
+  margin-left: -1em;
+  margin-bottom: 0em;
+}
 
-dt { margin-top: 1em; font-weight: bold; }
+dt {
+  margin-top: 1em;
+  font-weight: bold;
+}
 
-.box { border-width: 1px; border-style: solid; }
+.box {
+  border-width: 1px;
+  border-style: solid;
+}
 
 /* math fragments don't need any special positioning */
-.code, .mathblock, .mathblockrendered { border-left-width: 3px; border-left-style: solid; }
+.code, .mathblock, .mathblockrendered {
+  border-left-width: 3px;
+  border-left-style: solid;
+}
 
-a { text-decoration: none; }
+a {
+  text-decoration: none;
+}
 
-a:hover { text-decoration: underline; }
+a:hover {
+  text-decoration: underline;
+}
 
-.srclink { text-decoration: none; background-color: #e0e0e0; padding: 2px; /*  font-size: 100%; */ }
+.srclink {
+  text-decoration: none;
+  background-color: #e0e0e0;
+  padding: 2px;
+  /*  font-size: 100%; */
+}
 
-.srclink:hover { text-decoration: none; }
+.srclink:hover {
+  text-decoration: none;
+}
 
-hr { margin-top: 2em; }
+hr {
+  margin-top: 2em;
+}
 
-.dat_long { border-left-style: solid; border-left-width: 2px; margin-left: .2em; padding-left: 1em; }
+.dat_long {
+  border-left-style: solid;
+  border-left-width: 2px;
+  margin-left: 0.2em;
+  padding-left: 1em;
+}
 
-.ximg { text-align: center; }
+.ximg {
+  text-align: center;
+}
 
-.xtable { border-collapse: collapse; border: 1px solid black; }
+.xtable {
+  border-collapse: collapse;
+  border: 1px solid black;
+}
 
-.xtable td, .xtable th { vertical-align: top; padding: .5em; }
+.xtable td, .xtable th {
+  vertical-align: top;
+  padding: 0.5em;
+}
 
-.mathblock { /* not rendered block, so put on a red border */ border-left-color: #ff6060; }
+.mathblock {
+  /* not rendered block, so put on a red border */
+  border-left-color: #ff6060;
+}
 
-.mathfrag { /* not rendered snippet, so draw it in red */ color: #ff6060; }
+.mathfrag {
+  /* not rendered snippet, so draw it in red */
+  color: #ff6060;
+}
 
 /* Extra stuff for Symbolic Test Vectors at Centaur */
-.stv { margin-left: 1em; border: 1px; border-color: black; border-style: solid; }
-.stv th { font-family: "Lato", sans-serif; }
-.stv td { font-family: "Source Code Pro", monospace; text-align: right; padding-left: .5em; padding-right: .5em; }
+.stv {
+  margin-left: 1em;
+  border: 1px;
+  border-color: black;
+  border-style: solid;
+}
+.stv th {
+  font-family: "Lato", sans-serif;
+}
+.stv td {
+  font-family: "Source Code Pro", monospace;
+  text-align: right;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
 
-.stv_labels { background-color: #e0ffc3; }
-.stv_labels th:nth-child(even) { background-color: #e9ffd6; }
-.stv_labels th { font-family: "Lato", sans-serif; text-align: left; border-bottom: 2px; border-bottom-style: solid; border-bottom-color: #b0dda3; border-right: 1px; border-right-style: solid; border-right-color: #b0dda3; }
+.stv_labels {
+  background-color: #e0ffc3;
+}
+.stv_labels th:nth-child(even) {
+  background-color: #e9ffd6;
+}
+.stv_labels th {
+  font-family: "Lato", sans-serif;
+  text-align: left;
+  border-bottom: 2px;
+  border-bottom-style: solid;
+  border-bottom-color: #b0dda3;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #b0dda3;
+}
 
-.stv_input_line { background-color: #ffe0c3; }
-.stv_input_line td:nth-child(even) { background-color: #ffe9d6; }
-.stv_input_line td { border-bottom: 1px; border-bottom-color: #ddb0a3; border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #ddb0a3; }
+.stv_input_line {
+  background-color: #ffe0c3;
+}
+.stv_input_line td:nth-child(even) {
+  background-color: #ffe9d6;
+}
+.stv_input_line td {
+  border-bottom: 1px;
+  border-bottom-color: #ddb0a3;
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #ddb0a3;
+}
 
-.stv_output_line { background-color: #c3e0ff; }
-.stv_output_line td:nth-child(even) { background-color: #d6e9ff; }
-.stv_output_line td { border-bottom: 1px; border-bottom-color: #a3b0dd; border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #a3b0dd; }
+.stv_output_line {
+  background-color: #c3e0ff;
+}
+.stv_output_line td:nth-child(even) {
+  background-color: #d6e9ff;
+}
+.stv_output_line td {
+  border-bottom: 1px;
+  border-bottom-color: #a3b0dd;
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #a3b0dd;
+}
 
-.stv_override_line { background-color: #ffb0b0; }
-.stv_override_line td:nth-child(even) { background-color: #ffc0c0; }
-.stv_override_line td { border-bottom: 1px; border-bottom-color: #ff8080; border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #ff8080; }
+.stv_override_line {
+  background-color: #ffb0b0;
+}
+.stv_override_line td:nth-child(even) {
+  background-color: #ffc0c0;
+}
+.stv_override_line td {
+  border-bottom: 1px;
+  border-bottom-color: #ff8080;
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #ff8080;
+}
 
-.stv_internal_line { background-color: #ff0000; /* bozo fix colors */ }
-.stv_internal_line td:nth-child(even) { background-color: #ffcc00; /* bozo fix colors */ }
-.stv_internal_line td { border-bottom: 1px; border-bottom-color: #000000; /* bozo fix colors */ border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #000000; }
+.stv_internal_line {
+  background-color: #ff0000; /* bozo fix colors */
+}
+.stv_internal_line td:nth-child(even) {
+  background-color: #ffcc00; /* bozo fix colors */
+}
+.stv_internal_line td {
+  border-bottom: 1px;
+  border-bottom-color: #000000; /* bozo fix colors */
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #000000;
+}
 
-.stv_name { border-right: 2px; border-right-style: solid; border-right-color: #000060; text-align: left; padding-right: 1em; }
+.stv_name {
+  border-right: 2px;
+  border-right-style: solid;
+  border-right-color: #000060;
+  text-align: left;
+  padding-right: 1em;
+}
 
-.mobileonly { display: none; }
+.mobileonly {
+  display: none;
+}
 
 /* ---------------------------- LAYOUT -------------------------------- */
-body { background-color: white; padding: 2em; }
+body {
+  background-color: white;
+  padding: 2em;
+}
 
-#top { position: fixed; z-index: 100; left: 0; top: 0; height: 60px; width: 100%; border-top: solid 2px; border-bottom: solid 3px; }
+#top {
+  position: fixed;
+  z-index: 100;
+  left: 0;
+  top: 0;
+  height: 60px;
+  width: 100%;
+  border-top: solid 2px;
+  border-bottom: solid 3px;
+}
 
-#toolbar { padding: .5em; }
-#toolbar td { padding-left: 1em; }
+#toolbar {
+  padding: 0.5em;
+}
+#toolbar td {
+  padding-left: 1em;
+}
 
-#left { position: fixed; left: 0; top: 65px; bottom: 0em; width: 16em; padding: 0; overflow-y: scroll; overflow-x: hidden; display: block; }
+#left {
+  position: fixed;
+  left: 0;
+  top: 65px;
+  bottom: 0em;
+  width: 16em;
+  padding: 0;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  display: block;
+}
 
-#right { border-left: solid 1px; position: fixed; left: 16em; top: 65px; right: 0em; bottom: 0em; overflow: auto; margin: 0; padding-left: 0; padding-right: 0; padding-top: 0; padding-bottom: 1em; }
+#right {
+  border-left: solid 1px;
+  position: fixed;
+  left: 16em;
+  top: 65px;
+  right: 0em;
+  bottom: 0em;
+  overflow: auto;
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  padding-bottom: 1em;
+}
 
-#data { margin-left: 1em; margin-right: 1em; max-width: 45em; /*    height: 100%; */ }
+#data {
+  margin-left: 1em;
+  margin-right: 1em;
+  max-width: 45em;
+  /*    height: 100%; */
+}
 
-#still_loading { z-index: 200; position: fixed; left: 350px; top: 120px; border-radius: 7px; background-color: #007730; color: white; padding-left: 30px; padding-right: 30px; padding-top: 10px; padding-bottom: 10px; font-size: 120%; box-shadow: 0px 0px 0px 3px rgba(0, 0, 70, 0.3); }
+#still_loading {
+  z-index: 200;
+  position: fixed;
+  left: 350px;
+  top: 120px;
+  border-radius: 7px;
+  background-color: #007730;
+  color: white;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 120%;
+  box-shadow: 0px 0px 0px 3px rgba(0, 0, 70, 0.3);
+}
 
-.from { font-size: 90%; text-align: center; margin-left: 0; margin-right: 0; margin-top: -.2em; padding: 0; }
+.from {
+  font-size: 90%;
+  text-align: center;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: -0.2em;
+  padding: 0;
+}
 
-.basepkg { float: right; background-color: #990000; width: 5em; text-align: center; padding-top: 10px; padding-bottom: 10px; margin: 0; border-color: #ffd0b0; border-width: 3px; border-style: solid; border-radius: 5px; background-color: #ffffff; }
+.basepkg {
+  float: right;
+  background-color: #990000;
+  width: 5em;
+  text-align: center;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin: 0;
+  border-color: #ffd0b0;
+  border-width: 3px;
+  border-style: solid;
+  border-radius: 5px;
+  background-color: #ffffff;
+}
 
-@media all and (min-width: 70em) { .basepkg { margin-right: -5em; } }
+@media all and (min-width: 70em) {
+  .basepkg {
+    margin-right: -5em;
+  }
+}
 /* ------------------------ NAVIGATION MENU ---------------------- */
-.hindex { list-style-type: none; padding: 0; font-weight: normal; }
-.hindex li { margin-bottom: 0em; }
-.hindex li li { margin-left: 0.5em; }
+.hindex {
+  list-style-type: none;
+  padding: 0;
+  font-weight: normal;
+}
+.hindex li {
+  margin-bottom: 0em;
+}
+.hindex li li {
+  margin-left: 0.5em;
+}
 
-#flat ul { list-style-type: none; margin-left: 1em; padding: 0; }
-#flat li { margin-left: 0; margin-bottom: 0; }
+#flat ul {
+  list-style-type: none;
+  margin-left: 1em;
+  padding: 0;
+}
+#flat li {
+  margin-left: 0;
+  margin-bottom: 0;
+}
 
-.flatsec { margin-top: 2em; }
+.flatsec {
+  margin-top: 2em;
+}
 
-.tt-dropdown-menu { width: 450px; }
+.tt-dropdown-menu {
+  width: 450px;
+}
 
-h5 { margin-left: 1em; }
+h5 {
+  margin-left: 1em;
+}
 
-p, dl { margin-left: 1em; margin-right: 1em; }
+p, dl {
+  margin-left: 1em;
+  margin-right: 1em;
+}
 
-li { margin-left: 1.0em; margin-right: 1em; }
+li {
+  margin-left: 1em;
+  margin-right: 1em;
+}
 
-dt { margin-left: 1em; }
+dt {
+  margin-left: 1em;
+}
 
-.box { margin-left: 1.5em; margin-right: 1.5em; }
+.box {
+  margin-left: 1.5em;
+  margin-right: 1.5em;
+}
 
-.code, .mathblock, .mathblockrendered { margin-left: 2.5em; margin-right: 1em; padding: .5em; }
+.code, .mathblock, .mathblockrendered {
+  margin-left: 2.5em;
+  margin-right: 1em;
+  padding: 0.5em;
+}
 
-li .code { margin-left: 1em; }
+li .code {
+  margin-left: 1em;
+}
 
-.xtable { margin-left: 1.5em; margin-right: 1.5em; }
+.xtable {
+  margin-left: 1.5em;
+  margin-right: 1.5em;
+}
 
 /*# sourceMappingURL=desktop.css.map */

--- a/books/xdoc/fancy/mobile.css
+++ b/books/xdoc/fancy/mobile.css
@@ -1,223 +1,610 @@
-#top { background-color: #034569; }
+#top {
+  background-color: #034569;
+}
 
-#bottom { background-color: #228A4C; }
+#bottom {
+  background-color: #228A4C;
+}
 
-#left { background-color: #ffcba3; }
+#left {
+  background-color: #ffcba3;
+}
 
-#right { background-color: white; }
+#right {
+  background-color: white;
+}
 
-.xtable th { background-color: #ffdcb4; }
+.xtable th {
+  background-color: #ffdcb4;
+}
 
-.xtable tr:nth-child(odd) { background-color: #fff4e8; }
+.xtable tr:nth-child(odd) {
+  background-color: #fff4e8;
+}
 
 /*.xtable tr:nth-child(odd) td:nth-child(odd) { background-color:#fffff6; } */
-.xtable tr:nth-child(even) { background-color: #ffffff; }
+.xtable tr:nth-child(even) {
+  background-color: #ffffff;
+}
 
 /* .xtable tr:nth-child(even) td:nth-child(odd) { background-color:#fff6ff; } */
-#top, #bottom, #right, #left, #parents { border-color: #3C9DD0; }
+#top, #bottom, #right, #left, #parents {
+  border-color: #3C9DD0;
+}
 
-body { background-color: white; }
+body {
+  background-color: white;
+}
 
-h1, h2, h1 .tt, h2 .tt, h1 .v, h2 .v { color: #A64300; }
+h1, h2, h1 .tt, h2 .tt, h1 .v, h2 .v {
+  color: #A64300;
+}
 
-h3, h4, h5, h3 .tt, h4 .tt, h5 .tt, h3 .v, h4 .v, h5 .v { color: #FF6700; }
+h3, h4, h5, h3 .tt, h4 .tt, h5 .tt, h3 .v, h4 .v, h5 .v {
+  color: #FF6700;
+}
 
-.box { border-color: black; }
+.box {
+  border-color: black;
+}
 
-.code, .v, .tt { color: #306030; }
+.code, .v, .tt {
+  color: #306030;
+}
 
-.code a, .v a { color: #309030; }
+.code a, .v a {
+  color: #309030;
+}
 
-.code, .mathblockrendered { border-color: #3C9DD0; }
+.code, .mathblockrendered {
+  border-color: #3C9DD0;
+}
 
-#nav a:hover, #flat a:hover { background-color: #FFAB73; }
+#nav a:hover, #flat a:hover {
+  background-color: #FFAB73;
+}
 
-#data a:hover { background-color: #ffffa0; }
+#data a:hover {
+  background-color: #ffffa0;
+}
 
-#parents { background-color: #63DB93; }
+#parents {
+  background-color: #63DB93;
+}
 
-#parents li a:hover { background-color: #00B74A; text-decoration: none; }
+#parents li a:hover {
+  background-color: #00B74A;
+  text-decoration: none;
+}
 
-.tt-cursor { background-color: #ffffa0; }
+.tt-cursor {
+  background-color: #ffffa0;
+}
 
-#letters { padding-left: .4em; }
+#letters {
+  padding-left: 0.4em;
+}
 
-#letters a { color: #3C9DD0; }
+#letters a {
+  color: #3C9DD0;
+}
 
-#letters a:hover { text-decoration: none; color: white; background-color: #086CA2; }
+#letters a:hover {
+  text-decoration: none;
+  color: white;
+  background-color: #086CA2;
+}
 
-.dat_long { border-color: #FF6700; }
+.dat_long {
+  border-color: #FF6700;
+}
 
-.from { color: #3C9DD0; }
+.from {
+  color: #3C9DD0;
+}
 
 /* ----------------------- FONTS --------------------------------- */
 /* NOTE: don't just change these, there are also some additional fonts below. */
-body { font-family: "Noto Serif", serif; }
+body {
+  font-family: "Noto Serif", serif;
+}
 
-#parents, #toolbar, .basepkg, h1, h2, h3, h4, h5, .sf { font-family: "Lato", sans-serif; }
+#parents, #toolbar, .basepkg, h1, h2, h3, h4, h5, .sf {
+  font-family: "Lato", sans-serif;
+}
 
-dt, .hindex, #flat, #still_loading, .xtable th { font-family: "Lato", sans-serif; }
+dt, .hindex, #flat, #still_loading, .xtable th {
+  font-family: "Lato", sans-serif;
+}
 
-.code, .srclink, .tt, #letters, .from, .v { font-family: "Source Code Pro", monospace; }
+.code, .srclink, .tt, #letters, .from, .v {
+  font-family: "Source Code Pro", monospace;
+}
 
 /* ----------------------- PARENTS DISPLAY ----------------------- */
-#parents { padding: 10px; border-bottom-width: 1px; border-bottom-style: solid; }
-#parents ul { margin: 0; padding: 0; list-style-type: none; }
-#parents li { display: inline; }
-#parents li a { padding: .2em 1em; }
+#parents {
+  padding: 10px;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+#parents ul {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+#parents li {
+  display: inline;
+}
+#parents li a {
+  padding: 0.2em 1em;
+}
 
 /* ---------------------- JUMP TO BOX ---------------------------- */
-#jump { width: 10em; }
+#jump {
+  width: 10em;
+}
 
-#searchbox { width: 8em; }
+#searchbox {
+  width: 8em;
+}
 
-#jumpmsg, #searchmsg { color: white; margin-right: .1em; }
+#jumpmsg, #searchmsg {
+  color: white;
+  margin-right: 0.1em;
+}
 
-.typeahead { width: 10em; }
+.typeahead {
+  width: 10em;
+}
 
-#jump, #searchbox { box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.3); border-radius: 3px; border: 2px solid #dadada; background-clip: padding-box; background-color: #ffffa0; }
+#jump, #searchbox {
+  box-shadow: 0px 0px 0px 2px rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  border: 2px solid #dadada;
+  background-clip: padding-box;
+  background-color: #ffffa0;
+}
 
-#jump:focus, #searchbox:focus { outline: none; border-color: #9ecaed; box-shadow: 0 0 10px #9ecaed; }
+#jump:focus, #searchbox:focus {
+  outline: none;
+  border-color: #9ecaed;
+  box-shadow: 0 0 10px #9ecaed;
+}
 
 /* These are fancy things for the typeahead menu: */
-.tt-dropdown-menu { background-color: white; color: black; max-height: 500px; font-size: 90%; overflow-y: auto; overflow-x: hidden; border: 1px black solid; border-radius: 5px; }
+.tt-dropdown-menu {
+  background-color: white;
+  color: black;
+  max-height: 500px;
+  font-size: 90%;
+  overflow-y: auto;
+  overflow-x: hidden;
+  border: 1px black solid;
+  border-radius: 5px;
+}
 
-.tt-suggestion { border: 1px black solid; padding: .25em; }
-.tt-suggestion tt { font-size: 90%; }
+.tt-suggestion {
+  border: 1px black solid;
+  padding: 0.25em;
+}
+.tt-suggestion tt {
+  font-size: 90%;
+}
 
-.tt-highlight { background-color: #ffffd0; }
+.tt-highlight {
+  background-color: #ffffd0;
+}
+
+/* ----------------------- SEARCH ---------------------------------- */
+.search-score {
+  color: darkgray;
+}
 
 /* ----------------------- CONTENT --------------------------------- */
-img { border: 0px; }
+img {
+  border: 0px;
+}
 
-h1 { font-size: 2.2em; text-align: center; margin-bottom: 0; }
+h1 {
+  font-size: 2.2em;
+  text-align: center;
+  margin-bottom: 0;
+}
 
-h2 { font-size: 1.8em; }
+h2 {
+  font-size: 1.8em;
+}
 
-h3 { font-size: 1.5em; }
+h3 {
+  font-size: 1.5em;
+}
 
-h4 { font-size: 1.2em; }
+h4 {
+  font-size: 1.2em;
+}
 
-h5 { font-size: 1.1em; }
+h5 {
+  font-size: 1.1em;
+}
 
-h4, h5 { margin-bottom: 0; }
+h4, h5 {
+  margin-bottom: 0;
+}
 
-li { margin-bottom: 0.5em; }
+li {
+  margin-bottom: 0.5em;
+}
 
-li li { margin-left: -1.0em; margin-bottom: 0em; }
+li li {
+  margin-left: -1em;
+  margin-bottom: 0em;
+}
 
-dt { margin-top: 1em; font-weight: bold; }
+dt {
+  margin-top: 1em;
+  font-weight: bold;
+}
 
-.box { border-width: 1px; border-style: solid; }
+.box {
+  border-width: 1px;
+  border-style: solid;
+}
 
 /* math fragments don't need any special positioning */
-.code, .mathblock, .mathblockrendered { border-left-width: 3px; border-left-style: solid; }
+.code, .mathblock, .mathblockrendered {
+  border-left-width: 3px;
+  border-left-style: solid;
+}
 
-a { text-decoration: none; }
+a {
+  text-decoration: none;
+}
 
-a:hover { text-decoration: underline; }
+a:hover {
+  text-decoration: underline;
+}
 
-.srclink { text-decoration: none; background-color: #e0e0e0; padding: 2px; /*  font-size: 100%; */ }
+.srclink {
+  text-decoration: none;
+  background-color: #e0e0e0;
+  padding: 2px;
+  /*  font-size: 100%; */
+}
 
-.srclink:hover { text-decoration: none; }
+.srclink:hover {
+  text-decoration: none;
+}
 
-hr { margin-top: 2em; }
+hr {
+  margin-top: 2em;
+}
 
-.dat_long { border-left-style: solid; border-left-width: 2px; margin-left: .2em; padding-left: 1em; }
+.dat_long {
+  border-left-style: solid;
+  border-left-width: 2px;
+  margin-left: 0.2em;
+  padding-left: 1em;
+}
 
-.ximg { text-align: center; }
+.ximg {
+  text-align: center;
+}
 
-.xtable { border-collapse: collapse; border: 1px solid black; }
+.xtable {
+  border-collapse: collapse;
+  border: 1px solid black;
+}
 
-.xtable td, .xtable th { vertical-align: top; padding: .5em; }
+.xtable td, .xtable th {
+  vertical-align: top;
+  padding: 0.5em;
+}
 
-.mathblock { /* not rendered block, so put on a red border */ border-left-color: #ff6060; }
+.mathblock {
+  /* not rendered block, so put on a red border */
+  border-left-color: #ff6060;
+}
 
-.mathfrag { /* not rendered snippet, so draw it in red */ color: #ff6060; }
+.mathfrag {
+  /* not rendered snippet, so draw it in red */
+  color: #ff6060;
+}
 
 /* Extra stuff for Symbolic Test Vectors at Centaur */
-.stv { margin-left: 1em; border: 1px; border-color: black; border-style: solid; }
-.stv th { font-family: "Lato", sans-serif; }
-.stv td { font-family: "Source Code Pro", monospace; text-align: right; padding-left: .5em; padding-right: .5em; }
+.stv {
+  margin-left: 1em;
+  border: 1px;
+  border-color: black;
+  border-style: solid;
+}
+.stv th {
+  font-family: "Lato", sans-serif;
+}
+.stv td {
+  font-family: "Source Code Pro", monospace;
+  text-align: right;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+}
 
-.stv_labels { background-color: #e0ffc3; }
-.stv_labels th:nth-child(even) { background-color: #e9ffd6; }
-.stv_labels th { font-family: "Lato", sans-serif; text-align: left; border-bottom: 2px; border-bottom-style: solid; border-bottom-color: #b0dda3; border-right: 1px; border-right-style: solid; border-right-color: #b0dda3; }
+.stv_labels {
+  background-color: #e0ffc3;
+}
+.stv_labels th:nth-child(even) {
+  background-color: #e9ffd6;
+}
+.stv_labels th {
+  font-family: "Lato", sans-serif;
+  text-align: left;
+  border-bottom: 2px;
+  border-bottom-style: solid;
+  border-bottom-color: #b0dda3;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #b0dda3;
+}
 
-.stv_input_line { background-color: #ffe0c3; }
-.stv_input_line td:nth-child(even) { background-color: #ffe9d6; }
-.stv_input_line td { border-bottom: 1px; border-bottom-color: #ddb0a3; border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #ddb0a3; }
+.stv_input_line {
+  background-color: #ffe0c3;
+}
+.stv_input_line td:nth-child(even) {
+  background-color: #ffe9d6;
+}
+.stv_input_line td {
+  border-bottom: 1px;
+  border-bottom-color: #ddb0a3;
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #ddb0a3;
+}
 
-.stv_output_line { background-color: #c3e0ff; }
-.stv_output_line td:nth-child(even) { background-color: #d6e9ff; }
-.stv_output_line td { border-bottom: 1px; border-bottom-color: #a3b0dd; border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #a3b0dd; }
+.stv_output_line {
+  background-color: #c3e0ff;
+}
+.stv_output_line td:nth-child(even) {
+  background-color: #d6e9ff;
+}
+.stv_output_line td {
+  border-bottom: 1px;
+  border-bottom-color: #a3b0dd;
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #a3b0dd;
+}
 
-.stv_override_line { background-color: #ffb0b0; }
-.stv_override_line td:nth-child(even) { background-color: #ffc0c0; }
-.stv_override_line td { border-bottom: 1px; border-bottom-color: #ff8080; border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #ff8080; }
+.stv_override_line {
+  background-color: #ffb0b0;
+}
+.stv_override_line td:nth-child(even) {
+  background-color: #ffc0c0;
+}
+.stv_override_line td {
+  border-bottom: 1px;
+  border-bottom-color: #ff8080;
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #ff8080;
+}
 
-.stv_internal_line { background-color: #ff0000; /* bozo fix colors */ }
-.stv_internal_line td:nth-child(even) { background-color: #ffcc00; /* bozo fix colors */ }
-.stv_internal_line td { border-bottom: 1px; border-bottom-color: #000000; /* bozo fix colors */ border-bottom-style: solid; border-right: 1px; border-right-style: solid; border-right-color: #000000; }
+.stv_internal_line {
+  background-color: #ff0000; /* bozo fix colors */
+}
+.stv_internal_line td:nth-child(even) {
+  background-color: #ffcc00; /* bozo fix colors */
+}
+.stv_internal_line td {
+  border-bottom: 1px;
+  border-bottom-color: #000000; /* bozo fix colors */
+  border-bottom-style: solid;
+  border-right: 1px;
+  border-right-style: solid;
+  border-right-color: #000000;
+}
 
-.stv_name { border-right: 2px; border-right-style: solid; border-right-color: #000060; text-align: left; padding-right: 1em; }
+.stv_name {
+  border-right: 2px;
+  border-right-style: solid;
+  border-right-color: #000060;
+  text-align: left;
+  padding-right: 1em;
+}
 
 /* ---------------------------- LAYOUT -------------------------------- */
-.desktoponly { display: none; }
+.desktoponly {
+  display: none;
+}
 
-body { background-color: white; margin: 0; padding: 0; }
+body {
+  background-color: white;
+  margin: 0;
+  padding: 0;
+}
 
-#top { position: fixed; z-index: 100; left: 0; top: 0; height: 50px; width: 100%; border-top: solid 2px; border-bottom: solid 3px; }
+#top {
+  position: fixed;
+  z-index: 100;
+  left: 0;
+  top: 0;
+  height: 50px;
+  width: 100%;
+  border-top: solid 2px;
+  border-bottom: solid 3px;
+}
 
-#toolbar { padding: .4em; }
-#toolbar td { padding-left: 1em; }
+#toolbar {
+  padding: 0.4em;
+}
+#toolbar td {
+  padding-left: 1em;
+}
 
-#left { z-index: 50; position: fixed; left: 0; top: 55px; bottom: 0em; width: 16em; overflow-y: scroll; overflow-x: hidden; display: none; padding-left: 0.5em; padding-top: 0; padding-bottom: 0; padding-right: 0; }
+#left {
+  z-index: 50;
+  position: fixed;
+  left: 0;
+  top: 55px;
+  bottom: 0em;
+  width: 16em;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  display: none;
+  padding-left: 0.5em;
+  padding-top: 0;
+  padding-bottom: 0;
+  padding-right: 0;
+}
 
-#left.active { display: block; }
+#left.active {
+  display: block;
+}
 
-#right { border-left: solid 1px; position: fixed; left: 0; top: 55px; right: 0em; bottom: 0em; overflow: auto; margin: 0; width: 100%; padding-left: 0; padding-right: 0; padding-top: 0; padding-bottom: 1em; }
+#right {
+  border-left: solid 1px;
+  position: fixed;
+  left: 0;
+  top: 55px;
+  right: 0em;
+  bottom: 0em;
+  overflow: auto;
+  margin: 0;
+  width: 100%;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  padding-bottom: 1em;
+}
 
-#data { margin-left: 1em; margin-right: 1em; max-width: 45em; /*    height: 100%; */ }
+#data {
+  margin-left: 1em;
+  margin-right: 1em;
+  max-width: 45em;
+  /*    height: 100%; */
+}
 
-#still_loading { z-index: 200; position: fixed; left: 350px; top: 120px; border-radius: 7px; background-color: #007730; color: white; padding-left: 30px; padding-right: 30px; padding-top: 10px; padding-bottom: 10px; font-size: 120%; box-shadow: 0px 0px 0px 3px rgba(0, 0, 70, 0.3); }
+#still_loading {
+  z-index: 200;
+  position: fixed;
+  left: 350px;
+  top: 120px;
+  border-radius: 7px;
+  background-color: #007730;
+  color: white;
+  padding-left: 30px;
+  padding-right: 30px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 120%;
+  box-shadow: 0px 0px 0px 3px rgba(0, 0, 70, 0.3);
+}
 
-.from { font-size: 90%; text-align: center; margin-left: 0; margin-right: 0; margin-top: -.2em; padding: 0; }
+.from {
+  font-size: 90%;
+  text-align: center;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: -0.2em;
+  padding: 0;
+}
 
-.basepkg { float: right; background-color: #990000; width: 5em; text-align: center; padding-top: 10px; padding-bottom: 10px; margin: 0; border-color: #ffd0b0; border-width: 3px; border-style: solid; border-radius: 5px; background-color: #ffffff; }
+.basepkg {
+  float: right;
+  background-color: #990000;
+  width: 5em;
+  text-align: center;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  margin: 0;
+  border-color: #ffd0b0;
+  border-width: 3px;
+  border-style: solid;
+  border-radius: 5px;
+  background-color: #ffffff;
+}
 
 /* ---------------------------- COLORS -------------------------------- */
 /* ------------------------ NAVIGATION MENU ---------------------- */
-#nav { font-size: 110%; }
+#nav {
+  font-size: 110%;
+}
 
-.hindex { list-style-type: none; padding: 0em; }
-.hindex li { margin-bottom: .1em; }
-.hindex li li { margin-left: 0.5em; margin-bottom: 0.1em; }
-.hindex img { padding-left: 0.3em; padding-right: 0.3em; }
+.hindex {
+  list-style-type: none;
+  padding: 0em;
+}
+.hindex li {
+  margin-bottom: 0.1em;
+}
+.hindex li li {
+  margin-left: 0.5em;
+  margin-bottom: 0.1em;
+}
+.hindex img {
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+}
 
-#flat ul { list-style-type: none; margin-left: 1em; padding: 0; }
-#flat li { margin-left: 0; margin-bottom: 0; }
+#flat ul {
+  list-style-type: none;
+  margin-left: 1em;
+  padding: 0;
+}
+#flat li {
+  margin-left: 0;
+  margin-bottom: 0;
+}
 
-.flatsec { margin-top: 2em; }
+.flatsec {
+  margin-top: 2em;
+}
 
-.tt-dropdown-menu { width: 350px; }
+.tt-dropdown-menu {
+  width: 350px;
+}
 
-.box { margin-left: .5em; margin-right: .5em; }
+.box {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}
 
-.box p { margin-left: .5em; margin-right: .5em; }
+.box p {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}
 
-.code, .mathblock, .mathblockrendered { font-size: 90%; margin-left: 1em; margin-right: 1em; padding: .5em; }
+.code, .mathblock, .mathblockrendered {
+  font-size: 90%;
+  margin-left: 1em;
+  margin-right: 1em;
+  padding: 0.5em;
+}
 
-.code { overflow-x: auto; }
+.code {
+  overflow-x: auto;
+}
 
-li .code { margin-left: .5em; }
+li .code {
+  margin-left: 0.5em;
+}
 
-.xtable { margin-left: 0.5em; margin-right: 0.5em; }
+.xtable {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}
 
-dt { margin-left: 1em; }
+dt {
+  margin-left: 1em;
+}
 
-dd { margin-left: 1.5em; }
+dd {
+  margin-left: 1.5em;
+}
 
-blockquote { margin-left: 1em; margin-right: 1em; }
+blockquote {
+  margin-left: 1em;
+  margin-right: 1em;
+}
 
 /*# sourceMappingURL=mobile.css.map */

--- a/books/xdoc/fancy/xdata2sql.pl
+++ b/books/xdoc/fancy/xdata2sql.pl
@@ -131,18 +131,18 @@ my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "",
 print "; Creating xdoc_data table.\n";
 
 $dbh->do(q{
-    CREATE TABLE XTABLE (
-        XKEY TEXT PRIMARY KEY NOT NULL,
-        XPARENTS TEXT,
-        XSRC TEXT,
-        XPKG TEXT,
-        XLONG TEXT)
+    CREATE TABLE xtable (
+        xkey TEXT PRIMARY KEY NOT NULL,
+        xparents TEXT,
+        xsrc TEXT,
+        xpkg TEXT,
+        xlong TEXT)
 });
 
 
 print "; Populating xdoc_data table.\n";
 my $query = $dbh->prepare(q{
-    INSERT INTO XTABLE (XKEY, XPARENTS, XSRC, XPKG, XLONG)
+    INSERT INTO xtable (xkey, xparents, xsrc, xpkg, xlong)
     VALUES (?, ?, ?, ?, ?)
 });
 

--- a/books/xdoc/fancy/xdata2sql.pl
+++ b/books/xdoc/fancy/xdata2sql.pl
@@ -130,19 +130,30 @@ my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "",
 
 print "; Creating xdoc_data table.\n";
 
-$dbh->do("CREATE TABLE XTABLE ("
-         . "XKEY TEXT PRIMARY KEY NOT NULL,"
-         . "XDATA TEXT)");
+$dbh->do(q{
+    CREATE TABLE XTABLE (
+        XKEY TEXT PRIMARY KEY NOT NULL,
+        XPARENTS TEXT,
+        XSRC TEXT,
+        XPKG TEXT,
+        XLONG TEXT)
+});
 
 
 print "; Populating xdoc_data table.\n";
-my $query = $dbh->prepare("INSERT INTO XTABLE (XKEY, XDATA) VALUES (?, ?)");
+my $query = $dbh->prepare(q{
+    INSERT INTO XTABLE (XKEY, XPARENTS, XSRC, XPKG, XLONG)
+    VALUES (?, ?, ?, ?, ?)
+});
 
 while(my ($key,$val) = each %$xdata)
 {
-    my $enc = $xs->encode($val);
     $query->bind_param(1, $key);
-    $query->bind_param(2, $enc);
+    $query->bind_param(2, $xs->encode($val->[0]));
+    $query->bind_param(3, $xs->encode($val->[1]));
+    $query->bind_param(4, $xs->encode($val->[2]));
+    $query->bind_param(5, $xs->encode($val->[3]));
+
     $query->execute();
 }
 

--- a/books/xdoc/fancy/xdata2sql.pl
+++ b/books/xdoc/fancy/xdata2sql.pl
@@ -79,36 +79,59 @@ if (! -f "xdata.js") {
     exit(1);
 }
 
+if (! -f "xindex.js") {
+    print "Error: xindex.js not found.\n";
+    exit(1);
+}
+
 
 print "; Reading file\n";
 
-my $javascript = read_whole_file("xdata.js");
+my $xdata_javascript = read_whole_file("xdata.js");
+my $xindex_javascript = read_whole_file("xindex.js");
 
 
-print "; Checking file\n";
+print "; Checking files\n";
 
-my $json;
+my $xdata_json;
 my $start = "var xdata = ";
-if (length($start) < length($javascript)
-    && substr($javascript, 0, length($start)) eq $start
-    && substr($javascript, length($javascript)-1, 1) eq ";")
+if (length($start) < length($xdata_javascript)
+    && substr($xdata_javascript, 0, length($start)) eq $start
+    && substr($xdata_javascript, length($xdata_javascript)-1, 1) eq ";")
 {
-    my $stop = length($javascript) - length($start) - length(";");
-    $json = substr($javascript, length($start), $stop);
+    my $stop = length($xdata_javascript) - length($start) - length(";");
+    $xdata_json = substr($xdata_javascript, length($start), $stop);
 }
 else {
     print "Error: xdata.js does not have the expected format\n";
     exit(1);
 }
 
+my $xindex_json;
+my $start = "var xindex = ";
+if (length($start) < length($xindex_javascript)
+    && substr($xindex_javascript, 0, length($start)) eq $start
+    && substr($xindex_javascript, length($xindex_javascript)-1, 1) eq ";")
+{
+    my $stop = length($xindex_javascript) - length($start) - length(";");
+    $xindex_json = substr($xindex_javascript, length($start), $stop);
+}
+else {
+    print "Error: xindex.js does not have the expected format\n";
+    exit(1);
+}
+
 
 print "; Parsing JSON data.\n";
 my $xs = new JSON::XS;
-my $xdata = $xs->decode($json);
+my $xdata = $xs->decode($xdata_json);
 if (!(ref($xdata) eq "HASH")) {
     print "Error: JSON object within xdata.js not a hash?\n";
     exit(1);
 }
+
+my $xs = new JSON::XS;
+my $xindex = $xs->decode($xindex_json);
 
 if (-f "xdata.db") {
     print "; Deleting old xdata.db.\n";
@@ -133,40 +156,63 @@ print "; Creating xtable.\n";
 $dbh->do(q{
     CREATE TABLE xtable (
         xkey TEXT PRIMARY KEY NOT NULL,
+        xtopic TEXT,
         xparents TEXT,
         xsrc TEXT,
         xpkg TEXT,
+        xshort TEXT,
         xlong TEXT)
 });
 
 
 print "; Populating xtable.\n";
-my $query = $dbh->prepare(q{
+
+my $xdata_query = $dbh->prepare(q{
     INSERT INTO xtable (xkey, xparents, xsrc, xpkg, xlong)
     VALUES (?, ?, ?, ?, ?)
 });
-
 while(my ($key,$val) = each %$xdata)
 {
-    $query->bind_param(1, $key);
-    $query->bind_param(2, $xs->encode($val->[0]));
-    $query->bind_param(3, $xs->encode($val->[1]));
-    $query->bind_param(4, $xs->encode($val->[2]));
-    $query->bind_param(5, $xs->encode($val->[3]));
+    $xdata_query->bind_param(1, $key);
+    $xdata_query->bind_param(2, $xs->encode($val->[0]));
+    $xdata_query->bind_param(3, $xs->encode($val->[1]));
+    $xdata_query->bind_param(4, $xs->encode($val->[2]));
+    $xdata_query->bind_param(5, $xs->encode($val->[3]));
 
-    $query->execute();
+    $xdata_query->execute();
+}
+
+my $xindex_query = $dbh->prepare(q{
+    UPDATE xtable
+    SET xtopic=?, xshort=?
+    WHERE xkey=?;
+});
+foreach my $val (@$xindex)
+{
+    $xindex_query->bind_param(1, $xs->encode($val->[2]));
+    $xindex_query->bind_param(2, $xs->encode($val->[4]));
+    $xindex_query->bind_param(3, $val->[0]);
+
+    $xindex_query->execute();
 }
 
 print "; Creating xtable_fts.\n";
 
 $dbh->do(q{
     CREATE VIRTUAL TABLE xtable_fts
-    USING fts5(xkey, xlong, content='xtable', content_rowid='rowid')
+    USING fts5(
+        xkey,
+        xtopic,
+        xshort,
+        xlong,
+        content='xtable',
+        content_rowid='rowid')
 });
 
 print "; Populating xtable_fts.\n";
 $dbh->do(q{
-    INSERT INTO xtable_fts(xkey, xlong) SELECT xkey, xlong FROM xtable
+    INSERT INTO xtable_fts(xkey, xtopic, xshort, xlong)
+    SELECT xkey, xtopic, xshort, xlong FROM xtable
 });
 
 $dbh->commit();

--- a/books/xdoc/fancy/xdata2sql.pl
+++ b/books/xdoc/fancy/xdata2sql.pl
@@ -128,7 +128,7 @@ my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "",
                        {RaiseError=>1, AutoCommit=>0})
     or die $DBI::errstr;
 
-print "; Creating xdoc_data table.\n";
+print "; Creating xtable.\n";
 
 $dbh->do(q{
     CREATE TABLE xtable (
@@ -140,7 +140,7 @@ $dbh->do(q{
 });
 
 
-print "; Populating xdoc_data table.\n";
+print "; Populating xtable.\n";
 my $query = $dbh->prepare(q{
     INSERT INTO xtable (xkey, xparents, xsrc, xpkg, xlong)
     VALUES (?, ?, ?, ?, ?)
@@ -156,6 +156,18 @@ while(my ($key,$val) = each %$xdata)
 
     $query->execute();
 }
+
+print "; Creating xtable_fts.\n";
+
+$dbh->do(q{
+    CREATE VIRTUAL TABLE xtable_fts
+    USING fts5(xkey, xlong, content='xtable', content_rowid='rowid')
+});
+
+print "; Populating xtable_fts.\n";
+$dbh->do(q{
+    INSERT INTO xtable_fts(xkey, xlong) SELECT xkey, xlong FROM xtable
+});
 
 $dbh->commit();
 $dbh->disconnect();

--- a/books/xdoc/fancy/xdataget.pl
+++ b/books/xdoc/fancy/xdataget.pl
@@ -79,14 +79,19 @@ for my $key (@keys) {
     my $ret = $query->fetchrow_hashref();
 
     if (!$ret) {
-        push @results, "Error: no such topic.";
+        push @results, { error => "no such topic." };
     }
     else {
         my $xparents = $json->decode($ret->{"XPARENTS"});
         my $xsrc = $json->decode($ret->{"XSRC"});
         my $xpkg = $json->decode($ret->{"XPKG"});
         my $xlong = $json->decode($ret->{"XLONG"});
-        push @results, [$xparents, $xsrc, $xpkg, $xlong];
+        push @results, {
+            parents => $xparents,
+            src => $xsrc,
+            pkg => $xpkg,
+            long => $xlong
+        };
     }
 }
 my $output = { results => \@results };

--- a/books/xdoc/fancy/xdataget.pl
+++ b/books/xdoc/fancy/xdataget.pl
@@ -134,7 +134,6 @@ sub search {
     my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "", {RaiseError=>1});
     my $query = $dbh->prepare(q{
         SELECT xkey,
-               snippet(xtable_fts, 1, '<mark>', '</mark>', '...', 20) as snippet,
                bm25(xtable_fts, 0.0, 100.0, 5.0, 1.0) as score
         FROM xtable_fts
         WHERE xtable_fts MATCH ?
@@ -145,20 +144,7 @@ sub search {
 
     my $rows = $query->fetchall_arrayref({});
     my $json = JSON->new;
-    my @results = ();
-
-    foreach my $row (@$rows) {
-        my $safe_snippet = encode_entities($row->{snippet});
-        $safe_snippet =~ s/&lt;mark&gt;/<mark>/g;
-        $safe_snippet =~ s/&lt;\/mark&gt;/<\/mark>/g;
-        $safe_snippet =~ s/\\n//g;
-
-        $row->{snippet} = $safe_snippet;
-
-        push @results, $row;
-    }
-
-    my $json_output = $json->encode({results => \@results});
+    my $json_output = $json->encode({results => \@$rows});
     print $json_output;
 
     $query->finish();

--- a/books/xdoc/fancy/xdataget.pl
+++ b/books/xdoc/fancy/xdataget.pl
@@ -31,7 +31,8 @@
 # Original author: Jared Davis <jared@centtech.com>
 
 
-# xdataget.pl: look up a key (or several keys) from the XDATA SQL database.
+# xdataget.pl: Interact with the XDATA SQL database, by either looking up some
+# key(s) or searching a query with FTS5.
 #
 # This is a companion script for xdata2sql.pl.
 # Typically the flow is:
@@ -50,52 +51,113 @@ use strict;
 use DBI;
 use CGI;
 use JSON;
+use HTML::Entities;
 
 my $cgi = CGI->new;
 print $cgi->header("application/json");
 
-my $arg = $cgi->param("keys") || "";
+my $arg_keys = $cgi->param("keys") || "";
+my $arg_search = $cgi->param("search") || "";
 
-if (!($arg =~ /^[A-Za-z0-9:._\-]*$/))
-{
-    print "{\"error\":\"keys contain illegal characters, rejecting to prevent xss attacks.\"}\n";
-    exit;
-}
-
-my @keys = split(':', $arg);
-
-if (! -f "xdata.db") {
-    print "{\"error\":\"xdata.db not found\"}\n";
-    exit;
-}
-
-my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "", {RaiseError=>1});
-my $query = $dbh->prepare("SELECT * FROM xtable WHERE xkey=?");
-
-my @results;
 my $json = JSON->new;
-for my $key (@keys) {
-    $query->execute($key);
-    my $ret = $query->fetchrow_hashref();
 
-    if (!$ret) {
-        push @results, { error => "no such topic." };
+sub lookup_keys {
+    if (!($arg_keys =~ /^[A-Za-z0-9:._\-]*$/)) {
+        print $json->encode(
+            { error => "keys contain illegal characters, rejecting to prevent xss attacks." });
+        exit;
     }
-    else {
-        my $xparents = $json->decode($ret->{"xparents"});
-        my $xsrc = $json->decode($ret->{"xsrc"});
-        my $xpkg = $json->decode($ret->{"xpkg"});
-        my $xlong = $json->decode($ret->{"xlong"});
-        push @results, {
-            parents => $xparents,
-            src => $xsrc,
-            pkg => $xpkg,
-            long => $xlong
-        };
+
+    my @keys = split(':', $arg_keys);
+
+    if (! -f "xdata.db") {
+        print $json->encode({ error => "xdata.db not found" });
+        exit;
     }
+
+    my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "", {RaiseError=>1});
+    my $query = $dbh->prepare("SELECT * FROM xtable WHERE xkey=?");
+
+    my @results;
+    for my $key (@keys) {
+        $query->execute($key);
+        my $ret = $query->fetchrow_hashref();
+
+        if (!$ret) {
+            push @results, { error => "no such topic." };
+        }
+        else {
+            my $xparents = $json->decode($ret->{"xparents"});
+            my $xsrc = $json->decode($ret->{"xsrc"});
+            my $xpkg = $json->decode($ret->{"xpkg"});
+            my $xlong = $json->decode($ret->{"xlong"});
+            push @results, {
+                parents => $xparents,
+                src => $xsrc,
+                pkg => $xpkg,
+                long => $xlong
+            };
+        }
+    }
+    my $output = { results => \@results };
+    print $json->encode($output);
+
+    $query->finish();
+    $dbh->disconnect();
 }
-my $output = { results => \@results };
-print $json->encode($output);
 
-$query->finish();
-$dbh->disconnect();
+sub search {
+    if (!($arg_search =~ /^[A-Za-z0-9:._\- \"]*$/)) {
+        print $json->encode(
+            { error => "search contain illegal characters, rejecting to prevent xss attacks." });
+        exit;
+    }
+
+    if (! -f "xdata.db") {
+        print $json->encode({ error => "xdata.db not found" });
+        exit;
+    }
+
+    my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "", {RaiseError=>1});
+    my $query = $dbh->prepare(q{
+        SELECT XKEY,
+               snippet(XTABLE_fts, 1, '<mark>', '</mark>', '...', 20) as snippet,
+               rank
+        FROM XTABLE_fts
+        WHERE XLONG MATCH ?
+        ORDER BY rank
+        LIMIT 100
+    });
+    $query->execute($arg_search);
+
+    my $rows = $query->fetchall_arrayref({});
+    my $json = JSON->new;
+    my @results = ();
+
+    foreach my $row (@$rows) {
+        # Clean up the snippet
+        my $safe_snippet = encode_entities($row->{snippet});
+        $safe_snippet =~ s/&lt;mark&gt;/<mark>/g;
+        $safe_snippet =~ s/&lt;\/mark&gt;/<\/mark>/g;
+        $safe_snippet =~ s/\\n//g; # Remove all \n characters
+
+        # Update the row
+        $row->{snippet} = $safe_snippet;
+
+        # Add to results array
+        push @results, $row;
+    }
+
+    # THEN encode to JSON
+    my $json_output = $json->encode({results => \@results});
+    print $json_output;
+
+    $query->finish();
+    $dbh->disconnect();
+}
+
+if ($arg_keys ne "") {
+    lookup_keys();
+} else {
+    search();
+}

--- a/books/xdoc/fancy/xdataget.pl
+++ b/books/xdoc/fancy/xdataget.pl
@@ -70,7 +70,7 @@ if (! -f "xdata.db") {
 }
 
 my $dbh = DBI->connect("dbi:SQLite:dbname=xdata.db", "", "", {RaiseError=>1});
-my $query = $dbh->prepare("SELECT * FROM XTABLE WHERE XKEY=?");
+my $query = $dbh->prepare("SELECT * FROM xtable WHERE xkey=?");
 
 my @results;
 my $json = JSON->new;
@@ -82,10 +82,10 @@ for my $key (@keys) {
         push @results, { error => "no such topic." };
     }
     else {
-        my $xparents = $json->decode($ret->{"XPARENTS"});
-        my $xsrc = $json->decode($ret->{"XSRC"});
-        my $xpkg = $json->decode($ret->{"XPKG"});
-        my $xlong = $json->decode($ret->{"XLONG"});
+        my $xparents = $json->decode($ret->{"xparents"});
+        my $xsrc = $json->decode($ret->{"xsrc"});
+        my $xpkg = $json->decode($ret->{"xpkg"});
+        my $xlong = $json->decode($ret->{"xlong"});
         push @results, {
             parents => $xparents,
             src => $xsrc,

--- a/books/xdoc/fancy/xdoc.js
+++ b/books/xdoc/fancy/xdoc.js
@@ -947,8 +947,16 @@ function searchAddHit(matches, hits, key) {
 }
 
 function searchGoServer(query_str) {
-    const url = XDATAGET + "?search=" + encodeURIComponent(query_str);
+    // Should these first couple of things be factored out? Same between Server and Local
+    $("#searching_message").hide();
+    if (query_str.length === 0) {
+        $("#data").append("<h3>No results (empty search)</h3>");
+        return;
+    }
 
+    $("#data").append("<h1><u>" + htmlEncode(query_str) + "</u></h1>");
+
+    const url = XDATAGET + "?search=" + encodeURIComponent(query_str);
     fetch(url, {
         method: 'GET',
     }).then(res => res.json()).then(obj => {
@@ -962,7 +970,8 @@ function searchGoServer(query_str) {
             let hits = jQuery("<dl></dl>");
             for (let i = 0; i < results.length; i++) {
                 // TODO: check for error
-                const score = (-results[i].rank).toFixed(2);
+                // const score = (-results[i].rank).toFixed(2);
+                const score = (-results[i].score).toFixed(2);
                 hits.append("<dt><a href=\"index.html?topic=" + results[i].xkey + "\""
                             + " onclick=\"return dolink(event, '" + results[i].xkey + "');\">"
                             + xindexObj.topicName(results[i].xkey)
@@ -980,7 +989,7 @@ function searchGoServer(query_str) {
             console.error("Error: malformed response " + obj);
         }
     }).catch(err => {
-        const val = `Error: AJAX query failed. ${err}`;
+        const val = "Error: AJAX query failed. " + err;
         console.error(err);
     });
 }

--- a/books/xdoc/fancy/xdoc.js
+++ b/books/xdoc/fancy/xdoc.js
@@ -222,10 +222,10 @@ function keyTitle(key)
 
 function applySuborder(subkeys, keys) {
     var ret = [];
-    for(var i in subkeys) {
+    for (var i in subkeys) {
         ret.push(subkeys[i]);
     }
-    for(var i in keys) {
+    for (var i in keys) {
         var k = keys[i];
         var idx = ret.indexOf(k);
         if (idx == -1) { // new key, add it
@@ -240,7 +240,7 @@ function keySortedChildren(key) { // Returns a nicely sorted array of child_keys
     var children = xindexObj.topicChildKeys(key);
 
     var tmp = [];
-    for(var i in children) {
+    for (var i in children) {
         var child_key = children[i];
         var rawname = xindexObj.topicRawname(child_key);
         tmp.push({key:child_key, rawname:rawname});
@@ -248,7 +248,7 @@ function keySortedChildren(key) { // Returns a nicely sorted array of child_keys
     tmp.sort(function(a,b) { return alphanum(a.rawname, b.rawname); });
 
     var ret = [];
-    for(var i in tmp) {
+    for (var i in tmp) {
         ret.push(tmp[i].key);
     }
 
@@ -271,7 +271,7 @@ function keySortedChildren(key) { // Returns a nicely sorted array of child_keys
 function xdataLoadKeys(keys) {
     // Optimization, don't load keys we've already loaded
     const missing = [];
-    for(const key of keys) {
+    for (const key of keys) {
         if (!xdataObj.topicExists(key))
             missing.push(key);
     }
@@ -283,7 +283,7 @@ function xdataLoadKeys(keys) {
     if (!XDATAGET) {
         // We're running in local mode, so we can't load any more data from
         // the server.  Any missing keys are errors!
-        for(const missingKey of missing)
+        for (const missingKey of missing)
             xdataObj.addError(missingKey, "Error: no such topic.");
         return Promise.resolve();
     }
@@ -316,7 +316,7 @@ function xdataLoadKeys(keys) {
     }).catch(err => {
         const val = `Error: AJAX query failed. ${err}`;
         console.error(err);
-        for(const missingKey of missing) {
+        for (const missingKey of missing) {
             xdataObj.addError(missingKey, val);
         }
     });
@@ -415,7 +415,7 @@ function navExpand(id) {
     $("#_nav_ilink" + id).attr("href", "javascript:navRetract(" + id + ")");
     var key = nav_id_table[id]["key"];
 
-    if(nav_id_table[id]["ever_expanded"]) {
+    if (nav_id_table[id]["ever_expanded"]) {
         $("#_navTree" + id).show();
         return;
     }
@@ -425,14 +425,14 @@ function navExpand(id) {
 
     var start = nav_id_table.length; // stupid hack for tooltip activation
     var exp = "";
-    for(var i in children) {
+    for (var i in children) {
         exp += navMakeNode(children[i]);
     }
     $("#_navTree" + id).append(exp);
 
     // Activate only the tooltips that we have just added.  (If we try to
     // activate them more than once, they don't seem to work.)
-    for(var i = start; i < nav_id_table.length; ++i) {
+    for (var i = start; i < nav_id_table.length; ++i) {
         navActivateTooltip(i);
     }
 }
@@ -488,7 +488,7 @@ function navFlat() {
 function navFlatSort(array)
 {
     var len = array.length;
-    if(len < 2) {
+    if (len < 2) {
         return array;
     }
     var pivot = Math.ceil(len/2);
@@ -498,7 +498,7 @@ function navFlatSort(array)
 function navFlatMerge(left, right)
 {
     var result = [];
-    while((left.length > 0) && (right.length > 0))
+    while ((left.length > 0) && (right.length > 0))
     {
         if (alphanumChunks(left[0].chunks, right[0].chunks) == -1)
             result.push(left.shift());
@@ -549,7 +549,7 @@ function navFlatReallyInstall()
     var keys = xindexObj.allKeys();
 
     // Preprocessing: upcase and chunkify everything
-    for(const key of keys) {
+    for (const key of keys) {
         var rawname = xindexObj.topicRawname(key).toUpperCase();
         myarr.push({key:key, rawname: rawname, chunks: chunkify(rawname) });
     }
@@ -570,7 +570,7 @@ function navFlatReallyInstall()
     // alphabetic characters.  Now we inline this to gain some small
     // efficiency.
 
-    for(var i in myarr) {
+    for (var i in myarr) {
         var key = myarr[i].key;
         var name = xindexObj.topicName(key);
         var rawname = myarr[i].rawname;
@@ -653,7 +653,7 @@ function datLoadParents(key) {
         return;
     }
     acc += "<ul>";
-    for(var i in parent_keys) {
+    for (var i in parent_keys) {
         var pkey = parent_keys[i];
         var pname = parent_names[i];
         var tooltip = "Error: parent topic is missing!";
@@ -679,7 +679,7 @@ function datShortSubtopics(key)
     var children = keySortedChildren(key);
 
     var dl = jQuery("<div></div>");
-    for(var i in children) {
+    for (var i in children) {
         var child_key = children[i];
         dl.append("<dt><a href=\"index.html?topic=" + child_key + "\""
                   + " onclick=\"return dolink(event, '" + child_key + "');\""
@@ -710,7 +710,7 @@ function datExpand(dat_id)
     var children = keySortedChildren(key);
     xdataLoadKeys(children).then(() => {
         var div = $("#_dat_long" + dat_id);
-        for(var i in children) {
+        for (var i in children) {
             var child_key = children[i];
             div.append(datLongTopic(child_key));
             if (i != children.length - 1) {
@@ -867,7 +867,7 @@ function searchTokenize(plaintext) {
         // Correct for ridiculous behavior of string.split
         return [];
     }
-    for(var i in tokens) {
+    for (var i in tokens) {
         var orig = tokens[i];
         var trim = orig.replace(/^[()"'`.,;?!]*/, '')
             .replace(/[()"'`.,;?!]*$/, '');
@@ -886,7 +886,7 @@ function countOccurrences(haystack, needle) {
 
 // Check if all words in query appear in text (for multi-word queries)
 function allWordsMatch(text, query_words) {
-    for(let i = 0; i < query_words.length; i++) {
+    for (let i = 0; i < query_words.length; i++) {
         if (text.indexOf(query_words[i]) === -1) {
             return false;
         }
@@ -984,14 +984,14 @@ function searchGoMain(query_str) {
     // We borrow the ta_data structure from the "jump to" feature.
 
     // 0. Exact matches of topics
-    for(const key of ta_data) {
+    for (const key of ta_data) {
         if (key.rawlow === query_str_low) {
             if (addResult(key.value, 0)) break;
         }
     }
     if (results.length < max_display) {
         // 0.5. Prefix matches of topics
-        for(const key of ta_data) {
+        for (const key of ta_data) {
             if (key.value in matches) continue;
             if (key.rawlow.startsWith(query_str_low)) {
                 if (addResult(key.value, 0.5)) break;
@@ -1000,7 +1000,7 @@ function searchGoMain(query_str) {
     }
     if (results.length < max_display) {
         // 1. Substring matches in topics
-        for(const key of ta_data) {
+        for (const key of ta_data) {
             if (key.value in matches) continue;
             // Check for exact phrase first (higher priority)
             if (key.rawlow.indexOf(query_str_low) !== -1) {
@@ -1014,7 +1014,7 @@ function searchGoMain(query_str) {
     }
     if (results.length < max_display) {
         // 2. Short description matches
-        for(const key of ta_data) {
+        for (const key of ta_data) {
             if (key.value in matches) continue;
             // Perhaps it would be better to use topicShortPlaintext,
             // but this is *very* slow.
@@ -1120,7 +1120,7 @@ function ta_data_initialize() {
         return;
     }
     const keys = xindexObj.allKeys();
-    for(const key of keys) {
+    for (const key of keys) {
         ta_data.push({
             value: key,
             nicename: xindexObj.topicName(key),
@@ -1348,7 +1348,7 @@ function onIndexLoaded()
 
     var acc = "";
     var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    for(var i in chars) {
+    for (var i in chars) {
         var c = chars.charAt(i);
         acc += "<a href=\"javascript:navFlatToChar('" + c + "')\">" + c + "</a>";
         if (c == "M")
@@ -1414,7 +1414,7 @@ function getPageParameters ()
     }
     var param_strs = RegExp.$1.split("&");
     var param_arr = {};
-    for(var i in param_strs)
+    for (var i in param_strs)
     {
         var tmp = param_strs[i].split("=");
         var key = decodeURI(tmp[0]);

--- a/books/xdoc/fancy/xdoc.js
+++ b/books/xdoc/fancy/xdoc.js
@@ -298,16 +298,20 @@ function xdataLoadKeys(keys) {
         if (results && results.length == missing.length) {
             // TODO: we need to assume that the order of the returned
             // data is the same as the order of the requested keys.
-            for(let i = 0; i < results.length; i++) {
-                xdataObj.add(missing[i], results[i]);
+            for (let i = 0; i < results.length; i++) {
+                if (results[i].error !== undefined) {
+                    xdataObj.addError(missing[i], `Error: ${results[i].error}`);
+                } else {
+                    const xdata = [results[i].parents,
+                                   results[i].src,
+                                   results[i].pkg,
+                                   results[i].long];
+                    xdataObj.add(missing[i], xdata);
+                }
             }
         } else {
-            let val = "Error: malformed reply from " + url;
-            if ("error" in obj)
-                val = obj["error"];
-            for(const missingKey of missing) {
-                xdataObj.addError(missingKey, val);
-            }
+            const val = "Error: malformed response: " + obj;
+            console.error(err);
         }
     }).catch(err => {
         const val = `Error: AJAX query failed. ${err}`;

--- a/books/xdoc/fancy/xdoc.js
+++ b/books/xdoc/fancy/xdoc.js
@@ -211,12 +211,20 @@ function closeAllPowertips()
 
 function keyTitle(key)
 {
-    var prefix = XDOCTITLE;
+    let prefix = XDOCTITLE;
     if (!prefix) { prefix = "XDOC"; }
 
     return (xindexObj.topicExists(key))
         ? (prefix + " &mdash; " + xindexObj.topicName(key))
         : (prefix + " &mdash; " + key);
+}
+
+function searchTitle(query)
+{
+    let prefix = XDOCTITLE;
+    if (!prefix) { prefix = "XDOC"; }
+
+    return prefix + " Search &mdash; " + query;
 }
 
 
@@ -919,6 +927,8 @@ function searchGo(str) {
     // user navigates to a new page.
     $("#left").removeClass("active");
     closeAllPowertips();
+
+    $("title").html(searchTitle(str));
 
     ta_data_initialize();
 


### PR DESCRIPTION
This PR improves the web manual search by using sqlite FTS5 to quickly search topics/shorts/longs on the server.

Note that the `desktop.css` and `mobile.css` files are generated from the SCSS files. It looks like there are more changes than there actually are because the SCSS->CSS generator I used didn't match the style of the originals.

The sqlite database has been modified to include more data (topic names and shorts). It also builds an FTS table to allow for FTS5 searches. This increases the size of the database from 310M to 430M.

Search results are annotated with their "score", which is used to rank them. The calculation is fairly ad-hoc. It starts with the FTS BM25 score, but then we adjust it to overweight topics with exact results in the topic names and such.

You can preview these changes at: https://acl2.org/docs/test