### PR TITLE
[C$] Add `:keep-going` option to `input-files`

### DIFF
--- a/books/kestrel/c/syntax/input-files-doc.lisp
+++ b/books/kestrel/c/syntax/input-files-doc.lisp
@@ -59,6 +59,7 @@
      "             :preprocess-args   ...  ; no default"
      "             :process           ...  ; default :validate"
      "             :const             ...  ; required, no default"
+     "             :keep-going        ...  ; default nil"
      "             :gcc               ...  ; default nil"
      "             :short-bytes       ...  ; default 2"
      "             :int-bytes         ...  ; default 4"
@@ -244,6 +245,20 @@
      (xdoc::p
       "In the rest of this documentation page,
        let @('*const*') be the name of this constant."))
+
+    (xdoc::desc
+     "@(':keep-going') &mdash; default @('nil')"
+     (xdoc::p
+      "Boolean flag saying whether to keep going after failing to input a file.
+       When @('t'), files which fail parsing, disambiguation, or validation
+       are dropped and the relevant error is printed.
+       Furthermore, at the end of each stage, if any file has failed,
+       then the fraction of successful files is also printed.")
+     (xdoc::p
+      "This flag is provided primarily for debugging purposes.
+       Successful validation of later files following the first failure
+       may be erroneous due to the inability to perform certain cross-checks
+       against the dropped files."))
 
     (xdoc::desc
      "@(':gcc') &mdash; default @('nil')"

--- a/books/kestrel/c/syntax/tests/validator.lisp
+++ b/books/kestrel/c/syntax/tests/validator.lisp
@@ -61,7 +61,6 @@
                   (make-dummy-filepath-filedata-map (rest filepath-names)
                                                     (rest input)))))
 
-
 (define make-dummy-fileset (input)
   :returns (fileset fileset)
   (fileset (make-dummy-filepath-filedata-map
@@ -91,9 +90,9 @@
                         :gcc gcc))
        (fileset (make-dummy-fileset inputs)))
     `(assert-event
-       (b* (((mv erp1 ast) (parse-fileset ',fileset ,gcc))
-            ((mv erp2 ast) (dimb-transunit-ensemble ast ,gcc))
-            ((mv erp3 ?ast) (valid-transunit-ensemble ast ',ienv)))
+       (b* (((mv erp1 ast) (parse-fileset ',fileset ,gcc nil))
+            ((mv erp2 ast) (dimb-transunit-ensemble ast ,gcc nil))
+            ((mv erp3 ?ast) (valid-transunit-ensemble ast ',ienv nil)))
          (cond (erp1 (cw "~%PARSER ERROR: ~@0~%" erp1))
                (erp2 (cw "~%DISAMBIGUATOR ERROR: ~@0~%" erp2))
                (erp3 (cw "~%VALIDATOR ERROR: ~@0~%" erp3))
@@ -122,9 +121,9 @@
                         :gcc gcc))
        (fileset (make-dummy-fileset inputs)))
     `(assert-event
-       (b* (((mv erp1 ast) (parse-fileset ',fileset ,gcc))
-            ((mv erp2 ast) (dimb-transunit-ensemble ast ,gcc))
-            ((mv erp3 ?ast) (valid-transunit-ensemble ast ',ienv)))
+       (b* (((mv erp1 ast) (parse-fileset ',fileset ,gcc nil))
+            ((mv erp2 ast) (dimb-transunit-ensemble ast ,gcc nil))
+            ((mv erp3 ?ast) (valid-transunit-ensemble ast ',ienv nil)))
          (cond (erp1 (not (cw "~%PARSER ERROR: ~@0~%" erp1)))
                (erp2 (not (cw "~%DISAMBIGUATOR ERROR: ~@0~%" erp2)))
                (erp3 (not (cw "~%VALIDATOR ERROR: ~@0~%" erp3)))

--- a/books/kestrel/c/transformation/split-all-gso.lisp
+++ b/books/kestrel/c/transformation/split-all-gso.lisp
@@ -375,9 +375,9 @@
           ;; TODO: prove that splitgso preserves unambiguity and validity
           ;;   (it likely doesn't preserve the latter currently).
           ((erp tunits$)
-           (c$::dimb-transunit-ensemble tunits$ (c$::ienv->gcc ienv)))
+           (c$::dimb-transunit-ensemble tunits$ (c$::ienv->gcc ienv) nil))
           ((erp tunits$)
-           (c$::valid-transunit-ensemble tunits$ ienv))
+           (c$::valid-transunit-ensemble tunits$ ienv nil))
           ;; TODO: c$::valid-transunit-ensemble should return an annop
           ((unless (c$::transunit-ensemble-annop tunits$))
            (retmsg$ "Invalid translation unit ensemble.")))


### PR DESCRIPTION
Also adds `keep-going` arguments to the parser, disambiguator, and validator.