### PR TITLE
[system] Localize in-theory event

### DIFF
--- a/books/system/extend-pathname.lisp
+++ b/books/system/extend-pathname.lisp
@@ -109,9 +109,6 @@
 
 (verify-termination expand-tilde-to-user-home-dir)
 
-(verify-termination project-dir-lookup) ; and guards
-
 (verify-termination extend-pathname+) ; not guards
 
 (verify-termination extend-pathname) ; not guards
-

--- a/books/system/extend-pathname.lisp
+++ b/books/system/extend-pathname.lisp
@@ -66,7 +66,7 @@
                                   (acl2::x x)
                                   (acl2::y 'string)))))))
 
-(in-theory (disable coerce-inverse-1))
+(local (in-theory (disable coerce-inverse-1)))
 
 (local (defthm len-revappend
          (equal (len (revappend x y))


### PR DESCRIPTION
This localizes an `in-theory` event in `books/system/extend-pathname.lisp` (this books just brings `extend-pathname` into logic mode). Now, the book can be included without affecting the theory.

This also removes a call of `verify-termination` on a function which is already logic mode and guard verified.