### PR TITLE
[acl2s] Fix a type error in cgen's callback

### DIFF
--- a/books/acl2s/cgen/callback.lisp
+++ b/books/acl2s/cgen/callback.lisp
@@ -320,7 +320,8 @@ then it returns (value '(:do-not '(acl2::generalize)
        (- (cw? (debug-flag vl) "~| pspv-ust: ~x0 curr ust: ~x1 ctx:~x2 cgen-state.ctx:~x3~%" pspv-user-supplied-term (cget user-supplied-term) ctx (cget top-ctx)))
 
        ((unless (implies (and (not (eq (cget user-supplied-term) :undefined))
-                              (not (eq (car (cget top-ctx)) :user-defined))) ;allow test?/prove
+                              (or (not (consp (cget top-ctx)))
+                                  (not (eq (car (cget top-ctx)) :user-defined)))) ;allow test?/prove
                          (equal ctx (cget top-ctx))))
         (prog2$ ;Invariant
          (cw? (verbose-flag vl)


### PR DESCRIPTION
cgen's callback did not properly account for the fact that the ctx argument may be a string and thus under certain circumstances it would try to take the car of a string, causing a type error when ACL2 is built with `(safety 3)`.

This was fixed by adding a `consp` check before the offending `car` form.