### PR TITLE
[Remora] Add AST modes to deserializer

### DIFF
--- a/books/kestrel/remora/deserialize-from-file.lisp
+++ b/books/kestrel/remora/deserialize-from-file.lisp
@@ -22,18 +22,20 @@
 ; logic does not have to depend on (and pay the certification-load cost of)
 ; the JSON parser.
 
-(define deserialize-expr-from-file ((filename stringp) state)
+(define deserialize-top-exp-from-file ((filename stringp) (mode ast-modep) state)
   :parents (deserializer)
   :returns (mv erp (x exprp) state)
-  :short "Parse a JSON file and convert its contents to a @(tsee expr)."
+  :short "Parse a JSON file encoding a standalone Remora expression
+          and convert its contents to an @(tsee expr)."
   :long
   (xdoc::topstring
    (xdoc::p
     "Reads and parses @('filename') as JSON
-     (via @('parse-file-as-json')),
-     converts the parsed result to a @(tsee json::valuep)
-     (via @(tsee json::parsed-to-value)),
-     and converts that to an @(tsee expr) via @(tsee expr-fromJSON).
+     via @('parse-file-as-json'),
+     converts the parsed result to a @(tsee json::value)
+     via @(tsee json::parsed-to-value),
+     and converts that to an @(tsee expr) via @(tsee expr-fromJSON)
+     in the given @(tsee ast-mode).
      Returns @('(mv erp x state)'), where @('erp') is non-@('nil')
      (an error message) if any of these steps fails, in which case
      @('x') is an irrelevant placeholder @(tsee expr).
@@ -51,7 +53,7 @@
         (b* ((- (cw "The JSON parsed from ~s0 is malformed.~%" filename)))
           (mv erp (make-expr-var :name "") state)))
        ((mv erp exp)
-        (expr-fromJSON value))
+        (expr-fromJSON value mode))
        ((when erp)
         (b* ((- (cw "Error converting the JSON value from ~s0 ~
                      to a Remora expression: ~@1~%" filename erp)))
@@ -64,18 +66,20 @@
       (implies (not erp)
                (expr-huncheckedp x))))
 
-(define deserialize-file-from-file ((filename stringp) state)
+(define deserialize-from-file ((filename stringp) (mode ast-modep) state)
   :parents (deserializer)
   :returns (mv erp (x filep) state)
-  :short "Parse a JSON file and convert its contents to a @(tsee file)."
+  :short "Parse a JSON file encoding a Remora source file
+          and convert its contents to a @(tsee file)."
   :long
   (xdoc::topstring
    (xdoc::p
     "Reads and parses @('filename') as JSON
-     (via @('parse-file-as-json')),
-     converts the parsed result to a @(tsee json::valuep)
-     (via @(tsee json::parsed-to-value)),
-     and converts that to a @(tsee file) via @(tsee file-fromJSON).
+     via @('parse-file-as-json'),
+     converts the parsed result to a @(tsee json::value)
+     via @(tsee json::parsed-to-value),
+     and converts that to a @(tsee file) via @(tsee file-fromJSON)
+     in the given @(tsee ast-mode).
      Returns @('(mv erp x state)'), where @('erp') is non-@('nil')
      (an error message) if any of these steps fails, in which case
      @('x') is an irrelevant placeholder @(tsee file).
@@ -93,7 +97,7 @@
         (b* ((- (cw "The JSON parsed from ~s0 is malformed.~%" filename)))
           (mv erp (make-file :imports nil :decls nil) state)))
        ((mv erp exp)
-        (file-fromJSON value))
+        (file-fromJSON value mode))
        ((when erp)
         (b* ((- (cw "Error converting the JSON value from ~s0 ~
                      to a Remora file: ~@1~%" filename erp)))

--- a/books/kestrel/remora/deserialize-from-file.lisp
+++ b/books/kestrel/remora/deserialize-from-file.lisp
@@ -62,7 +62,7 @@
 
   ///
 
-  (defret expr-huncheckedp-of-deserialize-expr-from-file
+  (defret expr-huncheckedp-of-deserialize-top-exp-from-file
       (implies (not erp)
                (expr-huncheckedp x))))
 
@@ -106,6 +106,6 @@
 
   ///
 
-  (defret file-huncheckedp-of-deserialize-file-from-file
+  (defret file-huncheckedp-of-deserialize-from-file
       (implies (not erp)
                (file-huncheckedp x))))

--- a/books/kestrel/remora/deserializer.lisp
+++ b/books/kestrel/remora/deserializer.lisp
@@ -26,23 +26,23 @@
   (xdoc::topstring
    (xdoc::p
     "[impl] serializes its internal ASTs to JSON.
-     Here we define the inverse mapping, from "
-    (xdoc::seetopic "json::json" "JSON values")
-    " to the ASTs defined as "
-    (xdoc::seetopic "abstract-syntax-trees" "fixtypes")
+     Here we define the mapping, from those "
+    (xdoc::seetopic "json::values" "JSON values")
+    " to our "
+    (xdoc::seetopic "abstract-syntax-trees" "AST fixtypes")
     ", so that ASTs produced by [impl] can be recreated in ACL2.")
    (xdoc::p
-    "We currently deserialize only "
-    (xdoc::seetopic "ast-huncheckedp" "[impl]'s unchecked ASTs")
-    ".")
-   (xdoc::p
-    "TERecord, Struct, and FieldProj ASTs from [impl]
-     are not yet supported in ACL2.")
+    "[impl]'s ASTs are parameterized over types, type parameters,
+     type annotations, and variables. [impl] names three instantiations:
+     unchecked, unique, and checked (see @(tsee ast-mode)).
+     Each instantiation serializes to a distinct JSON encoding,
+     so the deserialization functions take an @(tsee ast-mode)
+     specifying which one to expect.")
    (xdoc::p
     "Each conversion function is named @('X-fromJSON'),
      where @('X') is the name of the corresponding AST fixtype
      (e.g. @('dim'), @('var+type?'), @('expr')).
-     Every @('X-fromJSON') function takes a @(tsee json::valuep)
+     Every @('X-fromJSON') function takes a @(tsee json::value)
      and returns @('(mv erp x)'):
      @('erp') is non-@('nil') (an error message) when the JSON value
      does not correspond to a valid AST,
@@ -52,9 +52,65 @@
      which is in the "
     (xdoc::seetopic "abstract-syntax-haskell" "subset corresponding to [impl]")
     ". JSON objects are dispatched on their @('\"tag\"') member,
-     whose string value names the [impl] AST node being decoded."))
+     whose string value names the [impl] AST node being decoded.")
+   (xdoc::p
+    "TERecord, Record, Struct, and FieldProj ASTs from [impl]
+     are not yet supported in ACL2."))
   :order-subtopics t
   :default-parent t)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Modes
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(fty::deftagsum ast-mode
+  :short "Fixtype of deserialization modes."
+  :long
+  (xdoc::topstring
+   (xdoc::p
+    "[impl]'s ASTs are parameterized over
+     types, type parameters, type annotations, and variables.
+     The deserialization mode picks the AST instantiation that a JSON value encodes.
+     The three modes are the three instantiations that [impl] names.")
+   (xdoc::ul
+    (xdoc::li
+     "@(':unchecked') selects
+      @('ProgBase TypeExp TypeParamExp NoInfo Text')
+      (aliased as @('UncheckedProg')).
+      This AST instantiation is produced by [impl]'s parser.
+      Types and type parameters are source-level,
+      type annotations are empty,
+      and variables are names.")
+    (xdoc::li
+     "@(':unique') selects
+      @('ProgBase TypeExp TypeParam NoInfo VName')
+      (aliased as @('UniqueProg').
+      This AST instantiation is produced by [impl]'s uniquifier.
+      Types are still source-level and type annotations are still empty,
+      but type parameters are always atom type parameters,
+      and variables are names paired with tags that make them unique.")
+    (xdoc::li
+     "@(':checked') selects
+      @('ProgBase Type TypeParam Info VName')
+      (aliased as @('Prog')).
+      This AST instantiation is produced by [impl]'s type checker
+      and all subsequent passes of the compiler.
+      Type parameters and variables are as in @(':unique'),
+      but types separate atom types from array types,
+      and type annotations carry type information."))
+   (xdoc::p
+    "The three modes differ in exactly the four parameters,
+     so a mode affects the deserialization of just four things:
+     types (see @(tsee type-fromJSON)),
+     type parameters (see @(tsee type-var-fromJSON)),
+     type annotations (which are dropped in all modes),
+     and variables (see @(tsee name-fromJSON))."))
+  (:unchecked ())
+  (:unique ())
+  (:checked ())
+  :pred ast-modep)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -131,13 +187,92 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
+;; Variables
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define tag-fromJSON ((j json::valuep) (mode ast-modep))
+  :returns (mv erp (x integerp))
+  :short "Convert a JSON value encoding a @('Tag') to an integer."
+  (b* (((acl2::reterr) 0))
+    (if (json::value-case j :object)
+        (b* ((tag-j
+              (json::object-member-value "tag" j)))
+          (if (json::value-case tag-j :string)
+              (b* ((tag
+                    (json::value-string->get tag-j)))
+                (cond
+                  ((equal tag "Tag")
+                   (b* ((gettag-j
+                         (json::object-member-value "getTag" j)))
+                     (if (json::value-case gettag-j :number)
+                         (b* ((gettag
+                               (json::value-number->get gettag-j)))
+                           (if (integerp gettag)
+                               (acl2::retok gettag)
+                             (acl2::reterr (msg "The \"getTag\" member of a Tag object must be an integer, but ~x0 is not." gettag))))
+                       (acl2::reterr (msg "The \"getTag\" member of a Tag object must be a number, but ~x0 is not." gettag-j)))))
+                  (t
+                   (acl2::reterr (msg "~x0 is not a recognized tag for a Tag." tag)))))
+            (acl2::reterr (msg "The \"tag\" member of a Tag object must be a string, but ~x0 is not." tag-j))))
+      (acl2::reterr (msg "A JSON value representing a Tag must be a JSON object, but ~x0 is not." j))))
+  :ignore-ok t)
+
+(define vname-fromJSON ((j json::valuep) (mode ast-modep))
+  :returns (mv erp (x stringp))
+  :short "Convert a JSON value encoding a @('VName') to a string."
+  (b* (((acl2::reterr) ""))
+    (if (json::value-case j :object)
+        (b* ((tag-j
+              (json::object-member-value "tag" j)))
+          (if (json::value-case tag-j :string)
+              (b* ((tag
+                    (json::value-string->get tag-j)))
+                (cond
+                  ((equal tag "VName")
+                   (b* ((varname-j
+                         (json::object-member-value "varName" j))
+                        (vartag-j
+                         (json::object-member-value "varTag" j)))
+                     (if (json::value-case varname-j :string)
+                         (b* ((varname
+                               (json::value-string->get varname-j))
+                              ((acl2::erp vartag)
+                               (tag-fromJSON vartag-j mode)))
+                           (acl2::retok
+                            (string-append
+                             varname
+                             (string-append
+                              "_"
+                              (str::int-to-dec-string vartag)))))
+                       (acl2::reterr (msg "The \"varName\" member of a VName object must be a string, but ~x0 is not." varname-j)))))
+                  (t
+                   (acl2::reterr (msg "~x0 is not a recognized tag for a VName." tag)))))
+            (acl2::reterr (msg "The \"tag\" member of a VName object must be a string, but ~x0 is not." tag-j))))
+      (acl2::reterr (msg "A JSON value representing a VName must be a JSON object, but ~x0 is not." j)))))
+
+(define name-fromJSON ((j json::valuep) (mode ast-modep))
+  :returns (mv erp (x stringp))
+  :short "Convert a JSON value encoding a variable name to a string."
+  (b* (((acl2::reterr) ""))
+    (ast-mode-case
+     mode
+     :unchecked
+     (if (json::value-case j :string)
+         (acl2::retok (json::value-string->get j))
+       (acl2::reterr (msg "The \"name\" member of a variable object must be a string, but ~x0 is not." j)))
+     :otherwise
+     (vname-fromJSON j mode))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
 ;; Dim
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defines dim-fromJSON
 
-    (define dim-fromJSON ((j json::valuep))
+    (define dim-fromJSON ((j json::valuep) (mode ast-modep))
       :returns (mv erp (x dimp))
       :measure (json::value-count j)
       :short "Convert a JSON value encoding a @('Dim') to a @(tsee dim)."
@@ -152,12 +287,10 @@
                     (cond
                       ((equal tag "DimVar")
                        (b* ((name-j
-                             (json::object-member-value "name" j)))
-                         (if (json::value-case name-j :string)
-                             (b* ((name
-                                   (json::value-string->get name-j)))
-                               (acl2::retok (make-dim-var :name name)))
-                           (acl2::reterr (msg "The \"name\" member of a DimVar object must be a string, but ~x0 is not." name-j)))))
+                             (json::object-member-value "name" j))
+                            ((acl2::erp name)
+                             (name-fromJSON name-j mode)))
+                         (acl2::retok (make-dim-var :name name))))
                       ((equal tag "DimN")
                        (b* ((val-j
                              (json::object-member-value "val" j)))
@@ -175,7 +308,7 @@
                              (b* ((dims-js
                                    (json::value-array->elements dims-j))
                                   ((acl2::erp dims)
-                                   (dim-list-fromJSON dims-js)))
+                                   (dim-list-fromJSON dims-js mode)))
                                (acl2::retok (make-dim-add :dims dims)))
                            (acl2::reterr (msg "The \"dims\" member of an Add object must be a JSON array, but ~x0 is not." dims-j)))))
                       ((equal tag "Mul")
@@ -185,7 +318,7 @@
                              (b* ((dims-js
                                    (json::value-array->elements dims-j))
                                   ((acl2::erp dims)
-                                   (dim-list-fromJSON dims-js)))
+                                   (dim-list-fromJSON dims-js mode)))
                                (acl2::retok (make-dim-mul :dims dims)))
                            (acl2::reterr (msg "The \"dims\" member of a Mul object must be a JSON array, but ~x0 is not." dims-j)))))
                       ((equal tag "Sub")
@@ -195,7 +328,7 @@
                              (b* ((dims-js
                                    (json::value-array->elements dims-j))
                                   ((acl2::erp dims)
-                                   (dim-list-fromJSON dims-js)))
+                                   (dim-list-fromJSON dims-js mode)))
                                (acl2::retok (make-dim-sub :dims dims)))
                            (acl2::reterr (msg "The \"dims\" member of a Sub object must be a JSON array, but ~x0 is not." dims-j)))))
                       (t
@@ -203,16 +336,16 @@
                 (acl2::reterr (msg "The \"tag\" member of a Dim object must be a string, but ~x0 is not." tag-j))))
           (acl2::reterr (msg "A JSON value representing a Dim must be a JSON object, but ~x0 is not." j)))))
 
-  (define dim-list-fromJSON ((js json::value-listp))
+  (define dim-list-fromJSON ((js json::value-listp) (mode ast-modep))
     :returns (mv erp (x dim-listp))
     :measure (json::value-list-count js)
     :short "Convert a JSON array's elements to a @(tsee dim-listp)."
     (b* (((acl2::reterr) nil))
       (if (consp js)
           (b* (((acl2::erp hd)
-                (dim-fromJSON (car js)))
+                (dim-fromJSON (car js) mode))
                ((acl2::erp tl)
-                (dim-list-fromJSON (cdr js))))
+                (dim-list-fromJSON (cdr js) mode)))
             (acl2::retok (cons hd tl)))
         (acl2::retok nil))))
 
@@ -229,7 +362,7 @@
 
 (defines shape-fromJSON
 
-  (define shape-fromJSON ((j json::valuep))
+  (define shape-fromJSON ((j json::valuep) (mode ast-modep))
     :returns (mv erp (x shapep))
     :measure (json::value-count j)
     :short "Convert a JSON value encoding a @('Shape') to a @(tsee shape)."
@@ -244,17 +377,15 @@
                   (cond
                     ((equal tag "ShapeVar")
                      (b* ((name-j
-                           (json::object-member-value "name" j)))
-                       (if (json::value-case name-j :string)
-                           (b* ((name
-                                 (json::value-string->get name-j)))
-                             (acl2::retok (make-shape-var :name name)))
-                         (acl2::reterr (msg "The \"name\" member of a ShapeVar object must be a string, but ~x0 is not." name-j)))))
+                           (json::object-member-value "name" j))
+                          ((acl2::erp name)
+                           (name-fromJSON name-j mode)))
+                       (acl2::retok (make-shape-var :name name))))
                     ((equal tag "ShapeDim")
                      (b* ((dim-j
                            (json::object-member-value "dim" j))
                           ((acl2::erp dim)
-                           (dim-fromJSON dim-j)))
+                           (dim-fromJSON dim-j mode)))
                        (acl2::retok (make-shape-dims :dims (list dim)))))
                     ((equal tag "Concat")
                      (b* ((shapes-j
@@ -263,7 +394,7 @@
                            (b* ((shapes-js
                                  (json::value-array->elements shapes-j))
                                 ((acl2::erp shapes)
-                                 (shape-list-fromJSON shapes-js)))
+                                 (shape-list-fromJSON shapes-js mode)))
                              (acl2::retok (make-shape-append :shapes shapes)))
                          (acl2::reterr (msg "The \"shapes\" member of a Concat object must be a JSON array, but ~x0 is not." shapes-j)))))
                     (t
@@ -271,16 +402,16 @@
               (acl2::reterr (msg "The \"tag\" member of a Shape object must be a string, but ~x0 is not." tag-j))))
         (acl2::reterr (msg "A JSON value representing a Shape must be a JSON object, but ~x0 is not." j)))))
 
-  (define shape-list-fromJSON ((js json::value-listp))
+  (define shape-list-fromJSON ((js json::value-listp) (mode ast-modep))
     :returns (mv erp (x shape-listp))
     :measure (json::value-list-count js)
     :short "Convert a JSON array's elements to a @(tsee shape-listp)."
     (b* (((acl2::reterr) nil))
       (if (consp js)
           (b* (((acl2::erp hd)
-                (shape-fromJSON (car js)))
+                (shape-fromJSON (car js) mode))
                ((acl2::erp tl)
-                (shape-list-fromJSON (cdr js))))
+                (shape-list-fromJSON (cdr js) mode)))
             (acl2::retok (cons hd tl)))
         (acl2::retok nil))))
 
@@ -306,7 +437,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define ispace-fromJSON ((j json::valuep))
+(define ispace-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x ispacep))
   :short "Convert a JSON value encoding an @('ISpace') to a @(tsee ispace)."
   (b* (((acl2::reterr)
@@ -322,13 +453,13 @@
                    (b* ((dim-j
                          (json::object-member-value "dim" j))
                         ((acl2::erp dim)
-                         (dim-fromJSON dim-j)))
+                         (dim-fromJSON dim-j mode)))
                      (acl2::retok (make-ispace-dim :dim dim))))
                   ((equal tag "Shape")
                    (b* ((shape-j
                          (json::object-member-value "shape" j))
                         ((acl2::erp shape)
-                         (shape-fromJSON shape-j)))
+                         (shape-fromJSON shape-j mode)))
                      (acl2::retok (make-ispace-shape :shape shape))))
                   (t
                    (acl2::reterr (msg "~x0 is not a recognized tag for an ISpace." tag)))))
@@ -342,16 +473,16 @@
                (ispace-huncheckedp x))
     :hints (("Goal" :in-theory (enable* ast-huncheckedp-rules)))))
 
-(define ispace-list-fromJSON ((js json::value-listp))
+(define ispace-list-fromJSON ((js json::value-listp) (mode ast-modep))
   :returns (mv erp (x ispace-listp))
   :measure (json::value-list-count js)
   :short "Convert a JSON array's elements to an @(tsee ispace-listp)."
   (b* (((acl2::reterr) nil))
     (if (consp js)
         (b* (((acl2::erp hd)
-              (ispace-fromJSON (car js)))
+              (ispace-fromJSON (car js) mode))
              ((acl2::erp tl)
-              (ispace-list-fromJSON (cdr js))))
+              (ispace-list-fromJSON (cdr js) mode)))
           (acl2::retok (cons hd tl)))
       (acl2::retok nil)))
 
@@ -364,14 +495,13 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; ISpaceParam
+;; ISpace-Var
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define ispace-var-fromJSON ((j json::valuep))
+(define ispace-var-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x ispace-varp))
-  :short "Convert a JSON value encoding an @('ISpaceParam')
-          to an @(tsee ispace-var)."
+  :short "Convert a JSON value encoding an @('ISpaceParam') to an @(tsee ispace-var)."
   (b* (((acl2::reterr)
         (make-ispace-var-dim :name "")))
     (if (json::value-case j :object)
@@ -383,47 +513,43 @@
                 (cond
                   ((equal tag "DimParam")
                    (b* ((name-j
-                         (json::object-member-value "name" j)))
-                     (if (json::value-case name-j :string)
-                         (b* ((name
-                               (json::value-string->get name-j)))
-                           (acl2::retok (make-ispace-var-dim :name name)))
-                       (acl2::reterr (msg "The \"name\" member of a DimParam object must be a string, but ~x0 is not." name-j)))))
+                         (json::object-member-value "name" j))
+                        ((acl2::erp name)
+                         (name-fromJSON name-j mode)))
+                     (acl2::retok (make-ispace-var-dim :name name))))
                   ((equal tag "ShapeParam")
                    (b* ((name-j
-                         (json::object-member-value "name" j)))
-                     (if (json::value-case name-j :string)
-                         (b* ((name
-                               (json::value-string->get name-j)))
-                           (acl2::retok (make-ispace-var-shape :name name)))
-                       (acl2::reterr (msg "The \"name\" member of a ShapeParam object must be a string, but ~x0 is not." name-j)))))
+                         (json::object-member-value "name" j))
+                        ((acl2::erp name)
+                         (name-fromJSON name-j mode)))
+                     (acl2::retok (make-ispace-var-shape :name name))))
                   (t
                    (acl2::reterr (msg "~x0 is not a recognized tag for an ISpaceParam." tag)))))
             (acl2::reterr (msg "The \"tag\" member of an ISpaceParam object must be a string, but ~x0 is not." tag-j))))
       (acl2::reterr (msg "A JSON value representing an ISpaceParam must be a JSON object, but ~x0 is not." j)))))
 
-(define ispace-var-list-fromJSON ((js json::value-listp))
+(define ispace-var-list-fromJSON ((js json::value-listp) (mode ast-modep))
   :returns (mv erp (x ispace-var-listp))
   :measure (json::value-list-count js)
   :short "Convert a JSON array's elements to an @(tsee ispace-var-listp)."
   (b* (((acl2::reterr) nil))
     (if (consp js)
         (b* (((acl2::erp hd)
-              (ispace-var-fromJSON (car js)))
+              (ispace-var-fromJSON (car js) mode))
              ((acl2::erp tl)
-              (ispace-var-list-fromJSON (cdr js))))
+              (ispace-var-list-fromJSON (cdr js) mode)))
           (acl2::retok (cons hd tl)))
       (acl2::retok nil))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; TypeParamExp
+;; Type-Var
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define type-var-fromJSON ((j json::valuep))
+(define type-var-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x type-varp))
-  :short "Convert a JSON value encoding a @('TypeParamExp')
+  :short "Convert a JSON value encoding a @('TypeParamExp') or a @('TypeParam')
           to a @(tsee type-var)."
   (b* (((acl2::reterr)
         (make-type-var-atom :name "")))
@@ -433,53 +559,212 @@
           (if (json::value-case tag-j :string)
               (b* ((tag
                     (json::value-string->get tag-j)))
-                (cond
-                  ((equal tag "TEAtomTypeParam")
-                   (b* ((name-j
-                         (json::object-member-value "name" j)))
-                     (if (json::value-case name-j :string)
-                         (b* ((name
-                               (json::value-string->get name-j)))
-                           (acl2::retok (make-type-var-atom :name name)))
-                       (acl2::reterr (msg "The \"name\" member of a TEAtomTypeParam object must be a string, but ~x0 is not." name-j)))))
-                  ((equal tag "TEArrayTypeParam")
-                   (b* ((name-j
-                         (json::object-member-value "name" j)))
-                     (if (json::value-case name-j :string)
-                         (b* ((name
-                               (json::value-string->get name-j)))
-                           (acl2::retok (make-type-var-array :name name)))
-                       (acl2::reterr (msg "The \"name\" member of a TEArrayTypeParam object must be a string, but ~x0 is not." name-j)))))
-                  (t
-                   (acl2::reterr (msg "~x0 is not a recognized tag for a TypeParamExp." tag)))))
+                (ast-mode-case
+                 mode
+                 :unchecked
+                 (cond
+                   ((equal tag "TEAtomTypeParam")
+                    (b* ((name-j
+                          (json::object-member-value "name" j))
+                         ((acl2::erp name)
+                          (name-fromJSON name-j mode)))
+                      (acl2::retok (make-type-var-atom :name name))))
+                   ((equal tag "TEArrayTypeParam")
+                    (b* ((name-j
+                          (json::object-member-value "name" j))
+                         ((acl2::erp name)
+                          (name-fromJSON name-j mode)))
+                      (acl2::retok (make-type-var-array :name name))))
+                   (t
+                    (acl2::reterr (msg "~x0 is not a recognized tag for a TypeParamExp." tag))))
+                 :otherwise
+                 (cond
+                   ((equal tag "AtomTypeParam")
+                    (b* ((name-j
+                          (json::object-member-value "name" j))
+                         ((acl2::erp name)
+                          (name-fromJSON name-j mode)))
+                      (acl2::retok (make-type-var-atom :name name))))
+                   (t
+                    (acl2::reterr (msg "~x0 is not a recognized tag for a TypeParam." tag))))))
             (acl2::reterr (msg "The \"tag\" member of a TypeParamExp object must be a string, but ~x0 is not." tag-j))))
       (acl2::reterr (msg "A JSON value representing a TypeParamExp must be a JSON object, but ~x0 is not." j)))))
 
-(define type-var-list-fromJSON ((js json::value-listp))
+(define type-var-list-fromJSON ((js json::value-listp) (mode ast-modep))
   :returns (mv erp (x type-var-listp))
   :measure (json::value-list-count js)
   :short "Convert a JSON array's elements to a @(tsee type-var-listp)."
   (b* (((acl2::reterr) nil))
     (if (consp js)
         (b* (((acl2::erp hd)
-              (type-var-fromJSON (car js)))
+              (type-var-fromJSON (car js) mode))
              ((acl2::erp tl)
-              (type-var-list-fromJSON (cdr js))))
+              (type-var-list-fromJSON (cdr js) mode)))
           (acl2::retok (cons hd tl)))
       (acl2::retok nil))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; TypeExp
+;; Type
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defines type-fromJSON
 
-  (define type-fromJSON ((j json::valuep))
+  (define type-fromJSON ((j json::valuep) (mode ast-modep))
     :returns (mv erp (x typep))
     :measure (json::value-count j)
-    :short "Convert a JSON value encoding a @('TypeExp') to a @(tsee type)."
+    :short "Convert a JSON value encoding a @('TypeExp') or a @('Type')
+            to a @(tsee type)."
+    (b* (((acl2::reterr)
+          (make-type-base :type (make-base-type-bool ))))
+      (if (json::value-case j :object)
+          (b* ((tag-j
+                (json::object-member-value "tag" j)))
+            (if (json::value-case tag-j :string)
+                (b* ((tag
+                      (json::value-string->get tag-j)))
+                  (ast-mode-case
+                   mode
+                   :checked
+                   (cond
+                     ((equal tag "AtomType")
+                      (b* ((type-j
+                            (json::object-member-value "type" j))
+                           ((acl2::erp type)
+                            (atom-type-fromJSON type-j mode)))
+                        (acl2::retok type)))
+                     ((equal tag "ArrayType")
+                      (b* ((type-j
+                            (json::object-member-value "type" j))
+                           ((acl2::erp type)
+                            (array-type-fromJSON type-j mode)))
+                        (acl2::retok type)))
+                     (t
+                      (acl2::reterr (msg "~x0 is not a recognized tag for a Type." tag))))
+                   :otherwise
+                   (cond
+                     ((equal tag "TEAtomVar")
+                      (b* ((name-j
+                            (json::object-member-value "name" j))
+                           ((acl2::erp name)
+                            (name-fromJSON name-j mode)))
+                        (acl2::retok (make-type-var
+                                      :var (make-type-var-atom :name name)))))
+                     ((equal tag "TEArrayVar")
+                      (b* ((name-j
+                            (json::object-member-value "name" j))
+                           ((acl2::erp name)
+                            (name-fromJSON name-j mode)))
+                        (acl2::retok (make-type-var
+                                      :var (make-type-var-array :name name)))))
+                     ((equal tag "TEBool")
+                      (acl2::retok (make-type-base
+                                    :type (make-base-type-bool ))))
+                     ((equal tag "TEInt")
+                      (acl2::retok (make-type-base
+                                    :type (make-base-type-int ))))
+                     ((equal tag "TEFloat")
+                      (acl2::retok (make-type-base
+                                    :type (make-base-type-float ))))
+                     ((equal tag "TEArray")
+                      (b* ((elem-j
+                            (json::object-member-value "elem" j))
+                           ((acl2::erp elem)
+                            (type-fromJSON elem-j mode))
+                           (shape-j
+                            (json::object-member-value "shape" j))
+                           ((acl2::erp shape)
+                            (shape-fromJSON shape-j mode)))
+                        (acl2::retok (make-type-array
+                                      :elem elem
+                                      :ispace (make-ispace-shape :shape shape)))))
+                     ((equal tag "TEArrow")
+                      (b* ((in-j
+                            (json::object-member-value "in" j))
+                           ((acl2::erp in)
+                            (type-fromJSON in-j mode))
+                           (out-j
+                            (json::object-member-value "out" j))
+                           ((acl2::erp out)
+                            (type-fromJSON out-j mode)))
+                        (acl2::retok (make-type-fun
+                                      :in in
+                                      :out out))))
+                     ((equal tag "TEForall")
+                      (b* ((params-j
+                            (json::object-member-value "params" j))
+                           (body-j
+                            (json::object-member-value "body" j)))
+                        (if (json::value-case params-j :array)
+                            (b* ((params-js
+                                  (json::value-array->elements params-j))
+                                 ((acl2::erp params)
+                                  (type-var-list-fromJSON params-js mode))
+                                 ((acl2::erp body)
+                                  (type-fromJSON body-j mode)))
+                              (if (consp params)
+                                  (acl2::retok
+                                   (make-type-forall/foralln params body))
+                                (acl2::reterr (msg "The \"params\" member of a TEForall object must be a nonempty list, but ~x0 is not." params))))
+                          (acl2::reterr (msg "The \"params\" member of a TEForall object must be a JSON array, but ~x0 is not." params-j)))))
+                     ((equal tag "TEPi")
+                      (b* ((params-j
+                            (json::object-member-value "params" j))
+                           (body-j
+                            (json::object-member-value "body" j)))
+                        (if (json::value-case params-j :array)
+                            (b* ((params-js
+                                  (json::value-array->elements params-j))
+                                 ((acl2::erp params)
+                                  (ispace-var-list-fromJSON params-js mode))
+                                 ((acl2::erp body)
+                                  (type-fromJSON body-j mode)))
+                              (if (consp params)
+                                  (acl2::retok (make-type-pi/pin params body))
+                                (acl2::reterr (msg "The \"params\" member of a TEPi object must be a nonempty list, but ~x0 is not." params))))
+                          (acl2::reterr (msg "The \"params\" member of a TEPi object must be a JSON array, but ~x0 is not." params-j)))))
+                     ((equal tag "TESigma")
+                      (b* ((params-j
+                            (json::object-member-value "params" j))
+                           (body-j
+                            (json::object-member-value "body" j)))
+                        (if (json::value-case params-j :array)
+                            (b* ((params-js
+                                  (json::value-array->elements params-j))
+                                 ((acl2::erp params)
+                                  (ispace-var-list-fromJSON params-js mode))
+                                 ((acl2::erp body)
+                                  (type-fromJSON body-j mode)))
+                              (if (consp params)
+                                  (acl2::retok
+                                   (make-type-sigma/sigman params body))
+                                (acl2::reterr (msg "The \"params\" member of a TESigma object must be a nonempty list, but ~x0 is not." params))))
+                          (acl2::reterr (msg "The \"params\" member of a TESigma object must be a JSON array, but ~x0 is not." params-j)))))
+                     ((equal tag "TERecord")
+                      (acl2::reterr (msg "TERecord objects are not yet supported")))
+                     (t
+                      (acl2::reterr (msg "~x0 is not a recognized tag for a TypeExp." tag))))))
+              (acl2::reterr (msg "The \"tag\" member of a TypeExp object must be a string, but ~x0 is not." tag-j))))
+        (acl2::reterr (msg "A JSON value representing a TypeExp must be a JSON object, but ~x0 is not." j)))))
+
+  (define type-list-fromJSON ((js json::value-listp) (mode ast-modep))
+    :returns (mv erp (x type-listp))
+    :measure (json::value-list-count js)
+    :short "Convert a JSON array's elements to a @(tsee type-listp)."
+    (b* (((acl2::reterr) nil))
+      (if (consp js)
+          (b* (((acl2::erp hd)
+                (type-fromJSON (car js) mode))
+               ((acl2::erp tl)
+                (type-list-fromJSON (cdr js) mode)))
+            (acl2::retok (cons hd tl)))
+        (acl2::retok nil))))
+
+  (define atom-type-fromJSON ((j json::valuep) (mode ast-modep))
+    :returns (mv erp (x typep))
+    :measure (json::value-count j)
+    :short "Convert a JSON value encoding an @('AtomType') to a @(tsee type)."
     (b* (((acl2::reterr)
           (make-type-base :type (make-base-type-bool ))))
       (if (json::value-case j :object)
@@ -489,126 +774,107 @@
                 (b* ((tag
                       (json::value-string->get tag-j)))
                   (cond
-                    ((equal tag "TEAtomVar")
+                    ((equal tag "AtomTypeVar")
                      (b* ((name-j
-                           (json::object-member-value "name" j)))
-                       (if (json::value-case name-j :string)
-                           (b* ((name
-                                 (json::value-string->get name-j)))
-                             (acl2::retok (make-type-var
-                                           :var (make-type-var-atom :name name))))
-                         (acl2::reterr (msg "The \"name\" member of a TEAtomVar object must be a string, but ~x0 is not." name-j)))))
-                    ((equal tag "TEArrayVar")
-                     (b* ((name-j
-                           (json::object-member-value "name" j)))
-                       (if (json::value-case name-j :string)
-                           (b* ((name
-                                 (json::value-string->get name-j)))
-                             (acl2::retok (make-type-var
-                                           :var (make-type-var-array :name name))))
-                         (acl2::reterr (msg "The \"name\" member of a TEArrayVar object must be a string, but ~x0 is not." name-j)))))
-                    ((equal tag "TEBool")
+                           (json::object-member-value "name" j))
+                          ((acl2::erp name)
+                           (name-fromJSON name-j mode)))
+                       (acl2::retok (make-type-var
+                                     :var (make-type-var-atom :name name)))))
+                    ((equal tag "Bool")
                      (acl2::retok (make-type-base
                                    :type (make-base-type-bool ))))
-                    ((equal tag "TEInt")
+                    ((equal tag "Int")
                      (acl2::retok (make-type-base
                                    :type (make-base-type-int ))))
-                    ((equal tag "TEFloat")
+                    ((equal tag "Float")
                      (acl2::retok (make-type-base
                                    :type (make-base-type-float ))))
-                    ((equal tag "TEArray")
-                     (b* ((elem-j
-                           (json::object-member-value "elem" j))
-                          ((acl2::erp elem)
-                           (type-fromJSON elem-j))
-                          (shape-j
-                           (json::object-member-value "shape" j))
-                          ((acl2::erp shape)
-                           (shape-fromJSON shape-j)))
-                       (acl2::retok (make-type-array
-                                     :elem elem
-                                     :ispace (make-ispace-shape :shape shape)))))
-                    ((equal tag "TEArrow")
+                    ((equal tag "(:->)")
                      (b* ((in-j
                            (json::object-member-value "in" j))
                           ((acl2::erp in)
-                           (type-fromJSON in-j))
+                           (array-type-fromJSON in-j mode))
                           (out-j
                            (json::object-member-value "out" j))
                           ((acl2::erp out)
-                           (type-fromJSON out-j)))
+                           (array-type-fromJSON out-j mode)))
                        (acl2::retok (make-type-fun
                                      :in in
                                      :out out))))
-                    ((equal tag "TEForall")
-                     (b* ((params-j
-                           (json::object-member-value "params" j))
+                    ((equal tag "Forall")
+                     (b* ((param-j
+                           (json::object-member-value "param" j))
                           (body-j
-                           (json::object-member-value "body" j)))
-                       (if (json::value-case params-j :array)
-                           (b* ((params-js
-                                 (json::value-array->elements params-j))
-                                ((acl2::erp params)
-                                 (type-var-list-fromJSON params-js))
-                                ((acl2::erp body)
-                                 (type-fromJSON body-j)))
-                             (if (consp params)
-                                 (acl2::retok
-                                  (make-type-forall/foralln params body))
-                               (acl2::reterr (msg "The \"params\" member of a TEForall object must be a nonempty list, but ~x0 is not." params))))
-                         (acl2::reterr (msg "The \"params\" member of a TEForall object must be a JSON array, but ~x0 is not." params-j)))))
-                    ((equal tag "TEPi")
-                     (b* ((params-j
-                           (json::object-member-value "params" j))
+                           (json::object-member-value "body" j))
+                          ((acl2::erp param)
+                           (type-var-fromJSON param-j mode))
+                          ((acl2::erp body)
+                           (array-type-fromJSON body-j mode)))
+                       (acl2::retok (make-type-forall
+                                     :param param
+                                     :body body))))
+                    ((equal tag "Pi")
+                     (b* ((param-j
+                           (json::object-member-value "param" j))
                           (body-j
-                           (json::object-member-value "body" j)))
-                       (if (json::value-case params-j :array)
-                           (b* ((params-js
-                                 (json::value-array->elements params-j))
-                                ((acl2::erp params)
-                                 (ispace-var-list-fromJSON params-js))
-                                ((acl2::erp body)
-                                 (type-fromJSON body-j)))
-                             (if (consp params)
-                                 (acl2::retok (make-type-pi/pin params body))
-                               (acl2::reterr (msg "The \"params\" member of a TEPi object must be a nonempty list, but ~x0 is not." params))))
-                         (acl2::reterr (msg "The \"params\" member of a TEPi object must be a JSON array, but ~x0 is not." params-j)))))
-                    ((equal tag "TESigma")
-                     (b* ((params-j
-                           (json::object-member-value "params" j))
+                           (json::object-member-value "body" j))
+                          ((acl2::erp param)
+                           (ispace-var-fromJSON param-j mode))
+                          ((acl2::erp body)
+                           (array-type-fromJSON body-j mode)))
+                       (acl2::retok (make-type-pi
+                                     :param param
+                                     :body body))))
+                    ((equal tag "Sigma")
+                     (b* ((param-j
+                           (json::object-member-value "param" j))
                           (body-j
-                           (json::object-member-value "body" j)))
-                       (if (json::value-case params-j :array)
-                           (b* ((params-js
-                                 (json::value-array->elements params-j))
-                                ((acl2::erp params)
-                                 (ispace-var-list-fromJSON params-js))
-                                ((acl2::erp body)
-                                 (type-fromJSON body-j)))
-                             (if (consp params)
-                                 (acl2::retok
-                                  (make-type-sigma/sigman params body))
-                               (acl2::reterr (msg "The \"params\" member of a TESigma object must be a nonempty list, but ~x0 is not." params))))
-                         (acl2::reterr (msg "The \"params\" member of a TESigma object must be a JSON array, but ~x0 is not." params-j)))))
-                    ((equal tag "TERecord")
-                     (acl2::reterr (msg "TERecord objects are not yet supported")))
+                           (json::object-member-value "body" j))
+                          ((acl2::erp param)
+                           (ispace-var-fromJSON param-j mode))
+                          ((acl2::erp body)
+                           (array-type-fromJSON body-j mode)))
+                       (acl2::retok (make-type-sigma
+                                     :param param
+                                     :body body))))
+                    ((equal tag "Record")
+                     (acl2::reterr (msg "Record objects are not yet supported")))
                     (t
-                     (acl2::reterr (msg "~x0 is not a recognized tag for a TypeExp." tag)))))
-              (acl2::reterr (msg "The \"tag\" member of a TypeExp object must be a string, but ~x0 is not." tag-j))))
-        (acl2::reterr (msg "A JSON value representing a TypeExp must be a JSON object, but ~x0 is not." j)))))
+                     (acl2::reterr (msg "~x0 is not a recognized tag for an AtomType." tag)))))
+              (acl2::reterr (msg "The \"tag\" member of an AtomType object must be a string, but ~x0 is not." tag-j))))
+        (acl2::reterr (msg "A JSON value representing an AtomType must be a JSON object, but ~x0 is not." j)))))
 
-  (define type-list-fromJSON ((js json::value-listp))
-    :returns (mv erp (x type-listp))
-    :measure (json::value-list-count js)
-    :short "Convert a JSON array's elements to a @(tsee type-listp)."
-    (b* (((acl2::reterr) nil))
-      (if (consp js)
-          (b* (((acl2::erp hd)
-                (type-fromJSON (car js)))
-               ((acl2::erp tl)
-                (type-list-fromJSON (cdr js))))
-            (acl2::retok (cons hd tl)))
-        (acl2::retok nil))))
+  (define array-type-fromJSON ((j json::valuep) (mode ast-modep))
+    :returns (mv erp (x typep))
+    :measure (json::value-count j)
+    :short "Convert a JSON value encoding an @('ArrayType') to a @(tsee type)."
+    (b* (((acl2::reterr)
+          (make-type-base :type (make-base-type-bool ))))
+      (if (json::value-case j :object)
+          (b* ((tag-j
+                (json::object-member-value "tag" j)))
+            (if (json::value-case tag-j :string)
+                (b* ((tag
+                      (json::value-string->get tag-j)))
+                  (cond
+                    ((equal tag "A")
+                     (b* ((elem-j
+                           (json::object-member-value "arrayTypeAtom" j))
+                          (shape-j
+                           (json::object-member-value "arrayTypeShape" j))
+                          ((acl2::erp elem)
+                           (atom-type-fromJSON elem-j mode))
+                          ((acl2::erp shape)
+                           (shape-fromJSON shape-j mode)))
+                       (acl2::retok (make-type-array
+                                     :elem elem
+                                     :ispace (make-ispace-shape
+                                              :shape shape)))))
+                    (t
+                     (acl2::reterr (msg "~x0 is not a recognized tag for an ArrayType." tag)))))
+              (acl2::reterr (msg "The \"tag\" member of an ArrayType object must be a string, but ~x0 is not." tag-j))))
+        (acl2::reterr (msg "A JSON value representing an ArrayType must be a JSON object, but ~x0 is not." j)))))
 
   :verify-guards nil
   :hints (("Goal" :in-theory (enable value-count-of-object-member-value)))
@@ -645,6 +911,14 @@
         (implies (not erp)
                  (type-list-huncheckedp x))
       :fn type-list-fromJSON)
+    (defret type-huncheckedp-of-atom-type-fromJSON
+        (implies (not erp)
+                 (type-huncheckedp x))
+      :fn atom-type-fromJSON)
+    (defret type-huncheckedp-of-array-type-fromJSON
+        (implies (not erp)
+                 (type-huncheckedp x))
+      :fn array-type-fromJSON)
     :hints (("Goal" :in-theory (enable* ast-huncheckedp-rules
                                         make-type-forall/foralln
                                         make-type-pi/pin
@@ -652,11 +926,11 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; Base
+;; Base-Lit
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define base-lit-fromJSON ((j json::valuep))
+(define base-lit-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x base-litp))
   :short "Convert a JSON value encoding a @('Base') literal
           to a @(tsee base-lit)."
@@ -705,15 +979,16 @@
                   (t
                    (acl2::reterr (msg "~x0 is not a recognized tag for a Base." tag)))))
             (acl2::reterr (msg "The \"tag\" member of a Base object must be a string, but ~x0 is not." tag-j))))
-      (acl2::reterr (msg "A JSON value representing a Base must be a JSON object, but ~x0 is not." j)))))
+      (acl2::reterr (msg "A JSON value representing a Base must be a JSON object, but ~x0 is not." j))))
+  :ignore-ok t)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; PatBase
+;; Var+Type?
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define var+type?-fromJSON ((j json::valuep))
+(define var+type?-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x var+type?-p))
   :short "Convert a JSON value encoding a @('PatBase')
           to a @(tsee var+type?)."
@@ -730,16 +1005,14 @@
                    (b* ((var-j
                          (json::object-member-value "var" j))
                         (type-j
-                         (json::object-member-value "type" j)))
-                     (if (json::value-case var-j :string)
-                         (b* ((var
-                               (json::value-string->get var-j))
-                              ((acl2::erp type)
-                               (type-fromJSON type-j)))
-                           (acl2::retok (make-var+type?
-                                         :var var
-                                         :type? (make-type-option-some :val type))))
-                       (acl2::reterr (msg "The \"var\" member of a PatId object must be a string, but ~x0 is not." var-j)))))
+                         (json::object-member-value "type" j))
+                        ((acl2::erp var)
+                         (name-fromJSON var-j mode))
+                        ((acl2::erp type)
+                         (type-fromJSON type-j mode)))
+                     (acl2::retok (make-var+type?
+                                   :var var
+                                   :type? (make-type-option-some :val type)))))
                   (t
                    (acl2::reterr (msg "~x0 is not a recognized tag for a PatBase." tag)))))
             (acl2::reterr (msg "The \"tag\" member of a PatBase object must be a string, but ~x0 is not." tag-j))))
@@ -752,16 +1025,16 @@
                (var+type?-huncheckedp x))
     :hints (("Goal" :in-theory (enable* ast-huncheckedp-rules)))))
 
-(define var+type?-list-fromJSON ((js json::value-listp))
+(define var+type?-list-fromJSON ((js json::value-listp) (mode ast-modep))
   :returns (mv erp (x var+type?-listp))
   :measure (json::value-list-count js)
   :short "Convert a JSON array's elements to a @(tsee var+type?-listp)."
   (b* (((acl2::reterr) nil))
     (if (consp js)
         (b* (((acl2::erp hd)
-              (var+type?-fromJSON (car js)))
+              (var+type?-fromJSON (car js) mode))
              ((acl2::erp tl)
-              (var+type?-list-fromJSON (cdr js))))
+              (var+type?-list-fromJSON (cdr js) mode)))
           (acl2::retok (cons hd tl)))
       (acl2::retok nil)))
 
@@ -774,16 +1047,13 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; AtomBase, BindBase, and ExpBase are mutually recursive,
-;; so their fromJSON counterparts (together with their list forms and the
-;; [Int]-to-nat-listp helper nat-list-fromJSON) are defined as a single
-;; mutually recursive clique below.
+;; Exprs / Atoms / Binds
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defines expr-fromJSON
 
-  (define atom-fromJSON ((j json::valuep))
+  (define atom-fromJSON ((j json::valuep) (mode ast-modep))
     :returns (mv erp (x atomp))
     :measure (json::value-count j)
     :short "Convert a JSON value encoding an @('AtomBase') to a @(tsee atom)."
@@ -800,17 +1070,17 @@
                      (b* ((lit-j
                            (json::object-member-value "lit" j))
                           ((acl2::erp lit)
-                           (base-lit-fromJSON lit-j)))
+                           (base-lit-fromJSON lit-j mode)))
                        (acl2::retok (make-atom-base :lit lit))))
                     ((equal tag "Lambda")
                      (b* ((param-j
                            (json::object-member-value "param" j))
                           ((acl2::erp param)
-                           (var+type?-fromJSON param-j))
+                           (var+type?-fromJSON param-j mode))
                           (body-j
                            (json::object-member-value "body" j))
                           ((acl2::erp body)
-                           (expr-fromJSON body-j)))
+                           (expr-fromJSON body-j mode)))
                        (acl2::retok (make-atom-lambda
                                      :param param
                                      :body body
@@ -819,11 +1089,11 @@
                      (b* ((param-j
                            (json::object-member-value "param" j))
                           ((acl2::erp param)
-                           (type-var-fromJSON param-j))
+                           (type-var-fromJSON param-j mode))
                           (body-j
                            (json::object-member-value "body" j))
                           ((acl2::erp body)
-                           (expr-fromJSON body-j)))
+                           (expr-fromJSON body-j mode)))
                        (acl2::retok (make-atom-tlambda
                                      :param param
                                      :body body))))
@@ -831,11 +1101,11 @@
                      (b* ((param-j
                            (json::object-member-value "param" j))
                           ((acl2::erp param)
-                           (ispace-var-fromJSON param-j))
+                           (ispace-var-fromJSON param-j mode))
                           (body-j
                            (json::object-member-value "body" j))
                           ((acl2::erp body)
-                           (expr-fromJSON body-j)))
+                           (expr-fromJSON body-j mode)))
                        (acl2::retok (make-atom-ilambda
                                      :param param
                                      :body body))))
@@ -843,11 +1113,11 @@
                      (b* ((ispace-j
                            (json::object-member-value "ispace" j))
                           ((acl2::erp ispace)
-                           (ispace-fromJSON ispace-j))
+                           (ispace-fromJSON ispace-j mode))
                           (array-j
                            (json::object-member-value "array" j))
                           ((acl2::erp array)
-                            (expr-fromJSON array-j))
+                            (expr-fromJSON array-j mode))
                           (type-j
                            (json::object-member-value "type" j)))
                        (if (json::value-case type-j :null)
@@ -856,7 +1126,7 @@
                                          :array array
                                          :type? (make-type-option-none )))
                          (b* (((acl2::erp type)
-                               (type-fromJSON type-j)))
+                               (type-fromJSON type-j mode)))
                            (acl2::retok (make-atom-box
                                          :ispace ispace
                                          :array array
@@ -867,20 +1137,20 @@
               (acl2::reterr (msg "The \"tag\" member of an AtomBase object must be a string, but ~x0 is not." tag-j))))
         (acl2::reterr (msg "A JSON value representing an AtomBase must be a JSON object, but ~x0 is not." j)))))
 
-  (define atom-list-fromJSON ((js json::value-listp))
+  (define atom-list-fromJSON ((js json::value-listp) (mode ast-modep))
     :returns (mv erp (x atom-listp))
     :measure (json::value-list-count js)
     :short "Convert a JSON array's elements to an @(tsee atom-listp)."
     (b* (((acl2::reterr) nil))
       (if (consp js)
           (b* (((acl2::erp hd)
-                (atom-fromJSON (car js)))
+                (atom-fromJSON (car js) mode))
                ((acl2::erp tl)
-                (atom-list-fromJSON (cdr js))))
+                (atom-list-fromJSON (cdr js) mode)))
             (acl2::retok (cons hd tl)))
         (acl2::retok nil))))
 
-  (define bind-fromJSON ((j json::valuep))
+  (define bind-fromJSON ((j json::valuep) (mode ast-modep))
     :returns (mv erp (x bindp))
     :measure (json::value-count j)
     :short "Convert a JSON value encoding a @('BindBase') to a @(tsee bind)."
@@ -900,44 +1170,42 @@
                           (type-j
                            (json::object-member-value "type" j))
                           (expr-j
-                           (json::object-member-value "expr" j)))
-                       (if (json::value-case var-j :string)
-                           (b* ((var
-                                 (json::value-string->get var-j))
-                                ((acl2::erp expr)
-                                 (expr-fromJSON expr-j)))
-                             (if (json::value-case type-j :null)
-                                 (acl2::retok (make-bind-val
-                                               :var var
-                                               :type? (make-type-option-none )
-                                               :expr expr))
-                               (b* (((acl2::erp type)
-                                     (type-fromJSON type-j)))
-                                 (acl2::retok (make-bind-val
-                                               :var var
-                                               :type? (make-type-option-some
-                                                       :val type)
-                                               :expr expr)))))
-                         (acl2::reterr (msg "The \"var\" member of a BindVal object must be a string, but ~x0 is not." var-j)))))
+                           (json::object-member-value "expr" j))
+                          ((acl2::erp var)
+                           (name-fromJSON var-j mode))
+                          ((acl2::erp expr)
+                           (expr-fromJSON expr-j mode)))
+                       (if (json::value-case type-j :null)
+                           (acl2::retok (make-bind-val
+                                         :var var
+                                         :type? (make-type-option-none )
+                                         :expr expr))
+                         (b* (((acl2::erp type)
+                               (type-fromJSON type-j mode)))
+                           (acl2::retok (make-bind-val
+                                         :var var
+                                         :type? (make-type-option-some
+                                                 :val type)
+                                         :expr expr))))))
                     ((equal tag "BindType")
                      (b* ((var-j
                            (json::object-member-value "var" j))
                           ((acl2::erp var)
-                           (type-var-fromJSON var-j))
+                           (type-var-fromJSON var-j mode))
                           (type-j
                            (json::object-member-value "type" j))
                           ((acl2::erp type)
-                           (type-fromJSON type-j)))
+                           (type-fromJSON type-j mode)))
                        (acl2::retok (make-bind-type :var var :type type))))
                     ((equal tag "BindISpace")
                      (b* ((var-j
                            (json::object-member-value "var" j))
                           ((acl2::erp var)
-                           (ispace-var-fromJSON var-j))
+                           (ispace-var-fromJSON var-j mode))
                           (ispace-j
                            (json::object-member-value "ispace" j))
                           ((acl2::erp ispace)
-                           (ispace-fromJSON ispace-j)))
+                           (ispace-fromJSON ispace-j mode)))
                        (acl2::retok (make-bind-ispace :var var :ispace ispace))))
                     ((equal tag "BindFun")
                      (b* ((var-j
@@ -948,34 +1216,32 @@
                            (json::object-member-value "type" j))
                           (expr-j
                            (json::object-member-value "expr" j)))
-                       (if (json::value-case var-j :string)
-                           (if (json::value-case params-j :array)
-                               (b* ((var
-                                     (json::value-string->get var-j))
-                                    (params-js
-                                     (json::value-array->elements params-j))
-                                    ((acl2::erp params)
-                                     (var+type?-list-fromJSON params-js))
-                                    ((acl2::erp expr)
-                                     (expr-fromJSON expr-j)))
-                                 (if (consp params)
-                                     (if (json::value-case type-j :null)
-                                         (acl2::retok (make-bind-fun
-                                                       :var var
-                                                       :params params
-                                                       :type? (make-type-option-none )
-                                                       :expr expr))
-                                       (b* (((acl2::erp type)
-                                             (type-fromJSON type-j)))
-                                         (acl2::retok (make-bind-fun
-                                                       :var var
-                                                       :params params
-                                                       :type? (make-type-option-some
-                                                               :val type)
-                                                       :expr expr))))
-                                   (acl2::reterr (msg "The \"params\" member of a BindFun object must be a nonempty list, but ~x0 is not." params))))
-                             (acl2::reterr (msg "The \"params\" member of a BindFun object must be a JSON array, but ~x0 is not." params-j)))
-                         (acl2::reterr (msg "The \"var\" member of a BindFun object must be a string, but ~x0 is not." var-j)))))
+                       (if (json::value-case params-j :array)
+                           (b* (((acl2::erp var)
+                                 (name-fromJSON var-j mode))
+                                (params-js
+                                 (json::value-array->elements params-j))
+                                ((acl2::erp params)
+                                 (var+type?-list-fromJSON params-js mode))
+                                ((acl2::erp expr)
+                                 (expr-fromJSON expr-j mode)))
+                             (if (consp params)
+                                 (if (json::value-case type-j :null)
+                                     (acl2::retok (make-bind-fun
+                                                   :var var
+                                                   :params params
+                                                   :type? (make-type-option-none )
+                                                   :expr expr))
+                                   (b* (((acl2::erp type)
+                                         (type-fromJSON type-j mode)))
+                                     (acl2::retok (make-bind-fun
+                                                   :var var
+                                                   :params params
+                                                   :type? (make-type-option-some
+                                                           :val type)
+                                                   :expr expr))))
+                               (acl2::reterr (msg "The \"params\" member of a BindFun object must be a nonempty list, but ~x0 is not." params))))
+                         (acl2::reterr (msg "The \"params\" member of a BindFun object must be a JSON array, but ~x0 is not." params-j)))))
                     ((equal tag "BindTFun")
                      (b* ((var-j
                            (json::object-member-value "var" j))
@@ -985,34 +1251,32 @@
                            (json::object-member-value "type" j))
                           (expr-j
                            (json::object-member-value "expr" j)))
-                       (if (json::value-case var-j :string)
-                           (if (json::value-case params-j :array)
-                               (b* ((var
-                                     (json::value-string->get var-j))
-                                    (params-js
-                                     (json::value-array->elements params-j))
-                                    ((acl2::erp params)
-                                     (type-var-list-fromJSON params-js))
-                                    ((acl2::erp expr)
-                                     (expr-fromJSON expr-j)))
-                                 (if (consp params)
-                                     (if (json::value-case type-j :null)
-                                         (acl2::retok (make-bind-tfun
-                                                       :var var
-                                                       :params params
-                                                       :type? (make-type-option-none )
-                                                       :expr expr))
-                                       (b* (((acl2::erp type)
-                                             (type-fromJSON type-j)))
-                                         (acl2::retok (make-bind-tfun
-                                                       :var var
-                                                       :params params
-                                                       :type? (make-type-option-some
-                                                               :val type)
-                                                       :expr expr))))
-                                   (acl2::reterr (msg "The \"params\" member of a BindTFun object must be a nonempty list, but ~x0 is not." params))))
-                             (acl2::reterr (msg "The \"params\" member of a BindTFun object must be a JSON array, but ~x0 is not." params-j)))
-                         (acl2::reterr (msg "The \"var\" member of a BindTFun object must be a string, but ~x0 is not." var-j)))))
+                       (if (json::value-case params-j :array)
+                           (b* (((acl2::erp var)
+                                 (name-fromJSON var-j mode))
+                                (params-js
+                                 (json::value-array->elements params-j))
+                                ((acl2::erp params)
+                                 (type-var-list-fromJSON params-js mode))
+                                ((acl2::erp expr)
+                                 (expr-fromJSON expr-j mode)))
+                             (if (consp params)
+                                 (if (json::value-case type-j :null)
+                                     (acl2::retok (make-bind-tfun
+                                                   :var var
+                                                   :params params
+                                                   :type? (make-type-option-none )
+                                                   :expr expr))
+                                   (b* (((acl2::erp type)
+                                         (type-fromJSON type-j mode)))
+                                     (acl2::retok (make-bind-tfun
+                                                   :var var
+                                                   :params params
+                                                   :type? (make-type-option-some
+                                                           :val type)
+                                                   :expr expr))))
+                               (acl2::reterr (msg "The \"params\" member of a BindTFun object must be a nonempty list, but ~x0 is not." params))))
+                         (acl2::reterr (msg "The \"params\" member of a BindTFun object must be a JSON array, but ~x0 is not." params-j)))))
                     ((equal tag "BindIFun")
                      (b* ((var-j
                            (json::object-member-value "var" j))
@@ -1022,53 +1286,51 @@
                            (json::object-member-value "type" j))
                           (expr-j
                            (json::object-member-value "expr" j)))
-                       (if (json::value-case var-j :string)
-                           (if (json::value-case params-j :array)
-                               (b* ((var
-                                     (json::value-string->get var-j))
-                                    (params-js
-                                     (json::value-array->elements params-j))
-                                    ((acl2::erp params)
-                                     (ispace-var-list-fromJSON params-js))
-                                    ((acl2::erp expr)
-                                     (expr-fromJSON expr-j)))
-                                 (if (consp params)
-                                     (if (json::value-case type-j :null)
-                                         (acl2::retok (make-bind-ifun
-                                                       :var var
-                                                       :params params
-                                                       :type? (make-type-option-none )
-                                                       :expr expr))
-                                       (b* (((acl2::erp type)
-                                             (type-fromJSON type-j)))
-                                         (acl2::retok (make-bind-ifun
-                                                       :var var
-                                                       :params params
-                                                       :type? (make-type-option-some
-                                                               :val type)
-                                                       :expr expr))))
-                                   (acl2::reterr (msg "The \"params\" member of a BindIFun object must be a nonempty list, but ~x0 is not." params))))
-                             (acl2::reterr (msg "The \"params\" member of a BindIFun object must be a JSON array, but ~x0 is not." params-j)))
-                         (acl2::reterr (msg "The \"var\" member of a BindIFun object must be a string, but ~x0 is not." var-j)))))
+                       (if (json::value-case params-j :array)
+                           (b* (((acl2::erp var)
+                                 (name-fromJSON var-j mode))
+                                (params-js
+                                 (json::value-array->elements params-j))
+                                ((acl2::erp params)
+                                 (ispace-var-list-fromJSON params-js mode))
+                                ((acl2::erp expr)
+                                 (expr-fromJSON expr-j mode)))
+                             (if (consp params)
+                                 (if (json::value-case type-j :null)
+                                     (acl2::retok (make-bind-ifun
+                                                   :var var
+                                                   :params params
+                                                   :type? (make-type-option-none )
+                                                   :expr expr))
+                                   (b* (((acl2::erp type)
+                                         (type-fromJSON type-j mode)))
+                                     (acl2::retok (make-bind-ifun
+                                                   :var var
+                                                   :params params
+                                                   :type? (make-type-option-some
+                                                           :val type)
+                                                   :expr expr))))
+                               (acl2::reterr (msg "The \"params\" member of a BindIFun object must be a nonempty list, but ~x0 is not." params))))
+                         (acl2::reterr (msg "The \"params\" member of a BindIFun object must be a JSON array, but ~x0 is not." params-j)))))
                     (t
                      (acl2::reterr (msg "~x0 is not a recognized tag for a BindBase." tag)))))
               (acl2::reterr (msg "The \"tag\" member of a BindBase object must be a string, but ~x0 is not." tag-j))))
         (acl2::reterr (msg "A JSON value representing a BindBase must be a JSON object, but ~x0 is not." j)))))
 
-  (define bind-list-fromJSON ((js json::value-listp))
+  (define bind-list-fromJSON ((js json::value-listp) (mode ast-modep))
     :returns (mv erp (x bind-listp))
     :measure (json::value-list-count js)
     :short "Convert a JSON array's elements to a @(tsee bind-listp)."
     (b* (((acl2::reterr) nil))
       (if (consp js)
           (b* (((acl2::erp hd)
-                (bind-fromJSON (car js)))
+                (bind-fromJSON (car js) mode))
                ((acl2::erp tl)
-                (bind-list-fromJSON (cdr js))))
+                (bind-list-fromJSON (cdr js) mode)))
             (acl2::retok (cons hd tl)))
         (acl2::retok nil))))
 
-  (define expr-fromJSON ((j json::valuep))
+  (define expr-fromJSON ((j json::valuep) (mode ast-modep))
     :returns (mv erp (x exprp))
     :measure (json::value-count j)
     :short "Convert a JSON value encoding an @('ExpBase') to a @(tsee expr)."
@@ -1083,12 +1345,10 @@
                   (cond
                     ((equal tag "Var")
                      (b* ((name-j
-                           (json::object-member-value "name" j)))
-                       (if (json::value-case name-j :string)
-                           (b* ((name
-                                 (json::value-string->get name-j)))
-                             (acl2::retok (make-expr-var :name name)))
-                         (acl2::reterr (msg "The \"name\" member of a Var object must be a string, but ~x0 is not." name-j)))))
+                           (json::object-member-value "name" j))
+                          ((acl2::erp name)
+                           (name-fromJSON name-j mode)))
+                       (acl2::retok (make-expr-var :name name))))
                     ((equal tag "Array")
                      (b* ((dims-j
                            (json::object-member-value "dims" j))
@@ -1103,7 +1363,7 @@
                                     (atoms-js
                                      (json::value-array->elements atoms-j))
                                     ((acl2::erp atoms)
-                                     (atom-list-fromJSON atoms-js)))
+                                     (atom-list-fromJSON atoms-js mode)))
                                  (if (consp atoms)
                                      (acl2::retok (make-expr-array
                                                    :dims dims
@@ -1122,7 +1382,7 @@
                                 ((acl2::erp dims)
                                  (nat-list-fromJSON dims-js))
                                 ((acl2::erp type)
-                                 (type-fromJSON type-j)))
+                                 (type-fromJSON type-j mode)))
                              (acl2::retok (make-expr-array-empty
                                                :dims dims
                                                :type type)))
@@ -1141,7 +1401,7 @@
                                     (exprs-js
                                      (json::value-array->elements exprs-j))
                                     ((acl2::erp exprs)
-                                     (expr-list-fromJSON exprs-js)))
+                                     (expr-list-fromJSON exprs-js mode)))
                                  (if (consp exprs)
                                      (acl2::retok (make-expr-frame
                                                    :dims dims
@@ -1160,7 +1420,7 @@
                                 ((acl2::erp dims)
                                  (nat-list-fromJSON dims-js))
                                 ((acl2::erp type)
-                                 (type-fromJSON type-j)))
+                                 (type-fromJSON type-j mode)))
                              (acl2::retok (make-expr-frame-empty
                                                :dims dims
                                                :type type)))
@@ -1169,11 +1429,11 @@
                      (b* ((fun-j
                            (json::object-member-value "fun" j))
                           ((acl2::erp fun)
-                           (expr-fromJSON fun-j))
+                           (expr-fromJSON fun-j mode))
                           (arg-j
                            (json::object-member-value "arg" j))
                           ((acl2::erp arg)
-                           (expr-fromJSON arg-j)))
+                           (expr-fromJSON arg-j mode)))
                        (acl2::retok (make-expr-app
                                      :fun fun
                                      :arg arg))))
@@ -1181,11 +1441,11 @@
                      (b* ((fun-j
                            (json::object-member-value "fun" j))
                           ((acl2::erp fun)
-                           (expr-fromJSON fun-j))
+                           (expr-fromJSON fun-j mode))
                           (arg-j
                            (json::object-member-value "arg" j))
                           ((acl2::erp arg)
-                           (type-fromJSON arg-j)))
+                           (type-fromJSON arg-j mode)))
                        (acl2::retok (make-expr-tapp
                                      :fun fun
                                      :arg arg))))
@@ -1193,11 +1453,11 @@
                      (b* ((fun-j
                            (json::object-member-value "fun" j))
                           ((acl2::erp fun)
-                           (expr-fromJSON fun-j))
+                           (expr-fromJSON fun-j mode))
                           (arg-j
                            (json::object-member-value "arg" j))
                           ((acl2::erp arg)
-                           (ispace-fromJSON arg-j)))
+                           (ispace-fromJSON arg-j mode)))
                        (acl2::retok (make-expr-iapp
                                      :fun fun
                                      :arg arg))))
@@ -1209,23 +1469,21 @@
                           (target-j
                            (json::object-member-value "target" j))
                           (body-j
-                           (json::object-member-value "body" j)))
-                       (if (json::value-case var-j :string)
-                           (b* (((acl2::erp ispace)
-                                 (ispace-var-fromJSON ispace-j))
-                                (var
-                                 (json::value-string->get var-j))
-                                ((acl2::erp target)
-                                 (expr-fromJSON target-j))
-                                ((acl2::erp body)
-                                 (expr-fromJSON body-j)))
-                             (acl2::retok (make-expr-unbox
-                                           :ispace ispace
-                                           :var var
-                                           :target target
-                                           :body body
-                                           :type? (make-type-option-none))))
-                         (acl2::reterr (msg "The \"var\" member of an Unbox object must be a string, but ~x0 is not." var-j)))))
+                           (json::object-member-value "body" j))
+                          ((acl2::erp ispace)
+                           (ispace-var-fromJSON ispace-j mode))
+                          ((acl2::erp var)
+                           (name-fromJSON var-j mode))
+                          ((acl2::erp target)
+                           (expr-fromJSON target-j mode))
+                          ((acl2::erp body)
+                           (expr-fromJSON body-j mode)))
+                       (acl2::retok (make-expr-unbox
+                                     :ispace ispace
+                                     :var var
+                                     :target target
+                                     :body body
+                                     :type? (make-type-option-none)))))
                     ((equal tag "Let")
                      (b* ((binds-j
                            (json::object-member-value "binds" j))
@@ -1235,9 +1493,9 @@
                            (b* ((binds-js
                                  (json::value-array->elements binds-j))
                                 ((acl2::erp binds)
-                                 (bind-list-fromJSON binds-js))
+                                 (bind-list-fromJSON binds-js mode))
                                 ((acl2::erp body)
-                                 (expr-fromJSON body-j)))
+                                 (expr-fromJSON body-j mode)))
                              (if (consp binds)
                                  (acl2::retok (make-expr-let
                                                :binds binds
@@ -1253,16 +1511,16 @@
               (acl2::reterr (msg "The \"tag\" member of an ExpBase object must be a string, but ~x0 is not." tag-j))))
         (acl2::reterr (msg "A JSON value representing an ExpBase must be a JSON object, but ~x0 is not." j)))))
 
-  (define expr-list-fromJSON ((js json::value-listp))
+  (define expr-list-fromJSON ((js json::value-listp) (mode ast-modep))
     :returns (mv erp (x expr-listp))
     :measure (json::value-list-count js)
     :short "Convert a JSON array's elements to an @(tsee expr-listp)."
     (b* (((acl2::reterr) nil))
       (if (consp js)
           (b* (((acl2::erp hd)
-                (expr-fromJSON (car js)))
+                (expr-fromJSON (car js) mode))
                ((acl2::erp tl)
-                (expr-list-fromJSON (cdr js))))
+                (expr-list-fromJSON (cdr js) mode)))
             (acl2::retok (cons hd tl)))
         (acl2::retok nil))))
 
@@ -1318,11 +1576,11 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; DeclBase
+;; Decl
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define decl-fromJSON ((j json::valuep))
+(define decl-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x declp))
   :short "Convert a JSON value encoding a @('DeclBase') to a @(tsee decl)."
   (b* (((acl2::reterr)
@@ -1342,7 +1600,7 @@
                    (b* ((bind-j
                          (json::object-member-value "bind" j))
                         ((acl2::erp bind)
-                         (bind-fromJSON bind-j)))
+                         (bind-fromJSON bind-j mode)))
                      (acl2::retok (make-decl-def :bind bind))))
                   ((equal tag "Entry")
                    (b* ((var-j
@@ -1353,32 +1611,30 @@
                          (json::object-member-value "type" j))
                         (expr-j
                          (json::object-member-value "expr" j)))
-                     (if (json::value-case var-j :string)
-                         (if (json::value-case params-j :array)
-                             (b* ((var
-                                   (json::value-string->get var-j))
-                                  (params-js
-                                   (json::value-array->elements params-j))
-                                  ((acl2::erp params)
-                                   (var+type?-list-fromJSON params-js))
-                                  ((acl2::erp expr)
-                                   (expr-fromJSON expr-j)))
-                               (if (json::value-case type-j :null)
-                                   (acl2::retok (make-decl-entry
-                                                 :var var
-                                                 :params params
-                                                 :type? (make-type-option-none )
-                                                 :expr expr))
-                                 (b* (((acl2::erp type)
-                                       (type-fromJSON type-j)))
-                                   (acl2::retok (make-decl-entry
-                                                 :var var
-                                                 :params params
-                                                 :type? (make-type-option-some
-                                                         :val type)
-                                                 :expr expr)))))
-                           (acl2::reterr (msg "The \"params\" member of an Entry object must be a JSON array, but ~x0 is not." params-j)))
-                       (acl2::reterr (msg "The \"var\" member of an Entry object must be a string, but ~x0 is not." var-j)))))
+                     (if (json::value-case params-j :array)
+                         (b* (((acl2::erp var)
+                               (name-fromJSON var-j mode))
+                              (params-js
+                               (json::value-array->elements params-j))
+                              ((acl2::erp params)
+                               (var+type?-list-fromJSON params-js mode))
+                              ((acl2::erp expr)
+                               (expr-fromJSON expr-j mode)))
+                           (if (json::value-case type-j :null)
+                               (acl2::retok (make-decl-entry
+                                             :var var
+                                             :params params
+                                             :type? (make-type-option-none )
+                                             :expr expr))
+                             (b* (((acl2::erp type)
+                                   (type-fromJSON type-j mode)))
+                               (acl2::retok (make-decl-entry
+                                             :var var
+                                             :params params
+                                             :type? (make-type-option-some
+                                                     :val type)
+                                             :expr expr)))))
+                       (acl2::reterr (msg "The \"params\" member of an Entry object must be a JSON array, but ~x0 is not." params-j)))))
                   (t
                    (acl2::reterr (msg "~x0 is not a recognized tag for a DeclBase." tag)))))
             (acl2::reterr (msg "The \"tag\" member of a DeclBase object must be a string, but ~x0 is not." tag-j))))
@@ -1391,16 +1647,16 @@
                (decl-huncheckedp x))
     :hints (("Goal" :in-theory (enable* ast-huncheckedp-rules)))))
 
-(define decl-list-fromJSON ((js json::value-listp))
+(define decl-list-fromJSON ((js json::value-listp) (mode ast-modep))
   :returns (mv erp (x decl-listp))
   :measure (json::value-list-count js)
   :short "Convert a JSON array's elements to a @(tsee decl-listp)."
   (b* (((acl2::reterr) nil))
     (if (consp js)
         (b* (((acl2::erp hd)
-              (decl-fromJSON (car js)))
+              (decl-fromJSON (car js) mode))
              ((acl2::erp tl)
-              (decl-list-fromJSON (cdr js))))
+              (decl-list-fromJSON (cdr js) mode)))
           (acl2::retok (cons hd tl)))
       (acl2::retok nil)))
 
@@ -1413,11 +1669,11 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; ProgBase
+;; File
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define file-fromJSON ((j json::valuep))
+(define file-fromJSON ((j json::valuep) (mode ast-modep))
   :returns (mv erp (x filep))
   :short "Convert a JSON value encoding a @('ProgBase') to a @(tsee file)."
   (b* (((acl2::reterr)
@@ -1436,7 +1692,7 @@
                          (b* ((decs-js
                                (json::value-array->elements decs-j))
                               ((acl2::erp decs)
-                               (decl-list-fromJSON decs-js)))
+                               (decl-list-fromJSON decs-js mode)))
                            (acl2::retok (make-file
                                          :imports nil
                                          :decls decs)))


### PR DESCRIPTION
Added three AST modes to the JSON deserializer specifying which instantiation of [impl]'s ASTs to expect. The modes are `:unchecked`, `:unique`, and `:checked`. Also renamed the file-I/O entry points to match similar Remora functions.