### PR TITLE
[JSONRPC] updated using usocket instead of hunchentoot

### DIFF
--- a/books/kestrel/jsonrpc/socket.lisp
+++ b/books/kestrel/jsonrpc/socket.lisp
@@ -11,7 +11,7 @@
 (in-package "JSONRPC")
 
 (include-book "tools/include-raw" :dir :system)
-(include-book "quicklisp/hunchentoot" :dir :system)
+(include-book "quicklisp/usocket" :dir :system)
 
 (include-book "process-rpc")
 


### PR DESCRIPTION
Updated JSON-RPC to use `quicklisp/usocket`

@gjurgensen 