### PR TITLE
[cpp-syntax] Speed up a file.

### DIFF
--- a/books/projects/filesystems/utilities/cpp-syntax/cpp-parser.lisp
+++ b/books/projects/filesystems/utilities/cpp-syntax/cpp-parser.lisp
@@ -41,6 +41,8 @@
 (local (include-book "kestrel/utilities/ordinals" :dir :system))
 (local (include-book "std/lists/len" :dir :system))
 
+(local (in-theory (disable member-equal acl2::member-of-cons string-append append)))
+
 (set-induction-depth-limit 0)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Speeds up cpp-parser.lisp from about 1630 seconds to about 350 seconds (measured before the recent addition of useless runes files).