### PR TITLE
[STS] Obtain parameter declaration type differently.

### DIFF
--- a/books/kestrel/c/syntax/exported-symbols.lisp
+++ b/books/kestrel/c/syntax/exported-symbols.lisp
@@ -761,6 +761,8 @@
     type-count
     type-void
     type-sint
+    type-unknown
+
     type-pointer->to
 
     type-listp

--- a/books/kestrel/c/transformation/struct-type-split.lisp
+++ b/books/kestrel/c/transformation/struct-type-split.lisp
@@ -597,6 +597,20 @@
       (c$::expr-type expr)
     (c$::type-unknown)))
 
+(define sts-param-declon-type ((pdeclon param-declonp))
+  :guard (param-declon-annop pdeclon)
+  :returns (type typep)
+  :short "Best-effort type of a parameter declaration,
+          read from its annotation."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This is similar in spirit to @(tsee sts-param-declon-type);
+     see that function's documentation for motivation."))
+  (if (param-declon-unambp pdeclon)
+      (param-declon-type pdeclon)
+    (type-unknown)))
+
 (define sts-split-member-right-name
   ((arg-type c$::typep)
    (memberp booleanp)
@@ -3235,11 +3249,9 @@
           (param-declon-fix param-declon)
           st)
          ((param-declon param-declon) param-declon)
-         ((type-option-vinfo info) param-declon.info)
+         (type (sts-param-declon-type param-declon))
          ((mv erp splitp)
-          (if info.type?
-              (sts-check-type info.type? st)
-            (mv nil nil)))
+          (sts-check-type type st))
          ((when erp)
           (retmsg$ "~@0~%~@1"
                    erp

--- a/books/kestrel/c/transformation/struct-type-split.lisp
+++ b/books/kestrel/c/transformation/struct-type-split.lisp
@@ -605,7 +605,7 @@
   :long
   (xdoc::topstring
    (xdoc::p
-    "This is similar in spirit to @(tsee sts-param-declon-type);
+    "This is similar in spirit to @(tsee sts-expr-type);
      see that function's documentation for motivation."))
   (if (param-declon-unambp pdeclon)
       (param-declon-type pdeclon)


### PR DESCRIPTION
There is now a function to obtain the type of a parameter declaration from validation annotations, specifically the ones at the underlying parameter declarators.