### PR TITLE
[RAC] Handle implicit conversion with lvalue type mismatch in mv assigments

### DIFF
--- a/books/projects/rac/src/program/parser/ast/statements.cpp
+++ b/books/projects/rac/src/program/parser/ast/statements.cpp
@@ -129,10 +129,10 @@ Sexpression *EnumConstDec::ACL2SymExpr() {
 // class VarDec : public SimpleStatement, public SymDec (variable declaration)
 // ---------------------------------------------------------------------------
 
-VarDec::VarDec(Location loc, const char *n, Type *t, Expression *i)
+VarDec::VarDec(Location loc, const char *n, const Type *t, Expression *i)
     : SymDec(idOf(this), loc, n, t, i) {}
 
-VarDec::VarDec(NodesId id, Location loc, const char *n, Type *t, Expression *i)
+VarDec::VarDec(NodesId id, Location loc, const char *n, const Type *t, Expression *i)
     : SymDec(id, loc, n, t, i) {}
 
 void VarDec::displaySimple(std::ostream &os) { displaySymDec(os); }
@@ -349,8 +349,8 @@ void MultipleAssignment::displaySimple(std::ostream &os) {
   rval_->display(os);
 }
 
-// In the event that each target of a multiple assignment is a simple variable,
-// the corrersponding S-expression  has the form
+// In the event that each target of a multiple assignment is a simple variable
+// list of the same type, the corrersponding S-expression has the form
 
 //   (MV-ASSIGN (var1 ... vark) fncall).
 
@@ -375,31 +375,66 @@ Sexpression *MultipleAssignment::ACL2Expr() {
 
   std::vector<Symbol *> tmp_vars;
   Plist *vars = new Plist();
-  bool needs_tmp_vars = false;
+
+  const auto *mv_type = always_cast<const MvType *>(rval_->get_type());
+  std::vector<Sexpression *> add_assign(lval_.size(), nullptr);
 
   for (unsigned i = 0; i < lval_.size(); ++i) {
 
     if (SymRef *ref = dynamic_cast<SymRef *>(lval_[i])) {
       vars->add(ref->symDec->sym);
       tmp_vars.push_back(nullptr);
+
+      // If the function returns multiple values (i.e., a tuple) and the lvalue
+      // type differs from the corresponding return component type, model the
+      // implicit per-element conversion by inserting an explicit cast
+      // assignment after the MV-ASSIGN.
+      const Type *dst_t = ref->get_type();
+      const Type *src_t = mv_type->get(i);
+      if (!dst_t->isEqual(src_t)) {
+        bool has_changed = false;
+        auto *tmp_dec = new VarDec(loc_, tmp_vars[i]->getname(), mv_type->get(i));
+        auto *tmp_ref = new SymRef(loc_, tmp_dec);
+        tmp_ref->set_type(mv_type->get(i));
+        Sexpression *casted = dst_t->cast(tmp_ref, has_changed);
+        if (has_changed) {
+          add_assign[i] = ref->ACL2Assign(casted);
+        }
+      }
     } else {
       Symbol *s_temp = new Symbol("temp-" + std::to_string(i));
       vars->add(s_temp);
       tmp_vars.push_back(s_temp);
-      needs_tmp_vars = true;
+      Sexpression *rval = tmp_vars[i];
+
+      // If we are assigning from a multiple-value return and the destination
+      // type differs, cast the temporary before writing into the target.
+      if (!lval_[i]->get_type()->isEqual(mv_type->get(i))) {
+        auto *tmp_dec = new VarDec(loc_, tmp_vars[i]->getname(), mv_type->get(i));
+        auto *tmp_ref = new SymRef(loc_, tmp_dec);
+        tmp_ref->set_type(mv_type->get(i));
+        bool has_changed = false;
+        Sexpression *casted = lval_[i]->get_type()->cast(tmp_ref, has_changed);
+        if (has_changed) {
+          rval = casted;
+        }
+      }
+
+      add_assign[i] = lval_[i]->ACL2Assign(rval);
     }
   }
 
   Plist *mv_assign = new Plist({&s_mv_assign, vars, rval_->ACL2Expr()});
 
-  if (!needs_tmp_vars) {
+  if (std::all_of(add_assign.begin(), add_assign.end(),
+                  [](Sexpression *s) { return s == nullptr; })) {
     return mv_assign;
   }
 
   Plist *result_with_tmp = new Plist({&s_block});
 
   for (int i = lval_.size() - 1; i >= 0; --i) {
-    if (lval_[i]) {
+    if (tmp_vars[i]) {
       result_with_tmp->add(new Plist({&s_declare, tmp_vars[i]}));
     }
   }
@@ -407,8 +442,8 @@ Sexpression *MultipleAssignment::ACL2Expr() {
   result_with_tmp->add(mv_assign);
 
   for (unsigned i = 0; i < lval_.size(); ++i) {
-    if (lval_[i]) {
-      result_with_tmp->add(lval_[i]->ACL2Assign(tmp_vars[i]));
+    if (add_assign[i]) {
+      result_with_tmp->add(add_assign[i]);
     }
   }
 

--- a/books/projects/rac/src/program/parser/ast/statements.h
+++ b/books/projects/rac/src/program/parser/ast/statements.h
@@ -93,8 +93,8 @@ public:
 
 class VarDec : public SymDec {
 public:
-  VarDec(Location loc, const char *n, Type *t, Expression *i = nullptr);
-  VarDec(NodesId id, Location loc, const char *n, Type *t,
+  VarDec(Location loc, const char *n, const Type *t, Expression *i = nullptr);
+  VarDec(NodesId id, Location loc, const char *n, const Type *t,
          Expression *i = nullptr);
   void displaySimple(std::ostream &os) override;
   Sexpression *ACL2Expr() override;

--- a/books/projects/rac/src/program/parser/ast/types.cpp
+++ b/books/projects/rac/src/program/parser/ast/types.cpp
@@ -29,8 +29,9 @@ std::string Type::to_string() const {
 }
 
 Sexpression *
-Type::cast(Expression *rval) const { // virtual (overridden by IntType)
+Type::cast(Expression *rval, bool &has_changed) const { // virtual (overridden by IntType)
   // Convert rval to an S-expression to be assigned to an object of this type.
+  has_changed = false;
   return rval->ACL2Expr();
 }
 
@@ -80,7 +81,7 @@ PrimType *uintType = PrimType::Uint();
 PrimType *int64Type = PrimType::Int64();
 PrimType *uint64Type = PrimType::Uint64();
 
-Sexpression *PrimType::cast(Expression *rval) const {
+Sexpression *PrimType::cast(Expression *rval, bool &has_changed) const {
 
   const Type *rval_type = rval->get_type();
   Sexpression *sexpr = rval->ACL2Expr();
@@ -89,8 +90,10 @@ Sexpression *PrimType::cast(Expression *rval) const {
 
   // If they are the same no conversion needed.
   if (rval_type->isEqual(this)) {
+    has_changed = false;
     return sexpr;
   }
+  has_changed = true;
 
   // If rval is a constant we are able to make optimize based on its value
   // rather its type.
@@ -103,7 +106,7 @@ Sexpression *PrimType::cast(Expression *rval) const {
   // If the destination is a bool, we should ensure that the result if
   // always_cast zero or one. TODO
   if (rank_ == PrimType::Rank::Bool) {
-    
+
     if (auto rt = dynamic_cast<const PrimType *>(rval_type))
       if (rt->ACL2ValWidth() <= 1)
         return sexpr;
@@ -287,16 +290,19 @@ unsigned IntType::ACL2ValWidth() const {
   return width()->evalConst();
 }
 
-Sexpression *IntType::cast(Expression *rval) const {
+Sexpression *IntType::cast(Expression *rval, bool &has_changed) const {
 
+  has_changed = true;
   // Try to figure out if the bits/si are really necessary.
   const Type *rval_type = rval->get_type();
 
   if (rval_type->isEqual(this)) {
     auto rt = always_cast<const IntType *>(rval_type);
     if (rt->isSigned()->isStaticallyEvaluable()
-        && !rt->isSigned()->evalConst())
+        && !rt->isSigned()->evalConst()) {
+      has_changed = false;
       return rval->ACL2Expr();
+    }
   }
 
   if (!disable_optimizations) {
@@ -311,6 +317,7 @@ Sexpression *IntType::cast(Expression *rval) const {
         if (!s) {
           if (auto c = dynamic_cast<Constant *>(rval)) {
             if (c->fitInside(s, w_dst)) {
+              has_changed = false;
               return rval->ACL2Expr();
             }
           }
@@ -321,6 +328,7 @@ Sexpression *IntType::cast(Expression *rval) const {
               p->isSigned()->isStaticallyEvaluable() &&
               !p->isSigned()->evalConst() &&
               rval_type->ACL2ValWidth() <= w_dst) {
+            has_changed = false;
             return rval->ACL2Expr();
           }
         }
@@ -330,6 +338,7 @@ Sexpression *IntType::cast(Expression *rval) const {
       // value to its binnary represenation and if it fits inside this.
       if (auto p = dynamic_cast<const PrimType *>(rval_type)) {
         if (!p->signed_ && p->ACL2ValWidth() <= w_dst) {
+          has_changed = false;
           return rval->ACL2Expr();
         }
       }
@@ -460,8 +469,9 @@ bool ArrayType::isEqual(const Type *other) const {
   }
 }
 
-Sexpression *ArrayType::cast(Expression *rval) const {
+Sexpression *ArrayType::cast(Expression *rval, bool &has_changed) const {
 
+  has_changed = false;
   if (auto init = dynamic_cast<Initializer *>(rval)) {
     // Array initializer must be a double initializer list (see comment in
     // typing.cpp). "vals" is guarranted to have a single element: an
@@ -481,10 +491,10 @@ Sexpression *ArrayType::default_initializer_value() const {
     return &s_nil;
   }
   Plist *result = new Plist({});
-  
+
   //TODO do not support template
   assert(dim->isStaticallyEvaluable());
-  
+
   result->add(&s_list);
   unsigned size = dim->evalConst();
   for (unsigned i = 0; i < size; ++i) {
@@ -573,8 +583,9 @@ bool StructType::isEqual(const Type *other) const {
   return false;
 }
 
-Sexpression *StructType::cast(Expression *rval) const {
+Sexpression *StructType::cast(Expression *rval, bool &has_changed) const {
 
+  has_changed = false;
   if (auto init = dynamic_cast<Initializer *>(rval)) {
     return init->ACL2StructExpr(this);
   } else {
@@ -741,7 +752,8 @@ bool CompositeType::isEqual(const Type *other) const {
 }
 } // namespace priv
 
-Sexpression *MvType::cast(Expression *rval) const {
+Sexpression *MvType::cast(Expression *rval, bool &has_changed) const {
+  has_changed = false;
   if (auto init = dynamic_cast<Initializer *>(rval)) {
     return init->ACL2TupleExpr(this);
   } else {

--- a/books/projects/rac/src/program/parser/ast/types.h
+++ b/books/projects/rac/src/program/parser/ast/types.h
@@ -64,7 +64,11 @@ public:
   // overridden by IntType
   // Convert rval to an S-expression to be assigned to an object of this
   virtual bool canBeImplicitlyCastTo(const Type *target) const = 0;
-  virtual Sexpression *cast(Expression *rval) const;
+  virtual Sexpression *cast(Expression *rval, bool &has_changed) const;
+  Sexpression *cast(Expression *rval) const {
+    bool b;
+    return cast(rval, b);
+  };
   virtual Sexpression *default_initializer_value() const = 0;
 
   // TODO refactore.
@@ -127,7 +131,7 @@ public:
                         false);
   }
 
-  Sexpression *cast(Expression *rval) const override;
+  Sexpression *cast(Expression *rval, bool &has_changed) const override;
 
   virtual void display(std::ostream &os) const override {
 
@@ -214,8 +218,8 @@ public:
     derefType()->makeDef(name, os);
   }
 
-  virtual Sexpression *cast(Expression *rval) const override {
-    return derefType()->cast(rval);
+  virtual Sexpression *cast(Expression *rval, bool &has_changed) const override {
+    return derefType()->cast(rval, has_changed);
   }
 
   unsigned ACL2ValWidth() const override { return derefType()->ACL2ValWidth(); }
@@ -270,7 +274,7 @@ public:
   static IntType *FromPrimType(const PrimType *t);
 
   void display(std::ostream &os = std::cout) const override;
-  Sexpression *cast(Expression *rval) const override;
+  Sexpression *cast(Expression *rval, bool &has_changed) const override;
 
   unsigned ACL2ValWidth() const override;
 
@@ -324,7 +328,7 @@ public:
     return isEqual(target);
   }
 
-  virtual Sexpression *cast(Expression *rval) const override;
+  virtual Sexpression *cast(Expression *rval, bool &has_changed) const override;
 
   inline void setSTDArray() { isSTDarray_ = true; }
   inline bool isSTDArray() const { return isSTDarray_; }
@@ -391,7 +395,7 @@ public:
     return isEqual(target);
   }
 
-  virtual Sexpression *cast(Expression *rval) const override;
+  virtual Sexpression *cast(Expression *rval, bool &has_changed) const override;
 
   Sexpression *default_initializer_value() const override;
 
@@ -473,7 +477,7 @@ public:
     return new MvType(loc(), std::move(tmp));
   }
 
-  Sexpression *cast(Expression *rval) const override;
+  Sexpression *cast(Expression *rval, bool &has_changed) const override;
 
   Sexpression *default_initializer_value() const override;
 };
@@ -524,8 +528,8 @@ public:
     Type::makeDef(name, os);
   }
 
-  Sexpression *cast(Expression *rval) const override {
-    return Type::cast(rval);
+  Sexpression *cast(Expression *rval, bool &has_changed) const override {
+    return Type::cast(rval, has_changed);
   }
 
   unsigned ACL2ValWidth() const override { return Type::ACL2ValWidth(); }

--- a/books/projects/rac/src/program/sexpressions.h
+++ b/books/projects/rac/src/program/sexpressions.h
@@ -13,6 +13,7 @@
 // S-expressions). Note that Constant is a derived class of Symbol.
 class Sexpression {
 public:
+  virtual ~Sexpression() = default;
   virtual void display(std::ostream &os) const = 0;
 };
 

--- a/books/projects/rac/tests/yaml_test/data_types/basic.yml
+++ b/books/projects/rac/tests/yaml_test/data_types/basic.yml
@@ -42,7 +42,7 @@
 - name: typedef-redeclaration
   should_report_error: true
 
-- name: enum 
+- name: enum
 
 - name: enum-default-values
 
@@ -181,3 +181,7 @@
 
 - name: fast-arrays-mixed
   should_report_error: true
+
+- name: return-mv-type-cast
+- name: mv-with-tmp
+- name: mv-with-tmp-partial

--- a/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp-partial.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp-partial.cpp
@@ -1,0 +1,16 @@
+#include <array>
+#include <tuple>
+using namespace std;
+
+// RAC begin
+
+tuple<int, int> foo() {
+  return tuple<int, int>(2, 1);
+}
+
+int main() {
+  array<int, 1> a = {{ 0 }};
+  int x = 0;
+  tie(x, a[0]) = foo();
+  return 0;
+}

--- a/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp-partial.cpp.ref.ast.lsp
+++ b/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp-partial.cpp.ref.ast.lsp
@@ -1,0 +1,3 @@
+
+
+(funcdef foo () (block (return (mv 2 1))))(funcdef main () (block (declare a (ainit (list (cons 0 0)))) (declare x 0) (block (declare temp-1) (mv-assign (x temp-1) (foo)) (assign a (as 0 temp-1 a))) (return 0)))

--- a/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp.cpp
@@ -1,0 +1,15 @@
+#include <array>
+#include <tuple>
+using namespace std;
+
+// RAC begin
+
+tuple<int, int> foo() {
+  return tuple<int, int>(2, 1);
+}
+
+int main() {
+  array<int, 2> a = {{ 0, 0 }};
+  tie(a[0], a[1]) = foo();
+  return 0;
+}

--- a/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp.cpp.ref.ast.lsp
+++ b/books/projects/rac/tests/yaml_test/data_types/mv-with-tmp.cpp.ref.ast.lsp
@@ -1,0 +1,3 @@
+
+
+(funcdef foo () (block (return (mv 2 1))))(funcdef main () (block (declare a (ainit (list (cons 0 0) (cons 1 0)))) (block (declare temp-1) (declare temp-0) (mv-assign (temp-0 temp-1) (foo)) (assign a (as 0 temp-0 a)) (assign a (as 1 temp-1 a))) (return 0)))

--- a/books/projects/rac/tests/yaml_test/data_types/return-mv-type-cast.cpp
+++ b/books/projects/rac/tests/yaml_test/data_types/return-mv-type-cast.cpp
@@ -1,0 +1,23 @@
+#include <ac_int.h>
+#include <array>
+#include <tuple>
+
+using namespace std;
+
+// RAC begin
+
+typedef ac_int<2, false> ui2;
+typedef ac_int<3, false> ui3;
+
+tuple<ui3, ui3> foo(ui3 x) {
+
+  return tuple<ui3, ui3>(x, x);
+}
+
+bool bar () {
+  ui2 x = 0, y = 0;
+  tie(x, y) = foo(3);
+  return true;
+}
+
+// RAC end

--- a/books/projects/rac/tests/yaml_test/data_types/return-mv-type-cast.cpp.ref.ast.lsp
+++ b/books/projects/rac/tests/yaml_test/data_types/return-mv-type-cast.cpp.ref.ast.lsp
@@ -1,0 +1,3 @@
+
+
+(funcdef foo (x) (block (return (mv x x))))(funcdef bar () (block (list (declare x 0) (declare y 0)) (block (mv-assign (x y) (foo 3)) (assign x (bits x 1 0)) (assign y (bits y 1 0))) (return (true$))))

--- a/books/projects/rac/tests/yaml_test/program_structure/basics.yml
+++ b/books/projects/rac/tests/yaml_test/program_structure/basics.yml
@@ -6,7 +6,7 @@
   args:                            # default value: ['acl2'], if provided the
                                    # cpp wont be run.
   input: empty.cpp                 # default value: NAME.cpp
-  should_report_error:             # default value: false
+  should_report_error: true        # default value: false
   ref_generated:                   # default value: NAME.ref.ast.lsp
   ref_stderr:                      # default value: NAME.ref.stderr
   ref_stdout:                      # default value: NAME.ref.stdout

--- a/books/projects/rac/tests/yaml_test/program_structure/empty.ref.stderr
+++ b/books/projects/rac/tests/yaml_test/program_structure/empty.ref.stderr
@@ -1,5 +1,4 @@
 empty.cpp:1-2 (0-0): syntax error, unexpected end of file
  1 | # 1 "empty.cpp"
    | ^^^^^^^^^^^^^^^^
- 2 | # 1 "empty.cpp"
-   | 
+ 2 |    | 


### PR DESCRIPTION
* Handle implicit conversion with lvalue type mismatch in mv assigments
* Add mv-with-tmp tests