### PR TITLE
[X86ISA] Move inclusion of raw Lisp code to tools/execution/top.

### DIFF
--- a/books/projects/x86isa/machine/cert.acl2
+++ b/books/projects/x86isa/machine/cert.acl2
@@ -41,7 +41,7 @@
 (set-waterfall-parallelism t)
 (include-book "../portcullis/sharp-dot-constants")
 (add-include-book-dir :utils "../utils")
-;; cert-flags: ? t :ttags (:syscall-exec :other-non-det :undef-flg) :skip-proofs-okp nil
+;; cert-flags: ? t :ttags (:syscall-exec) :skip-proofs-okp nil
 
 ; Matt K. mod 7/11/2022 for GCL to avoid exhausting storage, which happened in
 ; the following book before deciding simply to cover all books (including some

--- a/books/projects/x86isa/machine/other-non-det.lisp
+++ b/books/projects/x86isa/machine/other-non-det.lisp
@@ -101,26 +101,4 @@ HW_RND_GEN)\).</p>"
                    )
                   t)
 
-;; Exec definitions:
-
-(defsection other-non-deterministic-computations-exec
-  :parents (other-non-deterministic-computations)
-  :short "Definitions of non-deterministic computations to be used for
-  execution"
-  :long "<p>We smash the definition of @(see HW_RND_GEN) to provide
-  random numbers during execution by using Lisp's @('random')
-  function.</p>"
-
-; Instruction to cert.pl for dependency tracking.
-; (depends-on "other-non-det-raw.lsp")
-
-  (defttag :other-non-det)
-  (include-raw "other-non-det-raw.lsp"
-               :on-compile-fail
-               (format t "[other-non-det-raw.lsp] Compilation failed with message ~a~%"
-                       condition)
-               :on-load-fail
-               (cw "[other-non-det-raw.lsp] Load failed; Moving On.~%")
-               :host-readtable t))
-
 ;; ======================================================================

--- a/books/projects/x86isa/machine/register-readers-and-writers.lisp
+++ b/books/projects/x86isa/machine/register-readers-and-writers.lisp
@@ -1814,15 +1814,3 @@ values.</p>"
 
 
 ;; ----------------------------------------------------------------------
-
-(include-book "tools/include-raw" :dir :system)
-(defttag :undef-flg)
-(include-raw "register-readers-and-writers-raw.lsp"
-             :on-compile-fail
-             (format t "[register-readers-and-writers-raw.lsp] Compilation failed with message ~a~%"
-                     condition)
-             :on-load-fail
-             (cw "[register-readers-and-writers-raw.lsp] Load failed; Moving On.~%")
-             :host-readtable t)
-
-;; ----------------------------------------------------------------------

--- a/books/projects/x86isa/tools/execution/top.lisp
+++ b/books/projects/x86isa/tools/execution/top.lisp
@@ -45,6 +45,45 @@
 
 ;; ======================================================================
 
+(include-book "tools/include-raw" :dir :system)
+
+(defsection other-non-deterministic-computations-exec
+  :parents (other-non-deterministic-computations)
+  :short "Definitions of non-deterministic computations to be used for
+  execution"
+  :long "<p>We smash the definition of @(see HW_RND_GEN) to provide
+  random numbers during execution by using Lisp's @('random')
+  function.</p>"
+
+; Instruction to cert.pl for dependency tracking.
+; (depends-on "../../machine/other-non-det-raw.lsp")
+
+  (defttag :other-non-det)
+  (include-raw "../../machine/other-non-det-raw.lsp"
+               :on-compile-fail
+               (format t "[other-non-det-raw.lsp] Compilation failed with message ~a~%"
+                       condition)
+               :on-load-fail
+               (cw "[other-non-det-raw.lsp] Load failed; Moving On.~%")
+               :host-readtable t))
+
+;; ======================================================================
+
+(defttag :undef-flg)
+
+; Instruction to cert.pl for dependency tracking.
+; (depends-on "../../machine/register-readers-and-writers-raw.lsp")
+
+(include-raw "../../machine/register-readers-and-writers-raw.lsp"
+             :on-compile-fail
+             (format t "[register-readers-and-writers-raw.lsp] Compilation failed with message ~a~%"
+                     condition)
+             :on-load-fail
+             (cw "[register-readers-and-writers-raw.lsp] Load failed; Moving On.~%")
+             :host-readtable t)
+
+;; ======================================================================
+
 (defxdoc program-execution
   :parents (X86ISA)
 


### PR DESCRIPTION
This should allow the use of with-supporters to cherrypick certain definitions from the model.  (With-supporters does not work well with Raw Lisp code.)  It also reduces the scope of some trust tags.

I believe tools/execution/top is the book that people are told to include (at minimum) if they want to run the model.

It would be great if @acoglio or @yaso9 could check that running Linux still works.