### PR TITLE
[REMORA] add `prim-reify-dim` and `prim-reify-shape`

### DIFF
--- a/books/kestrel/remora/expression-values-and-environments.lisp
+++ b/books/kestrel/remora/expression-values-and-environments.lisp
@@ -531,6 +531,8 @@
                             (s2val nat-list)
                             (fval expr-value)
                             (zval expr-value)))
+    (:reify-dim ())
+    (:reify-shape ())
     :pred primop-valuep
     :measure (two-nats-measure (acl2-count x) 0))
 
@@ -2188,7 +2190,9 @@
                      :fold-t-t2-d-s nil
                      :fold-t-t2-d-s-s2 t
                      :fold-t-t2-d-s-s2-f t
-                     :fold-t-t2-d-s-s2-f-z t))
+                     :fold-t-t2-d-s-s2-f-z t
+                     :reify-dim nil
+                     :reify-shape nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2288,7 +2292,9 @@
                      :fold-t-t2-d-s nil
                      :fold-t-t2-d-s-s2 nil
                      :fold-t-t2-d-s-s2-f nil
-                     :fold-t-t2-d-s-s2-f-z nil))
+                     :fold-t-t2-d-s-s2-f-z nil
+                     :reify-dim nil
+                     :reify-shape nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2387,7 +2393,9 @@
                      :fold-t-t2-d-s t
                      :fold-t-t2-d-s-s2 nil
                      :fold-t-t2-d-s-s2-f nil
-                     :fold-t-t2-d-s-s2-f-z nil))
+                     :fold-t-t2-d-s-s2-f-z nil
+                     :reify-dim t
+                     :reify-shape t))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2578,6 +2586,8 @@
                      :fold-t-t2-d-s-s2 (primop-value-fold)
                      :fold-t-t2-d-s-s2-f (primop-value-fold)
                      :fold-t-t2-d-s-s2-f-z (primop-value-fold)
+                     :reify-dim (primop-value-reify-dim)
+                     :reify-shape (primop-value-reify-shape)
                      :otherwise (primop-value-fix op)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2940,7 +2950,9 @@
              (list (make-type-value-array :elem op.tval
                                           :dims (cons (1+ op.dval) op.sval)))
              (make-type-value-array :elem op.t2val :dims op.s2val))
-      :dims nil)))
+      :dims nil)
+     :reify-dim (prog2$ (impossible) (type-value-base (base-type-bool)))
+     :reify-shape (prog2$ (impossible) (type-value-base (base-type-bool)))))
   :guard-hints (("Goal" :in-theory (enable primop-value-funp)))
 
   ///
@@ -3637,7 +3649,9 @@
          (cons "transpose2d" (expr-value-primop (primop-value-transpose2d)))
          (cons "iota/static" (expr-value-primop (primop-value-iota/static)))
          (cons "reduce" (expr-value-primop (primop-value-reduce)))
-         (cons "fold" (expr-value-primop (primop-value-fold))))))
+         (cons "fold" (expr-value-primop (primop-value-fold)))
+         (cons "reify-dim" (expr-value-primop (primop-value-reify-dim)))
+         (cons "reify-shape" (expr-value-primop (primop-value-reify-shape))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/remora/primitives-evaluation-on-ispaces.lisp
+++ b/books/kestrel/remora/primitives-evaluation-on-ispaces.lisp
@@ -13,6 +13,9 @@
 (in-package "REMORA")
 
 (include-book "expression-values-and-environments")
+(include-book "abstract-syntax-constructors")
+
+(local (include-book "kestrel/lists-light/len" :dir :system))
 
 (acl2::controlled-configuration)
 
@@ -78,6 +81,90 @@
                                        nfix
                                        fix)))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-reify-dim ((d natp))
+  :returns (val expr-valuep)
+  :short "Evaluation of dimension reification."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This is the semantics of the instantiated @('reify-dim') operation:
+     the single ispace application supplies the dimension @('d'),
+     and the result is the integer scalar with that value.
+     Unlike most other operations, no argument cell is involved:
+     the ispace application directly yields the final scalar,
+     as with @('iota/static').
+     Also unlike the other operations, no error is possible,
+     so the result type is @(tsee expr-valuep),
+     not @(tsee expr-value-resultp)."))
+  (expr-value-base (base-value-int (int-value (lnfix d))))
+
+  ///
+
+  (defret expr-value-wfp-of-prim-reify-dim
+    (expr-value-wfp val)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define prim-reify-shape ((s nat-listp))
+  :returns (val expr-valuep)
+  :short "Evaluation of shape reification."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "This is the semantics of the instantiated @('reify-shape') operation:
+     the single ispace application supplies the shape @('s'),
+     and the result is a box whose array value is
+     the vector of the dimensions of the shape, as integers,
+     whose witness is the rank of the shape (the length of that vector),
+     and whose type is the existential type in
+     the operation's type in @(tsee primop-types).
+     Unlike most other operations, no argument cell is involved:
+     the ispace application directly yields the final box,
+     as with @('iota/static') and @('reify-dim');
+     like the latter, no error is possible.")
+   (xdoc::p
+    "If the shape is empty, the rank is 0,
+     and the boxed array value is the empty vector."))
+  (b* ((s (nat-list-fix s))
+       (rank (len s))
+       (stype (make-type-value-sigma
+               :param (ispace-var-dim "r")
+               :body (t[] :int (shp "$r"))
+               :denv (make-type-denv :ienv (make-ispace-denv :ispaces nil)
+                                     :types nil)))
+       ((when (endp s))
+        (make-expr-value-box
+         :ispace (ispace-value-dim 0)
+         :array (expr-value-with-empty-dim (list 0)
+                                           (type-value-base (base-type-int)))
+         :type stype))
+       (atoms (expr-value-base-list
+               (base-value-int-list
+                (int-value-list-of s)))))
+    (make-expr-value-box
+     :ispace (ispace-value-dim rank)
+     :array (expr-value-with-nonempty-dims (list rank) atoms)
+     :type stype))
+  :guard-hints
+  (("Goal" :in-theory (enable nfix
+                              fix
+                              nat-list-product
+                              expr-value-list-wfp-of-expr-value-base-list
+                              dims-of-expr-value-list-of-expr-value-base-list)))
+
+  ///
+
+  (defret expr-value-wfp-of-prim-reify-shape
+    (expr-value-wfp val)
+    :hyp (nat-listp s)
+    :hints (("Goal" :in-theory (enable expr-value-list-wfp-of-expr-value-base-list
+                                       dims-of-expr-value-list-of-expr-value-base-list
+                                       nat-list-product
+                                       nfix
+                                       fix)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define eval-primop-ifun ((op primop-valuep) (ival ispace-valuep))
@@ -103,8 +190,11 @@
      a dimension for the stages that store just a type value
      (except @(':reshape-t'), which expects the first of two shapes),
      a shape for the stages that also store a dimension or a shape;
-     the uninstantiated stage of @('sum'), which has no type parameter,
-     stores nothing and expects a shape directly.
+     the uninstantiated stages of
+     @('sum'), @('iota/static'), @('reify-dim'), and @('reify-shape'),
+     which have no type parameters,
+     store nothing and expect
+     a shape (a dimension, for @('reify-dim')) directly.
      We check that the ispace value has the expected sort;
      then we construct the next instantiation stage of the operation,
      which stores the ispace values received
@@ -117,7 +207,9 @@
      a shape for @('sum');
      two shapes for @('reshape');
      two dimensions for @('transpose2d')),
-     along with the previously received type values (if any).
+     along with the previously received type values (if any);
+     for @('iota/static'), @('reify-dim'), and @('reify-shape'),
+     the application instead directly yields the final result.
      Anything else is an error."))
   (primop-value-case
    op
@@ -307,6 +399,14 @@
                             :dval op.dval
                             :sval op.sval
                             :s2val ival.val)))
+   :reify-dim (ispace-value-case
+               ival
+               :dim (prim-reify-dim ival.val)
+               :shape (reserr nil))
+   :reify-shape (ispace-value-case
+                 ival
+                 :dim (reserr nil)
+                 :shape (prim-reify-shape ival.val))
    :otherwise (prog2$ (impossible) (reserr nil)))
   :guard-hints (("Goal" :in-theory (enable primop-value-ifunp)))
 

--- a/books/kestrel/remora/primitives-evaluation-on-ispaces.lisp
+++ b/books/kestrel/remora/primitives-evaluation-on-ispaces.lisp
@@ -47,13 +47,14 @@
   :long
   (xdoc::topstring
    (xdoc::p
-    "This is the semantics of the instantiated @('iota/static') operation:
+    "This is the semantics of the @('iota/static') operation:
      the single ispace application supplies the shape @('s'),
      and the result is the array of that shape
      whose atoms are the naturals below the number of elements,
      in row-major order.
-     Unlike all other operations, no argument cell is involved:
-     the ispace application directly yields the final array.")
+     Unlike most other operations, no argument cell is involved:
+     the ispace application directly yields the final array,
+     as with @('reify-dim') and @('reify-shape').")
    (xdoc::p
     "If the shape has a zero dimension, the result is empty;
      the element type is always the integer atom type."))
@@ -89,13 +90,14 @@
   :long
   (xdoc::topstring
    (xdoc::p
-    "This is the semantics of the instantiated @('reify-dim') operation:
+    "This is the semantics of the @('reify-dim') operation:
      the single ispace application supplies the dimension @('d'),
      and the result is the integer scalar with that value.
      Unlike most other operations, no argument cell is involved:
      the ispace application directly yields the final scalar,
-     as with @('iota/static').
-     Also unlike the other operations, no error is possible,
+     as with @('iota/static') and @('reify-shape').
+     Also unlike most other operations, no error is possible,
+     as with @('reify-shape'),
      so the result type is @(tsee expr-valuep),
      not @(tsee expr-value-resultp)."))
   (expr-value-base (base-value-int (int-value (lnfix d))))
@@ -113,7 +115,7 @@
   :long
   (xdoc::topstring
    (xdoc::p
-    "This is the semantics of the instantiated @('reify-shape') operation:
+    "This is the semantics of the @('reify-shape') operation:
      the single ispace application supplies the shape @('s'),
      and the result is a box whose array value is
      the vector of the dimensions of the shape, as integers,
@@ -190,10 +192,11 @@
      a dimension for the stages that store just a type value
      (except @(':reshape-t'), which expects the first of two shapes),
      a shape for the stages that also store a dimension or a shape;
-     the uninstantiated stages of
-     @('sum'), @('iota/static'), @('reify-dim'), and @('reify-shape'),
-     which have no type parameters,
-     store nothing and expect
+     the uninstantiated stage of @('sum'), which has no type parameter,
+     stores nothing and expects a shape directly;
+     the @('iota/static'), @('reify-dim'), and @('reify-shape') operations,
+     which consist of a single stage,
+     also store nothing and expect
      a shape (a dimension, for @('reify-dim')) directly.
      We check that the ispace value has the expected sort;
      then we construct the next instantiation stage of the operation,

--- a/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
+++ b/books/kestrel/remora/primitives-evaluation-polymorphic-tests.lisp
@@ -1192,3 +1192,66 @@
                                                             :s2val nil
                                                             :fval *add-fun*
                                                             :zval (iv 10))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; The polymorphic operation reify-dim:
+; a single ispace application directly yields the integer scalar.
+
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-reify-dim)
+                   (ispace-value-dim 3))
+ (iv 3))
+
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-reify-dim)
+                   (ispace-value-dim 0))
+ (iv 0))
+
+; A shape where a dimension is expected.
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (primop-value-reify-dim)
+                            (ispace-value-shape (list 3)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; The polymorphic operation reify-shape:
+; a single ispace application directly yields a boxed integer vector.
+
+(defconst *reify-shape-sigma*
+  (make-type-value-sigma
+   :param (ispace-var-dim "r")
+   :body (t[] :int (shp "$r"))
+   :denv (make-type-denv :ienv (make-ispace-denv :ispaces nil)
+                         :types nil)))
+
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-reify-shape)
+                   (ispace-value-shape (list 2 3)))
+ (make-expr-value-box
+  :ispace (ispace-value-dim 2)
+  :array (expr-value-vector (list (iv 2) (iv 3)))
+  :type *reify-shape-sigma*))
+
+; The empty shape reifies to a box of the empty vector, with rank 0.
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-reify-shape)
+                   (ispace-value-shape nil))
+ (make-expr-value-box
+  :ispace (ispace-value-dim 0)
+  :array (expr-value-with-empty-dim (list 0) *tv-int*)
+  :type *reify-shape-sigma*))
+
+; A shape with zero dimensions still reifies to their vector.
+(acl2::assert-equal
+ (eval-primop-ifun (primop-value-reify-shape)
+                   (ispace-value-shape (list 0 3)))
+ (make-expr-value-box
+  :ispace (ispace-value-dim 2)
+  :array (expr-value-vector (list (iv 0) (iv 3)))
+  :type *reify-shape-sigma*))
+
+; A dimension where a shape is expected.
+(acl2::assert-event
+ (reserrp (eval-primop-ifun (primop-value-reify-shape)
+                            (ispace-value-dim 3))))

--- a/books/kestrel/remora/static-environments.lisp
+++ b/books/kestrel/remora/static-environments.lisp
@@ -135,6 +135,13 @@
      its type is a product type of an array type,
      without any function type, as in [impl],
      since the single ispace application directly yields the array.
+     The @('reify-dim') and @('reify-shape') operations are polymorphic
+     only in a dimension and only in a shape, respectively:
+     their types are product types of, respectively,
+     the integer base type
+     and an existential type of an integer array type,
+     without any function type, as in [impl],
+     since the single ispace application directly yields the result.
      All these types are atom-kinded, without zero-rank array type wrapping:
      as explained in @(see types),
      atom-kinded types are allowed wherever array-kinded types are expected,
@@ -241,7 +248,13 @@
                             (t[] "&t2" "@s2"))
                        (t[] "&t2" "@s2")
                        (t[] "&t" (shp[] (dim+ 1 "$d") "@s"))
-                       (t[] "&t2" "@s2"))))))
+                       (t[] "&t2" "@s2")))))
+       (reify-dim-type
+        (tpi "$d" :int))
+       (reify-shape-type
+        (tpi "@s"
+             (tsi "$r"
+                  (t[] :int (shp "$r"))))))
     (omap::from-alist
      (list (cons "+" int-binop-type)
            (cons "-" int-binop-type)
@@ -305,7 +318,9 @@
            (cons "transpose2d" transpose2d-type)
            (cons "iota/static" iota/static-type)
            (cons "reduce" reduce-type)
-           (cons "fold" fold-type)))))
+           (cons "fold" fold-type)
+           (cons "reify-dim" reify-dim-type)
+           (cons "reify-shape" reify-shape-type)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/books/kestrel/remora/values-to-abstract-syntax.lisp
+++ b/books/kestrel/remora/values-to-abstract-syntax.lisp
@@ -1061,7 +1061,9 @@
                           :arg (ispace-shape
                                 (shape-dims (dim-const-list pval.s2val))))
                     :arg fexpr)
-              :arg zexpr)))))
+              :arg zexpr)))
+       :reify-dim (mv nil opvar)
+       :reify-shape (mv nil opvar)))
     :measure (primop-value-count pval))
 
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1168,4 +1170,6 @@
                                  primop-value-fix-when-transpose2d
                                  primop-value-fix-when-iota/static
                                  primop-value-fix-when-reduce
-                                 primop-value-fix-when-fold)))))
+                                 primop-value-fix-when-fold
+                                 primop-value-fix-when-reify-dim
+                                 primop-value-fix-when-reify-shape)))))


### PR DESCRIPTION
For `prim-reify-shape`, it produces a box, so the function body is calling `make-type-value-sigma` and `make-expr-value-box` directly. Do you think this is the correct approach?