### PR TITLE
[C$] Allow omap for preprocessor arguments

### DIFF
--- a/books/kestrel/c/syntax/input-files-doc.lisp
+++ b/books/kestrel/c/syntax/input-files-doc.lisp
@@ -124,8 +124,8 @@
      (xdoc::p
       "Specifies arguments to pass to the preprocessor.")
      (xdoc::p
-      "This must be either absent or a list of zero or more strings,
-       each of which is an argument to pass, e.g. @('-I').")
+      "If this is not absent, it must evaluate to a list of strings
+       or to an omap from strings to lists of strings.")
      (xdoc::p
       "If @(':preprocess') is @('nil'),
        the @(':preprocess-args') input must be absent.")
@@ -137,8 +137,22 @@
      (xdoc::p
       "If @(':preprocess') is not @('nil'),
        and @(':preprocess-args') input is present,
-       the argument @('-E') is passed to the preprocessor,
-       followed by the arguments in the list, in that order.")
+       the behavior depends on whether
+       it evaluates to a string list or to an omap.
+       For each file, the argument @('-E') is passed to the preprocessor.
+       If @(':preprocess-args') is a string list,
+       this list of arguments is also passed to the preprocessor,
+       following the @('-E') argument.
+       If @(':preprocess-args') is an omap,
+       then we provide the list of arguments associated with the file name
+       (again, after the @('-E') argument).
+       If the file name is not in the key set,
+       only the @('-E') argument is provided.
+       If @(':preprocess-args') is @('nil'),
+       it is technically both a string list and
+       an omap from strings to string lists.
+       The behavior is the same under either interpretation:
+       only the argument @('-E') is provided for each file.")
      (xdoc::p
       "See the preprocessor documentation for information about
        the arguments mentioned above."))

--- a/books/kestrel/c/syntax/input-files-doc.lisp
+++ b/books/kestrel/c/syntax/input-files-doc.lisp
@@ -74,14 +74,13 @@
     (xdoc::desc
      "@(':files')"
      (xdoc::p
-      "List of one or more file paths that specify the files to be read.")
+      "Term evaluating to a list of one or more file paths
+       that specify the files to be read.")
      (xdoc::p
       "Each file path must be a string.")
      (xdoc::p
       "These paths are relative to
-       the path specified by the @(':path') input.")
-     (xdoc::p
-      "This input to this macro is not evaluated."))
+       the path specified by the @(':path') input."))
 
     (xdoc::desc
      "@(':path') &mdash; default @('\".\"')"

--- a/books/kestrel/c/syntax/input-files.lisp
+++ b/books/kestrel/c/syntax/input-files.lisp
@@ -103,7 +103,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define input-files-process-files ((options symbol-alistp))
+(define input-files-process-files ((options symbol-alistp) state)
   :returns (mv erp (files string-listp))
   :short "Process the @(':files') input."
   (b* (((reterr) nil)
@@ -112,8 +112,17 @@
         (reterr (msg "The :FILES input must be supplied, ~
                       but it was not supplied.")))
        (files (cdr files-option))
+       ((unless (pseudo-termp files))
+        (reterr (msg "The :FILES input must be a term, ~
+                      but it is ~x0 instead."
+                     files)))
+       ((mv erp files/msg)
+        (acl2::magic-ev files nil state nil t))
+       ((when erp)
+        (reterr files/msg))
+       (files files/msg)
        ((unless (string-listp files))
-        (reterr (msg "The :FILES input must be a list of strings, ~
+        (reterr (msg "The :FILES input must evaluate to a list of strings, ~
                       but it is ~x0 instead."
                      files)))
        ((unless (no-duplicatesp-equal files))
@@ -441,7 +450,7 @@
                      *input-files-allowed-options*
                      extra)))
        ;; Process the inputs.
-       ((erp files) (input-files-process-files options))
+       ((erp files) (input-files-process-files options state))
        ((erp path) (input-files-process-path options))
        ((erp preprocessor) (input-files-process-preprocess options))
        ((erp preprocess-args-presentp preprocess-extra-args)

--- a/books/kestrel/c/syntax/tests/input-files.lisp
+++ b/books/kestrel/c/syntax/tests/input-files.lisp
@@ -25,7 +25,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c")
+(input-files :files '("simple.c")
              :process :parse
              :const *parsed-simple*)
 
@@ -41,7 +41,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c" "stdbool.c")
+(input-files :files '("simple.c" "stdbool.c")
              ;; We exclude stdint.c because it has occurrences of #define
              ;; (not at the left margin) even after preprocessing.
              :preprocess :auto
@@ -61,7 +61,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c" "stdbool.c")
+(input-files :files '("simple.c" "stdbool.c")
              :preprocess :auto
              :process :parse
              :preprocess-args '("-E" "-std=c17")
@@ -88,7 +88,7 @@
                               (list "-std=c17" "-P")
                               nil)))
 
-(input-files :files ("simple.c" "stdbool.c")
+(input-files :files '("simple.c" "stdbool.c")
              :preprocess :auto
              :process :parse
              :preprocess-args *preprocess-args-simple/stdbool*
@@ -108,7 +108,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c")
+(input-files :files '("simple.c")
              :process :disambiguate
              :const *disamb-simple*)
 
@@ -120,7 +120,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c" "stdbool.c")
+(input-files :files '("simple.c" "stdbool.c")
              ;; We exclude stdint.c because it has occurrences of #define
              ;; (not at the left margin) even after preprocessing.
              :preprocess :auto
@@ -135,7 +135,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c")
+(input-files :files '("simple.c")
              :process :validate
              :const *valid-simple*)
 
@@ -147,7 +147,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(input-files :files ("simple.c" "stdbool.c")
+(input-files :files '("simple.c" "stdbool.c")
              ;; We exclude stdint.c because it has occurrences of #define
              ;; (not at the left margin) even after preprocessing.
              :preprocess :auto
@@ -163,12 +163,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (must-fail
-  (input-files :files ("failparse.c")
+  (input-files :files '("failparse.c")
                :const *failparse*))
 
 ;; Ensures the error is in parsing, not a later step
 (must-fail
-  (input-files :files ("failparse.c")
+  (input-files :files '("failparse.c")
                :process :parse
                :const *failparse*))
 
@@ -179,18 +179,18 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (must-fail
-  (input-files :files ("faildimb.c")
+  (input-files :files '("faildimb.c")
                :const *faildimb*))
 
 ;; Ensures no error if we only parse, not disambiguate
-(input-files :files ("faildimb.c")
+(input-files :files '("faildimb.c")
              :process :parse
              :const *faildimb-parse-only*)
 
 ;; Ensures the error is not in validation (together with the above test, this
 ;; ensures the error is in disambiguation)
 (must-fail
-  (input-files :files ("faildimb.c")
+  (input-files :files '("faildimb.c")
                :process :disambiguate
                :const *faildimb*))
 
@@ -201,12 +201,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (must-fail
-  (input-files :files ("failvalidate.c")
+  (input-files :files '("failvalidate.c")
                :process :validate ; the default
                :const *failvalidate*))
 
 ;; Ensures no error if we only parse+disambiguate, not validate, so the error
 ;; must be in validation
-(input-files :files ("failvalidate.c")
+(input-files :files '("failvalidate.c")
              :process :disambiguate
              :const *failvalidate-parse-and-dimb-only*)

--- a/books/kestrel/c/syntax/tests/input-files.lisp
+++ b/books/kestrel/c/syntax/tests/input-files.lisp
@@ -57,6 +57,53 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; Preprocess with arguments and parse.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(input-files :files ("simple.c" "stdbool.c")
+             :preprocess :auto
+             :process :parse
+             :preprocess-args '("-E" "-std=c17")
+             :const *parsed-with-args-simple/stdbool*)
+
+(acl2::assert! (code-ensemblep *parsed-with-args-simple/stdbool*))
+
+(acl2::assert-equal
+ (transunit-ensemble-paths
+   (code-ensemble->transunits *parsed-with-args-simple/stdbool*))
+ (set::mergesort (list (filepath "simple.c")
+                       (filepath "stdbool.c"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Preprocess with omap arguments and parse.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defconst *preprocess-args-simple/stdbool*
+  (omap::update "simple.c"
+                (list "-P" "-std=c17")
+                (omap::update "stdbool.c"
+                              (list "-std=c17" "-P")
+                              nil)))
+
+(input-files :files ("simple.c" "stdbool.c")
+             :preprocess :auto
+             :process :parse
+             :preprocess-args *preprocess-args-simple/stdbool*
+             :const *parsed-with-omap-args-simple/stdbool*)
+
+(acl2::assert! (code-ensemblep *parsed-with-omap-args-simple/stdbool*))
+
+(acl2::assert-equal
+ (transunit-ensemble-paths
+   (code-ensemble->transunits *parsed-with-omap-args-simple/stdbool*))
+ (set::mergesort (list (filepath "simple.c")
+                       (filepath "stdbool.c"))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ; Parse and disambiguate.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/c/transformation/tests/call-graph/call-graph.lisp
+++ b/books/kestrel/c/transformation/tests/call-graph/call-graph.lisp
@@ -23,7 +23,7 @@
 (acl2::must-succeed*
   (c$::input-files
     :const *test*
-    :files ("main.c" "file1.c"))
+    :files '("main.c" "file1.c"))
 
   (defconst *call-graph*
     (call-graph-transunit-ensemble
@@ -73,7 +73,7 @@
 (acl2::must-succeed*
   (c$::input-files
     :const *test*
-    :files ("main2.c" "file1.c"))
+    :files '("main2.c" "file1.c"))
 
   (defconst *call-graph*
     (call-graph-transunit-ensemble

--- a/books/kestrel/c/transformation/tests/constant-propagation/constant-propagation.lisp
+++ b/books/kestrel/c/transformation/tests/constant-propagation/constant-propagation.lisp
@@ -22,7 +22,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (defconst *new*
@@ -46,7 +46,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test2.c")
+  (c$::input-files :files '("test2.c")
                    :process :parse
                    :const *old*)
 
@@ -72,7 +72,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test3.c")
+  (c$::input-files :files '("test3.c")
                    :const *old*)
 
   (defconst *new*

--- a/books/kestrel/c/transformation/tests/copy-fn/copy-fn.lisp
+++ b/books/kestrel/c/transformation/tests/copy-fn/copy-fn.lisp
@@ -21,7 +21,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   ;; TODO: transformation should define the const
@@ -51,7 +51,7 @@ int bar(int y, int z) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("fib.c")
+  (c$::input-files :files '("fib.c")
                    :const *old*)
 
   (defconst *new*
@@ -89,7 +89,7 @@ int fib(int x) {
 ;; should not be renamed.
 
 (acl2::must-succeed*
-  (c$::input-files :files ("generic-selection.c")
+  (c$::input-files :files '("generic-selection.c")
                    :gcc t
                    :const *old*)
 

--- a/books/kestrel/c/transformation/tests/rename/rename.lisp
+++ b/books/kestrel/c/transformation/tests/rename/rename.lisp
@@ -21,7 +21,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   ;; TODO: transformation should define the const

--- a/books/kestrel/c/transformation/tests/simpadd0/asg-int.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/asg-int.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("asg_int.c")
+(c$::input-files :files '("asg_int.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/bin.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/bin.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("bin.c")
+(c$::input-files :files '("bin.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/blocks.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/blocks.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("blocks.c")
+(c$::input-files :files '("blocks.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/cast-int-to-long.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/cast-int-to-long.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("cast_int_to_long.c")
+(c$::input-files :files '("cast_int_to_long.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/cast-long-to-int.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/cast-long-to-int.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("cast_long_to_int.c")
+(c$::input-files :files '("cast_long_to_int.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/constant.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/constant.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("constant.c")
+(c$::input-files :files '("constant.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/decl.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/decl.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("decl.c")
+(c$::input-files :files '("decl.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/file-scope.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/file-scope.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("file_scope.c")
+(c$::input-files :files '("file_scope.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/gg.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/gg.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("gg.c")
+(c$::input-files :files '("gg.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/global.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/global.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("global.c")
+(c$::input-files :files '("global.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/if.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/if.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("if.c")
+(c$::input-files :files '("if.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/ifelse.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/ifelse.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("ifelse.c")
+(c$::input-files :files '("ifelse.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/logand.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/logand.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("logand.c")
+(c$::input-files :files '("logand.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/logor.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/logor.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("logor.c")
+(c$::input-files :files '("logor.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/nonint-const.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/nonint-const.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("nonint_const.c")
+(c$::input-files :files '("nonint_const.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/nonint-param.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/nonint-param.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("nonint_param.c")
+(c$::input-files :files '("nonint_param.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/nonint-return.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/nonint-return.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("nonint_return.c")
+(c$::input-files :files '("nonint_return.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/noninteger.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/noninteger.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("noninteger.c")
+(c$::input-files :files '("noninteger.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/nosimp-int.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/nosimp-int.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("nosimp_int.c")
+(c$::input-files :files '("nosimp_int.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/nosimp-short.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/nosimp-short.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("nosimp_short.c")
+(c$::input-files :files '("nosimp_short.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/nosimp-ulong.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/nosimp-ulong.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("nosimp_ulong.c")
+(c$::input-files :files '("nosimp_ulong.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/paren.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/paren.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("paren.c")
+(c$::input-files :files '("paren.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/return-void.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/return-void.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("return_void.c")
+(c$::input-files :files '("return_void.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/stmt-null.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/stmt-null.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("stmt_null.c")
+(c$::input-files :files '("stmt_null.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/ternary-int.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/ternary-int.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("ternary_int.c")
+(c$::input-files :files '("ternary_int.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/simpadd0/var.lisp
+++ b/books/kestrel/c/transformation/tests/simpadd0/var.lisp
@@ -21,7 +21,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(c$::input-files :files ("var.c")
+(c$::input-files :files '("var.c")
                  :path "old"
                  :const *old-code*)
 

--- a/books/kestrel/c/transformation/tests/specialize/specialize.lisp
+++ b/books/kestrel/c/transformation/tests/specialize/specialize.lisp
@@ -21,7 +21,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (specialize *old*
@@ -50,7 +50,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test2.c")
+  (c$::input-files :files '("test2.c")
                    :const *old*)
 
   (specialize *old*

--- a/books/kestrel/c/transformation/tests/split-all-gso/split-all-gso.lisp
+++ b/books/kestrel/c/transformation/tests/split-all-gso/split-all-gso.lisp
@@ -26,7 +26,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (split-all-gso *old* *new*)
@@ -54,7 +54,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test2.c")
+  (c$::input-files :files '("test2.c")
                    :const *old*)
 
   (split-all-gso *old* *new*)
@@ -86,7 +86,7 @@ int main(void) {
 ;; Test an ensemble
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static-struct1.c"
+  (c$::input-files :files '("static-struct1.c"
                            "static-struct2.c"
                            "extern-struct.c")
                    :const *old*)
@@ -149,7 +149,7 @@ struct S_1 s_1 = {.x = 0};
 ;; Test typedefs
 
 (acl2::must-succeed*
-  (c$::input-files :files ("typedef1.c")
+  (c$::input-files :files '("typedef1.c")
                    :const *old*)
 
   (split-all-gso *old*
@@ -179,7 +179,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("typedef2.c")
+  (c$::input-files :files '("typedef2.c")
                    :const *old*)
 
   (split-all-gso *old*

--- a/books/kestrel/c/transformation/tests/split-fn-when/split-fn-when.lisp
+++ b/books/kestrel/c/transformation/tests/split-fn-when/split-fn-when.lisp
@@ -22,7 +22,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (split-fn-when *old*
@@ -50,7 +50,7 @@ int foo(int y) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test2.c")
+  (c$::input-files :files '("test2.c")
                    :const *old*)
 
   (split-fn-when *old*
@@ -88,7 +88,7 @@ int foo(int y) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test3.c")
+  (c$::input-files :files '("test3.c")
                    :const *old*)
 
   (split-fn-when *old*

--- a/books/kestrel/c/transformation/tests/split-fn/split-fn.lisp
+++ b/books/kestrel/c/transformation/tests/split-fn/split-fn.lisp
@@ -22,7 +22,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (split-fn *old*
@@ -50,7 +50,7 @@ int foo(int y) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test2.c")
+  (c$::input-files :files '("test2.c")
                    :const *old*)
 
   (split-fn *old*
@@ -84,7 +84,7 @@ unsigned long add_and_sub_all(long arr[], unsigned int len) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test3.c")
+  (c$::input-files :files '("test3.c")
                    :process :parse
                    :const *old*)
 
@@ -115,7 +115,7 @@ int foo(int x) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test4.c")
+  (c$::input-files :files '("test4.c")
                    :process :parse
                    :const *old*)
 
@@ -146,7 +146,7 @@ int foo(int x) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test5.c")
+  (c$::input-files :files '("test5.c")
                    :const *old*)
 
   (split-fn *old*
@@ -175,7 +175,7 @@ int foo() {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("alias.c")
+  (c$::input-files :files '("alias.c")
                    :process :parse
                    :const *old*)
 

--- a/books/kestrel/c/transformation/tests/splitgso/splitgso.lisp
+++ b/books/kestrel/c/transformation/tests/splitgso/splitgso.lisp
@@ -26,7 +26,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (splitgso *old*
@@ -58,7 +58,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (splitgso *old*
@@ -90,7 +90,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    :const *old*)
 
   (splitgso *old*
@@ -118,7 +118,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test2.c")
+  (c$::input-files :files '("test2.c")
                    :const *old*)
 
   (splitgso *old*
@@ -154,7 +154,7 @@ int main(void) {
 ;; Test an ensemble
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static-struct1.c"
+  (c$::input-files :files '("static-struct1.c"
                            "static-struct2.c"
                            "extern-struct.c")
                    :const *old*)
@@ -216,7 +216,7 @@ struct S2 s2 = {.x = 0};
 ;; Same as above, but with the :object-filepath
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static-struct1.c"
+  (c$::input-files :files '("static-struct1.c"
                            "static-struct2.c"
                            "extern-struct.c")
                    :const *old*)
@@ -276,7 +276,7 @@ struct S2 s2 = {.x = 0};
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static-struct1.c"
+  (c$::input-files :files '("static-struct1.c"
                            "static-struct2.c"
                            "extern-struct.c")
                    :const *old*)
@@ -333,7 +333,7 @@ struct S s = {.x = 0};
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static-struct1.c"
+  (c$::input-files :files '("static-struct1.c"
                            "static-struct2.c"
                            "extern-struct.c")
                    :const *old*)
@@ -388,7 +388,7 @@ struct S_1 s_1 = {.x = 0};
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("typedef1.c")
+  (c$::input-files :files '("typedef1.c")
                    :const *old*)
 
   (splitgso *old*
@@ -418,7 +418,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("typedef2.c")
+  (c$::input-files :files '("typedef2.c")
                    :const *old*)
 
   (splitgso *old*
@@ -450,7 +450,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test1.c")
+  (c$::input-files :files '("test1.c")
                    ;; Not validating
                    :process :disambiguate
                    :const *old*)
@@ -470,7 +470,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("test3.c")
+  (c$::input-files :files '("test3.c")
                    :const *old*)
 
   ;; Global struct object occurs outside of field access.
@@ -490,7 +490,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("weird_initializer.c")
+  (c$::input-files :files '("weird_initializer.c")
                    :process :validate
                    :const *old*)
 
@@ -512,7 +512,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static_assert_struct_declaration.c")
+  (c$::input-files :files '("static_assert_struct_declaration.c")
                    :process :validate
                    :const *old*)
 
@@ -534,7 +534,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("simultaneous_struct_fields.c")
+  (c$::input-files :files '("simultaneous_struct_fields.c")
                    :process :validate
                    :const *old*)
 
@@ -556,7 +556,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("simultaneous_init_declors.c")
+  (c$::input-files :files '("simultaneous_init_declors.c")
                    :process :validate
                    :const *old*)
 
@@ -578,7 +578,7 @@ int main(void) {
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (acl2::must-succeed*
-  (c$::input-files :files ("static-struct1.c"
+  (c$::input-files :files '("static-struct1.c"
                            "static-struct2.c"
                            "extern-struct.c")
                    :const *old*)


### PR DESCRIPTION
This also evaluates the `:files` and `:preprocess-args` inputs in order to support large ensembles. To do so, it uses `magic-ev` (based on `magic-ev-fncall`) instead of introducing an intermediate `make-event` step. Using a `make-event` would work for the main macro interface, but not for the programmatic `input-files-prog-fn`.