### PR TITLE
[Remora] add prim-flatten

### DIFF
--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -467,6 +467,17 @@
     (:reshape-t-s1-s2 ((tval type-value)
                        (s1val nat-list)
                        (s2val nat-list)))
+    (:flatten ())
+    (:flatten-t ((tval type-value)))
+    (:flatten-t-m ((tval type-value)
+                   (mval nat)))
+    (:flatten-t-m-n ((tval type-value)
+                     (mval nat)
+                     (nval nat)))
+    (:flatten-t-m-n-s ((tval type-value)
+                       (mval nat)
+                       (nval nat)
+                       (sval nat-list)))
     (:transpose2d ())
     (:transpose2d-t ((tval type-value)))
     (:transpose2d-t-m ((tval type-value)
@@ -2002,6 +2013,11 @@
                      :reshape-t nil
                      :reshape-t-s1 nil
                      :reshape-t-s1-s2 t
+                     :flatten nil
+                     :flatten-t nil
+                     :flatten-t-m nil
+                     :flatten-t-m-n nil
+                     :flatten-t-m-n-s t
                      :transpose2d nil
                      :transpose2d-t nil
                      :transpose2d-t-m nil
@@ -2083,6 +2099,11 @@
                      :reshape-t nil
                      :reshape-t-s1 nil
                      :reshape-t-s1-s2 nil
+                     :flatten t
+                     :flatten-t nil
+                     :flatten-t-m nil
+                     :flatten-t-m-n nil
+                     :flatten-t-m-n-s nil
                      :transpose2d t
                      :transpose2d-t nil
                      :transpose2d-t-m nil
@@ -2163,6 +2184,11 @@
                      :reshape-t t
                      :reshape-t-s1 t
                      :reshape-t-s1-s2 nil
+                     :flatten nil
+                     :flatten-t t
+                     :flatten-t-m t
+                     :flatten-t-m-n t
+                     :flatten-t-m-n-s nil
                      :transpose2d nil
                      :transpose2d-t t
                      :transpose2d-t-m t
@@ -2251,6 +2277,10 @@
                      :reshape-t (primop-value-reshape)
                      :reshape-t-s1 (primop-value-reshape)
                      :reshape-t-s1-s2 (primop-value-reshape)
+                     :flatten-t (primop-value-flatten)
+                     :flatten-t-m (primop-value-flatten)
+                     :flatten-t-m-n (primop-value-flatten)
+                     :flatten-t-m-n-s (primop-value-flatten)
                      :transpose2d (primop-value-transpose2d)
                      :transpose2d-t (primop-value-transpose2d)
                      :transpose2d-t-m (primop-value-transpose2d)
@@ -2521,6 +2551,19 @@
                               (make-type-value-array
                                :elem op.tval
                                :dims op.s2val))
+                       :dims nil)
+     :flatten (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :flatten-t (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :flatten-t-m (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :flatten-t-m-n (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :flatten-t-m-n-s (make-type-value-array
+                       :elem (nest-function-type-values
+                              (list (make-type-value-array
+                                     :elem op.tval
+                                     :dims (list* op.mval op.nval op.sval)))
+                              (make-type-value-array
+                               :elem op.tval
+                               :dims (cons (* op.mval op.nval) op.sval)))
                        :dims nil)
      :transpose2d (prog2$ (impossible) (type-value-base (base-type-bool)))
      :transpose2d-t (prog2$ (impossible) (type-value-base (base-type-bool)))
@@ -3249,6 +3292,7 @@
          (cons "index2d" (expr-value-primop (primop-value-index2d)))
          (cons "sum" (expr-value-primop (primop-value-sum)))
          (cons "reshape" (expr-value-primop (primop-value-reshape)))
+         (cons "flatten" (expr-value-primop (primop-value-flatten)))
          (cons "transpose2d" (expr-value-primop (primop-value-transpose2d))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -923,7 +923,7 @@
              (expr-value-list-wfp (append-all vals)))
     :induct t
     :enable append-all)
-  
+
   (defrule expr-value-list-list-wfp-of-transpose-list-list
     (implies (expr-value-list-list-wfp vals)
              (expr-value-list-list-wfp (transpose-list-list vals)))
@@ -1182,7 +1182,7 @@
            (cdr-list (dims-of-expr-value-list-list valss)))
     :induct t
     :enable cdr-list)
-  
+
   (defrule dims-of-expr-value-list-of-append-all
     (equal (dims-of-expr-value-list (append-all valss))
            (append-all (dims-of-expr-value-list-list valss)))

--- a/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
+++ b/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
@@ -768,6 +768,126 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; The polymorphic operation flatten:
+; instantiation stage transitions and application of the final stage.
+
+(defconst *mat222*
+  (expr-value-vector
+   (list (expr-value-vector
+          (list (expr-value-vector (list (iv 1) (iv 2)))
+                (expr-value-vector (list (iv 3) (iv 4)))))
+         (expr-value-vector
+          (list (expr-value-vector (list (iv 5) (iv 6)))
+                (expr-value-vector (list (iv 7) (iv 8))))))))
+
+; Type application: flatten applied to one atom type value.
+
+(acl2::assert-equal
+ (eval-primop-tfun (primop-value-flatten) *tv-int*)
+ (expr-value-primop (primop-value-flatten-t *tv-int*)))
+
+; Ispace applications: flatten-t applied to a dimension,
+; flatten-t-m applied to another dimension,
+; then flatten-t-m-n applied to a shape.
+
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-flatten-t *tv-int*)
+                   (ispace-value-dim 2))
+ (expr-value-primop (make-primop-value-flatten-t-m :tval *tv-int*
+                                                   :mval 2)))
+
+(acl2::assert-equal
+ (eval-primop-ifun (make-primop-value-flatten-t-m :tval *tv-int*
+                                                  :mval 2)
+                   (ispace-value-dim 3))
+ (expr-value-primop (make-primop-value-flatten-t-m-n :tval *tv-int*
+                                                      :mval 2
+                                                      :nval 3)))
+
+(acl2::assert-equal
+ (eval-primop-ifun (make-primop-value-flatten-t-m-n :tval *tv-int*
+                                                    :mval 2
+                                                    :nval 3)
+                   (ispace-value-shape nil))
+ (expr-value-primop (make-primop-value-flatten-t-m-n-s :tval *tv-int*
+                                                       :mval 2
+                                                       :nval 3
+                                                       :sval nil)))
+
+; A shape where a dimension is expected.
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (primop-value-flatten-t *tv-int*)
+                            (ispace-value-shape (list 3)))))
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (make-primop-value-flatten-t-m :tval *tv-int*
+                                                           :mval 2)
+                            (ispace-value-shape (list 3)))))
+
+; A dimension where a shape is expected.
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (make-primop-value-flatten-t-m-n :tval *tv-int*
+                                                             :mval 2
+                                                             :nval 3)
+                            (ispace-value-dim 3))))
+
+; Application of the fully instantiated flatten to argument cells.
+
+; With m = 2, n = 3, and s = (), the whole matrix is the cell,
+; and flattening it combines its two dimensions into one of size 6.
+(acl2::assert-equal
+ (prim-flatten *tv-int* 2 3 nil *mat23*)
+ (expr-value-vector
+  (list (iv 1) (iv 2) (iv 3) (iv 4) (iv 5) (iv 6))))
+
+; With m = 2, n = 2, and s = (2), the cells are the 2x2x2 cube's rows,
+; and flattening combines the outer two dimensions into one of size 4,
+; keeping the trailing shape (2) unchanged.
+(acl2::assert-equal
+ (prim-flatten *tv-int* 2 2 (list 2) *mat222*)
+ (expr-value-vector
+  (list (expr-value-vector (list (iv 1) (iv 2)))
+        (expr-value-vector (list (iv 3) (iv 4)))
+        (expr-value-vector (list (iv 5) (iv 6)))
+        (expr-value-vector (list (iv 7) (iv 8))))))
+
+; Flattening with a zero dimension yields an empty vector.
+; An expr-value-vector-empty's :dims field holds the dimensions
+; *after* the implicit leading 0 (see dims-of-expr-value):
+; here the argument has dimensions (0 3) and the result (0).
+(acl2::assert-equal
+ (prim-flatten *tv-int* 0 3 nil
+               (make-expr-value-vector-empty :dims (list 3) :elem *tv-int*))
+ (make-expr-value-vector-empty :dims nil :elem *tv-int*))
+
+; Cell dimensions not matching the instantiation.
+(acl2::assert-event (reserrp (prim-flatten *tv-int* 3 2 nil *mat23*)))
+(acl2::assert-event (reserrp (prim-flatten *tv-int* 2 3 (list 1) *mat23*)))
+
+; Via eval-primop-fun.
+
+(acl2::assert-equal
+ (eval-primop-fun (make-primop-value-flatten-t-m-n-s :tval *tv-int*
+                                                     :mval 2
+                                                     :nval 3
+                                                     :sval nil)
+                  *mat23*)
+ (expr-value-vector
+  (list (iv 1) (iv 2) (iv 3) (iv 4) (iv 5) (iv 6))))
+
+; Wrong number of argument cells:
+; one cell already yields a final result,
+; not an operation applicable to another cell.
+(acl2::assert-event
+ (not (expr-value-case
+       (eval-primop-fun (make-primop-value-flatten-t-m-n-s :tval *tv-int*
+                                                            :mval 2
+                                                            :nval 3
+                                                            :sval nil)
+                        *mat23*)
+       :primop)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ; The polymorphic operation transpose2d:
 ; instantiation stage transitions and application of the final stage.
 

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -2022,7 +2022,7 @@
           (expr-value-with-empty-dim s2 tval)))
        (atoms (expr-value-atoms val1)))
     (expr-value-with-nonempty-dims s2 atoms))
-  
+
   ///
 
   (defret expr-value-wfp-of-prim-reshape
@@ -2055,7 +2055,7 @@
      and the result is the array with the leading two axes
      merged into a single axis,
      whose dimensions are the dimension @('m*n')
-     followed by the shape @('s').     
+     followed by the shape @('s').
      The guard requires the argument cell to be well-formed;
      we defensively check that it has the expected dimensions.")
    (xdoc::p
@@ -2157,7 +2157,7 @@
                               consp-of-car-list-split)
            :expand ((nat-list-product (dims-of-expr-value val1))
                     (member-equal 0 (dims-of-expr-value val1)))))
-  
+
   ///
 
   (defret expr-value-wfp-of-prim-transpose2d
@@ -2654,7 +2654,7 @@
                            (make-primop-value-transpose2d-t-m-n :tval op.tval
                                                                 :mval op.mval
                                                                 :nval ival.val))
-                     :shape (reserr nil)) 
+                     :shape (reserr nil))
    :otherwise (prog2$ (impossible) (reserr nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-ifunp)))
 

--- a/books/kestrel/remora/primitives-evaluation.lisp
+++ b/books/kestrel/remora/primitives-evaluation.lisp
@@ -2033,6 +2033,68 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(define prim-flatten ((tval type-valuep)
+                      (m natp)
+                      (n natp)
+                      (s nat-listp)
+                      (val1 expr-valuep))
+  :guard (expr-value-wfp val1)
+  :returns (val expr-value-resultp)
+  :short "Evaluation of array flattening."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This is the semantics of the fully instantiated @('flatten') operation
+     (see the @(':flatten-t-m-n-s') summand of @(tsee primop-value)):
+     @('tval'), @('m'), @('n'), and @('s') are the instantiation values,
+     and @('val1') is the argument cell.
+     According to the instantiated type of the operation,
+     the argument cell is an array
+     whose dimensions are the dimension @('m') followed by the
+     dimension @('n') followed by the shape @('s'),
+     and the result is the array with the leading two axes
+     merged into a single axis,
+     whose dimensions are the dimension @('m*n')
+     followed by the shape @('s').     
+     The guard requires the argument cell to be well-formed;
+     we defensively check that it has the expected dimensions.")
+   (xdoc::p
+    "If the two leading dimensions or the remaining shape
+     has a zero dimension, the result is empty:
+     we build it via @(tsee expr-value-with-empty-dim),
+     which requires an atom type value.
+     Otherwise, we collect the atom values of the argument cell
+     via @(tsee expr-value-atoms),
+     and we arrange them according to the flattened shape
+     via @(tsee expr-value-with-nonempty-dims)."))
+  (b* ((m (lnfix m))
+       (n (lnfix n))
+       (s (nat-list-fix s))
+       ((unless (equal (dims-of-expr-value val1) (list* m n s)))
+        (reserr nil))
+       (s2 (cons (* m n) s))
+       ((when (member-equal 0 s2))
+        (b* (((when (type-value-case tval :array)) (reserr nil)))
+          (expr-value-with-empty-dim s2 tval)))
+       (atoms (expr-value-atoms val1)))
+    (expr-value-with-nonempty-dims s2 atoms))
+  :guard-hints
+  (("Goal" :in-theory (enable nat-list-product nfix)))
+
+  ///
+
+  (defret expr-value-wfp-of-prim-flatten
+      (implies (not (reserrp val))
+               (expr-value-wfp val))
+    :hyp (and (nat-listp s)
+              (expr-value-wfp val1))
+    :hints (("Goal" :in-theory (enable nat-list-product nfix)
+                    :use ((:instance expr-value-wfp-of-expr-value-with-nonempty-dims
+                                     (dims (cons (* m n) s))
+                                     (vals (expr-value-atoms val1))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (define prim-transpose2d ((tval type-valuep)
                           (m natp)
                           (n natp)
@@ -2299,6 +2361,11 @@
      :reshape-t (prog2$ (impossible) (reserr nil))
      :reshape-t-s1 (prog2$ (impossible) (reserr nil))
      :reshape-t-s1-s2 (prim-reshape op.tval op.s1val op.s2val arg)
+     :flatten (prog2$ (impossible) (reserr nil))
+     :flatten-t (prog2$ (impossible) (reserr nil))
+     :flatten-t-m (prog2$ (impossible) (reserr nil))
+     :flatten-t-m-n (prog2$ (impossible) (reserr nil))
+     :flatten-t-m-n-s (prim-flatten op.tval op.mval op.nval op.sval arg)
      :transpose2d (prog2$ (impossible) (reserr nil))
      :transpose2d-t (prog2$ (impossible) (reserr nil))
      :transpose2d-t-m (prog2$ (impossible) (reserr nil))
@@ -2379,6 +2446,11 @@
                            (list (type-var-atom "t"))))
                   (reserr nil)))
               (expr-value-primop (primop-value-reshape-t tval)))
+   :flatten (b* (((unless (type-values-match-type-vars-p
+                           (list tval)
+                           (list (type-var-atom "t"))))
+                  (reserr nil)))
+              (expr-value-primop (primop-value-flatten-t tval)))
    :transpose2d (b* (((unless (type-values-match-type-vars-p
                            (list tval)
                            (list (type-var-atom "t"))))
@@ -2429,7 +2501,7 @@
      which stores the ispace values received
      (a dimension and a shape
      for @('head'), @('tail'), @('length'), and @('reverse');
-     two dimensions and a shape for @('append');
+     two dimensions and a shape for @('append') and @('flatten');
      a dimension for @('index');
      two dimensions for @('index2d');
      a shape for @('sum');
@@ -2549,6 +2621,27 @@
                           (make-primop-value-reshape-t-s1-s2 :tval op.tval
                                                              :s1val op.s1val
                                                              :s2val ival.val)))
+   :flatten-t (ispace-value-case
+               ival
+               :dim (expr-value-primop
+                     (make-primop-value-flatten-t-m :tval op.tval
+                                                    :mval ival.val))
+               :shape (reserr nil))
+   :flatten-t-m (ispace-value-case
+                 ival
+                 :dim (expr-value-primop
+                       (make-primop-value-flatten-t-m-n :tval op.tval
+                                                        :mval op.mval
+                                                        :nval ival.val))
+                 :shape (reserr nil))
+   :flatten-t-m-n (ispace-value-case
+                   ival
+                   :dim (reserr nil)
+                   :shape (expr-value-primop
+                           (make-primop-value-flatten-t-m-n-s :tval op.tval
+                                                              :mval op.mval
+                                                              :nval op.nval
+                                                              :sval ival.val)))
    :transpose2d-t (ispace-value-case
                    ival
                    :dim (expr-value-primop

--- a/books/kestrel/remora/static-environments.lisp
+++ b/books/kestrel/remora/static-environments.lisp
@@ -124,7 +124,7 @@
      zero-rank array types of function types between base types.
      The @('head'), @('tail'), @('length'),
      @('append'), @('reverse'), @('index'), @('index2d'),
-     @('reshape'), and @('transpose2d') operations
+     @('reshape'), @('flatten'), and @('transpose2d') operations
      have polymorphic types:
      a universal type of a product type of a function type, as in [impl].
      The @('sum') operation is polymorphic only in the shape,
@@ -218,6 +218,12 @@
                            (t-> ((t[] "&t" "@s1"))
                                 (t[] "&t" "@s2"))))
              (shp)))
+       (flatten-type
+        (t[] (tforall ("&t")
+                      (tpi ("$m" "$n" "@s")
+                           (t-> ((t[] "&t" (shp++ (shp "$m") (shp "$n") "@s")))
+                                (t[] "&t" (shp++ (shp (dim* "$m" "$n")) "@s")))))
+             (shp)))
        (transpose2d-type
         (t[] (tforall ("&t")
                       (tpi ("$m" "$n")
@@ -283,6 +289,7 @@
            (cons "index2d" index2d-type)
            (cons "sum" sum-type)
            (cons "reshape" reshape-type)
+           (cons "flatten" flatten-type)
            (cons "transpose2d" transpose2d-type)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Added the primitive `prim-flatten`, which merges the leading two axes into a single axis.

Implementation closely follows that of `prim-reshape`.