### PR TITLE
Reduce `std/util` includes in centaur books

### DIFF
--- a/books/centaur/aig/aig2c.lisp
+++ b/books/centaur/aig/aig2c.lisp
@@ -29,7 +29,8 @@
 ; Original author: Jared Davis <jared@centtech.com>
 
 (in-package "ACL2")
-(include-book "std/util/top" :dir :system)
+(include-book "std/util/defaggregate" :dir :system)
+(include-book "std/util/define" :dir :system)
 (include-book "centaur/vl/util/defs" :dir :system)
 (include-book "centaur/vl/util/namedb" :dir :system)
 (include-book "aig-base")

--- a/books/centaur/clex/example.lisp
+++ b/books/centaur/clex/example.lisp
@@ -30,7 +30,10 @@
 
 (in-package "CLEX")
 (include-book "top")
-(include-book "std/util/top" :dir :system)
+(include-book "std/util/defaggregate" :dir :system)
+(include-book "std/util/defenum" :dir :system)
+(include-book "std/util/deflist" :dir :system)
+(include-book "std/util/define" :dir :system)
 (include-book "std/strings/top" :dir :system)
 ; Matt K. mod, 9/4/2023 (see that book for explanation), to avoid a failure
 ; for (defcharset whitespace ...).

--- a/books/centaur/esim/vcd/esim-snapshot.lisp
+++ b/books/centaur/esim/vcd/esim-snapshot.lisp
@@ -29,7 +29,7 @@
 ; Original author: Jared Davis <jared@centtech.com>
 
 (in-package "ACL2")
-(include-book "std/util/top" :dir :system)
+(include-book "std/util/deflist" :dir :system)
 (include-book "std/strings/top" :dir :system)
 (include-book "../esim-paths")
 

--- a/books/centaur/getopt/parsers.lisp
+++ b/books/centaur/getopt/parsers.lisp
@@ -29,7 +29,8 @@
 ; Original author: Jared Davis <jared@centtech.com>
 
 (in-package "GETOPT")
-(include-book "std/util/top" :dir :system)
+(include-book "std/util/define" :dir :system)
+(include-book "std/strings/cat-base" :dir :system)
 (include-book "std/strings/decimal" :dir :system)
 
 

--- a/books/centaur/getopt/top.lisp
+++ b/books/centaur/getopt/top.lisp
@@ -29,7 +29,11 @@
 ; Original author: Jared Davis <jared@centtech.com>
 
 (in-package "GETOPT")
-(include-book "std/util/top" :dir :system)
+(include-book "std/util/defaggregate" :dir :system)
+(include-book "std/util/defprojection" :dir :system)
+(include-book "std/util/define" :dir :system)
+(include-book "defsort/duplicated-members" :dir :system)
+(include-book "defsort/uniquep" :dir :system)
 (include-book "std/strings/case-conversion" :dir :system)
 (include-book "std/strings/strprefixp" :dir :system)
 (include-book "std/strings/subseq" :dir :system)

--- a/books/centaur/vl/util/defs.lisp
+++ b/books/centaur/vl/util/defs.lisp
@@ -40,7 +40,19 @@
 ; other, conflicting theorems about.
 
 (include-book "centaur/fty/deftypes" :dir :system)
-(include-book "std/util/top" :dir :system)
+(include-book "std/util/defaggregate" :dir :system)
+(include-book "std/util/defaggrify-defrec" :dir :system)
+(include-book "std/util/defalist" :dir :system)
+(include-book "std/util/defconsts" :dir :system)
+(include-book "std/util/defenum" :dir :system)
+(include-book "std/util/define" :dir :system)
+(include-book "std/util/defines" :dir :system)
+(include-book "std/util/deflist" :dir :system)
+(include-book "std/util/defmapappend" :dir :system)
+(include-book "std/util/defmvtypes" :dir :system)
+(include-book "std/util/defprojection" :dir :system)
+(include-book "std/util/defrule" :dir :system)
+(include-book "std/util/defval" :dir :system)
 (include-book "std/basic/two-nats-measure" :dir :system)
 (include-book "centaur/misc/alist-equiv" :dir :system)
 (include-book "std/strings/top" :dir :system)
@@ -714,4 +726,3 @@ versions of the standard.  We currently have some support for:</p>
                   (vl-maybe-string-listp x))
              (equal (string-listp x)
                     (true-listp x)))))
-


### PR DESCRIPTION
There are a couple of places in the `centaur` books where `std/util/top` is being included. With the recent addition of `std/util/definductive`, this caused a lot of unnecessary dependencies on `definductive`. This PR replaces `std/util/top` inclusions with just the necessary books, thereby reducing the number of unneeded dependencies.