### PR TITLE
[REMORA] added other integer operations into primitives-evaluation.lisp

### DIFF
--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -254,4 +254,3 @@
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        (bval (not (zerop i1.int))))
     (expr-value-base (base-value-bool bval))))
-      

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -12,6 +12,8 @@
 
 (include-book "values")
 
+(local (include-book "kestrel/arithmetic-light/mod" :dir :system))
+
 (acl2::controlled-configuration)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -99,7 +101,7 @@
 
 (define prim-int-div ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluaton of integer division."
+  :short "Evaluation of integer division."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        ((when (zerop i2.int)) (reserr nil)) ;; ERROR: division by zero
@@ -160,7 +162,7 @@
   :short "Evaluation of integer shift left."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
-       ((when (negp i2.int)) (reserr nil)) ;; ERROR: shift by negative bits
+       ((when (< i2.int 0)) (reserr nil)) ;; ERROR: shift by negative bits
        (ival (int-value (ash i1.int i2.int))))
     (expr-value-base (base-value-int ival))))
 
@@ -169,7 +171,7 @@
   :short "Evaluation of integer shift right."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
-       ((when (negp i2.int)) (reserr nil)) ;; ERROR: shift by negative bits
+       ((when (< i2.int 0)) (reserr nil)) ;; ERROR: shift by negative bits
        (ival (int-value (ash i1.int (- i2.int)))))
     (expr-value-base (base-value-int ival))))
 

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -198,11 +198,11 @@
 ; a negative integer would count the number of 1's in it's absolute
 ; value representation. Thus, there is a mismatch. We currently resolved this
 ; by only accepting positive integers and errs on a negative input.
-(define prim-int-popc ((val 1 expr-valuep))
+(define prim-int-popc ((val1 expr-valuep))
   :returns (val expr-value-resultp)
   :short "Evaluation of integer pop count."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
-       ((when (< i2.int 0)) (reserr nil)) ;; ERROR: negative input
+       ((when (< i1.int 0)) (reserr nil)) ;; ERROR: negative input
        (ival (int-value (logcount i1.int))))
     (expr-value-base (base-value-int ival))))
 

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -12,7 +12,6 @@
 (in-package "REMORA")
 
 (include-book "values")
-(include-book "kestrel/fty/boolean-result" :dir :system)
 
 (local (include-book "kestrel/arithmetic-light/mod" :dir :system))
 
@@ -21,8 +20,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (local (in-theory (enable int-valuep-when-result-not-error
-                          float-valuep-when-result-not-error
-                          booleanp-when-result-not-error)))
+                          float-valuep-when-result-not-error)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -269,5 +269,5 @@
   :returns (val expr-value-resultp)
   :short "Evaluation of integer conversion to boolean."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
-       (bval (not (zerop i1.int))))
+       (bval (not (= i1.int 0))))
     (expr-value-base (base-value-bool bval))))

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -4,13 +4,15 @@
 ;
 ; License: A 3-clause BSD license. See the LICENSE file distributed with ACL2.
 ;
-; Author: Alessandro Coglio (www.alessandrocoglio.info)
+; Authors: Alessandro Coglio (www.alessandrocoglio.info)
+;          Quan Luu (quan.luu@kestrel.edu)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (in-package "REMORA")
 
 (include-book "values")
+(include-book "kestrel/fty/boolean-result" :dir :system)
 
 (local (include-book "kestrel/arithmetic-light/mod" :dir :system))
 
@@ -19,7 +21,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (local (in-theory (enable int-valuep-when-result-not-error
-                          float-valuep-when-result-not-error)))
+                          float-valuep-when-result-not-error
+                          booleanp-when-result-not-error)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -102,24 +105,30 @@
 (define prim-int-div ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
   :short "Evaluation of integer division."
+  :long "<p>Integer division uses ACL2's @(tsee floor), which rounds towards
+  minus infinity. This is consistent with [impl], which uses Haskell's
+  @('div')</p>"
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
-       ((when (zerop i2.int)) (reserr nil)) ;; ERROR: division by zero
+       ((when (= i2.int 0)) (reserr nil)) ;; ERROR: division by zero
        (ival (int-value (floor i1.int i2.int))))
     (expr-value-base (base-value-int ival))))
 
 (define prim-int-mod ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
   :short "Evaluation of integer modulo."
+  :long "<p>Integer modulo uses ACL2's @(tsee mod), whose result takes the sign
+  of the divisor. This is consistent with [impl], which uses Haskell's
+  @('mod')</p>"
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
-       ((when (zerop i2.int)) (reserr nil)) ;; ERROR: modulo zero
+       ((when (= i2.int 0)) (reserr nil)) ;; ERROR: modulo zero
        (ival (int-value (mod i1.int i2.int))))
     (expr-value-base (base-value-int ival))))
 
 (define prim-int-max ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer max."
+  :short "Evaluation of integer maximum."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (ival (int-value (max i1.int i2.int))))
@@ -127,7 +136,7 @@
 
 (define prim-int-min ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer min."
+  :short "Evaluation of integer minimum."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (ival (int-value (min i1.int i2.int))))
@@ -135,7 +144,7 @@
 
 (define prim-int-bit-and ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer bit and."
+  :short "Evaluation of integer bitwise conjunction."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (ival (int-value (logand i1.int i2.int))))
@@ -143,7 +152,7 @@
 
 (define prim-int-bit-or ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer bit or."
+  :short "Evaluation of integer bitwise inclusive disjunction."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (ival (int-value (logior i1.int i2.int))))
@@ -151,7 +160,7 @@
 
 (define prim-int-bit-xor ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer bit xor."
+  :short "Evaluation of integer bitwise exclusive disjunction."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (ival (int-value (logxor i1.int i2.int))))
@@ -159,7 +168,7 @@
 
 (define prim-int-shl ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer shift left."
+  :short "Evaluation of integer left shift."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        ((when (< i2.int 0)) (reserr nil)) ;; ERROR: shift by negative bits
@@ -168,7 +177,7 @@
 
 (define prim-int-shr ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer shift right."
+  :short "Evaluation of integer right shift."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        ((when (< i2.int 0)) (reserr nil)) ;; ERROR: shift by negative bits
@@ -179,17 +188,25 @@
 
 (define prim-int-bit-not ((val1 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer bit not."
+  :short "Evaluation of integer bitwise negation."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        (ival (int-value (lognot i1.int))))
     (expr-value-base (base-value-int ival))))
 
 ; TODO: prim-int-popc
-; NOTE: I think Haskell's popCount on a negative Int works by counting the
+; NOTE: Haskell's popCount on a negative Int works by counting the
 ; number  of 1's in the two's complement version of the number. Since Int has a
 ; fixed width, the number of 1's is finite in this case. But ACL2's logcount on
 ; a negative integer would count the number of 1's in it's absolute
-; value representation. Thus, there is a mismatch.
+; value representation. Thus, there is a mismatch. We currently resolved this
+; by only accepting positive integers and errs on a negative input.
+(define prim-int-popc ((val 1 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer pop count."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((when (< i2.int 0)) (reserr nil)) ;; ERROR: negative input
+       (ival (int-value (logcount i1.int))))
+    (expr-value-base (base-value-int ival))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -211,7 +228,7 @@
 
 (define prim-int-lt ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer less than."
+  :short "Evaluation of integer less-than comparison."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (bval (< i1.int i2.int)))
@@ -219,7 +236,7 @@
 
 (define prim-int-gt ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer greater than."
+  :short "Evaluation of integer greater-than comparison."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (bval (> i1.int i2.int)))
@@ -227,7 +244,7 @@
 
 (define prim-int-leq ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer less than or equal."
+  :short "Evaluation of integer less-than-or-equal-to comparison."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (bval (<= i1.int i2.int)))
@@ -235,7 +252,7 @@
 
 (define prim-int-geq ((val1 expr-valuep) (val2 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer greater than or equal."
+  :short "Evaluation of integer greater-than-or-equal-to comparison."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        ((ok (int-value i2)) (check-expr-value-int val2))
        (bval (>= i1.int i2.int)))
@@ -252,7 +269,7 @@
 
 (define prim-int-to-bool ((val1 expr-valuep))
   :returns (val expr-value-resultp)
-  :short "Evaluation of integer conversion to bool."
+  :short "Evaluation of integer conversion to boolean."
   (b* (((ok (int-value i1)) (check-expr-value-int val1))
        (bval (not (zerop i1.int))))
     (expr-value-base (base-value-bool bval))))

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -81,4 +81,177 @@
        (ival (int-value (+ i1.int i2.int))))
     (expr-value-base (base-value-int ival))))
 
-; TODO: add others
+(define prim-int-sub ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer subtraction."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (- i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-mul ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer multiplication."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (* i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-div ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluaton of integer division."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       ((when (zerop i2.int)) (reserr nil)) ;; ERROR: division by zero
+       (ival (int-value (floor i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-mod ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer modulo."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       ((when (zerop i2.int)) (reserr nil)) ;; ERROR: modulo zero
+       (ival (int-value (mod i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-max ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer max."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (max i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-min ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer min."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (min i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-bit-and ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer bit and."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (logand i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-bit-or ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer bit or."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (logior i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-bit-xor ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer bit xor."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (ival (int-value (logxor i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-shl ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer shift left."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       ((when (negp i2.int)) (reserr nil)) ;; ERROR: shift by negative bits
+       (ival (int-value (ash i1.int i2.int))))
+    (expr-value-base (base-value-int ival))))
+
+(define prim-int-shr ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer shift right."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       ((when (negp i2.int)) (reserr nil)) ;; ERROR: shift by negative bits
+       (ival (int-value (ash i1.int (- i2.int)))))
+    (expr-value-base (base-value-int ival))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-int-bit-not ((val1 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer bit not."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       (ival (int-value (lognot i1.int))))
+    (expr-value-base (base-value-int ival))))
+
+; TODO: prim-int-popc
+; NOTE: I think Haskell's popCount on a negative Int works by counting the
+; number  of 1's in the two's complement version of the number. Since Int has a
+; fixed width, the number of 1's is finite in this case. But ACL2's logcount on
+; a negative integer would count the number of 1's in it's absolute
+; value representation. Thus, there is a mismatch.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-int-eq ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer equality."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (bval (= i1.int i2.int)))
+    (expr-value-base (base-value-bool bval))))
+
+(define prim-int-neq ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer inequality."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (bval (not (= i1.int i2.int))))
+    (expr-value-base (base-value-bool bval))))
+
+(define prim-int-lt ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer less than."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (bval (< i1.int i2.int)))
+    (expr-value-base (base-value-bool bval))))
+
+(define prim-int-gt ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer greater than."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (bval (> i1.int i2.int)))
+    (expr-value-base (base-value-bool bval))))
+
+(define prim-int-leq ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer less than or equal."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (bval (<= i1.int i2.int)))
+    (expr-value-base (base-value-bool bval))))
+
+(define prim-int-geq ((val1 expr-valuep) (val2 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer greater than or equal."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       ((ok (int-value i2)) (check-expr-value-int val2))
+       (bval (>= i1.int i2.int)))
+    (expr-value-base (base-value-bool bval))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-int-to-float ((val1 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer conversion to float."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       (fval (float-value-ratio i1.int)))
+    (expr-value-base (base-value-float fval))))
+
+(define prim-int-to-bool ((val1 expr-valuep))
+  :returns (val expr-value-resultp)
+  :short "Evaluation of integer conversion to bool."
+  (b* (((ok (int-value i1)) (check-expr-value-int val1))
+       (bval (not (zerop i1.int))))
+    (expr-value-base (base-value-bool bval))))
+      


### PR DESCRIPTION
Added other integer operations from `RemoraPrelude.hs` into `primitives-evaluation.lisp`, except for `popc`/`popCount` (specific reason is documented inside `primitives-evaluation.lisp`.