### PR TITLE
Strengthen FTY-generated theorem about oset intersect of typed sets

### DIFF
--- a/books/kestrel/fty/fty-set.lisp
+++ b/books/kestrel/fty/fty-set.lisp
@@ -381,8 +381,8 @@
            :induct t
            :enable (set::union set::emptyp set::setp set::head set::tail))
          (defrule ,pred-of-intersect
-           (implies (and (,x.pred ,x.xvar)
-                         (,x.pred ,y))
+           (implies (or (,x.pred ,x.xvar)
+                        (,x.pred ,y))
                     (,x.pred (set::intersect ,x.xvar ,y)))
            :induct t
            :enable set::intersect)


### PR DESCRIPTION
The intersection of two sets is of a type if either of the inputs is of that type (not necessarily both). This seems a clear improvement to me, but alternatively could be phrased as two theorems with the same conclusion and alternate hyps.