### PR TITLE
[smtlink] route declarations through the _SMT_ interface object

### DIFF
--- a/books/projects/smtlink/trusted/run.lisp
+++ b/books/projects/smtlink/trusted/run.lisp
@@ -42,7 +42,7 @@
     :verify-guards nil
     (b* (((mv exit-status lines state) (SMT-run fname smt-conf state))
          ((unless (equal exit-status 0))
-          (mv (er hard? 'SMT-run=>SMT-interpret "Z3 failure: ~q0" lines) state))
+          (mv (er hard? 'SMT-run=>SMT-interpret "SMT solver failure: ~q0" lines) state))
          ((if (equal lines nil))
           (mv (er hard? 'SMT-run=>SMT-interpret "Nothing returned from SMT solver.") state))
          ((if (equal (car lines) "proved"))
@@ -100,4 +100,3 @@ the check for (true-listp str) and (consp (car str)) failed: ~q0" str)
                      (:instance stringp-of-consp-of-string-listp (x (mv-nth 1 (smt-run fname smt-conf state))))))))
     )
 )
-

--- a/books/projects/smtlink/trusted/z3-py/translator.lisp
+++ b/books/projects/smtlink/trusted/z3-py/translator.lisp
@@ -951,7 +951,7 @@
          (type (if fty-item (fty-info->name (cdr fty-item)) type))
          (translated-type
           (translate-type type int-to-rat 'common-type)))
-      `(,translated-name = "z3.Const" #\( #\' ,translated-name #\' #\, #\Space
+      `(,translated-name = "_SMT_.Const" #\( #\' ,translated-name #\' #\, #\Space
                          ,translated-type #\) #\Newline)))
 
   (encapsulate ()
@@ -1049,7 +1049,7 @@
          (translated-returns
           (translate-uninterpreted-arguments 'returns f.returns
                                              fty-info int-to-rat)))
-      `(,(translate-symbol name) "= z3.Function("
+      `(,(translate-symbol name) "= _SMT_.Function("
         #\' ,name #\' ,translated-formals ,translated-returns
         ")" #\Newline)))
 

--- a/books/projects/smtlink/z3_interface/ACL2_to_Z3.py
+++ b/books/projects/smtlink/z3_interface/ACL2_to_Z3.py
@@ -72,6 +72,10 @@ class ACL22SMT(object):
     #                   Basic Functions
     #
 
+    # Declarations, so that generated scripts talk only to this object
+    def Const(self, name, sort): return Const(name, sort)
+    def Function(self, name, *sorts): return Function(name, *sorts)
+
     # Type declarations
     def IntSort(self): return IntSort()
     def RealSort(self): return RealSort()


### PR DESCRIPTION
This PR lets a different SMT solver be substituted, via `custom-smt-cnf`,
without editing the translator: the `_SMT_` interface object becomes the
single point of contact between a generated script and the solver.

Currently (before this PR), declarations are the one exception.
Generated scripts declare variables and uninterpreted functions with `z3.Const(...)` and
`z3.Function(...)`, and nothing binds the name `z3` on purpose: it resolves
only because `from z3 import *` happens to re-export the z3 package's
internal `z3.z3` submodule attribute, an undocumented accident of
z3-solver's packaging.  Everything else in a generated script already goes
through `_SMT_`.

This change emits `_SMT_.Const(...)` and `_SMT_.Function(...)` instead, and
adds the two methods to `ACL22SMT`.  Generated scripts are otherwise
unchanged.

Custom interface classes that extend `ACL22SMT` (like the existing
`RewriteExpt.py`) inherit the new methods.  A from-scratch class would need
to add them, and fails with a Python error rather than a wrong result if it
doesn't.

Also rewords a "Z3 failure" error message in `run.lisp`, since the code it
reports on is solver-generic.
