### PR TITLE
Make ACL2 Bridge Python and Ruby clients consistent wrt sending (STOP)

### DIFF
--- a/books/centaur/bridge/python/README
+++ b/books/centaur/bridge/python/README
@@ -39,8 +39,8 @@ displayed without disrupting the REPL.
 2. Start ACL2 in a shell
 3. Run ~(ld "demo.lsp")~ in ACL2
 4. Run ~python demo.py~ (or ~python async_demo.py~) in another shell
-5. Use ~^D~ to exit
-6. The Bridge server will continue for other clients.  Stop with ~^C~ or run ~python demo.py --stop~ (or ~python async_demo.py --stop~) to have the client send a (BRIDGE::STOP) command to stop the server.
+5. Use ~^D~ to exit, the Bridge server will continue for other clients.
+6. If demo.py or async_demo.py is ran with the flag --send-stop-on-eof, then the respective Python demo will send a (BRIDGE::STOP) message to the Bridge server when it exits.
 
 ** Manual Stop
 You can also stop the bridge server (or send any s-expression) from the CLI:

--- a/books/centaur/bridge/python/async_demo.py
+++ b/books/centaur/bridge/python/async_demo.py
@@ -72,4 +72,4 @@ async def repl(send_stop_on_eof=False):
 
 
 if __name__ == "__main__":
-    asyncio.run(repl(send_stop_on_eof="--stop" in sys.argv))
+    asyncio.run(repl(send_stop_on_eof="--send-stop-on-eof" in sys.argv))

--- a/books/centaur/bridge/python/demo.py
+++ b/books/centaur/bridge/python/demo.py
@@ -69,4 +69,4 @@ def repl(send_stop_on_eof=False):
 
 
 if __name__ == "__main__":
-    repl(send_stop_on_eof="--stop" in sys.argv)
+    repl(send_stop_on_eof="--send-stop-on-eof" in sys.argv)

--- a/books/centaur/bridge/ruby/README
+++ b/books/centaur/bridge/ruby/README
@@ -58,6 +58,7 @@ Trying the Demo:
    "./demo.rb --help" for information on how to connect.  You can connect
    multiple clients at a time, of course.
 
+
 Questions:
 
    For help, ask Jared Davis <jared@centtech.com>


### PR DESCRIPTION
- Don't send (BRIDGE::STOP) command on EOF by default; add --stop flag
- Add documentation about stopping the server to Python README
- Add Ruby installation instructions to Ruby README