### PR TITLE
[smtlink] keep proofs independent of the size of the operator/type table

### DIFF
--- a/books/projects/smtlink/trusted/z3-py/translator.lisp
+++ b/books/projects/smtlink/trusted/z3-py/translator.lisp
@@ -942,8 +942,7 @@
     :returns (translated
               paragraphp
               :hints (("Goal"
-                       :in-theory (enable translate-symbol translate-type
-                                          paragraphp wordp))))
+                       :in-theory (enable translate-symbol paragraphp wordp))))
     (b* ((name (symbol-fix name))
          (type (symbol-fix type))
          (translated-name (translate-symbol name))
@@ -1010,8 +1009,7 @@
                                              (fty-info fty-info-alist-p)
                                              (int-to-rat booleanp))
     :returns (translated paragraphp
-                         :hints (("Goal" :in-theory (e/d (wordp
-                                                          paragraphp translate-type)
+                         :hints (("Goal" :in-theory (e/d (wordp paragraphp)
                                                          (true-listp)))))
     :measure (len args)
     (b* ((type (symbol-fix type))
@@ -1033,8 +1031,7 @@
                                         (int-to-rat booleanp))
     :returns (translated
               paragraphp
-              :hints (("Goal" :in-theory (e/d (wordp
-                                               paragraphp translate-type)
+              :hints (("Goal" :in-theory (e/d (wordp paragraphp)
                                               (true-listp)))))
     (b* ((fn (func-fix fn))
          ;; Bind everything needed from fn

--- a/books/projects/smtlink/verified/basics.lisp
+++ b/books/projects/smtlink/verified/basics.lisp
@@ -26,6 +26,13 @@
               implies if not
               lambda)))
 
+;; Recognize the functions that Smtlink translates directly,
+;; with this wrapper so that the list stays closed during proofs.
+;; This becomes important when *SMT-basics* gets larger.
+(defund SMT-basic-function-p (fn)
+  (declare (xargs :guard (symbolp fn)))
+  (if (member-equal fn *SMT-basics*) t nil))
+
 (defval *SMT-functions*
   :parents (SMT-functions)
   :short "ACL2 functions and their corresponding Z3 functions."

--- a/books/projects/smtlink/verified/expand-cp.lisp
+++ b/books/projects/smtlink/verified/expand-cp.lisp
@@ -486,7 +486,7 @@
                   (prog2$
                    (er hard? 'SMT-goal-generator=>expand "Should be a function call: ~q0" fn-call)
                    (make-ex-outs :expanded-term-lst a.term-lst :expanded-fn-lst a.expand-lst)))
-                 (basic-function (member-equal fn-call *SMT-basics*))
+                 (basic-function (SMT-basic-function-p fn-call))
                  (flex? (fncall-of-flextype fn-call fty-info))
                  (abs? (member-equal fn-call abs))
                  (lvl-item (assoc-equal fn-call a.fn-lvls))


### PR DESCRIPTION
This is a small change with no semantic effect.

Smtlink's tables of supported operators and types (`*SMT-basics*`,
`*SMT-types*`, ...) are consulted in two ways that currently leak into
proofs:

1. Three `:returns` theorems in `trusted/z3-py/translator.lisp` enable
   `translate-type`, whose body looks up the type tables.  All these proofs
   actually need is the `stringp-of-translate-type` returns theorem; opening
   the definition instead makes ACL2 case-split over every table entry.

2. `verified/expand-cp.lisp` tests `(member-equal fn-call *SMT-basics*)`
   directly inside the `expand` function, so proofs about `expand` unroll
   the membership test into one case per list entry.

Not much performance change just from this, but it enables adding more
operators without proof time blowup.