### PR TITLE
[interface] Make elisp function argument optional

### DIFF
--- a/books/interface/emacs/acl2-indent.el
+++ b/books/interface/emacs/acl2-indent.el
@@ -412,7 +412,7 @@ by more than one line to cross a string literal."
   (indent-region-line-by-line (region-beginning) (region-end)))
 
 ;; Simpler than version from lisp-mode.el and more consistent with TAB
-(defun indent-sexp (arg)
+(defun indent-sexp (&optional arg)
   (interactive "P")
   (mark-sexp arg)
   (indent-region (point) (mark)))


### PR DESCRIPTION
This addresses an issue observed when attempting to do `M-x customize-variable`. This seemed to be calling indent-sexp with zero arguments, while it is defined in `acl2-indent.el` with 1 argument. Making the argument optional fixes the issue.