### PR TITLE
[C$] Add type parameter to pointer types

### DIFF
--- a/books/kestrel/c/syntax/tests/validator.lisp
+++ b/books/kestrel/c/syntax/tests/validator.lisp
@@ -919,3 +919,66 @@ void g() {
   (void)(f());
 }
 ")
+
+(test-valid-fail
+  "int f;
+
+void g() {
+   f();
+}
+")
+
+(test-valid
+  "void foo() {
+  int *a = 0;
+  int **x = &a;
+  unsigned int *y = *x;
+  short z = *y;
+}
+")
+
+(test-valid-fail
+  "struct s { int a; };
+
+void foo(struct my_struct * x) {
+  int * y = *x;
+}
+")
+
+(test-valid
+  "struct s { int a; };
+struct my_struct x;
+struct my_struct *y = &x;
+")
+
+(test-valid-fail
+  "struct s { int a; };
+struct t { int b; };
+
+void foo(struct my_struct * x) {
+  struct t * y = *x;
+}
+")
+
+(test-valid
+  "void foo (int **p) {
+  int *sp = *p;
+}
+")
+
+(test-valid
+  "struct s { int a; };
+
+void foo (struct s **p) {
+  struct s *sp = *p;
+}
+")
+
+(test-valid
+  "struct s { int a; };
+
+void foo () {
+  struct s **p;
+  struct s *sp = *p;
+}
+")

--- a/books/kestrel/c/syntax/tests/validator.lisp
+++ b/books/kestrel/c/syntax/tests/validator.lisp
@@ -982,3 +982,13 @@ void foo () {
   struct s *sp = *p;
 }
 ")
+
+(test-valid
+  "int a[10];
+
+int foo () {
+   int x = a[3];
+   int y = 3[a];
+   return x+y;
+}
+")

--- a/books/kestrel/c/syntax/types.lisp
+++ b/books/kestrel/c/syntax/types.lisp
@@ -24,6 +24,8 @@
 (local (acl2::disable-builtin-rewrite-rules-for-defaults))
 (set-induction-depth-limit 0)
 
+(local (include-book "kestrel/utilities/ordinals" :dir :system))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defxdoc+ types
@@ -39,111 +41,111 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(fty::deftagsum type
-  :short "Fixtype of C types [C17:6.2.5]."
-  :long
-  (xdoc::topstring
-   (xdoc::p
-    "Currently we do not model all the C types in detail,
-     but only an approximate version of them,
-     which still lets us perform some validation.
-     We plan to refine the types, and the rest of the validator,
-     to cover exactly all the validity checks prescribed by [C17]
-     (as well as applicable GCC extensions).")
-   (xdoc::p
-    "We capture the following types:")
-   (xdoc::ul
-    (xdoc::li
-     "The @('void') type [C17:6.2.5/19].")
-    (xdoc::li
-     "The plain @('char') type [C17:6.2.5/3].")
-    (xdoc::li
-     "The five standard signed integer types [C17:6.2.5/4]
-      and the corresponding unsigned integer types [C17:6.2.5/6].")
-    (xdoc::li
-     "The three real floating point types [C17:6.2.5/10].")
-    (xdoc::li
-     "The three complex types [C17:6.2.5/11].
-      These are a conditional feature,
-      but they must be included in this fixtype
-      because this fixtype consists of all the possible types.")
-    (xdoc::li
-     "The @('_Bool') type [C17:6.2.5/2].")
-    (xdoc::li
-     "A family of structure types [C17:6.2.5/20].
-      Structure types are characterized by an optional tag.
-      This is an approximation,
-      because there may be different structure types of a given tag,
-      or different tagless structure types.")
-    (xdoc::li
-     "A collective type for all union types [C17:6.2.5/20].
-      This is an approximation,
-      because there are different union types.")
-    (xdoc::li
-     "A collective type for all enumeration types [C17:6.2.5/20].
-      This is an approximation,
-      because there are different enumeration types.")
-    (xdoc::li
-     "A collective type for all array types [C17:6.2.5/20].
-      This is an approximation,
-      because there are different array types.")
-    (xdoc::li
-     "A collective type for all pointer types [C17:6.2.5/20].
-      This is an approximation,
-      because there are different pointer types.")
-    (xdoc::li
-     "A collective type for all function types [C17:6.2.5/20].
-      This is an approximation,
-      because there are different function types.")
-    (xdoc::li
-     "An ``unknown'' type that we need due to our current approximation.
-      Our validator must not reject valid code.
-      But due to our approximate treatment of types,
-      we cannot always calculate a type,
-      e.g. for a member expression of the form @('s.m')
-      where @('s') is an expression with structure type.
-      Since our approximate type for all structure types
-      has no information about the members,
-      we cannot calculate any actual type for @('s.m');
-      but if the expression is used elsewhere,
-      we need to accept it, because it could have the right type.
-      We use this unknown type for this purpose:
-      the expression @('s.m') has unknown type,
-      and unknown types are always acceptable."))
-   (xdoc::p
-    "Besides the approximations noted above,
-     currently we do not capture atomic types [C17:6.2.5/20],
-     which we approximate as the underlying (argument) type.
-     We also do not capture @('typedef') names,
-     which we approximate as unknown types.
-     Furthermore, we do not capture qualified types [C17:6.2.5/26]."))
-  (:void ())
-  (:char ())
-  (:schar ())
-  (:uchar ())
-  (:sshort ())
-  (:ushort ())
-  (:sint ())
-  (:uint ())
-  (:slong ())
-  (:ulong ())
-  (:sllong ())
-  (:ullong ())
-  (:float ())
-  (:double ())
-  (:ldouble ())
-  (:floatc ())
-  (:doublec ())
-  (:ldoublec ())
-  (:bool ())
-  (:struct ((tag? ident-optionp)))
-  (:union ())
-  (:enum ())
-  (:array ())
-  (:pointer ())
-  (:function ())
-  (:unknown ())
-  :pred typep)
+(encapsulate ()
+  (set-induction-depth-limit 1)
+
+  (fty::deftagsum type
+    :short "Fixtype of C types [C17:6.2.5]."
+    :long
+    (xdoc::topstring
+     (xdoc::p
+      "Currently we do not model all the C types in detail,
+       but only an approximate version of them,
+       which still lets us perform some validation.
+       We plan to refine the types, and the rest of the validator,
+       to cover exactly all the validity checks prescribed by [C17]
+       (as well as applicable GCC extensions).")
+     (xdoc::p
+      "We capture the following types:")
+     (xdoc::ul
+      (xdoc::li
+       "The @('void') type [C17:6.2.5/19].")
+      (xdoc::li
+       "The plain @('char') type [C17:6.2.5/3].")
+      (xdoc::li
+       "The five standard signed integer types [C17:6.2.5/4]
+        and the corresponding unsigned integer types [C17:6.2.5/6].")
+      (xdoc::li
+       "The three real floating point types [C17:6.2.5/10].")
+      (xdoc::li
+       "The three complex types [C17:6.2.5/11].
+        These are a conditional feature,
+        but they must be included in this fixtype
+        because this fixtype consists of all the possible types.")
+      (xdoc::li
+       "The @('_Bool') type [C17:6.2.5/2].")
+      (xdoc::li
+       "A family of structure types [C17:6.2.5/20].
+        Structure types are characterized by an optional tag.
+        This is an approximation,
+        because there may be different structure types of a given tag,
+        or different tagless structure types.")
+      (xdoc::li
+       "A collective type for all union types [C17:6.2.5/20].
+        This is an approximation,
+        because there are different union types.")
+      (xdoc::li
+       "A collective type for all enumeration types [C17:6.2.5/20].
+        This is an approximation,
+        because there are different enumeration types.")
+      (xdoc::li
+       "A collective type for all array types [C17:6.2.5/20].
+        This is an approximation,
+        because there are different array types.")
+      (xdoc::li
+       "A parameterized pointer type [C17:6.2.5/20].
+        A pointer type is derived from the so-called ``referenced type.''")
+      (xdoc::li
+       "A collective type for all function types [C17:6.2.5/20].
+        This is an approximation,
+        because there are different function types.")
+      (xdoc::li
+       "An ``unknown'' type that we need due to our current approximation.
+        Our validator must not reject valid code.
+        But due to our approximate treatment of types,
+        we cannot always calculate a type,
+        e.g. for a member expression of the form @('s.m')
+        where @('s') is an expression with structure type.
+        Since our approximate type for all structure types
+        has no information about the members,
+        we cannot calculate any actual type for @('s.m');
+        but if the expression is used elsewhere,
+        we need to accept it, because it could have the right type.
+        We use this unknown type for this purpose:
+        the expression @('s.m') has unknown type,
+        and unknown types are always acceptable."))
+     (xdoc::p
+      "Besides the approximations noted above,
+       currently we do not capture atomic types [C17:6.2.5/20],
+       which we approximate as the underlying (argument) type.
+       Furthermore, we do not capture qualified types [C17:6.2.5/26]."))
+    (:void ())
+    (:char ())
+    (:schar ())
+    (:uchar ())
+    (:sshort ())
+    (:ushort ())
+    (:sint ())
+    (:uint ())
+    (:slong ())
+    (:ulong ())
+    (:sllong ())
+    (:ullong ())
+    (:float ())
+    (:double ())
+    (:ldouble ())
+    (:floatc ())
+    (:doublec ())
+    (:ldoublec ())
+    (:bool ())
+    (:struct ((tag? ident-optionp)))
+    (:union ())
+    (:enum ())
+    (:array ())
+    (:pointer ((to type)))
+    (:function ())
+    (:unknown ())
+    :pred typep))
 
 ;;;;;;;;;;;;;;;;;;;;
 
@@ -234,7 +236,17 @@
   :short "Check if a type is a standard signed integer type [C17:6.2.5/4]."
   (and (member-eq (type-kind type) '(:schar :sshort :sint :slong :sllong))
        t)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-standard-signed-integerp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-standard-signed-integerp type)
+                    (and (member-equal kind
+                                       '(:schar :sshort :sint :slong :sllong))
+                         t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -248,7 +260,15 @@
      so the signed integer types coincide with
      the standard signed integer types."))
   (type-standard-signed-integerp type)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-signed-integerp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-signed-integerp type)
+                    (type-standard-signed-integerp type)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -257,7 +277,18 @@
   :short "Check if a type is a standard unsigned integer type [C17:6.2.5/6]."
   (and (member-eq (type-kind type) '(:bool :uchar :ushort :uint :ulong :ullong))
        t)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-standard-unsigned-integerp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-standard-unsigned-integerp type)
+                    (and (member-equal
+                           kind
+                           '(:bool :uchar :ushort :uint :ulong :ullong))
+                         t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -271,7 +302,15 @@
      so the unsigned integer types coincide with
      the standard unsigned integer types."))
   (type-standard-unsigned-integerp type)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-unsigned-integerp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-unsigned-integerp type)
+                    (type-standard-unsigned-integerp type)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -280,7 +319,16 @@
   :short "Check if a type is a standard integer type [C17:6.2.5/7]."
   (or (type-standard-signed-integerp type)
       (type-standard-unsigned-integerp type))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-standard-integerp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-standard-integerp type)
+                    (or (type-standard-signed-integerp type)
+                        (type-standard-unsigned-integerp type))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -289,7 +337,16 @@
   :short "Check if a type is a real floating type [C17:6.2.5/10]."
   (and (member-eq (type-kind type) '(:float :double :ldouble))
        t)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-real-floatingp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-real-floatingp type)
+                    (and (member-equal kind '(:float :double :ldouble))
+                         t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -298,7 +355,16 @@
   :short "Check if a type is a complex type [C17:6.2.5/11]."
   (and (member-eq (type-kind type) '(:floatc :doublec :ldoublec))
        t)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-complexp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-complexp type)
+                    (and (member-equal kind '(:floatc :doublec :ldoublec))
+                         t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -307,7 +373,16 @@
   :short "Check if a type is a floating type [C17:6.2.5/11]."
   (or (type-real-floatingp type)
       (type-complexp type))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-floatingp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-floatingp type)
+                    (or (type-real-floatingp type)
+                        (type-complexp type))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -318,7 +393,18 @@
       (type-signed-integerp type)
       (type-unsigned-integerp type)
       (type-floatingp type))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-basicp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-basicp type)
+                    (or (equal kind :char)
+                        (type-signed-integerp type)
+                        (type-unsigned-integerp type)
+                        (type-floatingp type))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -327,7 +413,16 @@
   :short "Check if a type is a character type [C17:6.2.5/15]."
   (and (member-eq (type-kind type) '(:char :schar :uchar))
        t)
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-characterp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-characterp type)
+                    (and (member-equal kind '(:char :schar :uchar))
+                         t)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -338,7 +433,18 @@
       (type-signed-integerp type)
       (type-unsigned-integerp type)
       (type-case type :enum))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-integerp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-integerp type)
+                    (or (equal kind :char)
+                        (type-signed-integerp type)
+                        (type-unsigned-integerp type)
+                        (type-case type :enum))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -347,7 +453,16 @@
   :short "Check if a type is a real type [C17:6.2.5/17]."
   (or (type-integerp type)
       (type-real-floatingp type))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-realp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-realp type)
+                    (or (type-integerp type)
+                        (type-real-floatingp type))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -360,16 +475,16 @@
 
   ///
 
+  (defrule type-arithmeticp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-arithmeticp type)
+                    (or (type-integerp type)
+                        (type-floatingp type)))))
+
   (defrule type-arithmeticp-when-type-integerp
     (implies (type-integerp type)
-             (type-arithmeticp type)))
-
-  (defrule type-arithmeticp-when-bool
-    (implies (type-case type :bool)
-             (type-arithmeticp type))
-    :enable (type-integerp
-             type-unsigned-integerp
-             type-standard-unsigned-integerp)))
+             (type-arithmeticp type))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -378,7 +493,16 @@
   :short "Check if a type is a scalar type [C17:6.2.5/21]."
   (or (type-arithmeticp type)
       (type-case type :pointer))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-scalarp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-scalarp type)
+                    (or (type-arithmeticp type)
+                        (type-case type :pointer))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -391,13 +515,12 @@
 
   ///
 
-  (defrule type-aggregatep-when-array
-    (implies (type-case type :array)
-             (type-aggregatep type)))
-
-  (defrule type-aggregatep-when-struct
-    (implies (type-case type :struct)
-             (type-aggregatep type))))
+  (defrule type-aggregatep-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-aggregatep type)
+                    (or (type-case type :array)
+                        (type-case type :struct))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -413,7 +536,17 @@
      the integer ones with rank below @('int')."))
   (not (member-eq (type-kind type)
                   '(:bool :char :schar :uchar :sshort :ushort :enum)))
-  :hooks (:fix))
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-promotedp-when-type-kind-syntaxp
+    (implies (and (equal (type-kind type) kind)
+                  (syntaxp (quotep kind)))
+             (equal (type-promotedp type)
+                    (not (member-equal kind
+                                       '(:bool :char :schar :uchar :sshort
+                                         :ushort :enum)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -427,9 +560,11 @@
      It leaves non-array types unchanged.")
    (xdoc::p
     "In our currently approximate type system,
-     there is just one type for arrays and one type for pointers."))
+     there is just one type for array.
+     Therefore, the sole array type is converted to
+     a pointer type derived from the unknown type."))
   (if (type-case type :array)
-      (type-pointer)
+      (make-type-pointer :to (type-unknown))
     (type-fix type))
   :hooks (:fix))
 
@@ -445,9 +580,11 @@
      It leaves non-function types unchanged.")
    (xdoc::p
     "In our currently approximate type system,
-     there is just one type for functions and one type for pointers."))
+     there is just one type for functions.
+     Therefore, the sole function type is converted to
+     a pointer type derived from the function type."))
   (if (type-case type :function)
-      (type-pointer)
+      (make-type-pointer :to (type-function))
     (type-fix type))
   :hooks (:fix))
 
@@ -727,7 +864,7 @@
    (xdoc::p
     "Type compatibility affects whether a redeclaration is permissible,
      whether one type may be used when another is expected,
-     and whether two declarations referring to the same object are
+     and whether two declarations referring to the same object or function are
      well-defined.
      This is a little weaker than type equality.
      For instance,
@@ -747,7 +884,7 @@
      "All structure types are currently considered compatible,
       due to their approximate representations.
       The same applies to
-      union, enumeration, array, pointer, and function types.")
+      union, enumeration, array, and function types.")
     (xdoc::li
      "Type qualifiers are ignored.")
     (xdoc::li
@@ -771,24 +908,71 @@
      @(':void') is compatible with @(':unknown'),
      as is @(':bool'),
      but @(':void') is <i>not</i> compatible with @(':bool')."))
-  (b* ((x (type-fix x))
-       (y (type-fix y)))
-    (or (equal x y)
-        (type-case x :unknown)
-        (type-case y :unknown)
-        (and (type-integerp x) (type-case y :enum))
-        (and (type-case x :enum) (type-integerp y))))
+  (or (type-case y :unknown)
+      (type-case
+        x
+        :unknown t
+        :pointer (type-case
+                   y
+                   :pointer (type-compatiblep x.to y.to)
+                   :otherwise nil)
+        :otherwise (or (equal (type-fix x) (type-fix y))
+                       (and (type-integerp x) (type-case y :enum))
+                       (and (type-case x :enum) (type-integerp y)))))
+  :measure (type-count x)
   :hooks (:fix)
 
   ///
 
   (defrule type-compatiblep-reflexive
     (type-compatiblep x x)
-    :enable type-compatiblep)
+    :induct t)
 
   (defrule type-compatiblep-symmetric
     (equal (type-compatiblep y x)
            (type-compatiblep x y))
+    :induct t))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define type-composite ((x typep) (y typep))
+  :guard (type-compatiblep x y)
+  :returns (composite typep)
+  :short "Construct a composite @(see type) [C17:6.2.7/3]."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "In our current approximate type system, the composite type is
+     the type of @('x') if the type of @('y') is unknown,
+     the type of @('y') if the type of @('x') is unknown,
+     and either type if neither are derived types.
+     For derived types, this is applied recursively on parameter types."))
+  (type-case
+    x
+    :pointer (type-case
+               y
+               :pointer (make-type-pointer :to (type-composite x.to y.to))
+               :unknown (type-fix x)
+               :otherwise (prog2$ (impossible) (irr-type)))
+    :unknown (type-fix y)
+    :otherwise (type-fix x))
+  :measure (type-count x)
+  :guard-hints (("Goal" :in-theory (enable type-compatiblep)))
+  :verify-guards :after-returns
+  :hooks (:fix)
+
+  ///
+
+  (defrule type-compatiblep-of-arg1-and-type-composite
+    (implies (type-compatiblep x y)
+             (type-compatiblep x (type-composite x y)))
+    :induct t
+    :enable type-compatiblep)
+
+  (defrule type-compatiblep-of-arg2-and-type-composite
+    (implies (type-compatiblep x y)
+             (type-compatiblep y (type-composite x y)))
+    :induct t
     :enable type-compatiblep))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1039,6 +1223,8 @@
    :sllong (type-sllong)
    :ullong (type-ullong)
    :struct (type-struct (ident (c::ident->name ctype.tag)))
-   :pointer (type-pointer)
+   :pointer (make-type-pointer :to (ildm-type ctype.to))
    :array (type-array))
+  :measure (c::type-count ctype)
+  :verify-guards :after-returns
   :hooks (:fix))

--- a/books/kestrel/c/syntax/types.lisp
+++ b/books/kestrel/c/syntax/types.lisp
@@ -985,6 +985,29 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define make-pointers-to ((pointers typequal/attribspec-list-listp)
+                          (type typep))
+  :returns (new-type typep)
+  :short "Derive a pointer type for each type qualifier and attribute specifier
+          list."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This takes the list of lists of type qualifiers and attribute specifiers
+     from a declarator or abstract declarator,
+     and creates the corresponding (possibly pointer) type.")
+   (xdoc::p
+    "Since our approximate type system does not incorporate type qualifiers,
+     each cons of the @('pointers') list
+     is used only to derive a pointer from the type."))
+  (if (endp pointers)
+      (type-fix type)
+    (make-type-pointer :to (make-pointers-to (rest pointers) type)))
+  :verify-guards :after-returns
+  :hooks (:fix))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define type-formalp ((type typep))
   :returns (yes/no booleanp)
   :short "Check if a type is supported in our formal semantics of C."

--- a/books/kestrel/c/syntax/types.lisp
+++ b/books/kestrel/c/syntax/types.lisp
@@ -41,111 +41,111 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(encapsulate ()
-  (set-induction-depth-limit 1)
-
-  (fty::deftagsum type
-    :short "Fixtype of C types [C17:6.2.5]."
-    :long
-    (xdoc::topstring
-     (xdoc::p
-      "Currently we do not model all the C types in detail,
-       but only an approximate version of them,
-       which still lets us perform some validation.
-       We plan to refine the types, and the rest of the validator,
-       to cover exactly all the validity checks prescribed by [C17]
-       (as well as applicable GCC extensions).")
-     (xdoc::p
-      "We capture the following types:")
-     (xdoc::ul
-      (xdoc::li
-       "The @('void') type [C17:6.2.5/19].")
-      (xdoc::li
-       "The plain @('char') type [C17:6.2.5/3].")
-      (xdoc::li
-       "The five standard signed integer types [C17:6.2.5/4]
-        and the corresponding unsigned integer types [C17:6.2.5/6].")
-      (xdoc::li
-       "The three real floating point types [C17:6.2.5/10].")
-      (xdoc::li
-       "The three complex types [C17:6.2.5/11].
-        These are a conditional feature,
-        but they must be included in this fixtype
-        because this fixtype consists of all the possible types.")
-      (xdoc::li
-       "The @('_Bool') type [C17:6.2.5/2].")
-      (xdoc::li
-       "A family of structure types [C17:6.2.5/20].
-        Structure types are characterized by an optional tag.
-        This is an approximation,
-        because there may be different structure types of a given tag,
-        or different tagless structure types.")
-      (xdoc::li
-       "A collective type for all union types [C17:6.2.5/20].
-        This is an approximation,
-        because there are different union types.")
-      (xdoc::li
-       "A collective type for all enumeration types [C17:6.2.5/20].
-        This is an approximation,
-        because there are different enumeration types.")
-      (xdoc::li
-       "A collective type for all array types [C17:6.2.5/20].
-        This is an approximation,
-        because there are different array types.")
-      (xdoc::li
-       "A parameterized pointer type [C17:6.2.5/20].
-        A pointer type is derived from the so-called ``referenced type.''")
-      (xdoc::li
-       "A collective type for all function types [C17:6.2.5/20].
-        This is an approximation,
-        because there are different function types.")
-      (xdoc::li
-       "An ``unknown'' type that we need due to our current approximation.
-        Our validator must not reject valid code.
-        But due to our approximate treatment of types,
-        we cannot always calculate a type,
-        e.g. for a member expression of the form @('s.m')
-        where @('s') is an expression with structure type.
-        Since our approximate type for all structure types
-        has no information about the members,
-        we cannot calculate any actual type for @('s.m');
-        but if the expression is used elsewhere,
-        we need to accept it, because it could have the right type.
-        We use this unknown type for this purpose:
-        the expression @('s.m') has unknown type,
-        and unknown types are always acceptable."))
-     (xdoc::p
-      "Besides the approximations noted above,
-       currently we do not capture atomic types [C17:6.2.5/20],
-       which we approximate as the underlying (argument) type.
-       Furthermore, we do not capture qualified types [C17:6.2.5/26]."))
-    (:void ())
-    (:char ())
-    (:schar ())
-    (:uchar ())
-    (:sshort ())
-    (:ushort ())
-    (:sint ())
-    (:uint ())
-    (:slong ())
-    (:ulong ())
-    (:sllong ())
-    (:ullong ())
-    (:float ())
-    (:double ())
-    (:ldouble ())
-    (:floatc ())
-    (:doublec ())
-    (:ldoublec ())
-    (:bool ())
-    (:struct ((tag? ident-optionp)))
-    (:union ())
-    (:enum ())
-    (:array ())
-    (:pointer ((to type)))
-    (:function ())
-    (:unknown ())
-    :pred typep))
+(fty::deftagsum type
+  :short "Fixtype of C types [C17:6.2.5]."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "Currently we do not model all the C types in detail,
+     but only an approximate version of them,
+     which still lets us perform some validation.
+     We plan to refine the types, and the rest of the validator,
+     to cover exactly all the validity checks prescribed by [C17]
+     (as well as applicable GCC extensions).")
+   (xdoc::p
+    "We capture the following types:")
+   (xdoc::ul
+    (xdoc::li
+     "The @('void') type [C17:6.2.5/19].")
+    (xdoc::li
+     "The plain @('char') type [C17:6.2.5/3].")
+    (xdoc::li
+     "The five standard signed integer types [C17:6.2.5/4]
+      and the corresponding unsigned integer types [C17:6.2.5/6].")
+    (xdoc::li
+     "The three real floating point types [C17:6.2.5/10].")
+    (xdoc::li
+     "The three complex types [C17:6.2.5/11].
+      These are a conditional feature,
+      but they must be included in this fixtype
+      because this fixtype consists of all the possible types.")
+    (xdoc::li
+     "The @('_Bool') type [C17:6.2.5/2].")
+    (xdoc::li
+     "A family of structure types [C17:6.2.5/20].
+      Structure types are characterized by an optional tag.
+      This is an approximation,
+      because there may be different structure types of a given tag,
+      or different tagless structure types.")
+    (xdoc::li
+     "A collective type for all union types [C17:6.2.5/20].
+      This is an approximation,
+      because there are different union types.")
+    (xdoc::li
+     "A collective type for all enumeration types [C17:6.2.5/20].
+      This is an approximation,
+      because there are different enumeration types.")
+    (xdoc::li
+     "A collective type for all array types [C17:6.2.5/20].
+      This is an approximation,
+      because there are different array types.")
+    (xdoc::li
+     "A pointer type [C17:6.2.5/20].
+      derived from the so-called ``referenced type.''")
+    (xdoc::li
+     "A collective type for all function types [C17:6.2.5/20].
+      This is an approximation,
+      because there are different function types.")
+    (xdoc::li
+     "An ``unknown'' type that we need due to our current approximation.
+      Our validator must not reject valid code.
+      But due to our approximate treatment of types,
+      we cannot always calculate a type,
+      e.g. for a member expression of the form @('s.m')
+      where @('s') is an expression with structure type.
+      Since our approximate type for all structure types
+      has no information about the members,
+      we cannot calculate any actual type for @('s.m');
+      but if the expression is used elsewhere,
+      we need to accept it, because it could have the right type.
+      We use this unknown type for this purpose:
+      the expression @('s.m') has unknown type,
+      and unknown types are always acceptable."))
+   (xdoc::p
+    "Besides the approximations noted above,
+     currently we do not capture atomic types [C17:6.2.5/20],
+     which we approximate as the underlying (argument) type.
+     We also do not capture @('typedef') names,
+     which are instead expanded to their normal form.
+     Furthermore, we do not capture qualified types [C17:6.2.5/26]."))
+  (:void ())
+  (:char ())
+  (:schar ())
+  (:uchar ())
+  (:sshort ())
+  (:ushort ())
+  (:sint ())
+  (:uint ())
+  (:slong ())
+  (:ulong ())
+  (:sllong ())
+  (:ullong ())
+  (:float ())
+  (:double ())
+  (:ldouble ())
+  (:floatc ())
+  (:doublec ())
+  (:ldoublec ())
+  (:bool ())
+  (:struct ((tag? ident-optionp)))
+  (:union ())
+  (:enum ())
+  (:array ())
+  (:pointer ((to type)))
+  (:function ())
+  (:unknown ())
+  :pred typep
+  :prepwork ((set-induction-depth-limit 1)))
 
 ;;;;;;;;;;;;;;;;;;;;
 
@@ -943,10 +943,10 @@
   (xdoc::topstring
    (xdoc::p
     "In our current approximate type system, the composite type is
-     the type of @('x') if the type of @('y') is unknown,
-     the type of @('y') if the type of @('x') is unknown,
-     and either type if neither are derived types.
-     For derived types, this is applied recursively on parameter types."))
+     @('x') if @('y') is unknown,
+     @('y') if @('x') is unknown,
+     and an arbitrary choice between the two if neither are derived types.
+     For derived types, this is applied recursively."))
   (type-case
     x
     :pointer (type-case

--- a/books/kestrel/c/syntax/validator.lisp
+++ b/books/kestrel/c/syntax/validator.lisp
@@ -1454,8 +1454,9 @@
      to be used as an operand while the other operand has pointer type.
      But we found it accepted by practical compilers,
      so it is probably a GCC extension.
-     We therefore accept this when the GCC flag of the
-     @(see implementation-environment) is enabled.
+     We therefore accept this when the GCC flag of the "
+    (xdoc::seetopic "implementation-environments" "implementation-environment")
+     " is enabled.
      Since we do not have code yet to recognize null pointer constants,
      we accept any integer expression;
      that is, we allow one pointer operand and one integer operand.")
@@ -2268,7 +2269,8 @@
   (if (endp pointers)
       (type-fix type)
     (make-type-pointer :to (make-pointers-to (rest pointers) type)))
-  :verify-guards :after-returns)
+  :verify-guards :after-returns
+  :hooks (:fix))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/c/syntax/validator.lisp
+++ b/books/kestrel/c/syntax/validator.lisp
@@ -1136,9 +1136,10 @@
      one sub-expression must have pointer type,
      and the other sub-expression must have integer type
      [C17:6.5.2.1/1].
-     The expression should have the type referenced by the pointer type,
-     but since for now we model just one pointer type,
-     the type of the expression is unknown.")
+     The expression has the type referenced by the pointer type.
+     However, since we currently model just one array type,
+     all array types are converted to pointers to the unknown type
+     and the type of the expression is therefore unknown.")
    (xdoc::p
     "There is no need to perform function-to-pointer conversion,
      because that would result in a pointer to function,
@@ -1151,22 +1152,24 @@
         (retok (type-unknown)))
        (type1 (type-apconvert type-arg1))
        (type2 (type-apconvert type-arg2))
-       ((unless (or (and (type-case type1 :pointer)
-                         (type-integerp type2))
-                    (and (type-integerp type1)
-                         (type-case type2 :pointer))))
+       ((when (and (type-case type1 :pointer)
+                   (type-integerp type2)))
+        (retok (type-pointer->to type1)))
+       ((unless (and (type-integerp type1)
+                     (type-case type2 :pointer)))
         (retmsg$ "In the array subscripting expression ~x0, ~
                   the first sub-expression has type ~x1, ~
                   and the second sub-expression has type ~x2."
                  (expr-fix expr)
                  (type-fix type-arg1)
                  (type-fix type-arg2))))
-    (retok (type-unknown)))
+    (retok (type-pointer->to type2)))
   :hooks (:fix))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define valid-funcall ((expr exprp) (type-fun typep) (types-arg type-listp))
+  (declare (ignore types-arg))
   :guard (expr-case expr :funcall)
   :returns (mv (erp maybe-msgp) (type typep))
   :short "Validate a function call expression,
@@ -1176,11 +1179,10 @@
    (xdoc::p
     "After converting function types to pointer types,
      the first sub-expression must have pointer type [C17:6.5.2.2/1];
-     since we currently have just one pointer type,
-     we cannot check that it is a pointer to a function.
-     For the same reason,
+     Furthermore, it must be a pointer to a function type.
+     Since we currently have just one function type,
      we do not check the argument types against the function type [C17:6.5.2.2/2].
-     Also for the same reason,
+     For the same reason,
      we return the unknown type,
      because we do not have information about the result type.")
    (xdoc::p
@@ -1189,11 +1191,12 @@
      but only (complete) object element types [C17:6.2.5/20].
      Thus, the conversion could never result into a pointer to a function."))
   (b* (((reterr) (irr-type))
-       ((when (or (type-case type-fun :unknown)
-                  (member-equal (type-unknown) (type-list-fix types-arg))))
+       ((when (type-case type-fun :unknown))
         (retok (type-unknown)))
        (type (type-fpconvert type-fun))
-       ((unless (type-case type :pointer))
+       ((unless (and (type-case type :pointer)
+                     (or (type-case (type-pointer->to type) :unknown)
+                         (type-case (type-pointer->to type) :function))))
         (retmsg$ "In the function call expression ~x0, ~
                   the first sub-expression has type ~x1."
                  (expr-fix expr)
@@ -1243,9 +1246,11 @@
    (xdoc::p
     "The argument type must be a pointer to a structure or union type
      [C17:6.5.2.3/2].
-     We need to convert arrays to pointers,
-     and then we just check that we have the (one) pointer type;
-     we will refine this when we refine our type system.
+     We perform array-to-pointer conversion,
+     then check that the type is a pointer to a struct type.
+     As we refine our type system,
+     we will eventually check that the struct type
+     has a member of the name being accessed.
      We do not conver functions to pointers,
      because that would result into a pointer to function,
      which is not a pointer to structure or union as required;
@@ -1257,7 +1262,9 @@
        ((when (type-case type-arg :unknown))
         (retok (type-unknown)))
        (type (type-apconvert type-arg))
-       ((unless (type-case type :pointer))
+       ((unless (and (type-case type :pointer)
+                     (or (type-case (type-pointer->to type) :unknown)
+                         (type-case (type-pointer->to type) :struct))))
         (retmsg$ "In the member pointer expression ~x0, ~
                   the sub-expression has type ~x1."
                  (expr-fix expr) (type-fix type-arg))))
@@ -1277,14 +1284,14 @@
     "The @('&') operator requires an lvalue of any type as operand
      [C17:6.5.3.2/1] [C17:6.5.3.2/3],
      but we are not yet distinguishing lvalues from non-lvalues,
-     so we allow any type of operand, and we return the (one) pointer type.")
+     so we allow any type of operand,
+     and we return the pointer type derived from the operand type.")
    (xdoc::p
     "The @('*') unary operator requires an operand of a pointer type
      [C17:6.5.3.2/2],
      after array-to-pointer and function-to-pointer conversions;
      as always, we also need to allow the unknown type.
-     Since we only have one type for pointers for now,
-     the resulting type is unknown.")
+     The result is the referenced type.")
    (xdoc::p
     "The @('+') and @('-') unary operators
      require an operand of an arithmetic type [C17:6.5.3.3/1],
@@ -1328,29 +1335,38 @@
      We do not perform array-to-pointer or function-to-pointer conversions,
      because those result in pointers, not lvalues as required [C17:6.5.2.4/1]."))
   (b* (((reterr) (irr-type))
-       ((when (type-case type-arg :unknown))
-        (retok (type-unknown)))
        (msg (msg$ "In the unary expression ~x0, ~
                    the sub-expression has type ~x1."
                  (expr-fix expr) (type-fix type-arg))))
     (case (unop-kind op)
-      (:address (retok (type-pointer)))
-      (:indir (b* ((type (type-fpconvert (type-apconvert type-arg)))
-                   ((unless (type-case type :pointer))
-                    (reterr msg)))
-                (retok (type-unknown))))
-      ((:plus :minus) (b* (((unless (type-arithmeticp type-arg))
+      (:address (retok (make-type-pointer :to type-arg)))
+      (:indir (b* (((when (type-case type-arg :unknown))
+                    (retok (type-unknown)))
+                   (type (type-fpconvert (type-apconvert type-arg))))
+                (type-case
+                  type
+                  :pointer (retok type.to)
+                  :otherwise (reterr msg))))
+      ((:plus :minus) (b* (((when (type-case type-arg :unknown))
+                            (retok (type-unknown)))
+                           ((unless (type-arithmeticp type-arg))
                             (reterr msg)))
                         (retok (type-promote type-arg ienv))))
-      (:bitnot (b* (((unless (type-integerp type-arg))
+      (:bitnot (b* (((when (type-case type-arg :unknown))
+                     (retok (type-unknown)))
+                    ((unless (type-integerp type-arg))
                      (reterr msg)))
                  (retok (type-promote type-arg ienv))))
-      (:lognot (b* ((type (type-fpconvert (type-apconvert type-arg)))
+      (:lognot (b* (((when (type-case type-arg :unknown))
+                     (retok (type-unknown)))
+                    (type (type-fpconvert (type-apconvert type-arg)))
                     ((unless (type-scalarp type))
                      (reterr msg)))
                  (retok (type-sint))))
       ((:preinc :predec :postinc :postdec)
-       (b* (((unless (or (type-realp type-arg)
+       (b* (((when (type-case type-arg :unknown))
+             (retok (type-unknown)))
+            ((unless (or (type-realp type-arg)
                          (type-case type-arg :pointer)))
              (reterr msg)))
          (retok (type-fix type-arg))))
@@ -1391,7 +1407,8 @@
      [C17:6.5.6/2].
      In the first case, the result is from the usual arithmetic conversions
      [C17:6.5.6/4].
-     In the second case, the result is the pointer type [C17:6.5.6/8].
+     In the second case,
+     the result is the type of the pointer operand [C17:6.5.6/8].
      Because of that second case, which involves pointers,
      we perform array-to-pointer conversion.
      We do not perform function-to-pointer conversion,
@@ -1408,7 +1425,8 @@
      In the second case, the result has type @('ptrdiff_t') [C17:6.5.6/9],
      which has an implementation-specific definition,
      and so we return the unknown type in this case.
-     In the third case, the result has the pointer type [C17:6.5.6/8].
+     In the third case,
+     the result has the type of the pointer operand [C17:6.5.6/8].
      Because of the second and third cases, which involve pointers,
      we perform array-to-pointer conversion.
      We do not perform function-to-pointer conversion,
@@ -1429,24 +1447,24 @@
      We do not perform function-to-pointer conversion,
      because that would result in a pointer to function,
      while a pointer to object type is required.
+     When the converted types are pointer types,
+     we check that they point to compatible object types.
      The standard does not allow
-     a null pointer constants [C17:6.3.2.3/3] without the @('void *') cast
+     a null pointer constant [C17:6.3.2.3/3] without the @('void *') cast
      to be used as an operand while the other operand has pointer type.
      But we found it accepted by practical compilers,
-     so it is probably a GCC extensions,
-     and for this reason we accept it for now;
-     we should extend our implementation environments with
-     information about whether GCC extensions are allowed,
-     and condition acceptance under that flag.
+     so it is probably a GCC extension.
+     We therefore accept this when the GCC flag of the
+     @(see implementation-environment) is enabled.
      Since we do not have code yet to recognize null pointer constants,
      we accept any integer expression;
      that is, we allow one pointer operand and one integer operand.")
    (xdoc::p
     "The @('==') and @('!=') operators require
      arithmetic types or pointer types [C17:6.5.9/2];
-     Distinctions betwen qualified and unqualified pointer types,
-     as well as @('void') or non-@('void') pointers types are ignored
-     since we currently approximate all of these as a single pointer type.
+     When the converted types are pointer types,
+     we check that they point to compatible object types,
+     or that one of them points to @('void').
      Since we do not yet implement evaluation of constant expressions,
      all integer expressions are considered potential null pointer constants:
      so we allow an operand to be a pointer and the other to be an integer,
@@ -1472,7 +1490,8 @@
      an lvalue as left operand [C17:6.5.16/2],
      but currently we do not check that.
      In our currently approximate type system,
-     the requirements in [C17:6.5.16.1/1] reduce to the following four cases.")
+     the requirements in [C17:6.5.16.1/1] reduce
+     to the following simplified cases.")
    (xdoc::ol
     (xdoc::li
      "Both operands have arithmetic types.")
@@ -1480,9 +1499,14 @@
      "The left operand has a structure or union type, and the two operand types
       are compatible.")
     (xdoc::li
-     "The left operand has the pointer type and the right operand is either a
-      pointer or a null pointer constant (approximated as anything of an
-      integer type).")
+     "Both operands have compatible pointer types.")
+    (xdoc::li
+     "One operand is a pointer to an object type
+      and the other is a pointer to the @('void') type.")
+    (xdoc::li
+     "The left operand is a pointer type
+      and the right operand is a null pointer constant
+      (approximated as anything of an integer type).")
     (xdoc::li
      "The left operand has the boolean type and the right operand has the
       pointer type."))
@@ -1534,11 +1558,12 @@
                ((and (type-arithmeticp type1)
                      (type-arithmeticp type2))
                 (retok (type-uaconvert type1 type2 ienv)))
-               ((or (and (type-integerp type1)
-                         (type-case type2 :pointer))
-                    (and (type-case type1 :pointer)
-                         (type-integerp type2)))
-                (retok (type-pointer)))
+               ((and (type-integerp type1)
+                     (type-case type2 :pointer))
+                (retok type2))
+               ((and (type-case type1 :pointer)
+                     (type-integerp type2))
+                (retok type1))
                (t (reterr msg)))))
       (:sub (b* ((type1 (type-apconvert type-arg1))
                  (type2 (type-apconvert type-arg2)))
@@ -1548,7 +1573,7 @@
                 (retok (type-uaconvert type1 type2 ienv)))
                ((and (type-case type1 :pointer)
                      (type-integerp type2))
-                (retok (type-pointer)))
+                (retok type1))
                ((and (type-case type1 :pointer)
                      (type-case type2 :pointer))
                 (retok (type-unknown)))
@@ -1563,23 +1588,36 @@
             ((unless (or (and (type-realp type1)
                               (type-realp type2))
                          (if (type-case type1 :pointer)
-                             (or (type-case type2 :pointer)
+                             (and (type-case type2 :pointer)
+                                  (let ((type-to1 (type-pointer->to type1))
+                                        (type-to2 (type-pointer->to type2)))
+                                    (and (not (type-case type-to1 :function))
+                                         (not (type-case type-to2 :function))
+                                         (type-compatiblep type-to1 type-to2))))
+                           (and (ienv->gcc ienv)
+                                (expr-null-pointer-constp (expr-binary->arg1 expr) type1)
+                                (type-case type2 :pointer)))))
+             (reterr msg)))
+         (retok (type-sint))))
+      ((:eq :ne)
+       (b* ((type1 (type-fpconvert (type-apconvert type-arg1)))
+            (type2 (type-fpconvert (type-apconvert type-arg2)))
+            ((unless (or (and (type-arithmeticp type1)
+                              (type-arithmeticp type2))
+                         (if (type-case type1 :pointer)
+                             (or (type-compatiblep type1 type2)
+                                 (and (type-case type2 :pointer)
+                                      (let ((type-to1 (type-pointer->to type1))
+                                            (type-to2 (type-pointer->to type2)))
+                                        (or (and (type-case type-to1 :void)
+                                                 (not (type-case type-to2 :function)))
+                                            (and (type-case type-to2 :void)
+                                                 (not (type-case type-to1 :function))))))
                                  (expr-null-pointer-constp (expr-binary->arg2 expr) type2))
                            (and (expr-null-pointer-constp (expr-binary->arg1 expr) type1)
                                 (type-case type2 :pointer)))))
              (reterr msg)))
          (retok (type-sint))))
-      ((:eq :ne) (b* ((type1 (type-fpconvert (type-apconvert type-arg1)))
-                      (type2 (type-fpconvert (type-apconvert type-arg2)))
-                      ((unless (or (and (type-arithmeticp type1)
-                                        (type-arithmeticp type2))
-                                   (if (type-case type1 :pointer)
-                                       (or (type-case type2 :pointer)
-                                           (expr-null-pointer-constp (expr-binary->arg2 expr) type2))
-                                     (and (expr-null-pointer-constp (expr-binary->arg1 expr) type1)
-                                          (type-case type2 :pointer)))))
-                       (reterr msg)))
-                   (retok (type-sint))))
       ((:bitand :bitxor :bitior)
        (b* (((unless (and (type-integerp type-arg1)
                           (type-integerp type-arg2)))
@@ -1592,20 +1630,28 @@
                           (type-scalarp type2)))
              (reterr msg)))
          (retok (type-sint))))
-      (:asg (b* ((type1 type-arg1)
-                 (type2 (type-fpconvert (type-apconvert type-arg2)))
-                 ((unless (or (and (type-arithmeticp type1)
-                                   (type-arithmeticp type2))
-                              (and (or (type-case type1 :struct)
-                                       (type-case type1 :union))
-                                   (type-compatiblep type1 type2))
-                              (and (type-case type1 :pointer)
-                                   (or (type-case type2 :pointer)
-                                       (expr-null-pointer-constp (expr-binary->arg2 expr) type2)))
-                              (and (type-case type1 :bool)
-                                   (type-case type2 :pointer))))
-                  (reterr msg)))
-              (retok (type-fix type-arg1))))
+      (:asg
+       (b* ((type1 type-arg1)
+            (type2 (type-fpconvert (type-apconvert type-arg2)))
+            ((unless (or (and (type-arithmeticp type1)
+                              (type-arithmeticp type2))
+                         (and (or (type-case type1 :struct)
+                                  (type-case type1 :union))
+                              (type-compatiblep type1 type2))
+                         (and (type-case type1 :pointer)
+                              (or (and (type-case type2 :pointer)
+                                       (let ((type-to1 (type-pointer->to type1))
+                                             (type-to2 (type-pointer->to type2)))
+                                         (or (type-compatiblep type-to1 type-to2)
+                                             (and (type-case type-to1 :void)
+                                                  (not (type-case type-to2 :function)))
+                                             (and (type-case type-to2 :void)
+                                                  (not (type-case type-to1 :function))))))
+                                  (expr-null-pointer-constp (expr-binary->arg2 expr) type2)))
+                         (and (type-case type1 :bool)
+                              (type-case type2 :pointer))))
+             (reterr msg)))
+         (retok (type-fix type-arg1))))
       ((:asg-mul :asg-div)
        (b* (((unless (and (type-arithmeticp type-arg1)
                           (type-arithmeticp type-arg2)))
@@ -1723,8 +1769,9 @@
      or both the same structure type,
      or both the union type,
      or both the void type,
-     or both the pointer type,
-     or one pointer type and the other operand a null pointer constant
+     or compatible pointer types,
+     or one pointer type and the other operand a null pointer constant,
+     or one pointer to an object type and one pointer to @('void')
      [C17:6.5.15/3].
      Currently, null pointer constants [C17:6.3.2.3/3] are approximated as any
      expression with an integer type.
@@ -1760,14 +1807,25 @@
        ((when (and (type-case type2 :union)
                    (type-case type3 :union)))
         (retok (type-union)))
-       ((when (if (type-case type2 :pointer)
-                  (or (type-case type3 :pointer)
-                      (expr-null-pointer-constp (expr-cond->else expr) type3))
-                (and (if (expr-cond->then expr)
-                         (expr-null-pointer-constp (expr-cond->then expr) type2)
-                       (expr-null-pointer-constp (expr-cond->test expr) type2))
-                     (type-case type3 :pointer))))
-        (retok (type-pointer))))
+       ((when (and (type-case type2 :pointer)
+                   (type-compatiblep type2 type3)))
+        (retok (type-composite type2 type3)))
+       ((when (and (type-case type2 :pointer)
+                   (expr-null-pointer-constp (expr-cond->else expr) type3)))
+        (retok (type-fix type2)))
+       ((when (and (type-case type3 :pointer)
+                   (expr-cond->then expr)
+                   (expr-null-pointer-constp (expr-cond->then expr) type2)))
+        (retok (type-fix type3)))
+       ((when (and (type-case type2 :pointer)
+                   (type-case type3 :pointer)
+                   (let ((type-to2 (type-pointer->to type2))
+                         (type-to3 (type-pointer->to type3)))
+                     (or (and (type-case type-to2 :void)
+                              (not (type-case type-to3 :function)))
+                         (and (type-case type-to3 :void)
+                              (not (type-case type-to2 :function)))))))
+        (retok (make-type-pointer :to (type-void)))))
     (retmsg$ "In the conditional expression ~x0, ~
               the second operand has type ~x1 ~
               and the third operand has type ~x2."
@@ -2191,6 +2249,28 @@
                  (endp storspecs)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define make-pointers-to ((pointers typequal/attribspec-list-listp)
+                          (type typep))
+  :returns (new-type typep)
+  :short "Derive a pointer type for each type qualifier and attribute specifier
+          list."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This takes the list of lists of type qualifiers and attribute specifiers
+     from a declarator or abstract declarator,
+     and creates the corresponding (possibly pointer) type.")
+   (xdoc::p
+    "Since our approximate type system does not incorporate type qualifiers,
+     each cons of the @('pointers') list
+     is used only to derive a pointer from the type."))
+  (if (endp pointers)
+      (type-fix type)
+    (make-type-pointer :to (make-pointers-to (rest pointers) type)))
+  :verify-guards :after-returns)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defines valid-exprs/decls/stmts
   :short "Validate expressions, declarations, statements,
@@ -3474,7 +3554,14 @@
                                (or (type-case type :pointer)
                                    (type-case type :unknown)))
                           (and (type-case target-type :pointer)
-                               (or (type-case type :pointer)
+                               (or (and (type-case type :pointer)
+                                        (let ((target-type-to (type-pointer->to target-type))
+                                              (type-to (type-pointer->to type)))
+                                          (or (type-compatiblep target-type-to type-to)
+                                              (and (type-case target-type-to :void)
+                                                   (not (type-case type-to :function)))
+                                              (and (type-case type-to :void)
+                                                   (not (type-case target-type-to :function))))))
                                    (type-case type :unknown)
                                    (expr-null-pointer-constp expr type)))))
               (retmsg$ "The initializer ~x0 for the target type ~x1 ~
@@ -3813,7 +3900,7 @@
       "In our currently approximate type system,
        we do not validate type qualifiers, or attributes.
        So the only role of the @('pointers') component of @(tsee declor)
-       is to refine the type passed as input into the pointer type
+       is to refine the type passed as input into the derived pointer type
        [C17:6.7.6.1/1].
        This resulting type is then passed to
        the function to validate the direct declarator that follows.")
@@ -3826,9 +3913,7 @@
        and we have not validated the parameters yet."))
     (b* (((reterr) (irr-declor) nil (irr-type) (irr-ident) nil (irr-valid-table))
          ((declor declor) declor)
-         (type (if (consp declor.pointers)
-                   (type-pointer)
-                 type))
+         (type (make-pointers-to declor.pointers type))
          ((erp new-dirdeclor fundef-params-p type ident types table)
           (valid-dirdeclor declor.direct fundef-params-p type table ienv)))
       (retok (make-declor :pointers declor.pointers :direct new-dirdeclor)
@@ -4184,9 +4269,7 @@
        not an abstract declarator."))
     (b* (((reterr) (irr-absdeclor) (irr-type) nil (irr-valid-table))
          ((absdeclor absdeclor) absdeclor)
-         (type (if (consp absdeclor.pointers)
-                   (type-pointer)
-                 type))
+         (type (make-pointers-to absdeclor.pointers type))
          ((erp new-direct? type types table)
           (valid-dirabsdeclor-option absdeclor.direct? type table ienv)))
       (retok (make-absdeclor :pointers absdeclor.pointers :direct? new-direct?)
@@ -4440,10 +4523,10 @@
                     is for a function definition but has no identifier."
                    (param-declon-fix paramdecl)))
          (type (if (type-case type :array)
-                   (type-pointer)
+                   (make-type-pointer :to (type-unknown))
                  type))
          (type (if (type-case type :function)
-                   (type-pointer)
+                   (make-type-pointer :to type)
                  type))
          ((when (not ident?))
           (retok (make-param-declon :specs new-specs :declor new-decl)

--- a/books/kestrel/c/syntax/validator.lisp
+++ b/books/kestrel/c/syntax/validator.lisp
@@ -2251,29 +2251,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define make-pointers-to ((pointers typequal/attribspec-list-listp)
-                          (type typep))
-  :returns (new-type typep)
-  :short "Derive a pointer type for each type qualifier and attribute specifier
-          list."
-  :long
-  (xdoc::topstring
-   (xdoc::p
-    "This takes the list of lists of type qualifiers and attribute specifiers
-     from a declarator or abstract declarator,
-     and creates the corresponding (possibly pointer) type.")
-   (xdoc::p
-    "Since our approximate type system does not incorporate type qualifiers,
-     each cons of the @('pointers') list
-     is used only to derive a pointer from the type."))
-  (if (endp pointers)
-      (type-fix type)
-    (make-type-pointer :to (make-pointers-to (rest pointers) type)))
-  :verify-guards :after-returns
-  :hooks (:fix))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (defines valid-exprs/decls/stmts
   :short "Validate expressions, declarations, statements,
           and related artifacts."


### PR DESCRIPTION
Many theorems of the name `<function>-when-type-kind-syntaxp` are added to `types.lisp`. These are added to functions which are decided solely by the `type-kind` value of the argument. These theorems just expand the function definition when there is a hypothesis `(equal (type-kind type) kind)` where `kind` is a constant.

I introduce `type-composite` to explicitly construct composite types. Currently, this function is not doing very much interesting, just biasing the "merging" toward more specific (i.e. non-unknown) types. The interesting behavior for composite types has to do with array size and function parameter type lists [C17:6.2.7/3], which we are not modelling in the approximate type system.