### PR TITLE
[utilities] Add :guard-debug arg to verify-guards-program.

### DIFF
--- a/books/kestrel/utilities/verify-guards-program-tests.lisp
+++ b/books/kestrel/utilities/verify-guards-program-tests.lisp
@@ -72,3 +72,6 @@
 ;Also test :otf-flg
 (verify-guards-program bar :otf-flg t
                        :hints (("Goal" :in-theory (enable car-cons))))
+;Also test :guard-debug
+(verify-guards-program bar :guard-debug t
+                       :hints (("Goal" :in-theory (enable car-cons))))


### PR DESCRIPTION
I tested the new :guard-debug option on an example, and it helped me quickly find a small bug in Axe that was revealed in a build with safety 3.