### PR TITLE
[C$] Refine our model of array types.

### DIFF
--- a/books/kestrel/c/syntax/package.lsp
+++ b/books/kestrel/c/syntax/package.lsp
@@ -71,6 +71,8 @@
                 packn-pos
                 pos
                 pos-fix
+                pos-option
+                pos-optionp
                 pseudo-event-formp
                 pseudo-event-form-listp
                 reterr

--- a/books/kestrel/c/syntax/types.lisp
+++ b/books/kestrel/c/syntax/types.lisp
@@ -170,9 +170,22 @@
         because there are different enumeration types.")
       (xdoc::li
        "An array type [C17:6.2.5/20],
-        derived from the ``element type.''
+        derived from the ``element type.'',
+        and with an optional positive size.
         This is an approximation,
-        because we do not track the size of the array type.")
+        because variable length arrays have a size
+        that is an expression in general
+        (e.g. a declaration @('int a[n+1];'), where @('n') is a variable).
+        For now we only track array types with known constant size,
+        using @('nil') to mean `unknown size',
+        making the type partially unknown,
+        as opposed to totally unknown
+        as in the @(':unknown') case described below.
+        We use a positive integer instead of a natural
+        because arrays are not empty [C17:6.2.5/20],
+        and so a known constant size must not be 0
+        (but we can revise this if we discover that
+        array types may need to track a 0 size).")
       (xdoc::li
        "A pointer type [C17:6.2.5/20],
         derived from the ``referenced type.''")
@@ -225,7 +238,8 @@
              (tunit? filepath-option)
              (tag/members type-struni-tag/members)))
     (:enum ())
-    (:array ((of type)))
+    (:array ((of type)
+             (size pos-option)))
     (:pointer ((to type)))
     (:function ((ret type) (params type-params)))
     (:unknown ())
@@ -1463,8 +1477,14 @@
             :otherwise nil)
           :array (type-case
                    y
-                   :array (type-compatible-p-aux
-                            x.of y.of completions incomplete ienv)
+                   :array (and (type-compatible-p-aux x.of
+                                                      y.of
+                                                      completions
+                                                      incomplete
+                                                      ienv)
+                               (or (not x.size)
+                                   (not y.size)
+                                   (equal x.size y.size)))
                    :otherwise nil)
           :pointer (type-case
                      y
@@ -1813,8 +1833,13 @@
       [C17:6.7.6.1/2].")
     (xdoc::li
      "Array types are considered compatible
-      if their element types are compatible;
-      their size is not currently considered [C17:6.7.6.2/6].")
+      if their element types are compatible.
+      If they both have a size, it must be the same size [C17:6.7.6.2/6];
+      if any of them does not have a size, which means unknown size for us,
+      then we consider them compatible,
+      because we are approximating,
+      and the two sizes could be the same
+      (otherwise we may be rejecting legal code).")
     (xdoc::li
      "Enumeration types are considered compatible
       with <i>all</i> integer types.
@@ -2018,8 +2043,12 @@
                                            completions
                                            next-uid
                                            ienv
-                                           (- (the unsigned-byte count) 1))))
-                   (mv (make-type-array :of of-type)
+                                           (- (the unsigned-byte count) 1)))
+                      (size (cond ((equal x.size y.size) x.size)
+                                  ((not x.size) y.size)
+                                  ((not y.size) x.size)
+                                  (t nil))))
+                   (mv (make-type-array :of of-type :size size)
                        completions
                        next-uid))
           :unknown (mv (type-fix x)
@@ -2278,7 +2307,10 @@
      we return @('nil') instead.")
    (xdoc::p
     "These values largely come directly from the implementation environment.
-     The size of the complex floating types is given by [C17:6.2.5/13]."))
+     The size of the complex floating types is given by [C17:6.2.5/13].")
+   (xdoc::p
+    "The size of an array type is known iff
+     the size of its element type and the size component of the type are."))
   (b* (((ienv ienv) ienv))
     (type-case
       type
@@ -2304,10 +2336,14 @@
       :struct nil
       :union nil
       :enum nil
-      :array nil
+      :array (b* ((elem-size (type-size-exact type.of ienv)))
+               (if (and elem-size type.size)
+                   (* elem-size type.size)
+                 nil))
       :pointer ienv.pointer-bytes
       :function nil
-      :unknown nil)))
+      :unknown nil))
+  :measure (type-count type))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2403,12 +2439,6 @@
      pointer types,
      and struct types with tags.")
    (xdoc::p
-    "The array types are not supported because
-     they are too coarse compared to their @(tsee c::type) counterparts:
-     they do not include size information.
-     Struct types without tag are not supported,
-     because they always have a tag in @(tsee c::type).")
-   (xdoc::p
     "This predicate can be regarded as an extension of
      the collection of @('-formalp') predicates in @(see formalized-subset)."))
   (or (and (member-eq (type-kind type)
@@ -2426,7 +2456,9 @@
              (type-struni-tag/members-case
                tag/members
                :tagged (ident-formalp tag/members.tag)
-               :untagged nil))))
+               :untagged nil)))
+      (and (type-case type :array)
+           (type-formalp (type-array->of type))))
   :measure (type-count type))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2507,7 +2539,8 @@
                                         (type-fix type)))))
      :union (reterr (msg "Type ~x0 not supported." (type-fix type)))
      :enum (reterr (msg "Type ~x0 not supported." (type-fix type)))
-     :array (reterr (msg "Type ~x0 not supported." (type-fix type)))
+     :array (b* (((erp elty) (ldm-type type.of)))
+              (retok (c::make-type-array :of elty :size type.size)))
      :pointer (b* (((erp refd-type) (ldm-type type.to)))
                 (retok (c::make-type-pointer :to refd-type)))
      :function (reterr (msg "Type ~x0 not supported." (type-fix type)))
@@ -2634,6 +2667,6 @@
    ;; and tunit. Then, we could perhaps create an incomplete struct type.
    :struct (irr-type)
    :pointer (make-type-pointer :to (ildm-type ctype.to))
-   :array (make-type-array :of (ildm-type ctype.of)))
+   :array (make-type-array :of (ildm-type ctype.of) :size ctype.size))
   :measure (c::type-count ctype)
   :verify-guards :after-returns)

--- a/books/kestrel/c/syntax/validator.lisp
+++ b/books/kestrel/c/syntax/validator.lisp
@@ -1228,14 +1228,15 @@
      the literal may have type @('wchar_t') or @('char16_t') or @('char32_t').
      Since we do not yet model the values of these type definitions,
      we return an array type with an unknown element type in these cases."))
-  (b* (((reterr) (make-type-array :of (irr-type)))
+  (b* (((reterr) (make-type-array :of (irr-type) :size nil))
        ((stringlit strlit) strlit)
        ((erp &) (valid-s-char-list strlit.schars strlit.prefix? ienv)))
     (retok (make-type-array
             :of (if (or (not strlit.prefix?)
                         (eprefix-case strlit.prefix? :locase-u8))
                     (type-char)
-                  (type-unknown)))))
+                  (type-unknown))
+            :size nil))) ; TODO: size
 
   ///
 
@@ -1283,7 +1284,7 @@
      This covers both the case of well-defined wide string literals
      (whose types we do not yet model),
      and the implementation-defined mixed string encoding."))
-  (b* (((reterr) (make-type-array :of (irr-type)))
+  (b* (((reterr) (make-type-array :of (irr-type) :size nil))
        ((unless (consp strlits))
         (retmsg$ "There must be at least one string literal."))
        ((erp prefix? conflictp) (valid-stringlit-list-loop strlits ienv))
@@ -1298,7 +1299,8 @@
             :of (if (or conflictp
                         (and prefix? (not (eprefix-case prefix? :locase-u8))))
                     (type-unknown)
-                  (type-char)))))
+                  (type-char))
+            :size nil))) ; TODO: size
   :prepwork
   ((define valid-stringlit-list-loop ((strlits stringlit-listp) (ienv ienvp))
      :returns (mv (erp maybe-msgp)
@@ -5399,7 +5401,7 @@
                 types
                 vstate))
        :array
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-dirdeclor type ident types vstate)
              (valid-dirdeclor dirdeclor.declor fundef-params-p type vstate))
             ((erp new-expr? index-type? more-types vstate)
@@ -5420,7 +5422,7 @@
                 (set::union types more-types)
                 vstate))
        :array-static1
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-dirdeclor type ident types vstate)
              (valid-dirdeclor dirdeclor.declor fundef-params-p type vstate))
             ((erp new-expr index-type more-types vstate)
@@ -5440,7 +5442,7 @@
                 (set::union types more-types)
                 vstate))
        :array-static2
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-dirdeclor type ident types vstate)
              (valid-dirdeclor dirdeclor.declor fundef-params-p type vstate))
             ((erp new-expr index-type more-types vstate)
@@ -5460,7 +5462,7 @@
                 (set::union types more-types)
                 vstate))
        :array-star
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-dirdeclor type ident types vstate)
              (valid-dirdeclor
               dirdeclor.declor fundef-params-p type vstate)))
@@ -5657,7 +5659,7 @@
                 types
                 vstate))
        :array
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-declor? type types vstate)
              (valid-dirabsdeclor-option dirabsdeclor.declor? type vstate))
             ((erp new-size? index-type? more-types vstate)
@@ -5678,7 +5680,7 @@
                 (set::union types more-types)
                 vstate))
        :array-static1
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-declor? type types vstate)
              (valid-dirabsdeclor-option dirabsdeclor.declor? type vstate))
             ((erp new-size index-type more-types vstate)
@@ -5698,7 +5700,7 @@
                 (set::union types more-types)
                 vstate))
        :array-static2
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-declor? type types vstate)
              (valid-dirabsdeclor-option dirabsdeclor.declor? type vstate))
             ((erp new-size index-type more-types vstate)
@@ -5718,7 +5720,7 @@
                 (set::union types more-types)
                 vstate))
        :array-star
-       (b* ((type (make-type-array :of type))
+       (b* ((type (make-type-array :of type :size nil)) ; TODO: size
             ((erp new-declor? type types vstate)
              (valid-dirabsdeclor-option dirabsdeclor.declor? type vstate)))
          (retok (dirabsdeclor-array-star new-declor?)
@@ -7835,7 +7837,8 @@
        ((mv uid vstate) (vstate-get-fresh-uid ident (linkage-none) vstate))
        (vstate (vstate-add-ord (ident "__func__")
                               (make-valid-ord-info-objfun
-                               :type (make-type-array :of (type-char))
+                               :type (make-type-array :of (type-char)
+                                                      :size nil) ; TODO: size
                                :linkage (linkage-none)
                                :defstatus (valid-defstatus-defined)
                                :uid uid)
@@ -7844,7 +7847,8 @@
        (vstate (if (ienv->gcc/clang ienv)
                   (vstate-add-ord (ident "__FUNCTION__")
                                   (make-valid-ord-info-objfun
-                                   :type (make-type-array :of (type-char))
+                                   :type (make-type-array :of (type-char)
+                                                          :size nil) ; TODO: size
                                    :linkage (linkage-none)
                                    :defstatus (valid-defstatus-defined)
                                    :uid uid)
@@ -7854,7 +7858,8 @@
        (vstate (if (ienv->gcc/clang ienv)
                   (vstate-add-ord (ident "__PRETTY_FUNCTION__")
                                   (make-valid-ord-info-objfun
-                                   :type (make-type-array :of (type-char))
+                                   :type (make-type-array :of (type-char)
+                                                          :size nil) ; TODO: size
                                    :linkage (linkage-none)
                                    :defstatus (valid-defstatus-defined)
                                    :uid uid)


### PR DESCRIPTION
Add an optional positive integer as size. Extend notions of type compatibility and composite types accordingtly.

Since this matches the notion of array types in the language formalization, the formalp predicates and the mapping to the language formalization have been extended to include array types.

There are intentional TODOs in the validator to try and set the size if possible.  It is currently always set to `nil` (i.e. unknown size), so the behavior is essentially like before this change. But this change paves the way for further changes.