### PR TITLE
Remove vestigial include from cert

### DIFF
--- a/books/std/osets/cert.acl2
+++ b/books/std/osets/cert.acl2
@@ -33,5 +33,4 @@
 #!ACL2
 (in-package "ACL2")
 (include-book "std/portcullis" :dir :system)
-(include-book "cowles/portcullis" :dir :system)
 ; cert-flags: ? t :ttags :all


### PR DESCRIPTION
`cowles/portcullis` consists of package definitions for commutative algebraic structures.  It is not used in the osets library and the community books rebuild fine without it.