### PR TITLE
[REMORA] added prim-sum

### DIFF
--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -1576,20 +1576,20 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defines expr-value-atoms/list
-  :short "Collect the atoms of expression values."
+  :short "Collect the flattened list of atom values of expression values."
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
   (define expr-value-atoms ((val expr-valuep))
     :returns (vals expr-value-listp)
     :parents (expression-values-and-environments expr-value-atoms/list)
-    :short "Collect the atoms of an expression value."
+    :short "Collect the flattened list of atom values of an expression value."
     :long
     (xdoc::topstring
      (xdoc::p
       "Recall that we fold atom values into expression values
        (see @(tsee expr-value)):
-       the atoms of an array are the expression values at its leaves,
+       the atom values of an array are the expression values at its leaves,
        i.e. the ones that are neither vectors nor empty vectors.
        We return them in row-major order,
        i.e. in the order in which they occur in the nested vectors.")
@@ -1597,12 +1597,12 @@
       "This is the inverse of
        @(tsee expr-value-with-nonempty-dims),
        which builds an expression value
-       from its dimensions and from its atoms in the same order.
-       An empty vector has no atoms,
-       and a non-empty vector has the atoms of its elements.")
+       from its dimensions and from its atom values in the same order.
+       An empty vector has no atom values,
+       and a non-empty vector has the atom values of its elements.")
      (xdoc::p
       "This function is total:
-       every expression value that is not a vector is an atom,
+       every expression value that is not a vector is an atom value,
        including boxes and lambda abstractions."))
     (expr-value-case
      val
@@ -1616,11 +1616,11 @@
   (define expr-value-list-atoms ((vals expr-value-listp))
     :returns (vals1 expr-value-listp)
     :parents (expression-values-and-environments expr-value-atoms/list)
-    :short "Collect the atoms of a list of expression values."
+    :short "Collect the flattened list of atom values of a list of expression values."
     :long
     (xdoc::topstring
      (xdoc::p
-      "We concatenate the atoms of each expression value in the list,
+      "We concatenate the atom values of each expression value in the list,
        preserving the order."))
     (b* (((when (endp vals)) nil))
       (append (expr-value-atoms (car vals))

--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -339,7 +339,15 @@
        @(':int-binary-x') is the operation applied to
        its first argument value
        (which we call @('x'), based on the idea that
-       the two arguments are @('x') and @('y')."))
+       the two arguments are @('x') and @('y').")
+     (xdoc::p
+      "Not every polymorphic operation has a stage for every kind of value.
+       For example, @('sum') is monomorphic in the element type,
+       which is always integer,
+       so it has no type stage:
+       @(':sum') is the uninstantiated operation, and
+       @(':sum-s') is the operation applied to
+       a list of natural numbers for its shape parameter."))
     (:int-unary ((op int-unary-primop)))
     (:int-binary ((op int-binary-primop)))
     (:int-binary-x ((op int-binary-primop)
@@ -431,6 +439,8 @@
                        (mval nat)
                        (nval nat)
                        (xval expr-value)))
+    (:sum ())
+    (:sum-s ((sval nat-list)))
     :pred primop-valuep
     :measure (two-nats-measure (acl2-count x) 0))
 
@@ -1189,6 +1199,39 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defines expr-value-atoms/list
+  :short "Collect the atoms of expression values."
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (define expr-value-atoms ((val expr-valuep))
+    :returns (vals expr-value-listp)
+    :parents (expression-values-and-environments expr-value-atoms/list)
+    :short "Collect the atoms of an expression value."
+    (expr-value-case
+     val
+     :vector (expr-value-list-atoms val.elems)
+     :vector-empty nil
+     :otherwise (list (expr-value-fix val)))
+    :measure (expr-value-count val))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (define expr-value-list-atoms ((vals expr-value-listp))
+    :returns (vals1 expr-value-listp)
+    :parents (expression-values-and-environments expr-value-atoms/list)
+    :short "Collect the atoms of a list of expression values."
+    (b* (((when (endp vals)) nil))
+      (append (expr-value-atoms (car vals))
+              (expr-value-list-atoms (cdr vals))))
+    :measure (expr-value-list-count vals))
+
+  ///
+
+  (fty::deffixequiv-mutual expr-value-atoms/list))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define expr-value-with-empty-dim ((dims nat-listp) (elem type-valuep))
   :guard (and (member-equal 0 dims)
               (not (type-value-case elem :array)))
@@ -1532,6 +1575,64 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defines expr-value-atoms/list
+  :short "Collect the atoms of expression values."
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (define expr-value-atoms ((val expr-valuep))
+    :returns (vals expr-value-listp)
+    :parents (expression-values-and-environments expr-value-atoms/list)
+    :short "Collect the atoms of an expression value."
+    :long
+    (xdoc::topstring
+     (xdoc::p
+      "Recall that we fold atom values into expression values
+       (see @(tsee expr-value)):
+       the atoms of an array are the expression values at its leaves,
+       i.e. the ones that are neither vectors nor empty vectors.
+       We return them in row-major order,
+       i.e. in the order in which they occur in the nested vectors.")
+     (xdoc::p
+      "This is the inverse of
+       @(tsee expr-value-with-nonempty-dims),
+       which builds an expression value
+       from its dimensions and from its atoms in the same order.
+       An empty vector has no atoms,
+       and a non-empty vector has the atoms of its elements.")
+     (xdoc::p
+      "This function is total:
+       every expression value that is not a vector is an atom,
+       including boxes and lambda abstractions."))
+    (expr-value-case
+     val
+     :vector (expr-value-list-atoms val.elems)
+     :vector-empty nil
+     :otherwise (list (expr-value-fix val)))
+    :measure (expr-value-count val))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (define expr-value-list-atoms ((vals expr-value-listp))
+    :returns (vals1 expr-value-listp)
+    :parents (expression-values-and-environments expr-value-atoms/list)
+    :short "Collect the atoms of a list of expression values."
+    :long
+    (xdoc::topstring
+     (xdoc::p
+      "We concatenate the atoms of each expression value in the list,
+       preserving the order."))
+    (b* (((when (endp vals)) nil))
+      (append (expr-value-atoms (car vals))
+              (expr-value-list-atoms (cdr vals))))
+    :measure (expr-value-list-count vals))
+
+  ///
+
+  (fty::deffixequiv-mutual expr-value-atoms/list))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define primop-value-funp ((op primop-valuep))
   :returns (yes/no booleanp)
   :short "Check if a primitive operation value is
@@ -1609,7 +1710,9 @@
                      :index2d-t nil
                      :index2d-t-m nil
                      :index2d-t-m-n t
-                     :index2d-t-m-n-x t))
+                     :index2d-t-m-n-x t
+                     :sum nil
+                     :sum-s t))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1680,7 +1783,9 @@
                      :index2d-t nil
                      :index2d-t-m nil
                      :index2d-t-m-n nil
-                     :index2d-t-m-n-x nil))
+                     :index2d-t-m-n-x nil
+                     :sum nil
+                     :sum-s nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1750,7 +1855,9 @@
                      :index2d-t t
                      :index2d-t-m t
                      :index2d-t-m-n nil
-                     :index2d-t-m-n-x nil))
+                     :index2d-t-m-n-x nil
+                     :sum t
+                     :sum-s nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1831,6 +1938,7 @@
                      :index2d-t-m (primop-value-index2d)
                      :index2d-t-m-n (primop-value-index2d)
                      :index2d-t-m-n-x (primop-value-index2d)
+                     :sum-s (primop-value-sum)
                      :otherwise (primop-value-fix op)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2077,7 +2185,15 @@
                               :out (make-type-value-array
                                     :elem op.tval
                                     :dims nil))
-                       :dims nil)))
+                       :dims nil)
+     :sum (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :sum-s (make-type-value-array
+             :elem (make-type-value-fun
+                    :in (list (make-type-value-array
+                               :elem (type-value-base (base-type-int))
+                               :dims op.sval))
+                    :out int-tv)
+             :dims nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-funp)))
 
   ///
@@ -2780,7 +2896,8 @@
          (cons "append" (expr-value-primop (primop-value-append)))
          (cons "reverse" (expr-value-primop (primop-value-reverse)))
          (cons "index" (expr-value-primop (primop-value-index)))
-         (cons "index2d" (expr-value-primop (primop-value-index2d))))))
+         (cons "index2d" (expr-value-primop (primop-value-index2d)))
+         (cons "sum" (expr-value-primop (primop-value-sum))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -1289,39 +1289,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defines expr-value-atoms/list
-  :short "Collect the atoms of expression values."
-
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-  (define expr-value-atoms ((val expr-valuep))
-    :returns (vals expr-value-listp)
-    :parents (expression-values-and-environments expr-value-atoms/list)
-    :short "Collect the atoms of an expression value."
-    (expr-value-case
-     val
-     :vector (expr-value-list-atoms val.elems)
-     :vector-empty nil
-     :otherwise (list (expr-value-fix val)))
-    :measure (expr-value-count val))
-
-  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-  (define expr-value-list-atoms ((vals expr-value-listp))
-    :returns (vals1 expr-value-listp)
-    :parents (expression-values-and-environments expr-value-atoms/list)
-    :short "Collect the atoms of a list of expression values."
-    (b* (((when (endp vals)) nil))
-      (append (expr-value-atoms (car vals))
-              (expr-value-list-atoms (cdr vals))))
-    :measure (expr-value-list-count vals))
-
-  ///
-
-  (fty::deffixequiv-mutual expr-value-atoms/list))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (define expr-value-with-empty-dim ((dims nat-listp) (elem type-valuep))
   :guard (and (member-equal 0 dims)
               (not (type-value-case elem :array)))
@@ -1665,7 +1632,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defines expr-value-atoms/list
+(defines expr-values-atoms
   :short "Collect the flattened list of atom values of expression values."
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1719,7 +1686,7 @@
 
   ///
 
-  (fty::deffixequiv-mutual expr-value-atoms/list))
+  (fty::deffixequiv-mutual expr-values-atoms))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
+++ b/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
@@ -592,3 +592,55 @@
                   (list *mat23*
                         (expr-value-vector (list (iv 1) (iv 0)))))
  (iv 4))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; The polymorphic operation sum:
+; instantiation stage transition and application of the final stage.
+; This operation has no type stage,
+; because it is monomorphic in the element type.
+
+; Ispace application: sum applied to a shape.
+
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-sum) (ispace-value-shape (list 3)))
+ (expr-value-primop (make-primop-value-sum-s :sval (list 3))))
+
+; A dimension where a shape is expected.
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (primop-value-sum) (ispace-value-dim 3))))
+
+; Application of the fully instantiated operation.
+
+; Summing a vector.
+(acl2::assert-equal (prim-sum (list 3) *vec3*) (iv 6))
+
+; Summing a matrix adds all of its elements.
+(acl2::assert-equal (prim-sum (list 2 3) *mat23*) (iv 21))
+
+; Summing a scalar yields the scalar.
+(acl2::assert-equal (prim-sum nil (iv 5)) (iv 5))
+
+; Summing an empty vector yields zero.
+(acl2::assert-equal
+ (prim-sum (list 0) (make-expr-value-vector-empty :dims nil :elem *tv-int*))
+ (iv 0))
+
+; Cell dimensions not matching the instantiation.
+(acl2::assert-event (reserrp (prim-sum (list 2) *vec3*)))
+(acl2::assert-event (reserrp (prim-sum nil *vec3*)))
+
+; A cell whose atoms are not integers.
+(acl2::assert-event
+ (reserrp (prim-sum (list 2) (expr-value-vector (list (bv t) (bv nil))))))
+
+; Via eval-primop-fun, including the arity check.
+
+(acl2::assert-equal
+ (eval-primop-fun (make-primop-value-sum-s :sval (list 3)) (list *vec3*))
+ (iv 6))
+
+; Wrong number of argument cells.
+(acl2::assert-event
+ (reserrp (eval-primop-fun (make-primop-value-sum-s :sval (list 3))
+                           (list *vec3* *vec3*))))

--- a/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
+++ b/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
@@ -643,13 +643,14 @@
 (acl2::assert-event
  (reserrp (prim-sum (list 2) (expr-value-vector (list (bv t) (bv nil))))))
 
-; Via eval-primop-fun, including the arity check.
+; Via eval-primop-fun.
 
 (acl2::assert-equal
- (eval-primop-fun (make-primop-value-sum-s :sval (list 3)) (list *vec3*))
+ (eval-primop-fun (make-primop-value-sum-s :sval (list 3)) *vec3*)
  (iv 6))
 
 ; Wrong number of argument cells.
 (acl2::assert-event
- (reserrp (eval-primop-fun (make-primop-value-sum-s :sval (list 3))
-                           (list *vec3* *vec3*))))
+ (reserrp
+  (eval-primop-fun-chain (make-primop-value-sum-s :sval (list 3))
+                         (list *vec3* *vec3*))))

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -1957,7 +1957,7 @@
      (which the interpreter in [impl] does not use),
      and that all the atoms of the argument cell are integers.")
    (xdoc::p
-    "We collect the atoms of the argument cell via @(tsee expr-value-atoms),
+    "We collect the atom values of the argument cell via @(tsee expr-value-atoms),
      turn them into integers via @(tsee expr-value-list-ints),
      and add them via @(tsee integer-list-sum)."))
   (b* ((s (nat-list-fix s))

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -144,6 +144,16 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define check-expr-value-list-int ((vals expr-value-listp))
+  :returns (ivals integer-list-resultp)
+  :short "Check if an expression value is an integer list value, returning it if so"
+  (b* (((when (endp vals)) nil)
+       ((ok (int-value ival)) (check-expr-value-int (car vals)))
+       ((ok rest) (check-expr-value-list-int (cdr vals))))
+    (cons ival.int rest)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define check-expr-value-float ((val expr-valuep))
   :returns (fval float-value-resultp)
   :short "Check if an expression value is a float value, returning it if so."
@@ -1923,20 +1933,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define expr-value-list-ints ((vals expr-value-listp))
-  :returns (ints integer-list-resultp)
-  :short "Turn a list of expression values into a list of integers."
-  :long
-  (xdoc::topstring
-   (xdoc::p
-    "This fails if any of the expression values is not a scalar integer."))
-  (b* (((when (endp vals)) nil)
-       ((ok (int-value ival)) (check-expr-value-int (car vals)))
-       ((ok rest) (expr-value-list-ints (cdr vals))))
-    (cons ival.int rest)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
 (define prim-sum ((s nat-listp) (val1 expr-valuep))
   :guard (expr-value-wfp val1)
   :returns (val expr-value-resultp)
@@ -1959,11 +1955,11 @@
      and that all the atoms of the argument cell are integers.")
    (xdoc::p
     "We collect the atom values of the argument cell via @(tsee expr-value-atoms),
-     turn them into integers via @(tsee expr-value-list-ints),
+     turn them into integers via @(tsee check-expr-value-list-int),
      and add them via @(tsee integer-list-sum)."))
   (b* ((s (nat-list-fix s))
        ((unless (equal (dims-of-expr-value val1) s)) (reserr nil))
-       ((ok ints) (expr-value-list-ints (expr-value-atoms val1))))
+       ((ok ints) (check-expr-value-list-int (expr-value-atoms val1))))
     (expr-value-base (base-value-int (int-value (integer-list-sum ints)))))
   ///
 

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -12,7 +12,10 @@
 (in-package "REMORA")
 
 (include-book "expression-values-and-environments")
+(include-book "integer-lists")
 
+(include-book "kestrel/fty/integer-result" :dir :system)
+(include-book "kestrel/fty/integer-list-result" :dir :system)
 (include-book "kestrel/fty/boolean-result" :dir :system)
 
 (local (include-book "kestrel/arithmetic-light/expt" :dir :system))
@@ -26,7 +29,9 @@
 
 (local (in-theory (enable int-valuep-when-result-not-error
                           float-valuep-when-result-not-error
-                          booleanp-when-result-not-error)))
+                          booleanp-when-result-not-error
+                          acl2::integerp-when-result-not-error
+                          acl2::integer-listp-when-result-not-error)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -91,7 +96,7 @@
     "The polymorphic primitives currently implemented are
      @(tsee prim-head), @(tsee prim-tail), @(tsee prim-length),
      @(tsee prim-append), @(tsee prim-reverse),
-     @(tsee prim-index), and @(tsee prim-index2d).")
+     @(tsee prim-index), @(tsee prim-index2d), and @(tsee prim-sum).")
    (xdoc::p
     "For integers, we currently model Remora integer values as unbounded
      mathematical integers, matching ACL2's own integer type.
@@ -1915,6 +1920,56 @@
     (("Goal"
       :in-theory (enable expr-value-wfp-of-nth-when-expr-value-list-wfp nfix)))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define expr-value-list-ints ((vals expr-value-listp))
+  :returns (ints integer-list-resultp)
+  :short "Turn a list of expression values into a list of integers."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This fails if any of the expression values is not a scalar integer."))
+  (b* (((when (endp vals)) nil)
+       ((ok (int-value ival)) (check-expr-value-int (car vals)))
+       ((ok rest) (expr-value-list-ints (cdr vals))))
+    (cons ival.int rest)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-sum ((s nat-listp) (val1 expr-valuep))
+  :guard (expr-value-wfp val1)
+  :returns (val expr-value-resultp)
+  :short "Evaluation of array summation."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This is the semantics of the fully instantiated @('sum') operation
+     (see the @(':sum-s') summand of @(tsee primop-value)):
+     @('s') is the instantiation value,
+     and @('val1') is the argument cell.
+     According to the instantiated type of the operation,
+     the argument cell is an array of integers
+     whose dimensions are the shape @('s'),
+     and the result is the sum of all of its integers,
+     as a scalar integer value.
+     The guard requires the argument cell to be well-formed;
+     we defensively check that it has the expected dimensions
+     (which the interpreter in [impl] does not use),
+     and that all the atoms of the argument cell are integers.")
+   (xdoc::p
+    "We collect the atoms of the argument cell via @(tsee expr-value-atoms),
+     turn them into integers via @(tsee expr-value-list-ints),
+     and add them via @(tsee integer-list-sum)."))
+  (b* ((s (nat-list-fix s))
+       ((unless (equal (dims-of-expr-value val1) s)) (reserr nil))
+       ((ok ints) (expr-value-list-ints (expr-value-atoms val1))))
+    (expr-value-base (base-value-int (int-value (integer-list-sum ints)))))
+  ///
+
+  (defret expr-value-wfp-of-prim-sum
+    (implies (not (reserrp val))
+             (expr-value-wfp val))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define eval-primop-fun ((op primop-valuep) (args expr-value-listp))
@@ -2052,7 +2107,9 @@
      :index2d-t-m (prog2$ (impossible) (reserr nil))
      :index2d-t-m-n (prim-index2d op.tval op.mval op.nval
                                   (first args) (second args))
-     :index2d-t-m-n-x (reserr :todo)))
+     :index2d-t-m-n-x (reserr :todo)
+     :sum (prog2$ (impossible) (reserr nil))
+     :sum-s (prim-sum op.sval (first args))))
   :guard-hints (("Goal" :in-theory (enable primop-value-funp
                                            arity-of-primop-value-fun
                                            type-of-primop-value-fun)))
@@ -2160,7 +2217,9 @@
      namely the sort of the next ispace parameter
      in the operation's type in @(tsee primop-types):
      a dimension for the stages that store just a type value,
-     a shape for the stages that also store a dimension.
+     a shape for the stages that also store a dimension;
+     the uninstantiated stage of @('sum'), which has no type parameter,
+     stores nothing and expects a shape directly.
      We check that the ispace value has the expected sort;
      then we construct the next instantiation stage of the operation,
      which stores the ispace values received
@@ -2168,8 +2227,9 @@
      for @('head'), @('tail'), @('length'), and @('reverse');
      two dimensions and a shape for @('append');
      a dimension for @('index');
-     two dimensions for @('index2d')),
-     along with the previously received type values.
+     two dimensions for @('index2d');
+     a shape for @('sum')),
+     along with the previously received type values (if any).
      Anything else is an error."))
   (primop-value-case
    op
@@ -2265,6 +2325,11 @@
                                                         :mval op.mval
                                                         :nval ival.val))
                  :shape (reserr nil))
+   :sum (ispace-value-case
+         ival
+         :dim (reserr nil)
+         :shape (expr-value-primop
+                 (make-primop-value-sum-s :sval ival.val)))
    :otherwise (prog2$ (impossible) (reserr nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-ifunp)))
 

--- a/books/kestrel/remora/static-environments.lisp
+++ b/books/kestrel/remora/static-environments.lisp
@@ -126,6 +126,10 @@
      @('append'), @('reverse'), @('index'), and @('index2d') operations
      have polymorphic types:
      a universal type of a product type of a function type, as in [impl].
+     The @('sum') operation is polymorphic only in the shape,
+     not in the element type, which is always integer:
+     its type is a product type of a function type,
+     without an enclosing universal type, as in [impl].
      Like the monomorphic types,
      the whole type is a zero-rank array type,
      but the bodies of the universal and product types
@@ -201,6 +205,11 @@
                            (t-> ((t[] "&t" (shape++ "$m" "$n"))
                                  (t[] :int (shp 2)))
                                 "&t")))
+             (shp)))
+       (sum-type
+        (t[] (tpi ("@s")
+                  (t-> ((t[] :int "@s"))
+                       :int))
              (shp))))
     (omap::from-alist
      (list (cons "+" int-binop-type)
@@ -258,7 +267,8 @@
            (cons "append" append-type)
            (cons "reverse" reverse-type)
            (cons "index" index-type)
-           (cons "index2d" index2d-type)))))
+           (cons "index2d" index2d-type)
+           (cons "sum" sum-type)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Added the primitive `prim-sum`, which sums everything in the flattened list. 

To support this, I added a helper in `expression-values-and-environments.lisp` that takes in an `expr-value` and returns an `expr-value-list` that is the flattened list of elements in the original `expr-value`. This will potentially be useful for primitives like `flatten` and `reshape` as well.

@acoglio 