### PR TITLE
[REMORA] added `reshape`

### DIFF
--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -359,7 +359,13 @@
        so it has no type stage:
        @(':sum') is the uninstantiated operation, and
        @(':sum-s') is the operation applied to
-       a list of natural numbers for its shape parameter."))
+       a list of natural numbers for its shape parameter.
+       Conversely, an operation may have several stages
+       for the same kind of value:
+       @('reshape') has no dimension stage,
+       but has two shape stages,
+       @(':reshape-t-s1') and @(':reshape-t-s1-s2'),
+       for its two shape parameters."))
     (:int-unary ((op int-unary-primop)))
     (:int-binary ((op int-binary-primop)))
     (:int-binary-x ((op int-binary-primop)
@@ -453,6 +459,13 @@
                        (xval expr-value)))
     (:sum ())
     (:sum-s ((sval nat-list)))
+    (:reshape ())
+    (:reshape-t ((tval type-value)))
+    (:reshape-t-s1 ((tval type-value)
+                    (s1val nat-list)))
+    (:reshape-t-s1-s2 ((tval type-value)
+                       (s1val nat-list)
+                       (s2val nat-list)))
     :pred primop-valuep
     :measure (two-nats-measure (acl2-count x) 0))
 
@@ -793,7 +806,19 @@
              repeat
              len
              acl2::not-reserrp-when-nat-list-listp)
-    :prep-books ((local (include-book "arithmetic-3/top" :dir :system)))))
+    :prep-books ((local (include-book "arithmetic-3/top" :dir :system))))
+
+  (defruled check-dims-of-expr-value-list-of-append
+    (equal (check-dims-of-expr-value-list (append vals1 vals2))
+           (b* (((ok dimss1) (check-dims-of-expr-value-list vals1))
+                ((ok dimss2) (check-dims-of-expr-value-list vals2)))
+             (append dimss1 dimss2)))
+    :induct t
+    :enable (check-dims-of-expr-value-list
+             append
+             acl2::not-reserrp-when-nat-list-listp
+             acl2::nat-listp-when-result-not-error
+             acl2::nat-list-listp-when-result-not-error)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1697,9 +1722,112 @@
               (expr-value-list-atoms (cdr vals))))
     :measure (expr-value-list-count vals))
 
+  :prepwork ((local (include-book "arithmetic-3/top" :dir :system)))
+
   ///
 
-  (fty::deffixequiv-mutual expr-values-atoms))
+  (fty::deffixequiv-mutual expr-values-atoms)
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (defret-mutual check-dims-of-expr-values-atoms
+    (defret check-dims-of-expr-value-list-of-expr-value-atoms
+      (equal (check-dims-of-expr-value-list vals)
+             (repeat (len vals) nil))
+      :hyp (not (reserrp (check-dims-of-expr-value val)))
+      :fn expr-value-atoms)
+    (defret check-dims-of-expr-value-list-of-expr-value-list-atoms
+      (equal (check-dims-of-expr-value-list vals1)
+             (repeat (len vals1) nil))
+      :hyp (not (reserrp (check-dims-of-expr-value-list vals)))
+      :fn expr-value-list-atoms)
+    :hints (("Goal"
+             :expand ((check-dims-of-expr-value val))
+             :in-theory (enable expr-value-atoms
+                                expr-value-list-atoms
+                                check-dims-of-expr-value
+                                check-dims-of-expr-value-list
+                                check-dims-of-expr-value-list-of-append
+                                append-of-repeats-same
+                                acl2::not-reserrp-when-nat-list-listp
+                                acl2::nat-listp-when-result-not-error
+                                acl2::nat-list-listp-when-result-not-error
+                                repeat
+                                len
+                                nfix))))
+
+  (defret-mutual len-of-expr-values-atoms
+    (defret len-of-expr-value-atoms
+      (equal (len vals)
+             (nat-list-product (check-dims-of-expr-value val)))
+      :hyp (not (reserrp (check-dims-of-expr-value val)))
+      :fn expr-value-atoms)
+    (defret len-of-expr-value-list-atoms
+      (equal (len vals1)
+             (* (len vals)
+                (nat-list-product
+                 (car (check-dims-of-expr-value-list vals)))))
+      :hyp (and (not (reserrp (check-dims-of-expr-value-list vals)))
+                (list-repeatp (check-dims-of-expr-value-list vals)))
+      :fn expr-value-list-atoms)
+    :hints (("Goal"
+             :expand ((check-dims-of-expr-value val))
+             :in-theory (enable expr-value-atoms
+                                expr-value-list-atoms
+                                check-dims-of-expr-value
+                                check-dims-of-expr-value-list
+                                nat-list-product
+                                list-repeatp
+                                acl2::not-reserrp-when-nat-list-listp
+                                acl2::nat-listp-when-result-not-error
+                                acl2::nat-list-listp-when-result-not-error
+                                len
+                                nfix))))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (defret expr-value-list-wfp-of-expr-value-atoms
+    (expr-value-list-wfp vals)
+    :hyp (expr-value-wfp val)
+    :fn expr-value-atoms
+    :hints (("Goal"
+             :in-theory (enable expr-value-wfp
+                                expr-value-list-wfp-alt-def
+                                acl2::not-reserrp-when-nat-list-listp))))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (defret expr-value-list-wfp-of-expr-value-list-atoms
+    (expr-value-list-wfp vals1)
+    :hyp (expr-value-list-wfp vals)
+    :fn expr-value-list-atoms
+    :hints (("Goal"
+             :in-theory (enable expr-value-list-wfp-alt-def
+                                acl2::not-reserrp-when-nat-list-listp))))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (defret dims-of-expr-value-list-of-expr-value-atoms
+    (equal (dims-of-expr-value-list vals)
+           (repeat (len vals) nil))
+    :hyp (expr-value-wfp val)
+    :fn expr-value-atoms
+    :hints (("Goal"
+             :in-theory
+             (enable expr-value-wfp
+                     expr-value-list-wfp-alt-def
+                     dims-of-expr-value-list-when-expr-value-list-wfp
+                     acl2::not-reserrp-when-nat-list-listp))))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (defret len-of-expr-value-atoms-when-expr-value-wfp
+    (equal (len vals)
+           (nat-list-product (dims-of-expr-value val)))
+    :hyp (expr-value-wfp val)
+    :fn expr-value-atoms
+    :hints (("Goal" :in-theory (enable expr-value-wfp
+                                       dims-of-expr-value)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1782,7 +1910,11 @@
                      :index2d-t-m-n t
                      :index2d-t-m-n-x t
                      :sum nil
-                     :sum-s t))
+                     :sum-s t
+                     :reshape nil
+                     :reshape-t nil
+                     :reshape-t-s1 nil
+                     :reshape-t-s1-s2 t))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1855,7 +1987,11 @@
                      :index2d-t-m-n nil
                      :index2d-t-m-n-x nil
                      :sum nil
-                     :sum-s nil))
+                     :sum-s nil
+                     :reshape t
+                     :reshape-t nil
+                     :reshape-t-s1 nil
+                     :reshape-t-s1-s2 nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1927,7 +2063,11 @@
                      :index2d-t-m-n nil
                      :index2d-t-m-n-x nil
                      :sum t
-                     :sum-s nil))
+                     :sum-s nil
+                     :reshape nil
+                     :reshape-t t
+                     :reshape-t-s1 t
+                     :reshape-t-s1-s2 nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2009,6 +2149,9 @@
                      :index2d-t-m-n (primop-value-index2d)
                      :index2d-t-m-n-x (primop-value-index2d)
                      :sum-s (primop-value-sum)
+                     :reshape-t (primop-value-reshape)
+                     :reshape-t-s1 (primop-value-reshape)
+                     :reshape-t-s1-s2 (primop-value-reshape)
                      :otherwise (primop-value-fix op)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2263,7 +2406,19 @@
                            :elem (type-value-base (base-type-int))
                            :dims op.sval))
                     int-tv)
-             :dims nil)))
+             :dims nil)
+     :reshape (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :reshape-t (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :reshape-t-s1 (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :reshape-t-s1-s2 (make-type-value-array
+                       :elem (make-arrow-type-value
+                              (list (make-type-value-array
+                                     :elem op.tval
+                                     :dims op.s1val))
+                              (make-type-value-array
+                               :elem op.tval
+                               :dims op.s2val))
+                       :dims nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-funp)))
 
   ///
@@ -2977,7 +3132,8 @@
          (cons "reverse" (expr-value-primop (primop-value-reverse)))
          (cons "index" (expr-value-primop (primop-value-index)))
          (cons "index2d" (expr-value-primop (primop-value-index2d)))
-         (cons "sum" (expr-value-primop (primop-value-sum))))))
+         (cons "sum" (expr-value-primop (primop-value-sum)))
+         (cons "reshape" (expr-value-primop (primop-value-reshape))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/remora/lists.lisp
+++ b/books/kestrel/remora/lists.lisp
@@ -69,6 +69,15 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defruled append-of-repeats-same
+  (equal (append (repeat m x) (repeat n x))
+         (repeat (+ (nfix m) (nfix n)) x))
+  :induct (repeat m x)
+  :enable (repeat nfix)
+  :expand ((repeat (+ m n) x)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define append-all ((lists true-list-listp))
   :returns (list true-listp)
   :short "Append all the lists in a list, in that order."

--- a/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
+++ b/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
@@ -654,3 +654,96 @@
  (reserrp
   (eval-primop-fun-chain (make-primop-value-sum-s :sval (list 3))
                          (list *vec3* *vec3*))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; The polymorphic operation reshape:
+; instantiation stage transitions and application of the final stage.
+
+; Type application: reshape applied to one atom type value.
+
+(acl2::assert-equal
+ (eval-primop-tfun (primop-value-reshape) *tv-int*)
+ (expr-value-primop (primop-value-reshape-t *tv-int*)))
+
+; Ispace applications: reshape-t applied to a shape,
+; then reshape-t-s1 applied to another shape.
+
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-reshape-t *tv-int*)
+                   (ispace-value-shape (list 2 3)))
+ (expr-value-primop (make-primop-value-reshape-t-s1 :tval *tv-int*
+                                                    :s1val (list 2 3))))
+
+(acl2::assert-equal
+ (eval-primop-ifun (make-primop-value-reshape-t-s1 :tval *tv-int*
+                                                   :s1val (list 2 3))
+                   (ispace-value-shape (list 6)))
+ (expr-value-primop (make-primop-value-reshape-t-s1-s2 :tval *tv-int*
+                                                       :s1val (list 2 3)
+                                                       :s2val (list 6))))
+
+; A dimension where a shape is expected.
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (primop-value-reshape-t *tv-int*)
+                            (ispace-value-dim 3))))
+
+; Application of the fully instantiated operation.
+
+; Flattening a matrix into a vector.
+(acl2::assert-equal
+ (prim-reshape *tv-int* (list 2 3) (list 6) *mat23*)
+ (expr-value-vector
+  (list (iv 1) (iv 2) (iv 3) (iv 4) (iv 5) (iv 6))))
+
+; Reshaping a matrix into its transpose's shape
+; (note: NOT a transpose; atoms stay in row-major order).
+(acl2::assert-equal
+ (prim-reshape *tv-int* (list 2 3) (list 3 2) *mat23*)
+ (expr-value-vector
+  (list (expr-value-vector (list (iv 1) (iv 2)))
+        (expr-value-vector (list (iv 3) (iv 4)))
+        (expr-value-vector (list (iv 5) (iv 6))))))
+
+; Reshaping a vector to itself.
+(acl2::assert-equal
+ (prim-reshape *tv-int* (list 3) (list 3) *vec3*) *vec3*)
+
+; Reshaping a one-element vector into a scalar and back.
+(acl2::assert-equal (prim-reshape *tv-int* (list 1) nil *vec1*) (iv 1))
+(acl2::assert-equal
+ (prim-reshape *tv-int* nil (list 1) (iv 1)) *vec1*)
+
+; Reshaping an empty vector into another empty shape.
+(acl2::assert-equal
+ (prim-reshape *tv-int* (list 0) (list 0 2)
+               (make-expr-value-vector-empty :dims nil :elem *tv-int*))
+ (make-expr-value-vector-empty :dims (list 2) :elem *tv-int*))
+
+; Shapes with different products.
+(acl2::assert-event
+ (reserrp (prim-reshape *tv-int* (list 2 3) (list 5) *mat23*)))
+(acl2::assert-event
+ (reserrp (prim-reshape *tv-int* (list 3) (list 0) *vec3*)))
+
+; Cell dimensions not matching the first shape.
+(acl2::assert-event
+ (reserrp (prim-reshape *tv-int* (list 6) (list 2 3) *mat23*)))
+
+; Via eval-primop-fun.
+
+(acl2::assert-equal
+ (eval-primop-fun (make-primop-value-reshape-t-s1-s2 :tval *tv-int*
+                                                     :s1val (list 2 3)
+                                                     :s2val (list 6))
+                  *mat23*)
+ (expr-value-vector
+  (list (iv 1) (iv 2) (iv 3) (iv 4) (iv 5) (iv 6))))
+
+; Wrong number of argument cells.
+(acl2::assert-event
+ (reserrp
+  (eval-primop-fun-chain (make-primop-value-reshape-t-s1-s2 :tval *tv-int*
+                                                            :s1val (list 2 3)
+                                                            :s2val (list 6))
+                         (list *mat23* *mat23*))))

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -97,7 +97,8 @@
     "The polymorphic primitives currently implemented are
      @(tsee prim-head), @(tsee prim-tail), @(tsee prim-length),
      @(tsee prim-append), @(tsee prim-reverse),
-     @(tsee prim-index), @(tsee prim-index2d), and @(tsee prim-sum).")
+     @(tsee prim-index), @(tsee prim-index2d), @(tsee prim-sum),
+     and @(tsee prim-reshape).")
    (xdoc::p
     "For integers, we currently model Remora integer values as unbounded
      mathematical integers, matching ACL2's own integer type.
@@ -1961,11 +1962,72 @@
        ((unless (equal (dims-of-expr-value val1) s)) (reserr nil))
        ((ok ints) (check-expr-value-list-int (expr-value-atoms val1))))
     (expr-value-base (base-value-int (int-value (integer-list-sum ints)))))
+
   ///
 
   (defret expr-value-wfp-of-prim-sum
     (implies (not (reserrp val))
              (expr-value-wfp val))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-reshape ((tval type-valuep)
+                      (s1 nat-listp)
+                      (s2 nat-listp)
+                      (val1 expr-valuep))
+  :guard (expr-value-wfp val1)
+  :returns (val expr-value-resultp)
+  :short "Evaluation of array reshaping."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This is the semantics of the fully instantiated @('reshape') operation
+     (see the @(':reshape-t-s1-s2') summand of @(tsee primop-value)):
+     @('tval'), @('s1'), and @('s2') are the instantiation values,
+     and @('val1') is the argument cell.
+     According to the instantiated type of the operation,
+     the argument cell is an array with dimensions @('s1'),
+     and the result is an array with dimensions @('s2')
+     containing the same atom values in the same (row-major) order.
+     The two shapes must have the same product,
+     i.e. the same total number of atom values;
+     the interpreter in [impl] checks this
+     when the operation is applied to the second shape,
+     while we defensively check it here,
+     along with the dimensions of the argument cell.")
+   (xdoc::p
+    "If the new shape has a zero dimension, the result is empty:
+     we build it via @(tsee expr-value-with-empty-dim),
+     which requires an atom type value.
+     Otherwise, we collect the atom values of the argument cell
+     via @(tsee expr-value-atoms),
+     and we arrange them according to the new shape
+     via @(tsee expr-value-with-nonempty-dims).")
+   (xdoc::p
+    "Note that the interpreter in [impl] crashes
+     when the argument cell is a scalar,
+     because, unlike the other array operations,
+     it does not normalize non-array values to zero-rank arrays:
+     we treat the scalar case uniformly,
+     consistently with the other operations in [impl] and here."))
+  (b* ((s1 (nat-list-fix s1))
+       (s2 (nat-list-fix s2))
+       ((unless (equal (dims-of-expr-value val1) s1)) (reserr nil))
+       ((unless (equal (nat-list-product s1) (nat-list-product s2)))
+        (reserr nil))
+       ((when (member-equal 0 s2))
+        (b* (((when (type-value-case tval :array)) (reserr nil)))
+          (expr-value-with-empty-dim s2 tval)))
+       (atoms (expr-value-atoms val1)))
+    (expr-value-with-nonempty-dims s2 atoms))
+
+  ///
+
+  (defret expr-value-wfp-of-prim-reshape
+    (implies (not (reserrp val))
+             (expr-value-wfp val))
+    :hyp (and (nat-listp s2)
+              (expr-value-wfp val1))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2142,7 +2204,11 @@
                                                         :xval arg))
      :index2d-t-m-n-x (prim-index2d op.tval op.mval op.nval op.xval arg)
      :sum (prog2$ (impossible) (reserr nil))
-     :sum-s (prim-sum op.sval arg)))
+     :sum-s (prim-sum op.sval arg)
+     :reshape (prog2$ (impossible) (reserr nil))
+     :reshape-t (prog2$ (impossible) (reserr nil))
+     :reshape-t-s1 (prog2$ (impossible) (reserr nil))
+     :reshape-t-s1-s2 (prim-reshape op.tval op.s1val op.s2val arg)))
   :guard-hints (("Goal" :in-theory (enable primop-value-funp)))
 
   ///
@@ -2258,7 +2324,12 @@
                            (list tval)
                            (list (type-var-atom "t"))))
                   (reserr nil)))
-            (expr-value-primop (primop-value-index2d-t tval)))
+              (expr-value-primop (primop-value-index2d-t tval)))
+   :reshape (b* (((unless (type-values-match-type-vars-p
+                           (list tval)
+                           (list (type-var-atom "t"))))
+                  (reserr nil)))
+              (expr-value-primop (primop-value-reshape-t tval)))
    :otherwise (prog2$ (impossible) (reserr nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-tfunp
                                            type-values-match-type-vars-p)))
@@ -2294,8 +2365,9 @@
      an ispace value of a specific sort,
      namely the sort of the next ispace parameter
      in the operation's type in @(tsee primop-types):
-     a dimension for the stages that store just a type value,
-     a shape for the stages that also store a dimension;
+     a dimension for the stages that store just a type value
+     (except @(':reshape-t'), which expects the first of two shapes),
+     a shape for the stages that also store a dimension or a shape;
      the uninstantiated stage of @('sum'), which has no type parameter,
      stores nothing and expects a shape directly.
      We check that the ispace value has the expected sort;
@@ -2306,7 +2378,8 @@
      two dimensions and a shape for @('append');
      a dimension for @('index');
      two dimensions for @('index2d');
-     a shape for @('sum')),
+     a shape for @('sum');
+     two shapes for @('reshape')),
      along with the previously received type values (if any).
      Anything else is an error."))
   (primop-value-case
@@ -2408,6 +2481,19 @@
          :dim (reserr nil)
          :shape (expr-value-primop
                  (make-primop-value-sum-s :sval ival.val)))
+   :reshape-t (ispace-value-case
+               ival
+               :dim (reserr nil)
+               :shape (expr-value-primop
+                       (make-primop-value-reshape-t-s1 :tval op.tval
+                                                       :s1val ival.val)))
+   :reshape-t-s1 (ispace-value-case
+                  ival
+                  :dim (reserr nil)
+                  :shape (expr-value-primop
+                          (make-primop-value-reshape-t-s1-s2 :tval op.tval
+                                                             :s1val op.s1val
+                                                             :s2val ival.val)))
    :otherwise (prog2$ (impossible) (reserr nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-ifunp)))
 

--- a/books/kestrel/remora/static-environments.lisp
+++ b/books/kestrel/remora/static-environments.lisp
@@ -123,7 +123,8 @@
     "The operations from @('+') to @('bool->f') have monomorphic types:
      zero-rank array types of function types between base types.
      The @('head'), @('tail'), @('length'),
-     @('append'), @('reverse'), @('index'), and @('index2d') operations
+     @('append'), @('reverse'), @('index'), @('index2d'),
+     and @('reshape') operations
      have polymorphic types:
      a universal type of a product type of a function type, as in [impl].
      The @('sum') operation is polymorphic only in the shape,
@@ -210,6 +211,12 @@
         (t[] (tpi ("@s")
                   (t-> ((t[] :int "@s"))
                        :int))
+             (shp)))
+       (reshape-type
+        (t[] (tforall ("&t")
+                      (tpi ("@s1" "@s2")
+                           (t-> ((t[] "&t" "@s1"))
+                                (t[] "&t" "@s2"))))
              (shp))))
     (omap::from-alist
      (list (cons "+" int-binop-type)
@@ -268,7 +275,8 @@
            (cons "reverse" reverse-type)
            (cons "index" index-type)
            (cons "index2d" index2d-type)
-           (cons "sum" sum-type)))))
+           (cons "sum" sum-type)
+           (cons "reshape" reshape-type)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Added `prim-reshape` as well as some theories about `expr-values-atoms`, which was introduced before for `prim-sum`, by matching it closely to `expr-values-with-nonempty-dims`.

@acoglio 