### PR TITLE
[STD] Fix `define` untranslate on nullary function macros

### DIFF
--- a/books/std/util/define.lisp
+++ b/books/std/util/define.lisp
@@ -1622,11 +1622,10 @@ examples.</p>")
                 (let ((macro-args
                        (getprop macro 'macro-args nil
                                 'current-acl2-world world)))
-                  (and macro-args
-                       (mv-let (ok newargs)
-                         (untrans-macro-args (cdr term) macro-args nil)
-                         (and ok
-                              (cons macro newargs)))))))))
+                  (mv-let (ok newargs)
+                    (untrans-macro-args (cdr term) macro-args nil)
+                    (and ok
+                         (cons macro newargs))))))))
 
 
   (table user-defined-functions-table

--- a/books/std/util/tests/define.lisp
+++ b/books/std/util/tests/define.lisp
@@ -579,6 +579,17 @@
 (assert! (equal (notinline-test$notinline 2) 2))
 (assert! (equal (notinline-test 2) 2))
 
+(assert! (equal (acl2::untranslate-preproc-for-define
+                  '(inline-test$inline 1) (w state))
+                '(inline-test 1)))
+
+(define nullary-inline-test ()
+  :inline t
+  nil)
+
+(assert! (equal (acl2::untranslate-preproc-for-define
+                  '(nullary-inline-test$inline) (w state))
+                '(nullary-inline-test)))
 
 
 ;; Alessandro Coglio reported a bug to do with giving hints when using :t-proof.


### PR DESCRIPTION
The procedure to untranslate macro aliases of functions introduced by "define" was not attempting to untranslate nullary functions. This change fixes that.

A couple of tests were added of the untranslate procedure, including one for a nullary function.