### PR TITLE
[jenkins] Simplify scripts.

### DIFF
--- a/books/build/jenkins/build-multi.sh
+++ b/books/build/jenkins/build-multi.sh
@@ -13,7 +13,7 @@
 
 # Cause the script to exit immediately upon failure
 set -e
-echo "acl2dir is $ACL2DIR"
+
 echo "Starting build-multi.sh"
 echo " -- Running in `pwd`"
 echo " -- Running on `hostname`"
@@ -25,8 +25,6 @@ echo "NAGINATOR_MAXCOUNT is $NAGINATOR_MAXCOUNT" # How many times the build can 
 echo "NAGINATOR_BUILD_NUMBER is $NAGINATOR_BUILD_NUMBER" # The build number of the failed build causing the reschedule.
 
 source $JENKINS_HOME/env.sh
-
-ACL2DIR=`pwd`
 
 if [ -z "$STARTJOB" ]; then
   echo "Setting STARTJOB to bash";

--- a/books/build/jenkins/build-single.sh
+++ b/books/build/jenkins/build-single.sh
@@ -5,7 +5,7 @@
 
 # Cause the script to exit immediately upon failure
 set -e
-echo "acl2dir is $ACL2DIR"
+
 echo "Starting build-single.sh"
 echo " -- Running in `pwd`"
 echo " -- Running on `hostname`"
@@ -17,8 +17,6 @@ echo "NAGINATOR_MAXCOUNT is $NAGINATOR_MAXCOUNT" # How many times the build can 
 echo "NAGINATOR_BUILD_NUMBER is $NAGINATOR_BUILD_NUMBER" # The build number of the failed build causing the reschedule.
 
 source $JENKINS_HOME/env.sh
-
-ACL2DIR=`pwd`
 
 if [ -z "$STARTJOB" ]; then
   echo "Setting STARTJOB to bash";


### PR DESCRIPTION
Remove unused var ACL2DIR.  It doesn't seem to be used anywhere.  And, oddly, its value was printed and then overwritten with the pwd.  When leeroy prints the value initially, it seems to be undefined.